### PR TITLE
release: v4.3.10

### DIFF
--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.3.9"
+var version = "4.3.10"
 
 func main() {
 	// Top-level crash recovery — catches panics that escape all other handlers.

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1819,13 +1819,20 @@ func (s *Server) executeScanSession(sess *scanSession) {
 
 	s.saveScanRecordTo(sess.record, sess.scanDir)
 
-	// 10. Generate report if requested
-	if sess.genReport && len(sess.record.Vulns) > 0 {
+	// 10. Generate report if requested (always generate, even for clean scans)
+	if sess.genReport {
 		if p, err := s.generateReportAt(sess.record, sess.scanDir); err == nil {
 			log.Printf("PDF report saved: %s", p)
-			desc := fmt.Sprintf("**Target:** %s\n**Vulnerabilities:** %d found\n**Completed at:** %s",
-				sess.target, len(sess.record.Vulns), time.Now().Format("15:04:05 MST"))
-			s.sendDiscordWithFile(0x3b82f6, "✅ Scan Finished - Report Ready", desc, p)
+			vulnCount := len(sess.record.Vulns)
+			if vulnCount > 0 {
+				desc := fmt.Sprintf("**Target:** %s\n**Vulnerabilities:** %d found\n**Completed at:** %s",
+					sess.target, vulnCount, time.Now().Format("15:04:05 MST"))
+				s.sendDiscordWithFile(0x3b82f6, "✅ Scan Finished - Report Ready", desc, p)
+			} else {
+				desc := fmt.Sprintf("**Target:** %s\n**Result:** No vulnerabilities found (clean scan)\n**Completed at:** %s",
+					sess.target, time.Now().Format("15:04:05 MST"))
+				s.sendDiscordWithFile(0x2dd4bf, "✅ Scan Finished - Clean Report", desc, p)
+			}
 			if sess.instanceID != "" {
 				s.broadcastToInstance(sess.instanceID, WSEvent{Type: "report_ready", Content: fmt.Sprintf("/api/report/%s", sess.id)})
 			} else {


### PR DESCRIPTION
### Changes

- fix: generate PDF report for all scans, not only when vulns > 0

Reports were gated by `len(Vulns) > 0`, meaning clean scans never produced a PDF. Now reports are always generated when `genReport` is true, with differentiated Discord notifications for clean vs vulnerable scans.