### PR TITLE
release: v4.3.11

### DIFF
--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.3.10"
+var version = "4.3.11"
 
 func main() {
 	// Top-level crash recovery — catches panics that escape all other handlers.

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -393,12 +393,8 @@ func printUsage() {
 
 // handleStart installs and starts xalgorix as a systemd service
 func handleStart() {
-	// Determine install path
-	goPath := os.Getenv("GOPATH")
-	if goPath == "" {
-		goPath = filepath.Join(os.Getenv("HOME"), "go")
-	}
-	installPath := filepath.Join(goPath, "bin", "xalgorix")
+	// Determine install path — use the same resolver as --update
+	installPath := resolveInstallPath()
 
 	// Check if binary exists
 	if _, err := os.Stat(installPath); os.IsNotExist(err) {
@@ -489,12 +485,8 @@ func startBackground() {
 		os.Exit(1)
 	}
 
-	// Use GOPATH
-	goPath := os.Getenv("GOPATH")
-	if goPath == "" {
-		goPath = filepath.Join(os.Getenv("HOME"), "go")
-	}
-	installPath := filepath.Join(goPath, "bin", "xalgorix")
+	// Use the same resolver as --update / --start
+	installPath := resolveInstallPath()
 
 	// Start via bash to source env file
 	homeDir := os.Getenv("HOME")
@@ -568,12 +560,8 @@ func handleUninstall() {
 	cmd := exec.Command("pkill", "-f", "xalgorix")
 	cmd.Run()
 
-	// Determine install path
-	goPath := os.Getenv("GOPATH")
-	if goPath == "" {
-		goPath = filepath.Join(os.Getenv("HOME"), "go")
-	}
-	installPath := filepath.Join(goPath, "bin", "xalgorix")
+	// Determine install path — use the same resolver as --update
+	installPath := resolveInstallPath()
 
 	// Remove binary
 	if _, err := os.Stat(installPath); err == nil {


### PR DESCRIPTION
### Fix: --start/--stop/--uninstall use wrong binary path

**Problem:** `handleStart()`, `startBackground()`, and `handleUninstall()` each manually constructed the binary path from `$GOPATH/bin/xalgorix`. On servers where GOPATH differs from the actual install location (e.g. `GOPATH=/root/go/packages` but binary is at `/root/go/bin/xalgorix`), the path resolution fails.

**Fix:** All three functions now call `resolveInstallPath()` which uses `os.Executable()` to find the actual running binary — the same logic `--update` already used successfully.