### PR TITLE
Fix workspace isolation and OOM handling

### DIFF
--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -416,25 +416,11 @@ func handleStart() {
 	if home == "" {
 		home = "/root"
 	}
-	serviceContent := fmt.Sprintf(`[Unit]
-Description=Xalgorix - Autonomous AI Pentesting Engine
-After=network.target
-
-[Service]
-Type=simple
-User=root
-WorkingDirectory=%s
-Environment="PATH=%s/go/bin:%s/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-Environment="GOPATH=%s/go"
-EnvironmentFile=%s/.xalgorix.env
-ExecStart=%s --web
-Restart=always
-RestartSec=10
-OOMScoreAdjust=-500
-
-[Install]
-WantedBy=multi-user.target
-`, home, home, home, home, home, installPath)
+	workspaceDir := filepath.Join(home, "xalgorix-workspace")
+	if err := os.MkdirAll(workspaceDir, 0o755); err != nil {
+		log.Printf("Warning: failed to create workspace directory %s: %v", workspaceDir, err)
+	}
+	serviceContent := serviceUnitContent(home, workspaceDir, installPath)
 	// Try to write service file (requires sudo)
 	servicePath := "/etc/systemd/system/xalgorix.service"
 	err := os.WriteFile(servicePath, []byte(serviceContent), 0644)
@@ -478,6 +464,30 @@ WantedBy=multi-user.target
 	fmt.Println("   Status: systemctl status xalgorix")
 }
 
+func serviceUnitContent(home, workspaceDir, installPath string) string {
+	return fmt.Sprintf(`[Unit]
+Description=Xalgorix - Autonomous AI Pentesting Engine
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=%s
+Environment="PATH=%s/go/bin:%s/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+Environment="GOPATH=%s/go"
+Environment="XALGORIX_WORKSPACE=%s"
+EnvironmentFile=%s/.xalgorix.env
+ExecStart=%s --web
+Restart=always
+RestartSec=10
+OOMScoreAdjust=-500
+OOMPolicy=continue
+
+[Install]
+WantedBy=multi-user.target
+`, workspaceDir, home, home, home, workspaceDir, home, installPath)
+}
+
 func startBackground() {
 	logFile, err := os.OpenFile("/tmp/xalgorix.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
@@ -493,10 +503,16 @@ func startBackground() {
 	if homeDir == "" {
 		homeDir = "/root"
 	}
+	workspaceDir := filepath.Join(homeDir, "xalgorix-workspace")
+	if err := os.MkdirAll(workspaceDir, 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "❌ Failed to create workspace directory: %v\n", err)
+		os.Exit(1)
+	}
 	startCmd := exec.Command("/bin/bash", "-c", "source "+homeDir+"/.xalgorix.env && "+installPath+" --web")
 	startCmd.Stdout = logFile
 	startCmd.Stderr = logFile
-	startCmd.Env = os.Environ()
+	startCmd.Dir = workspaceDir
+	startCmd.Env = append(os.Environ(), "XALGORIX_WORKSPACE="+workspaceDir)
 
 	if err := startCmd.Start(); err != nil {
 		fmt.Fprintf(os.Stderr, "❌ Failed to start xalgorix: %v\n", err)

--- a/cmd/xalgorix/main_test.go
+++ b/cmd/xalgorix/main_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // TestIsNewer covers the semver comparison used by the auto-update path.
 // Pre-release ordering is intentionally not modeled (the comment in main.go
@@ -43,6 +46,21 @@ func TestIsNewer(t *testing.T) {
 		got := isNewer(tc.a, tc.b)
 		if got != tc.want {
 			t.Errorf("isNewer(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestServiceUnitUsesDedicatedWorkspaceAndContinuesAfterChildOOM(t *testing.T) {
+	unit := serviceUnitContent("/root", "/root/xalgorix-workspace", "/usr/local/bin/xalgorix")
+
+	for _, want := range []string{
+		"WorkingDirectory=/root/xalgorix-workspace",
+		`Environment="XALGORIX_WORKSPACE=/root/xalgorix-workspace"`,
+		"OOMScoreAdjust=-500",
+		"OOMPolicy=continue",
+	} {
+		if !strings.Contains(unit, want) {
+			t.Fatalf("service unit missing %q:\n%s", want, unit)
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -38,4 +38,5 @@ require (
 	github.com/ysmood/leakless v0.9.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.3.8 // indirect
+	golang.org/x/time v0.14.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -66,3 +66,5 @@ golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
 golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
+golang.org/x/time v0.14.0 h1:MRx4UaLrDotUKUdCIqzPC48t1Y9hANFKIRpNx+Te8PI=
+golang.org/x/time v0.14.0/go.mod h1:eL/Oa2bBBK0TkX57Fyni+NgnyQQN4LitPmob2Hjnqw4=

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1104,12 +1104,12 @@ func (a *Agent) buildSystemPrompt(targets []string, instruction string) string {
 ### Execution Rules
 1. You MUST call tools using the XML format below. NEVER describe what you would do — DO IT.
 2. Every response MUST contain at least one tool call. NO EXCEPTIONS.
-3. **ALWAYS use maximum threads and comprehensive flags!** Examples:
-   - subfinder -d TARGET -all -recursive -t 100
-   - dnsx -silent -a -resp -threads 100
-   - nuclei -u TARGET -severity critical,high,medium -rl 100
-   - ffuf -u TARGET/FUZZ -w wordlist.txt -t 100 -mc 200,301,302,403
-   - NEVER run: subfinder -d TARGET (without -all -recursive -t !)
+3. **Use bounded, resource-safe concurrency with comprehensive flags.** Examples:
+   - subfinder -d TARGET -all -recursive -t 50
+   - dnsx -silent -a -resp -threads 50
+   - nuclei -u TARGET -severity critical,high,medium -rl 50
+   - ffuf -u TARGET/FUZZ -w wordlist.txt -t 40 -mc 200,301,302,403
+   - NEVER run unbounded/max-thread scans that can OOM the service.
 4. **LARGE TARGET LISTS**: If you are testing multiple targets at once (e.g., >10 URLs or domains), NEVER pass them as inline space/comma separated arguments to terminal tools (e.g. 'nmap a b c d e f g h...'). This causes OS "file name too long" argument crashes! ALWAYS save the targets to a text file first (e.g. 'echo -e "t1\nt2\n..." > targets.txt') and pass the file to the tool using input list flags (e.g. 'subfinder -dL targets.txt', 'httpx -l targets.txt', 'nmap -iL targets.txt', 'findomain -f targets.txt').
 5. If a tool or command fails, try alternatives. NEVER give up after one failure.
 6. Minimum 50 iterations for a thorough assessment. Don't rush to finish.
@@ -1549,7 +1549,7 @@ curl -sk "https://TARGET/endpoint?param={{7*7}}" | grep "49"
 **AFTER MANUAL TESTING**: You may optionally run nuclei as a SUPPLEMENT (not replacement):
 ` + "`" + `bash` + "`" + `
 # Nuclei — run ONLY after manual testing, treat results as leads to verify manually
-nuclei -u https://TARGET -severity critical,high,medium -rl 100 -o ./nuclei_results.txt -stats
+nuclei -u https://TARGET -severity critical,high,medium -rl 50 -o ./nuclei_results.txt -stats
 ` + "`" + `
 
 **CRITICAL: DO NOT trust scanner results blindly.**
@@ -2018,7 +2018,7 @@ cat ./all_subdomains.txt | while read sub; do
 done
 
 # Or use subjack/subzy
-subjack -w ./all_subdomains.txt -t 100 -timeout 30 -ssl -o ./takeovers.txt 2>/dev/null
+subjack -w ./all_subdomains.txt -t 50 -timeout 30 -ssl -o ./takeovers.txt 2>/dev/null
 ` + "`" + `
 
 ### PHASE 14: Open Redirect Testing

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,9 @@ type Config struct {
 	// Rate limiting & API settings
 	RateLimitRequests int // XALGORIX_RATE_LIMIT_REQUESTS — requests per window
 	RateLimitWindow   int // XALGORIX_RATE_LIMIT_WINDOW — window in seconds
+	RateLimitRPS      float64
+	RateLimitBurst    int
+	TLSSkipVerify     bool
 
 	// Caido proxy
 	CaidoPort     int    // CAIDO_PORT
@@ -121,6 +124,9 @@ func load() *Config {
 		// Rate limiting (defaults: 60 requests per 60 seconds)
 		RateLimitRequests: envOrInt("XALGORIX_RATE_LIMIT_REQUESTS", 60),
 		RateLimitWindow:   envOrInt("XALGORIX_RATE_LIMIT_WINDOW", 60),
+		RateLimitRPS:      envOrFloat("XALGORIX_RATE_RPS", 10),
+		RateLimitBurst:    envOrInt("XALGORIX_RATE_BURST", 20),
+		TLSSkipVerify:     envOrBool("XALGORIX_TLS_SKIP_VERIFY", envOrBool("XALGORIX_TLS_INSECURE_SKIP_VERIFY", false)),
 
 		// Caido
 		CaidoPort:     envOrInt("CAIDO_PORT", 0), // 0 = auto-detect
@@ -258,6 +264,15 @@ func envOr(key, fallback string) string {
 func envOrInt(key string, fallback int) int {
 	if v := os.Getenv(key); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return fallback
+}
+
+func envOrFloat(key string, fallback float64) float64 {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.ParseFloat(v, 64); err == nil {
 			return n
 		}
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -133,6 +133,9 @@ func TestLoad_ReadsDashboardProviderProxyAndAgentMailSettings(t *testing.T) {
 		"XALGORIX_MAX_ITERATIONS=12",
 		"XALGORIX_RATE_LIMIT_REQUESTS=7",
 		"XALGORIX_RATE_LIMIT_WINDOW=11",
+		"XALGORIX_RATE_RPS=2.5",
+		"XALGORIX_RATE_BURST=9",
+		"XALGORIX_TLS_SKIP_VERIFY=true",
 		"CAIDO_PORT=9090",
 		"CAIDO_API_TOKEN=caido-token",
 		"XALGORIX_TELEMETRY=false",
@@ -160,6 +163,9 @@ func TestLoad_ReadsDashboardProviderProxyAndAgentMailSettings(t *testing.T) {
 	}
 	if cfg.RateLimitRequests != 7 || cfg.RateLimitWindow != 11 {
 		t.Fatalf("rate limit settings not loaded: %#v", cfg)
+	}
+	if cfg.RateLimitRPS != 2.5 || cfg.RateLimitBurst != 9 || !cfg.TLSSkipVerify {
+		t.Fatalf("request throttle/TLS settings not loaded: %#v", cfg)
 	}
 	if cfg.CaidoPort != 9090 || cfg.CaidoAPIToken != "caido-token" {
 		t.Fatalf("Caido settings not loaded: %#v", cfg)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -8,6 +8,7 @@ package proxy
 
 import (
 	"bufio"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -199,6 +200,24 @@ func NewClient(p *Proxy, timeout time.Duration) (*http.Client, error) {
 		Transport: tr,
 		Timeout:   timeout,
 	}, nil
+}
+
+// NewDirectClient returns a direct HTTP client using Go's tuned default
+// transport, optionally disabling TLS verification for explicit testing cases.
+func NewDirectClient(tlsSkipVerify bool) *http.Client {
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	if tlsSkipVerify {
+		if tr.TLSClientConfig == nil {
+			tr.TLSClientConfig = &tls.Config{} //nolint:gosec // caller explicitly requested insecure TLS
+		} else {
+			tr.TLSClientConfig = tr.TLSClientConfig.Clone()
+		}
+		tr.TLSClientConfig.InsecureSkipVerify = true //nolint:gosec // controlled by XALGORIX_TLS_SKIP_VERIFY
+	}
+	return &http.Client{
+		Transport: tr,
+		Timeout:   30 * time.Second,
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -10,6 +10,7 @@
 package ratelimit
 
 import (
+	"context"
 	"net/url"
 	"sync"
 
@@ -69,7 +70,7 @@ func (l *Limiter) Wait(targetURL string) {
 	}
 	host := domain(targetURL)
 	rl := l.limiterFor(host)
-	_ = rl.Wait(nil) //nolint:errcheck // context is nil — never returns an error
+	_ = rl.Wait(context.Background()) //nolint:errcheck // background context cannot be canceled
 }
 
 // Allow reports whether a token is immediately available for targetURL

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -86,7 +86,7 @@ var (
 
 	// Total RAM budget per running scan instance. This is the admission-control
 	// unit used to decide how many scans can run concurrently.
-	scanMemoryBudgetMB = envInt64("XALGORIX_SCAN_MEMORY_BUDGET_MB", 1024)
+	scanMemoryBudgetMB = envInt64("XALGORIX_SCAN_MEMORY_BUDGET_MB", 2048)
 
 	// Extra RAM budget per running scan for the Go process, browser state,
 	// LLM history, buffers, and small helper tools around one heavy command.

--- a/internal/tools/fileedit/fileedit.go
+++ b/internal/tools/fileedit/fileedit.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/xalgord/xalgorix/v4/internal/config"
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
 	"github.com/xalgord/xalgorix/v4/internal/tools"
 )
 
@@ -26,7 +27,9 @@ func Register(r *tools.Registry) {
 			{Name: "view_range", Description: "Line range to view, e.g. '1-50' (for view)", Required: false},
 			{Name: "file_text", Description: "Full file content (for create)", Required: false},
 		},
-		Execute: strReplaceEditor,
+		Execute: func(args map[string]string) (tools.Result, error) {
+			return strReplaceEditorForContext(r.GetScanContextID(), args)
+		},
 	})
 
 	r.Register(&tools.Tool{
@@ -35,7 +38,9 @@ func Register(r *tools.Registry) {
 		Parameters: []tools.Parameter{
 			{Name: "path", Description: "Directory path to list (relative to workspace or absolute)", Required: true},
 		},
-		Execute: listFiles,
+		Execute: func(args map[string]string) (tools.Result, error) {
+			return listFilesForContext(r.GetScanContextID(), args)
+		},
 	})
 
 	r.Register(&tools.Tool{
@@ -46,7 +51,9 @@ func Register(r *tools.Registry) {
 			{Name: "path", Description: "Directory to search in", Required: false},
 			{Name: "include", Description: "File glob to include (e.g. *.go)", Required: false},
 		},
-		Execute: searchFiles,
+		Execute: func(args map[string]string) (tools.Result, error) {
+			return searchFilesForContext(r.GetScanContextID(), args)
+		},
 	})
 }
 
@@ -57,10 +64,84 @@ func resolvePath(path string) string {
 	return config.Get().WorkspacePath(path)
 }
 
+func workspaceRootForContext(contextID string) string {
+	if sc := scanctx.Get(strings.TrimSpace(contextID)); sc != nil {
+		if sc.Terminal != nil {
+			if wd := strings.TrimSpace(sc.Terminal.GetWorkDir()); wd != "" {
+				return filepath.Clean(wd)
+			}
+		}
+		if sc.ScanDir != "" {
+			return filepath.Clean(sc.ScanDir)
+		}
+	}
+	if cfg := config.Get(); cfg != nil && cfg.Workspace != "" {
+		return filepath.Clean(cfg.Workspace)
+	}
+	return "."
+}
+
+func resolvePathForContext(contextID, rawPath string) (string, error) {
+	root := workspaceRootForContext(contextID)
+	path := strings.TrimSpace(rawPath)
+	if path == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	if path == "~" {
+		path = root
+	} else if strings.HasPrefix(path, "~/") {
+		path = filepath.Join(root, strings.TrimPrefix(path, "~/"))
+	} else if !filepath.IsAbs(path) {
+		path = filepath.Join(root, path)
+	}
+
+	resolved := filepath.Clean(path)
+	if envAllowsAbsoluteFileEdit() {
+		return resolved, nil
+	}
+	if !isWithinPath(root, resolved) {
+		return "", fmt.Errorf("path %s is outside the active scan workspace %s", resolved, root)
+	}
+	return resolved, nil
+}
+
+func envAllowsAbsoluteFileEdit() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("XALGORIX_ALLOW_ABSOLUTE_FILEEDIT")))
+	return v == "1" || v == "true" || v == "yes"
+}
+
+func isWithinPath(root, path string) bool {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		absRoot = filepath.Clean(root)
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		absPath = filepath.Clean(path)
+	}
+	rel, err := filepath.Rel(absRoot, absPath)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}
+
 func strReplaceEditor(args map[string]string) (tools.Result, error) {
 	command := args["command"]
 	path := resolvePath(args["path"])
+	return runEditor(command, path, args)
+}
 
+func strReplaceEditorForContext(contextID string, args map[string]string) (tools.Result, error) {
+	command := args["command"]
+	path, err := resolvePathForContext(contextID, args["path"])
+	if err != nil {
+		return tools.Result{}, err
+	}
+	return runEditor(command, path, args)
+}
+
+func runEditor(command, path string, args map[string]string) (tools.Result, error) {
 	switch command {
 	case "view":
 		return viewFile(path, args["view_range"])
@@ -183,7 +264,18 @@ func insertInFile(path, newStr, insertLineStr string) (tools.Result, error) {
 
 func listFiles(args map[string]string) (tools.Result, error) {
 	path := resolvePath(args["path"])
+	return listFilesAtPath(path)
+}
 
+func listFilesForContext(contextID string, args map[string]string) (tools.Result, error) {
+	path, err := resolvePathForContext(contextID, args["path"])
+	if err != nil {
+		return tools.Result{}, err
+	}
+	return listFilesAtPath(path)
+}
+
+func listFilesAtPath(path string) (tools.Result, error) {
 	entries, err := os.ReadDir(path)
 	if err != nil {
 		return tools.Result{}, fmt.Errorf("cannot read directory: %w", err)
@@ -214,9 +306,23 @@ func searchFiles(args map[string]string) (tools.Result, error) {
 		path = "."
 	}
 	path = resolvePath(path)
+	return searchFilesAtPath(pattern, path, args["include"])
+}
 
-	include := args["include"]
+func searchFilesForContext(contextID string, args map[string]string) (tools.Result, error) {
+	pattern := args["pattern"]
+	path := args["path"]
+	if path == "" {
+		path = "."
+	}
+	resolved, err := resolvePathForContext(contextID, path)
+	if err != nil {
+		return tools.Result{}, err
+	}
+	return searchFilesAtPath(pattern, resolved, args["include"])
+}
 
+func searchFilesAtPath(pattern, path, include string) (tools.Result, error) {
 	// Use ripgrep if available, fallback to grep
 	cmdArgs := []string{"-n", "--color=never", "-r"}
 	binary := "rg"

--- a/internal/tools/fileedit/fileedit_test.go
+++ b/internal/tools/fileedit/fileedit_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
 )
 
 func TestStrReplaceEditor_CreateViewReplaceAndInsert(t *testing.T) {
@@ -116,5 +118,33 @@ func TestListFiles_EmptyAndPopulatedDirectory(t *testing.T) {
 	}
 	if !strings.Contains(res.Output, "a.txt") || !strings.Contains(res.Output, "subdir/") {
 		t.Fatalf("populated list output = %q", res.Output)
+	}
+}
+
+func TestContextFileEditorStaysInsideScanWorkspace(t *testing.T) {
+	sc := scanctx.New("fileedit-scope", t.TempDir())
+	sc.Terminal.SetWorkDir(sc.ScanDir)
+	scanctx.Activate(sc)
+	defer scanctx.Deactivate(sc.ID)
+
+	if _, err := strReplaceEditorForContext(sc.ID, map[string]string{
+		"command":   "create",
+		"path":      "notes.txt",
+		"file_text": "scoped",
+	}); err != nil {
+		t.Fatalf("create in scan workspace: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(sc.ScanDir, "notes.txt")); err != nil {
+		t.Fatalf("expected file in scan workspace: %v", err)
+	}
+
+	outside := filepath.Join(t.TempDir(), "outside.txt")
+	_, err := strReplaceEditorForContext(sc.ID, map[string]string{
+		"command":   "create",
+		"path":      outside,
+		"file_text": "outside",
+	})
+	if err == nil || !strings.Contains(err.Error(), "outside the active scan workspace") {
+		t.Fatalf("outside path error = %v", err)
 	}
 }

--- a/internal/tools/python/python.go
+++ b/internal/tools/python/python.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -80,7 +81,9 @@ func executePythonForContext(contextID string, args map[string]string) (tools.Re
 	} else {
 		cmd.Dir = config.Get().Workspace
 	}
-	cmd.Env = append(os.Environ(), "PYTHONDONTWRITEBYTECODE=1")
+	cmd.Dir = filepath.Clean(cmd.Dir)
+	preparePythonWorkspace(cmd.Dir)
+	cmd.Env = pythonWorkspaceEnv(cmd.Dir)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	stdout := newLimitedBuffer(1024 * 1024)
@@ -143,6 +146,42 @@ func executePythonForContext(contextID string, args map[string]string) (tools.Re
 	}
 
 	return tools.Result{Output: b.String()}, nil
+}
+
+func preparePythonWorkspace(workDir string) {
+	_ = os.MkdirAll(filepath.Join(workDir, ".tmp"), 0o755)
+	_ = os.MkdirAll(filepath.Join(workDir, ".cache"), 0o755)
+	_ = os.MkdirAll(filepath.Join(workDir, ".config"), 0o755)
+	_ = os.MkdirAll(filepath.Join(workDir, ".local", "share"), 0o755)
+}
+
+func pythonWorkspaceEnv(workDir string) []string {
+	replace := map[string]bool{
+		"HOME":                    true,
+		"TMPDIR":                  true,
+		"XDG_CACHE_HOME":          true,
+		"XDG_CONFIG_HOME":         true,
+		"XDG_DATA_HOME":           true,
+		"XALGORIX_WORKSPACE":      true,
+		"PYTHONDONTWRITEBYTECODE": true,
+	}
+	env := make([]string, 0, len(os.Environ())+7)
+	for _, kv := range os.Environ() {
+		key, _, ok := strings.Cut(kv, "=")
+		if ok && replace[key] {
+			continue
+		}
+		env = append(env, kv)
+	}
+	return append(env,
+		"HOME="+workDir,
+		"TMPDIR="+filepath.Join(workDir, ".tmp"),
+		"XDG_CACHE_HOME="+filepath.Join(workDir, ".cache"),
+		"XDG_CONFIG_HOME="+filepath.Join(workDir, ".config"),
+		"XDG_DATA_HOME="+filepath.Join(workDir, ".local", "share"),
+		"XALGORIX_WORKSPACE="+workDir,
+		"PYTHONDONTWRITEBYTECODE=1",
+	)
 }
 
 type limitedBuffer struct {

--- a/internal/tools/terminal/terminal.go
+++ b/internal/tools/terminal/terminal.go
@@ -112,8 +112,8 @@ func computeTimeout(command string) time.Duration {
 
 // setProcessLimits applies resource constraints to a child process:
 // - Adjusts OOM score so the kernel kills scan tools before xalgorix
-// - Sets RLIMIT_AS (virtual memory limit) for heavy tools
-func setProcessLimits(cmd *exec.Cmd, heavy bool) {
+// - Sets RLIMIT_AS (virtual memory limit) when memoryLimited is true
+func setProcessLimits(cmd *exec.Cmd, memoryLimited bool) {
 	if cmd.Process == nil {
 		return
 	}
@@ -129,10 +129,10 @@ func setProcessLimits(cmd *exec.Cmd, heavy bool) {
 		log.Printf("[RESOURCES] Cannot set OOM score for PID %d: %v", pid, err)
 	}
 
-	// ── Memory limit for heavy tools ──
+	// ── Memory limit for scanner subprocesses ──
 	// Uses prlimit64 syscall to set RLIMIT_AS on the child process.
 	// If the tool exceeds this, it gets ENOMEM / SIGSEGV — xalgorix survives.
-	if heavy && resources.HeavyToolMemLimitBytes > 0 {
+	if memoryLimited && resources.HeavyToolMemLimitBytes > 0 {
 		newLimit := syscall.Rlimit{
 			Cur: uint64(resources.HeavyToolMemLimitBytes),
 			Max: uint64(resources.HeavyToolMemLimitBytes),
@@ -149,7 +149,7 @@ func setProcessLimits(cmd *exec.Cmd, heavy bool) {
 		if errno != 0 {
 			log.Printf("[RESOURCES] Cannot set RLIMIT_AS for PID %d: %v", pid, errno)
 		} else {
-			log.Printf("[RESOURCES] Heavy tool PID %d: OOM score=500, mem limit=%d MB",
+			log.Printf("[RESOURCES] Tool PID %d: OOM score=500, mem limit=%d MB",
 				pid, resources.HeavyToolMemLimitBytes/(1024*1024))
 		}
 	} else {
@@ -629,6 +629,139 @@ func runShell(command string) (string, int) {
 	return runShellInternal(scanctx.Default().ID, command)
 }
 
+func effectiveWorkDirForContext(contextID string, cfg *config.Config) string {
+	workDir := strings.TrimSpace(GetWorkDirForContext(contextID))
+	if workDir == "" {
+		if sc := scanctx.Get(contextID); sc != nil {
+			workDir = strings.TrimSpace(sc.ScanDir)
+		}
+	}
+	if workDir == "" && cfg != nil {
+		workDir = strings.TrimSpace(cfg.Workspace)
+	}
+	if workDir == "" {
+		if cwd, err := os.Getwd(); err == nil {
+			workDir = cwd
+		}
+	}
+	if workDir == "" {
+		workDir = "/tmp/xalgorix-workspace"
+	}
+	if !filepath.IsAbs(workDir) {
+		if abs, err := filepath.Abs(workDir); err == nil {
+			workDir = abs
+		}
+	}
+	return filepath.Clean(workDir)
+}
+
+func prepareCommandWorkspace(workDir string) error {
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		return err
+	}
+	for _, dir := range []string{
+		filepath.Join(workDir, ".tmp"),
+		filepath.Join(workDir, ".cache"),
+		filepath.Join(workDir, ".config"),
+		filepath.Join(workDir, ".local", "share"),
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+}
+
+func commandEnv(homeDir, goPath, workDir string) []string {
+	dynamicPath := goPath + "/bin:" + homeDir + "/go/bin:" + homeDir + "/.local/bin"
+	dynamicPath += ":" + homeDir + "/.cargo/bin"
+	dynamicPath += ":/usr/local/bin:/snap/bin"
+
+	replace := map[string]bool{
+		"PATH":               true,
+		"GOPATH":             true,
+		"HOME":               true,
+		"TMPDIR":             true,
+		"XDG_CACHE_HOME":     true,
+		"XDG_CONFIG_HOME":    true,
+		"XDG_DATA_HOME":      true,
+		"XALGORIX_WORKSPACE": true,
+	}
+	env := make([]string, 0, len(os.Environ())+8)
+	for _, kv := range os.Environ() {
+		key, _, ok := strings.Cut(kv, "=")
+		if ok && replace[key] {
+			continue
+		}
+		env = append(env, kv)
+	}
+
+	return append(env,
+		"PATH="+dynamicPath+":"+os.Getenv("PATH"),
+		"GOPATH="+goPath,
+		"HOME="+workDir,
+		"TMPDIR="+filepath.Join(workDir, ".tmp"),
+		"XDG_CACHE_HOME="+filepath.Join(workDir, ".cache"),
+		"XDG_CONFIG_HOME="+filepath.Join(workDir, ".config"),
+		"XDG_DATA_HOME="+filepath.Join(workDir, ".local", "share"),
+		"XALGORIX_WORKSPACE="+workDir,
+	)
+}
+
+func shellPrelude(homeDir, workDir string) string {
+	var b strings.Builder
+	if resources.HeavyToolMemLimitBytes > 0 {
+		limitKB := resources.HeavyToolMemLimitBytes / 1024
+		fmt.Fprintf(&b, "ulimit -Sv %d 2>/dev/null || true\n", limitKB)
+		fmt.Fprintf(&b, "ulimit -Hv %d 2>/dev/null || true\n", limitKB)
+	}
+	fmt.Fprintf(&b, "export HOME=%s\n", shellQuote(workDir))
+	fmt.Fprintf(&b, "export TMPDIR=%s\n", shellQuote(filepath.Join(workDir, ".tmp")))
+	fmt.Fprintf(&b, "export XDG_CACHE_HOME=%s\n", shellQuote(filepath.Join(workDir, ".cache")))
+	fmt.Fprintf(&b, "export XDG_CONFIG_HOME=%s\n", shellQuote(filepath.Join(workDir, ".config")))
+	fmt.Fprintf(&b, "export XDG_DATA_HOME=%s\n", shellQuote(filepath.Join(workDir, ".local", "share")))
+	fmt.Fprintf(&b, "export XALGORIX_WORKSPACE=%s\n", shellQuote(workDir))
+	b.WriteString(`__xalgorix_workspace="$(pwd -P)"
+__xalgorix_resolve_path() {
+  realpath -m "$1" 2>/dev/null || readlink -m "$1" 2>/dev/null || printf '%s\n' "$1"
+}
+cd() {
+  local dest target resolved before after
+  if [ "$#" -eq 0 ]; then
+    dest="$__xalgorix_workspace"
+  else
+    dest="$1"
+  fi
+  if [ "$dest" = "-" ]; then
+    before="$PWD"
+    builtin cd - >/dev/null || return
+    after="$(pwd -P)"
+    case "$after" in
+      "$__xalgorix_workspace"|"$__xalgorix_workspace"/*) pwd; return ;;
+      *) builtin cd "$before"; printf '[WORKSPACE GUARD] cd outside scan workspace blocked: %s\n' "$dest" >&2; return 1 ;;
+    esac
+  fi
+  case "$dest" in
+    "~") target="$__xalgorix_workspace" ;;
+    "~/"*) target="$__xalgorix_workspace/${dest#~/}" ;;
+    /*) target="$dest" ;;
+    *) target="$PWD/$dest" ;;
+  esac
+  resolved="$(__xalgorix_resolve_path "$target")"
+  case "$resolved" in
+    "$__xalgorix_workspace"|"$__xalgorix_workspace"/*) builtin cd "$resolved" ;;
+    *) printf '[WORKSPACE GUARD] cd outside scan workspace blocked: %s\n' "$dest" >&2; return 1 ;;
+  esac
+}
+`)
+	fmt.Fprintf(&b, "source %s 2>/dev/null || true\n", shellQuote(filepath.Join(homeDir, "venv", "bin", "activate")))
+	return b.String()
+}
+
 func runShellInternal(contextID string, command string) (string, int) {
 	contextID = normalizeContextID(contextID)
 	// Ensure venv exists
@@ -638,14 +771,10 @@ func runShellInternal(contextID string, command string) (string, int) {
 	if homeDir == "" {
 		homeDir = "/root"
 	}
-	// Activate venv if it exists — use semicolon so failure doesn't block the command
-	venvActivate := "source " + filepath.Join(homeDir, "venv", "bin", "activate") + " 2>/dev/null; "
-
-	// Wrap command with venv activation
-	command = venvActivate + command
 
 	// Compute timeout based on command type
-	timeout := computeTimeout(command)
+	cleanCmd := command
+	timeout := computeTimeout(cleanCmd)
 	if timeout > hardMaxTimeout {
 		timeout = hardMaxTimeout
 	}
@@ -654,46 +783,33 @@ func runShellInternal(contextID string, command string) (string, int) {
 	defer cancel()
 
 	cfg := config.Get()
+	workDir := effectiveWorkDirForContext(contextID, cfg)
+	if err := prepareCommandWorkspace(workDir); err != nil {
+		return fmt.Sprintf("Failed to prepare command workspace %s: %v", workDir, err), -1
+	}
 
 	// Set PATH to include common tool locations (dynamic - works for any user)
 	goPath := os.Getenv("GOPATH")
 	if goPath == "" {
 		goPath = homeDir + "/go"
 	}
-
-	// Build dynamic PATH including all possible tool locations
-	dynamicPath := goPath + "/bin:" + homeDir + "/go/bin:" + homeDir + "/.local/bin"
-	dynamicPath += ":" + homeDir + "/.cargo/bin" // Rust tools (findomain, rustscan, feroxbuster)
-	dynamicPath += ":/usr/local/bin:/snap/bin"   // Common install locations
-
-	cmdEnv := append(os.Environ(),
-		"PATH="+dynamicPath+":"+os.Getenv("PATH"),
-		"GOPATH="+goPath,
-	)
+	command = shellPrelude(homeDir, workDir) + cleanCmd
 
 	cmd := exec.CommandContext(ctx, "bash", "-c", command)
-	// Use goroutine-scoped workdir if set, otherwise default to config workspace
-	if wd := GetWorkDirForContext(contextID); wd != "" {
-		cmd.Dir = wd
-	} else {
-		cmd.Dir = cfg.Workspace
-	}
-	cmd.Env = cmdEnv
+	cmd.Dir = workDir
+	cmd.Env = commandEnv(homeDir, goPath, workDir)
 
 	// Create new process group for this command
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid: true,
 	}
 
-	// Store a clean version of the command (strip venv activation prefix)
-	cleanCmd := strings.TrimPrefix(command, venvActivate)
-
 	// ── Layer 2: Pre-exec resource throttle ──
 	// Before launching, check if the system has enough resources.
 	// Heavy tools (nuclei, masscan, etc.) are gated more strictly.
 	// If a heavy tool can't get resources within the timeout, abort it
 	// to prevent the kernel OOM killer from nuking the whole server.
-	heavy := isHeavyTool(command)
+	heavy := isHeavyTool(cleanCmd)
 	if heavy {
 		if !resources.WaitForResources(true, 2*time.Minute, cleanCmd) {
 			return fmt.Sprintf("[THROTTLE] Refused to launch heavy tool %q — system resources exhausted after 2m wait", cleanCmd), -1
@@ -718,8 +834,8 @@ func runShellInternal(contextID string, command string) (string, int) {
 	}
 
 	// ── Layer 3: Post-start process limits ──
-	// Set OOM score and memory limits on the child process.
-	setProcessLimits(cmd, heavy)
+	// Set OOM score and a per-process memory limit on the shell and children.
+	setProcessLimits(cmd, true)
 
 	TrackProcessForContext(contextID, cmd, cancel, cleanCmd)
 	defer UntrackProcessForContext(contextID, cmd)

--- a/internal/tools/terminal/terminal_test.go
+++ b/internal/tools/terminal/terminal_test.go
@@ -3,7 +3,9 @@ package terminal
 import (
 	"context"
 	"encoding/base64"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"
@@ -164,5 +166,38 @@ func TestWorkDirPrefersScanContext(t *testing.T) {
 
 	if got := GetWorkDirForContext(sc.ID); got != "/tmp/from-scanctx" {
 		t.Fatalf("GetWorkDirForContext = %q", got)
+	}
+}
+
+func TestRunShellScopesHomeAndBlocksCdOutsideWorkspace(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is not available")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	sc := scanctx.New("term-scope", t.TempDir())
+	sc.Terminal.SetWorkDir(sc.ScanDir)
+	scanctx.Activate(sc)
+	defer func() {
+		CleanupContext(sc.ID)
+		scanctx.Deactivate(sc.ID)
+	}()
+
+	out, code := runShellInternal(sc.ID, `printf 'home=%s\npwd=%s\n' "$HOME" "$PWD"; cd /root; printf 'after=%s\n' "$PWD"`)
+	if code != 0 {
+		t.Fatalf("runShellInternal exit=%d output=%q", code, out)
+	}
+	if !strings.Contains(out, "home="+sc.ScanDir) {
+		t.Fatalf("HOME was not scoped to scan dir: %q", out)
+	}
+	if !strings.Contains(out, "pwd="+sc.ScanDir) || !strings.Contains(out, "after="+sc.ScanDir) {
+		t.Fatalf("command escaped scan dir: %q", out)
+	}
+	if !strings.Contains(out, "[WORKSPACE GUARD] cd outside scan workspace blocked") {
+		t.Fatalf("workspace guard did not report blocked cd: %q", out)
+	}
+	if _, err := os.Stat(filepath.Join(sc.ScanDir, ".tmp")); err != nil {
+		t.Fatalf("workspace temp dir missing: %v", err)
 	}
 }

--- a/internal/web/autonomous.go
+++ b/internal/web/autonomous.go
@@ -34,7 +34,7 @@ If a tool discovers a local/internal IP, SKIP IT and move to the next target. Do
 
 ### Phase 1: RECONNAISSANCE (automated)
 - Port scanning, technology fingerprinting, URL crawling, parameter discovery
-- Save all results in organized folders: mkdir -p ./TARGET
+- Save all results directly inside the current scan workspace with clear filenames. Do not cd out of the workspace and do not write to /root, /tmp, or another home directory.
 
 ### Phase 2: MANUAL VULNERABILITY TESTING (understand the target first)
 - For EACH endpoint with parameters: send baseline request, test special characters, check reflections
@@ -204,15 +204,15 @@ func buildPhaseFilterInstruction(phases []int) string {
 
 	// Map phase numbers to human-readable names for clarity
 	phaseNames := map[int]string{
-		1: "Deep Reconnaissance & Attack Surface Mapping",
-		2: "Manual Vulnerability Discovery",
-		3: "Directory & File Discovery",
-		4: "CORS & Cookie Analysis",
-		5: "Authentication & Session Testing",
-		6: "Injection Testing",
-		7: "SSRF Testing",
-		8: "IDOR & Broken Access Control",
-		9: "API & GraphQL Testing",
+		1:  "Deep Reconnaissance & Attack Surface Mapping",
+		2:  "Manual Vulnerability Discovery",
+		3:  "Directory & File Discovery",
+		4:  "CORS & Cookie Analysis",
+		5:  "Authentication & Session Testing",
+		6:  "Injection Testing",
+		7:  "SSRF Testing",
+		8:  "IDOR & Broken Access Control",
+		9:  "API & GraphQL Testing",
 		10: "File Upload Testing",
 		11: "Deserialization & RCE",
 		12: "Race Conditions & Business Logic",
@@ -255,7 +255,7 @@ YOUR TARGET: ` + target + `
 **⛔ NEVER scan:** 127.0.0.1, localhost, 0.0.0.0, ::1, 10.x.x.x, 172.16-31.x.x, 192.168.x.x, 169.254.x.x — these are local/internal and NOT the target.
 
 ## ORGANIZE YOUR WORK
-Create folder: mkdir -p ./TARGET && cd ./TARGET
+You are already inside the target's scan workspace. Save evidence and tool output in the current directory with clear filenames. Do not use cd to leave this workspace and do not write to /root, /tmp, or another home directory.
 
 ## CORE RULE: DETECT → EXPLOIT → REPORT
 ⚠️ The report_vulnerability tool REJECTS reports without exploitation proof.

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -643,14 +643,14 @@ type VulnSummary struct {
 // ScanRecord is a persisted scan result.
 type ScanRecord struct {
 	ID             string        `json:"id"`
-	Name           string        `json:"name,omitempty"`          // user-defined scan name
+	Name           string        `json:"name,omitempty"` // user-defined scan name
 	Target         string        `json:"target"`
 	ParentTarget   string        `json:"parent_target,omitempty"` // parent domain for subdomain scans (wildcard mode)
 	StartedAt      string        `json:"started_at"`
 	FinishedAt     string        `json:"finished_at,omitempty"`
-	Status         string        `json:"status"`                // saved, running, finished, stopped
-	StopReason     string        `json:"stop_reason,omitempty"` // why scan stopped (error, user, watchdog, etc.)
-	ScanMode       string        `json:"scan_mode,omitempty"`   // single, wildcard, dast
+	Status         string        `json:"status"`                    // saved, running, finished, stopped
+	StopReason     string        `json:"stop_reason,omitempty"`     // why scan stopped (error, user, watchdog, etc.)
+	ScanMode       string        `json:"scan_mode,omitempty"`       // single, wildcard, dast
 	Instruction    string        `json:"instruction,omitempty"`     // custom scan instructions
 	SeverityFilter []string      `json:"severity_filter,omitempty"` // severity filter for scan
 	DiscordWebhook string        `json:"discord_webhook,omitempty"` // discord notification webhook
@@ -677,7 +677,7 @@ type QueueState struct {
 // ScanInstance represents a running or completed scan instance.
 type ScanInstance struct {
 	ID                string        `json:"id"`
-	Name              string        `json:"name,omitempty"`          // user-defined scan name
+	Name              string        `json:"name,omitempty"` // user-defined scan name
 	Targets           string        `json:"targets"`
 	ParentTarget      string        `json:"parent_target,omitempty"` // parent domain for subdomain scans
 	Status            string        `json:"status"`                  // saved, running, paused, finished, stopped
@@ -2611,6 +2611,7 @@ func (s *Server) runWildcardTarget(_ context.Context, scanCfg *config.Config, re
 
 		// Force GC between subdomain scans to free accumulated memory
 		runtime.GC()
+		debug.FreeOSMemory()
 
 		log.Printf("[INFO] Starting subdomain %d/%d: %s (parent: %s)", j+1, len(subdomains), subdomain, target)
 
@@ -2711,6 +2712,7 @@ func (s *Server) runWildcardTarget(_ context.Context, scanCfg *config.Config, re
 
 	log.Printf("[INFO] Wildcard scan complete for %s: scanned %d subdomains", target, len(subdomains))
 	logMemStats(fmt.Sprintf("Wildcard scan complete for %s", target))
+	debug.FreeOSMemory()
 	// Clean up processes before next target — use instance's terminal if available
 	s.instancesMu.RLock()
 	if inst, ok := s.instances[req.InstanceID]; ok {
@@ -2766,7 +2768,7 @@ curl -s "https://dns.bufferover.run/dns?q=.TARGET" | jq -r '.RDNS[]' 2>/dev/null
 curl -s "https://web.archive.org/cdx/search/cdx?url=*.TARGET/*&output=json&fl=original&filter=statuscode:200" | jq -r '.[].original' 2>/dev/null | cut -d'/' -f3 | sort -u > ./archive_subdomains.txt
 
 # 7. Active enumeration
-subfinder -d TARGET -all -recursive -t 100 -o ./active_subfinder.txt
+subfinder -d TARGET -all -recursive -t 50 -o ./active_subfinder.txt
 
 # 8. MERGE ALL RESULTS
 cat ./passive_*.txt ./active_*.txt ./archive_subdomains.txt 2>/dev/null | grep -v '*' | grep -v '@' | sort -u > ./all_subdomains.txt
@@ -2774,7 +2776,7 @@ echo "Total unique subdomains found:"
 wc -l ./all_subdomains.txt
 
 # 9. RESOLVE TO FIND LIVE HOSTS
-cat ./all_subdomains.txt | dnsx -silent -a -resp -threads 100 -o ./live_resolved.txt 2>/dev/null || true
+cat ./all_subdomains.txt | dnsx -silent -a -resp -threads 50 -o ./live_resolved.txt 2>/dev/null || true
 cat ./live_resolved.txt | cut -d' ' -f1 | grep -v '^$' | sort -u > ./live_subdomains.txt
 echo "Live subdomains:"
 wc -l ./live_subdomains.txt
@@ -4123,7 +4125,7 @@ func isBlockedTarget(target string) bool {
 		"127.0.0.0/8",
 		"169.254.0.0/16", // link-local
 		"::1/128",
-		"fc00::/7", // IPv6 unique local
+		"fc00::/7",  // IPv6 unique local
 		"fe80::/10", // IPv6 link-local
 	}
 	for _, cidr := range privateCIDRs {


### PR DESCRIPTION
## Summary
- run the service from a dedicated `~/xalgorix-workspace` and set `XALGORIX_WORKSPACE` for systemd/background startup
- add `OOMPolicy=continue`, restore the 2GB scan memory budget, and apply memory limits/workspace env to terminal and Python tools
- keep file tools scoped to the active scan workspace and reduce default scan prompt concurrency from max-thread behavior
- fix the synced rate-limit/proxy integration so current `main` builds

## Testing
- `go test ./...`
- `go build ./cmd/xalgorix`
