### PR TITLE
release: v4.3.13

### DIFF
--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.3.12"
+var version = "4.3.13"
 
 func main() {
 	// Top-level crash recovery — catches panics that escape all other handlers.


### PR DESCRIPTION
Release v4.3.13 using the repository release script.\n\nThe script verified the build and generated the release commit, but direct pushes to main are blocked by repository rules, so this PR carries the release bump through the required workflow.\n\nTesting:\n- ./release.sh build step passed\n- linux/amd64 release binary built successfully