### PR TITLE
Fix scan details and phase-scoped reporting

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -71,6 +71,7 @@ type Agent struct {
 	activityMu    sync.Mutex
 	scanStart     time.Time     // when Run() was called
 	discoveryMode bool          // When true, allow finish at any iteration (for Phase 1 enumeration)
+	allowedPhases []int         // selected methodology phases, empty means all
 	hooks         *HookRegistry // extensible lifecycle hooks
 	state         *ScanState    // shared mutable scan state for hooks
 }
@@ -171,6 +172,24 @@ func NewAgent(cfg *config.Config, name string, events chan Event, sc ...*scanctx
 // Used for Phase 1 subdomain enumeration where we want the agent to exit immediately.
 func (a *Agent) SetDiscoveryMode(enabled bool) {
 	a.discoveryMode = enabled
+}
+
+// SetPhaseRestrictions configures the selected methodology phases for policy hooks.
+// An empty slice means the full methodology is allowed.
+func (a *Agent) SetPhaseRestrictions(phases []int) {
+	a.allowedPhases = append([]int(nil), phases...)
+}
+
+func isReconReportOnlyPhaseSelection(phases []int) bool {
+	if len(phases) == 0 {
+		return false
+	}
+	for _, phase := range phases {
+		if phase != 1 && phase != 22 {
+			return false
+		}
+	}
+	return true
 }
 
 // stripThink removes <think>...</think> blocks from the response.
@@ -391,6 +410,38 @@ func (a *Agent) executeToolAsync(toolName string, toolArgs map[string]string) (t
 	}
 }
 
+func (a *Agent) shouldBlockForPhaseRestriction(toolName string, toolArgs map[string]string) (bool, string) {
+	if !isReconReportOnlyPhaseSelection(a.allowedPhases) {
+		return false, ""
+	}
+
+	lowerTool := strings.ToLower(toolName)
+	if lowerTool == "report_vulnerability" {
+		return true, "report_vulnerability is out of scope for a reconnaissance/report-only scan. Record recon findings in notes and finish with a recon-focused summary instead."
+	}
+
+	combined := lowerTool
+	for _, value := range toolArgs {
+		combined += " " + strings.ToLower(value)
+	}
+
+	blockedPatterns := []string{
+		"sqlmap", "dalfox", "nuclei", "nikto", "xsstrike", "commix",
+		"tplmap", "ssrfmap", "msfconsole", "metasploit", "searchsploit",
+		"exploit-db", "wpscan", "joomscan",
+		"union select", "<script", "alert(", "sleep(", "pg_sleep",
+		"waitfor delay", "../etc/passwd", "/etc/passwd", "169.254.169.254",
+		"__proto__", "%0d%0a", "jndi:", "burp collaborator",
+	}
+	for _, pattern := range blockedPatterns {
+		if strings.Contains(combined, pattern) {
+			return true, fmt.Sprintf("Blocked %q because this scan is limited to reconnaissance and reporting. Allowed recon includes DNS records, IP resolution, ports, services, HTTP metadata, technologies, URLs, and non-exploit evidence collection.", pattern)
+		}
+	}
+
+	return false, ""
+}
+
 // Run starts the agent loop with the given targets and instructions.
 func (a *Agent) Run(targets []string, instruction string) {
 	a.scanStart = time.Now()
@@ -410,6 +461,11 @@ func (a *Agent) Run(targets []string, instruction string) {
 	// Initialize scan state for hooks (replaces 17+ local tracking variables)
 	a.state = NewScanState()
 	a.state.DiscoveryMode = a.discoveryMode
+	a.state.AllowedPhases = append([]int(nil), a.allowedPhases...)
+	a.state.ReconOnlyMode = isReconReportOnlyPhaseSelection(a.allowedPhases)
+	if a.state.ReconOnlyMode {
+		a.state.DiscoveryMode = true
+	}
 
 	// Helper to get current token count
 	tokenCount := func() int {
@@ -570,6 +626,17 @@ func (a *Agent) Run(targets []string, instruction string) {
 			for k, v := range tc.Args {
 				toolArgs[k] = v
 			}
+
+			if blocked, reason := a.shouldBlockForPhaseRestriction(tc.Name, tc.Args); blocked {
+				blockMsg := "⛔ PHASE RESTRICTION BLOCKED TOOL — " + reason
+				a.emit(Event{Type: "tool_call", ToolName: tc.Name, ToolArgs: tc.Args})
+				a.emit(Event{Type: "tool_result", ToolName: tc.Name, ToolResult: tools.Result{Output: blockMsg}, TotalTokens: tokenCount()})
+				a.msgMu.Lock()
+				a.messages = append(a.messages, llm.Message{Role: "user", Content: blockMsg})
+				a.msgMu.Unlock()
+				continue
+			}
+
 			a.hooks.Fire(OnToolCall, a.state, toolArgs)
 
 			// ── Hook: OnStuckCheck (nudge/force-skip based on stuck counters) ──

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -13,14 +13,14 @@ import (
 // ── Hook Events ──────────────────────────────────────────────────────────────
 
 const (
-	OnToolCall       = "OnToolCall"       // Before every tool execution
-	OnToolResult     = "OnToolResult"     // After every tool execution
-	OnFinishAttempt  = "OnFinishAttempt"  // When agent calls finish
-	OnStuckCheck     = "OnStuckCheck"     // After stuck-loop counter updates (every tool call)
-	OnEmptyResponse  = "OnEmptyResponse"  // When LLM returns empty
-	OnNoToolResponse = "OnNoToolResponse" // When LLM responds without tools
-	OnIterationStart = "OnIterationStart" // At the start of each iteration
-	OnContextPrune   = "OnContextPrune"   // After message history is pruned
+	OnToolCall        = "OnToolCall"        // Before every tool execution
+	OnToolResult      = "OnToolResult"      // After every tool execution
+	OnFinishAttempt   = "OnFinishAttempt"   // When agent calls finish
+	OnStuckCheck      = "OnStuckCheck"      // After stuck-loop counter updates (every tool call)
+	OnEmptyResponse   = "OnEmptyResponse"   // When LLM returns empty
+	OnNoToolResponse  = "OnNoToolResponse"  // When LLM responds without tools
+	OnIterationStart  = "OnIterationStart"  // At the start of each iteration
+	OnContextPrune    = "OnContextPrune"    // After message history is pruned
 	OnHealthyResponse = "OnHealthyResponse" // After a non-empty response with tool calls (resets error counters)
 )
 
@@ -40,15 +40,17 @@ type ScanState struct {
 	ScannerUsed         bool
 	FinishAttempts      int
 	DiscoveryMode       bool
+	ReconOnlyMode       bool
+	AllowedPhases       []int
 
 	// Stuck-loop detection
-	StuckDomain          string
-	StuckIterations      int
-	ConsecutiveBrowser   int
-	ConsecutiveSearch    int
-	ConsecutiveErrors    int
-	EmptyResponseCount   int
-	NoToolCount          int
+	StuckDomain        string
+	StuckIterations    int
+	ConsecutiveBrowser int
+	ConsecutiveSearch  int
+	ConsecutiveErrors  int
+	EmptyResponseCount int
+	NoToolCount        int
 
 	// New enrichment hooks
 	WAFDetected          bool
@@ -70,12 +72,12 @@ func NewScanState() *ScanState {
 // Multiple hooks fire per event; results are merged (first non-empty wins for strings,
 // OR logic for bools).
 type HookResult struct {
-	Nudge       string // message to inject into conversation
-	Block       bool   // prevent the action (e.g., block finish)
-	BlockReason string // why it was blocked
-	ForceSkip   bool   // skip current tool call
-	EmitMessage string // emit to UI without injecting into conversation
-	CleanupBrowser bool // signal to force-close browser
+	Nudge          string // message to inject into conversation
+	Block          bool   // prevent the action (e.g., block finish)
+	BlockReason    string // why it was blocked
+	ForceSkip      bool   // skip current tool call
+	EmitMessage    string // emit to UI without injecting into conversation
+	CleanupBrowser bool   // signal to force-close browser
 }
 
 // ── Hook Registry ────────────────────────────────────────────────────────────
@@ -279,6 +281,10 @@ func hookStuckTracker(state *ScanState, args map[string]string) HookResult {
 // Fires on OnStuckCheck. Produces soft nudge or hard force-skip based on
 // stuck counters accumulated by hookStuckTracker.
 func hookStuckNudge(state *ScanState, args map[string]string) HookResult {
+	if state.ReconOnlyMode {
+		return HookResult{}
+	}
+
 	// Hard limit: force-skip after too many stuck iterations
 	if state.StuckIterations >= StuckHardLimit {
 		forceMsg := fmt.Sprintf(`⛔ EXHAUSTION LIMIT: You have spent %d iterations on %q. You have exhausted browser-based approaches for this target. Close the browser and:
@@ -411,6 +417,12 @@ func hookFinishGatekeeper(state *ScanState, args map[string]string) HookResult {
 	// Discovery mode (Phase 1 enumeration): allow finish after minimum work
 	if state.DiscoveryMode {
 		if state.TerminalCalls < 3 {
+			if state.ReconOnlyMode {
+				return HookResult{
+					Block:       true,
+					BlockReason: fmt.Sprintf("Recon-only scan: only %d commands executed. Run at least 3 reconnaissance tools (for example dig/nslookup, nmap/naabu, httpx/whatweb/curl -I) before finishing.", state.TerminalCalls),
+				}
+			}
 			return HookResult{
 				Block:       true,
 				BlockReason: fmt.Sprintf("Discovery phase: only %d commands executed. Run at least 3 enumeration tools (subfinder, crt.sh, findomain, assetfinder) before finishing.", state.TerminalCalls),
@@ -578,6 +590,10 @@ Call a tool NOW in your next response.`,
 // On iteration start, suggests loading skills if techs have been detected
 // but no skills have been loaded yet. Only fires once, at iteration 15.
 func hookAutoSkillSuggester(state *ScanState, args map[string]string) HookResult {
+	if state.ReconOnlyMode {
+		return HookResult{}
+	}
+
 	// Fire once at iteration >= 15 — early enough to help, late enough to have tech data
 	if state.Iteration < 15 || state.SkillSuggestionFired {
 		return HookResult{}

--- a/internal/web/autonomous.go
+++ b/internal/web/autonomous.go
@@ -202,45 +202,39 @@ func buildPhaseFilterInstruction(phases []int) string {
 		return ""
 	}
 
-	// Map phase numbers to human-readable names for clarity
-	phaseNames := map[int]string{
-		1:  "Deep Reconnaissance & Attack Surface Mapping",
-		2:  "Manual Vulnerability Discovery",
-		3:  "Directory & File Discovery",
-		4:  "CORS & Cookie Analysis",
-		5:  "Authentication & Session Testing",
-		6:  "Injection Testing",
-		7:  "SSRF Testing",
-		8:  "IDOR & Broken Access Control",
-		9:  "API & GraphQL Testing",
-		10: "File Upload Testing",
-		11: "Deserialization & RCE",
-		12: "Race Conditions & Business Logic",
-		13: "Subdomain Takeover",
-		14: "Open Redirect Testing",
-		15: "Email Security Testing",
-		16: "Cloud & Infrastructure",
-		17: "WebSocket Testing",
-		18: "CMS-Specific Testing",
-		19: "Broken Link Hijacking & Content Spoofing",
-		20: "Exploit Verification",
-		21: "Zero-Day & Novel Vulnerability Discovery",
-		22: "Final Report",
-	}
-
 	instruction := "\n\n## ⚠️ PHASE RESTRICTION (MANDATORY — DO NOT IGNORE)\n"
 	instruction += "You are RESTRICTED to ONLY the following methodology phases. "
 	instruction += "SKIP ALL phases not listed below. Do NOT perform work from excluded phases.\n\n"
 	instruction += "**Allowed phases:**\n"
 	for _, p := range phases {
-		name, ok := phaseNames[p]
+		name, ok := methodologyPhaseNames[p]
 		if !ok {
 			name = "Unknown"
 		}
 		instruction += fmt.Sprintf("- Phase %d: %s\n", p, name)
 	}
 	instruction += "\n**All other phases are OUT OF SCOPE for this scan. Skip them entirely.**\n"
-	instruction += "After completing the allowed phases, proceed directly to the Final Report phase.\n"
+	if isReconReportOnlyPhaseSelection(phases) {
+		instruction += `
+## RECONNAISSANCE-ONLY SCOPE
+This selection means reconnaissance plus reporting only. Do NOT run vulnerability scanners, exploit searches, proof-of-concept payloads, SQLi/XSS/SSRF/IDOR tests, or exploit verification.
+
+Reconnaissance should collect and summarize:
+- DNS records: A, AAAA, CNAME, MX, NS, TXT, SOA where available
+- Resolved IP addresses and hostnames
+- Open ports, detected services, and service versions where safely discoverable
+- HTTP status, headers, TLS/certificate metadata, WAF/CDN hints
+- Technology fingerprints, frameworks, CMS, JavaScript frameworks, server software
+- URLs/endpoints discovered passively or by crawling without exploit payloads
+
+If you notice a possible vulnerability during recon, record it as an observation only. Do not exploit it, do not call report_vulnerability, and do not escalate into excluded vulnerability phases.
+`
+	}
+	if !phaseAllowed(phases, 22) {
+		instruction += "After completing the allowed phases, call finish with a concise summary. Do not enter the Final Report phase unless it was selected.\n"
+	} else {
+		instruction += "After completing the allowed non-report phases, proceed directly to the Final Report phase.\n"
+	}
 	return instruction
 }
 

--- a/internal/web/report.go
+++ b/internal/web/report.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -79,17 +80,145 @@ func riskLabel(score float64) string {
 	}
 }
 
+type reconReportSummary struct {
+	DNSRecords   []string
+	IPAddresses  []string
+	Ports        []string
+	Technologies []string
+	URLs         []string
+}
+
+func (s reconReportSummary) hasData() bool {
+	return len(s.DNSRecords)+len(s.IPAddresses)+len(s.Ports)+len(s.Technologies)+len(s.URLs) > 0
+}
+
+var (
+	ipv4Re      = regexp.MustCompile(`\b(?:\d{1,3}\.){3}\d{1,3}\b`)
+	dnsRecordRe = regexp.MustCompile(`(?im)\b([a-z0-9_.-]+)\s+(?:\d+\s+)?(?:in\s+)?(a|aaaa|cname|mx|ns|txt|soa)\s+([^\r\n]{1,160})`)
+	openPortRe  = regexp.MustCompile(`(?im)\b([0-9]{1,5})/(tcp|udp)\s+open\s+([^\s]+)?([^\r\n]{0,100})`)
+)
+
+func collectReconReportSummary(events []WSEvent) reconReportSummary {
+	var summary reconReportSummary
+	seenDNS := map[string]bool{}
+	seenIP := map[string]bool{}
+	seenPort := map[string]bool{}
+	seenTech := map[string]bool{}
+	seenURL := map[string]bool{}
+
+	techSignals := map[string][]string{
+		"Cloudflare": {"cloudflare", "cf-ray"},
+		"Nginx":      {"nginx"},
+		"Apache":     {"apache"},
+		"IIS":        {"microsoft-iis", "iis/"},
+		"WordPress":  {"wordpress", "wp-content"},
+		"Laravel":    {"laravel"},
+		"PHP":        {"x-powered-by: php", "phpsessid", ".php"},
+		"Node.js":    {"node.js", "express", "x-powered-by: express"},
+		"Next.js":    {"next.js", "_next/"},
+		"React":      {"react", "react-dom"},
+		"jQuery":     {"jquery"},
+		"Django":     {"django", "csrftoken"},
+		"Flask":      {"flask"},
+		"Spring":     {"spring", "jsessionid"},
+		"Tomcat":     {"tomcat"},
+		"GraphQL":    {"graphql"},
+	}
+
+	for _, evt := range events {
+		text := evt.Content + "\n" + evt.Output + "\n" + evt.Error
+		for _, value := range evt.ToolArgs {
+			text += "\n" + value
+		}
+		lower := strings.ToLower(text)
+
+		for _, ip := range ipv4Re.FindAllString(text, -1) {
+			if validIPv4(ip) {
+				addUnique(&summary.IPAddresses, seenIP, ip, 40)
+			}
+		}
+
+		for _, match := range dnsRecordRe.FindAllStringSubmatch(text, -1) {
+			if len(match) == 4 {
+				record := fmt.Sprintf("%s %s %s", strings.TrimSpace(match[1]), strings.ToUpper(match[2]), strings.TrimSpace(match[3]))
+				addUnique(&summary.DNSRecords, seenDNS, record, 40)
+			}
+		}
+
+		for _, match := range openPortRe.FindAllStringSubmatch(text, -1) {
+			if len(match) >= 4 {
+				port := strings.TrimSpace(match[1])
+				service := strings.TrimSpace(match[3] + match[4])
+				if service == "" {
+					service = "unknown"
+				}
+				addUnique(&summary.Ports, seenPort, fmt.Sprintf("%s/%s %s", port, strings.ToLower(match[2]), service), 40)
+			}
+		}
+
+		for tech, signals := range techSignals {
+			for _, signal := range signals {
+				if strings.Contains(lower, signal) {
+					addUnique(&summary.Technologies, seenTech, tech, 30)
+					break
+				}
+			}
+		}
+
+		for _, word := range strings.Fields(text) {
+			if strings.Contains(word, "http://") || strings.Contains(word, "https://") {
+				if u := extractURL(word); u != "" {
+					addUnique(&summary.URLs, seenURL, u, 50)
+				}
+			}
+		}
+	}
+
+	sort.Strings(summary.DNSRecords)
+	sort.Strings(summary.IPAddresses)
+	sort.Strings(summary.Ports)
+	sort.Strings(summary.Technologies)
+	sort.Strings(summary.URLs)
+	return summary
+}
+
+func addUnique(values *[]string, seen map[string]bool, value string, max int) {
+	value = strings.TrimSpace(value)
+	if value == "" || seen[value] || len(*values) >= max {
+		return
+	}
+	seen[value] = true
+	*values = append(*values, value)
+}
+
+func validIPv4(ip string) bool {
+	parts := strings.Split(ip, ".")
+	if len(parts) != 4 {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" {
+			return false
+		}
+		var n int
+		if _, err := fmt.Sscanf(part, "%d", &n); err != nil || n < 0 || n > 255 {
+			return false
+		}
+	}
+	return true
+}
+
 // methodologyPhaseNames maps phase number to name for report display.
 var methodologyPhaseNames = map[int]string{
-	1: "Deep Reconnaissance & Attack Surface Mapping",
-	2: "Manual Vulnerability Discovery",
-	3: "Directory & File Discovery",
-	4: "CORS & Cookie Analysis",
-	5: "Authentication & Session Testing",
-	6: "Injection Testing",
-	7: "SSRF Testing",
-	8: "IDOR & Broken Access Control",
-	9: "API & GraphQL Testing",
+	1:  "Deep Reconnaissance & Attack Surface Mapping",
+	2:  "Manual Vulnerability Discovery",
+	3:  "Directory & File Discovery",
+	4:  "CORS & Cookie Analysis",
+	5:  "Authentication & Session Testing",
+	6:  "Injection Testing",
+	7:  "SSRF Testing",
+	8:  "IDOR & Broken Access Control",
+	9:  "API & GraphQL Testing",
 	10: "File Upload Testing",
 	11: "Deserialization & RCE",
 	12: "Race Conditions & Business Logic",
@@ -111,17 +240,17 @@ func (s *Server) generateReport(scan *ScanRecord) (string, error) {
 	pdf.SetAutoPageBreak(true, 20)
 
 	// Colors - dark theme to match UI
-	darkBg := [3]int{15, 23, 42}      // #0f172a - main background
-	coral := [3]int{244, 63, 94}      // #F43F5E - primary accent (coral rose)
-	teal := [3]int{45, 212, 191}      // #2DD4BF - secondary accent
-	white := [3]int{240, 240, 242}    // #f0f0f2 - text
-	gray := [3]int{148, 163, 184}     // muted text
-	red := [3]int{220, 53, 69}        // critical
-	orange := [3]int{220, 120, 50}    // high
-	amber := [3]int{220, 170, 50}     // medium
-	greenLow := [3]int{40, 167, 69}   // low
-	cyan := [3]int{6, 182, 212}       // info
-	sectionBg := [3]int{30, 41, 59}   // #1e293b
+	darkBg := [3]int{15, 23, 42}    // #0f172a - main background
+	coral := [3]int{244, 63, 94}    // #F43F5E - primary accent (coral rose)
+	teal := [3]int{45, 212, 191}    // #2DD4BF - secondary accent
+	white := [3]int{240, 240, 242}  // #f0f0f2 - text
+	gray := [3]int{148, 163, 184}   // muted text
+	red := [3]int{220, 53, 69}      // critical
+	orange := [3]int{220, 120, 50}  // high
+	amber := [3]int{220, 170, 50}   // medium
+	greenLow := [3]int{40, 167, 69} // low
+	cyan := [3]int{6, 182, 212}     // info
+	sectionBg := [3]int{30, 41, 59} // #1e293b
 
 	// Helper: set text color
 	setColor := func(c [3]int) {
@@ -459,21 +588,36 @@ func (s *Server) generateReport(scan *ScanRecord) (string, error) {
 		if phaseNum%2 == 0 {
 			bgColor = sectionBg
 		}
+		if executed {
+			bgColor = [3]int{18, 65, 75}
+		}
 		drawRect(10, rowY, 190, 7, bgColor)
 		// Status indicator
 		if executed {
-			drawRect(12, rowY+1.5, 4, 4, teal)
+			drawRect(10, rowY, 3, 7, teal)
+			drawRect(14, rowY+1.5, 4, 4, teal)
 		} else {
-			drawRect(12, rowY+1.5, 4, 4, gray)
+			drawRect(14, rowY+1.5, 4, 4, gray)
 		}
-		pdf.SetXY(20, rowY)
+		pdf.SetXY(22, rowY)
 		pdf.SetFont("Helvetica", "", 8)
 		if executed {
 			setColor(white)
 		} else {
 			setColor(gray)
 		}
-		pdf.CellFormat(180, 7, fmt.Sprintf("Phase %d: %s", phaseNum, name), "", 1, "L", false, 0, "")
+		status := "SKIPPED"
+		if executed {
+			status = "SELECTED"
+		}
+		pdf.CellFormat(145, 7, fmt.Sprintf("Phase %d: %s", phaseNum, name), "", 0, "L", false, 0, "")
+		pdf.SetFont("Helvetica", "B", 7)
+		if executed {
+			setColor(teal)
+		} else {
+			setColor(gray)
+		}
+		pdf.CellFormat(25, 7, status, "", 1, "R", false, 0, "")
 	}
 
 	// Legend
@@ -487,6 +631,65 @@ func (s *Server) generateReport(scan *ScanRecord) (string, error) {
 	drawRect(50, pdf.GetY()+1, 3, 3, gray)
 	pdf.SetX(56)
 	pdf.CellFormat(30, 5, "= Skipped", "", 1, "L", false, 0, "")
+
+	// ─── RECONNAISSANCE FINDINGS ─────────────────────────
+	recon := collectReconReportSummary(scan.Events)
+	if recon.hasData() {
+		pdf.AddPage()
+		drawRect(0, 0, 210, 297, darkBg)
+		drawRect(0, 0, 210, 1.5, teal)
+
+		pdf.SetY(15)
+		pdf.SetFont("Helvetica", "B", 22)
+		setColor(teal)
+		pdf.CellFormat(190, 12, "Reconnaissance Findings", "", 1, "L", false, 0, "")
+		drawRect(10, pdf.GetY()+2, 62, 0.8, teal)
+		pdf.Ln(8)
+
+		pdf.SetFont("Helvetica", "", 9)
+		setColor(white)
+		pdf.SetX(10)
+		pdf.MultiCell(190, 4.5, "The following non-exploit reconnaissance observations were extracted from the scan feed and tool outputs. These are included for attack-surface documentation and operational handoff.", "", "L", false)
+		pdf.Ln(5)
+
+		drawReconList := func(title string, items []string) {
+			if len(items) == 0 {
+				return
+			}
+			if pdf.GetY() > 245 {
+				pdf.AddPage()
+				drawRect(0, 0, 210, 297, darkBg)
+				drawRect(0, 0, 210, 1.5, teal)
+				pdf.SetY(15)
+			}
+			headerY := pdf.GetY()
+			drawRect(10, headerY, 190, 8, sectionBg)
+			pdf.SetXY(14, headerY+1)
+			pdf.SetFont("Helvetica", "B", 9)
+			setColor(teal)
+			pdf.CellFormat(180, 6, strings.ToUpper(title), "", 1, "L", false, 0, "")
+			pdf.Ln(2)
+			pdf.SetFont("Courier", "", 7)
+			setColor(white)
+			for _, item := range items {
+				if pdf.GetY() > 270 {
+					pdf.AddPage()
+					drawRect(0, 0, 210, 297, darkBg)
+					drawRect(0, 0, 210, 1.5, teal)
+					pdf.SetY(15)
+				}
+				pdf.SetX(14)
+				pdf.MultiCell(182, 4, "- "+item, "", "L", false)
+			}
+			pdf.Ln(4)
+		}
+
+		drawReconList("DNS Records", recon.DNSRecords)
+		drawReconList("Resolved IP Addresses", recon.IPAddresses)
+		drawReconList("Open Ports & Services", recon.Ports)
+		drawReconList("Detected Technologies", recon.Technologies)
+		drawReconList("Observed URLs & Endpoints", recon.URLs)
+	}
 
 	// ─── BLUE TEAM TIMESTAMPS ─────────────────────────────
 	pdf.Ln(10)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/xalgord/xalgorix/v4/internal/agent"
 	"github.com/xalgord/xalgorix/v4/internal/config"
+	"github.com/xalgord/xalgorix/v4/internal/llm"
 	"github.com/xalgord/xalgorix/v4/internal/resources"
 	"github.com/xalgord/xalgorix/v4/internal/scanctx"
 	"github.com/xalgord/xalgorix/v4/internal/tools/agentsgraph"
@@ -618,6 +619,7 @@ type WSEvent struct {
 	SubTargetIndex int               `json:"sub_target_index,omitempty"` // subdomain index within a wildcard target
 	SubTargetTotal int               `json:"sub_target_total,omitempty"` // total subdomains for current wildcard target
 	ParentTarget   string            `json:"parent_target,omitempty"`    // parent domain for subdomain scans
+	CurrentPhase   int               `json:"current_phase,omitempty"`    // inferred active methodology phase
 }
 
 // VulnSummary is a simplified vulnerability for the UI.
@@ -662,6 +664,7 @@ type ScanRecord struct {
 	CompanyName    string        `json:"company_name,omitempty"` // report branding: company name
 	LogoPath       string        `json:"logo_path,omitempty"`    // report branding: logo path
 	Phases         []int         `json:"phases,omitempty"`       // selected methodology phases
+	CurrentPhase   int           `json:"current_phase,omitempty"`
 }
 
 // QueueState persists scan queue state for recovery after restart
@@ -696,11 +699,14 @@ type ScanInstance struct {
 	LogoPath          string        `json:"logo_path,omitempty"`       // report branding: logo path
 	DiscordWebhook    string        `json:"-"`                         // discord webhook (not exposed to API)
 	Vulns             []VulnSummary `json:"vulns,omitempty"`
+	CurrentPhase      int           `json:"current_phase,omitempty"`
 	agent             *agent.Agent
 	cancel            context.CancelFunc
 	scanDir           string
 	sctx              *scanctx.ScanContext // per-instance session state (vulns, notes, terminal, browser)
 	events            []WSEvent            // buffered events for replay
+	chatCfg           *config.Config       // provider settings for post-scan chat (not exposed)
+	chatMessages      []llm.Message        // lightweight post-scan chat history (not exposed)
 	mu                sync.RWMutex
 	lastSessionTokens int // tracks token count from current session for delta calculation
 }
@@ -813,6 +819,7 @@ type Server struct {
 	rateLimiter        *RateLimiter
 	instances          map[string]*ScanInstance // concurrent scan instances
 	instancesMu        sync.RWMutex
+	postScanChatFn     func(*config.Config, []llm.Message) (string, error)
 }
 
 // NewServer creates a new web server.
@@ -836,6 +843,11 @@ func NewServer(cfg *config.Config, port int) *Server {
 		discordMinSeverity: strings.ToLower(strings.TrimSpace(os.Getenv("XALGORIX_DISCORD_MIN_SEVERITY"))),
 		rateLimiter:        rl,
 		instances:          make(map[string]*ScanInstance),
+		postScanChatFn: func(cfg *config.Config, messages []llm.Message) (string, error) {
+			client := llm.NewClient(cfg)
+			client.SetContext(context.Background())
+			return client.Chat(messages)
+		},
 	}
 
 	// Rebuild instances map from disk so dashboard shows historical scans on startup
@@ -1139,10 +1151,13 @@ func (s *Server) handleScan(w http.ResponseWriter, r *http.Request) {
 			Instruction:    req.Instruction,
 			SeverityFilter: req.SeverityFilter,
 			Phases:         req.Phases,
+			CurrentPhase:   firstSelectedPhase(req.Phases),
 			CompanyName:    req.CompanyName,
 			LogoPath:       req.LogoPath,
 			DiscordWebhook: req.DiscordWebhook,
 		}
+		chatCfg := scanCfg
+		inst.chatCfg = &chatCfg
 		s.instancesMu.Lock()
 		s.instances[instanceID] = inst
 		s.instancesMu.Unlock()
@@ -1163,6 +1178,7 @@ func (s *Server) handleScan(w http.ResponseWriter, r *http.Request) {
 				Instruction:    req.Instruction,
 				SeverityFilter: req.SeverityFilter,
 				Phases:         req.Phases,
+				CurrentPhase:   firstSelectedPhase(req.Phases),
 				CompanyName:    req.CompanyName,
 				LogoPath:       req.LogoPath,
 				DiscordWebhook: req.DiscordWebhook,
@@ -1248,10 +1264,16 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	// Count running instances
 	s.instancesMu.RLock()
 	runningCount := 0
+	runningInstanceID := ""
+	currentPhase := 0
 	for _, inst := range s.instances {
 		inst.mu.RLock()
 		if inst.Status == "running" {
 			runningCount++
+			if runningInstanceID == "" {
+				runningInstanceID = inst.ID
+				currentPhase = inst.CurrentPhase
+			}
 		}
 		inst.mu.RUnlock()
 	}
@@ -1272,6 +1294,8 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]any{
 		"running":           s.running.Load() || runningCount > 0,
 		"scan_id":           scanID,
+		"instance_id":       runningInstanceID,
+		"current_phase":     currentPhase,
 		"vulns":             totalVulns,
 		"running_instances": runningCount,
 	})
@@ -1285,20 +1309,23 @@ func (s *Server) handleInstances(w http.ResponseWriter, r *http.Request) {
 	for _, inst := range s.instances {
 		inst.mu.RLock()
 		instances = append(instances, &ScanInstance{
-			ID:          inst.ID,
-			Name:        inst.Name,
-			Targets:     inst.Targets,
-			Status:      inst.Status,
-			StartedAt:   inst.StartedAt,
-			FinishedAt:  inst.FinishedAt,
-			Iterations:  inst.Iterations,
-			ToolCalls:   inst.ToolCalls,
-			VulnCount:   inst.VulnCount,
-			TotalTokens: inst.TotalTokens,
-			ScanMode:    inst.ScanMode,
-			Phases:      inst.Phases,
-			CompanyName: inst.CompanyName,
-			LogoPath:    inst.LogoPath,
+			ID:             inst.ID,
+			Name:           inst.Name,
+			Targets:        inst.Targets,
+			Status:         inst.Status,
+			StartedAt:      inst.StartedAt,
+			FinishedAt:     inst.FinishedAt,
+			Iterations:     inst.Iterations,
+			ToolCalls:      inst.ToolCalls,
+			VulnCount:      inst.VulnCount,
+			TotalTokens:    inst.TotalTokens,
+			ScanMode:       inst.ScanMode,
+			Instruction:    inst.Instruction,
+			SeverityFilter: append([]string(nil), inst.SeverityFilter...),
+			Phases:         inst.Phases,
+			CompanyName:    inst.CompanyName,
+			LogoPath:       inst.LogoPath,
+			CurrentPhase:   inst.CurrentPhase,
 		})
 		inst.mu.RUnlock()
 	}
@@ -1582,26 +1609,29 @@ func (s *Server) handleInstanceAction(w http.ResponseWriter, r *http.Request) {
 // scanSession isolates all per-scan state. Crashes in one session
 // cannot corrupt server-level state or leak into subsequent scans.
 type scanSession struct {
-	id             string
-	target         string
-	parentTarget   string // parent domain for subdomain scans (wildcard mode)
-	scanDir        string
-	cfg            *config.Config
-	agent          *agent.Agent
-	events         chan agent.Event
-	record         *ScanRecord
-	server         *Server
-	instruction    string
-	severityFilter []string
-	discoveryMode  bool
-	genReport      bool
-	resetState     bool
-	instanceID     string               // parent instance ID for multi-instance tracking
-	scanMode       string               // single, wildcard, dast — persisted so dashboard shows correct mode
-	sctx           *scanctx.ScanContext // per-session isolated state
-	companyName    string               // report branding: company name
-	logoPath       string               // report branding: logo path
-	phases         []int                // selected methodology phases
+	id              string
+	target          string
+	parentTarget    string // parent domain for subdomain scans (wildcard mode)
+	scanDir         string
+	cfg             *config.Config
+	agent           *agent.Agent
+	events          chan agent.Event
+	record          *ScanRecord
+	server          *Server
+	instruction     string
+	name            string
+	userInstruction string
+	severityFilter  []string
+	discordWebhook  string
+	discoveryMode   bool
+	genReport       bool
+	resetState      bool
+	instanceID      string               // parent instance ID for multi-instance tracking
+	scanMode        string               // single, wildcard, dast — persisted so dashboard shows correct mode
+	sctx            *scanctx.ScanContext // per-session isolated state
+	companyName     string               // report branding: company name
+	logoPath        string               // report branding: logo path
+	phases          []int                // selected methodology phases
 
 	// Wildcard lifecycle flags
 	skipNotesCleanup     bool   // when true, don't delete notes store on cleanup (discovery phase)
@@ -1772,7 +1802,8 @@ func (s *Server) executeScanSession(sess *scanSession) {
 	events := make(chan agent.Event, 512)
 	sess.events = events
 	agnt := agent.NewAgent(sess.cfg, "XalgorixAgent", events, sctx)
-	if sess.discoveryMode {
+	agnt.SetPhaseRestrictions(sess.phases)
+	if sess.discoveryMode || isReconReportOnlyPhaseSelection(sess.phases) {
 		agnt.SetDiscoveryMode(true)
 	}
 	sess.agent = agnt
@@ -1799,17 +1830,22 @@ func (s *Server) executeScanSession(sess *scanSession) {
 
 	// 4. Initialize scan record
 	sess.record = &ScanRecord{
-		ID:           sess.id,
-		Target:       sess.target,
-		ParentTarget: sess.parentTarget,
-		ScanMode:     sess.scanMode,
-		StartedAt:    time.Now().Format(time.RFC3339),
-		Status:       "running",
-		Events:       []WSEvent{},
-		Vulns:        []VulnSummary{},
-		CompanyName:  sess.companyName,
-		LogoPath:     sess.logoPath,
-		Phases:       sess.phases,
+		ID:             sess.id,
+		Name:           sess.name,
+		Target:         sess.target,
+		ParentTarget:   sess.parentTarget,
+		ScanMode:       sess.scanMode,
+		Instruction:    sess.userInstruction,
+		SeverityFilter: append([]string(nil), sess.severityFilter...),
+		DiscordWebhook: sess.discordWebhook,
+		StartedAt:      time.Now().Format(time.RFC3339),
+		Status:         "running",
+		Events:         []WSEvent{},
+		Vulns:          []VulnSummary{},
+		CompanyName:    sess.companyName,
+		LogoPath:       sess.logoPath,
+		Phases:         append([]int(nil), sess.phases...),
+		CurrentPhase:   firstSelectedPhase(sess.phases),
 	}
 	s.saveScanRecordTo(sess.record, sess.scanDir)
 
@@ -1867,7 +1903,11 @@ func (s *Server) executeScanSession(sess *scanSession) {
 				s.sendDiscordWithFile(0x2dd4bf, "✅ Scan Finished - Clean Report", desc, p)
 			}
 			if sess.instanceID != "" {
-				s.broadcastToInstance(sess.instanceID, WSEvent{Type: "report_ready", Content: fmt.Sprintf("/api/report/%s", sess.id)})
+				reportEvt := WSEvent{Type: "report_ready", Content: fmt.Sprintf("/api/report/%s", sess.id)}
+				if phaseAllowed(sess.phases, 22) {
+					reportEvt.CurrentPhase = 22
+				}
+				s.broadcastToInstance(sess.instanceID, reportEvt)
 			} else {
 				s.broadcast(WSEvent{Type: "report_ready", Content: fmt.Sprintf("/api/report/%s", sess.id)})
 			}
@@ -1972,6 +2012,13 @@ func (s *Server) processEvent(evt agent.Event, sess *scanSession) {
 					log.Printf("[VULN] Vuln filtered out by severity: %s (filter: %v)", vs.Severity, sess.severityFilter)
 				}
 			}
+		}
+	}
+
+	if phase := inferCurrentPhase(wsEvt, sess.phases); phase > 0 {
+		wsEvt.CurrentPhase = phase
+		if sess.record != nil {
+			sess.record.CurrentPhase = phase
 		}
 	}
 
@@ -2084,6 +2131,149 @@ func buildSeverityPrefix(severityFilter []string) string {
 	return severityText
 }
 
+func firstSelectedPhase(phases []int) int {
+	if len(phases) == 0 {
+		return 1
+	}
+	first := 0
+	for _, phase := range phases {
+		if phase < 1 || phase > 22 {
+			continue
+		}
+		if first == 0 || phase < first {
+			first = phase
+		}
+	}
+	if first == 0 {
+		return 1
+	}
+	return first
+}
+
+func phaseAllowed(phases []int, phase int) bool {
+	if phase < 1 || phase > 22 {
+		return false
+	}
+	if len(phases) == 0 {
+		return true
+	}
+	for _, allowed := range phases {
+		if allowed == phase {
+			return true
+		}
+	}
+	return false
+}
+
+func isReconReportOnlyPhaseSelection(phases []int) bool {
+	if len(phases) == 0 {
+		return false
+	}
+	for _, phase := range phases {
+		if phase != 1 && phase != 22 {
+			return false
+		}
+	}
+	return true
+}
+
+var phaseMentionRe = regexp.MustCompile(`(?i)\bphase\s+([0-9]{1,2})\b`)
+
+func inferCurrentPhase(evt WSEvent, allowed []int) int {
+	if phase := parsePhaseMention(evt.Content); phaseAllowed(allowed, phase) {
+		return phase
+	}
+	switch evt.Type {
+	case "queue_started", "target_started", "scan_started":
+		return firstSelectedPhase(allowed)
+	case "finished", "queue_finished", "report_ready":
+		if phaseAllowed(allowed, 22) {
+			return 22
+		}
+	}
+
+	if evt.Type != "tool_call" {
+		return 0
+	}
+	tool := strings.ToLower(evt.ToolName)
+	args := strings.ToLower(strings.Join(mapValues(evt.ToolArgs), " "))
+
+	switch {
+	case tool == "finish" || tool == "report_vulnerability":
+		if phaseAllowed(allowed, 22) {
+			return 22
+		}
+	case strings.Contains(args, "sqlmap") || strings.Contains(args, "dalfox") ||
+		strings.Contains(args, "union select") || strings.Contains(args, "<script") ||
+		strings.Contains(args, "sleep("):
+		if phaseAllowed(allowed, 6) {
+			return 6
+		}
+	case strings.Contains(args, "ffuf") || strings.Contains(args, "gobuster") ||
+		strings.Contains(args, "dirsearch") || strings.Contains(args, "feroxbuster"):
+		if phaseAllowed(allowed, 3) {
+			return 3
+		}
+	case strings.Contains(args, "ssrf") || strings.Contains(args, "169.254.169.254"):
+		if phaseAllowed(allowed, 7) {
+			return 7
+		}
+	case strings.Contains(args, "idor") || strings.Contains(args, "authorization") ||
+		strings.Contains(args, "role=admin"):
+		if phaseAllowed(allowed, 8) {
+			return 8
+		}
+	case strings.Contains(args, "graphql") || strings.Contains(args, "/api/"):
+		if phaseAllowed(allowed, 9) {
+			return 9
+		}
+	case strings.Contains(args, "cors") || strings.Contains(args, "cookie"):
+		if phaseAllowed(allowed, 4) {
+			return 4
+		}
+	case strings.Contains(args, "login") || strings.Contains(args, "session") ||
+		strings.Contains(args, "agentmail"):
+		if phaseAllowed(allowed, 5) {
+			return 5
+		}
+	case strings.Contains(args, "nmap") || strings.Contains(args, "naabu") ||
+		strings.Contains(args, "masscan") || strings.Contains(args, "dig ") ||
+		strings.Contains(args, "nslookup") || strings.Contains(args, "host ") ||
+		strings.Contains(args, "whatweb") || strings.Contains(args, "wappalyzer") ||
+		strings.Contains(args, "httpx") || strings.Contains(args, "wafw00f") ||
+		strings.Contains(args, "subfinder") || strings.Contains(args, "amass") ||
+		strings.Contains(args, "crt.sh"):
+		if phaseAllowed(allowed, 1) {
+			return 1
+		}
+	}
+
+	return 0
+}
+
+func parsePhaseMention(text string) int {
+	match := phaseMentionRe.FindStringSubmatch(text)
+	if len(match) != 2 {
+		return 0
+	}
+	var phase int
+	if _, err := fmt.Sscanf(match[1], "%d", &phase); err != nil {
+		return 0
+	}
+	if phase < 1 || phase > 22 {
+		return 0
+	}
+	return phase
+}
+
+func mapValues(values map[string]string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		out = append(out, value)
+	}
+	return out
+}
+
 // ────────────────────────────────────────────────────────
 // runMultiScan — orchestrates scanning across all targets
 // ────────────────────────────────────────────────────────
@@ -2137,10 +2327,13 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 		Instruction:    req.Instruction,
 		SeverityFilter: req.SeverityFilter,
 		Phases:         req.Phases,
+		CurrentPhase:   firstSelectedPhase(req.Phases),
 		CompanyName:    req.CompanyName,
 		LogoPath:       req.LogoPath,
 		DiscordWebhook: req.DiscordWebhook,
 	}
+	chatCfg := *scanCfg
+	instance.chatCfg = &chatCfg
 	s.instancesMu.Lock()
 	s.instances[instanceID] = instance
 	s.instancesMu.Unlock()
@@ -2169,6 +2362,9 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 			instance.Status = "finished"
 		}
 		instance.FinishedAt = time.Now().Format(time.RFC3339)
+		instance.agent = nil
+		instance.cancel = nil
+		instance.sctx = nil
 		instance.mu.Unlock()
 
 		// Full post-scan cleanup only when the scan actually ran.
@@ -2198,7 +2394,11 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 		}
 		s.mu.Unlock()
 
-		s.broadcastToInstance(instanceID, WSEvent{Type: "queue_finished", Content: "Scan queue ended"})
+		queueDoneEvt := WSEvent{Type: "queue_finished", Content: "Scan queue ended"}
+		if phaseAllowed(req.Phases, 22) {
+			queueDoneEvt.CurrentPhase = 22
+		}
+		s.broadcastToInstance(instanceID, queueDoneEvt)
 		s.broadcastDashboard(WSEvent{Type: "instance_updated", Content: instanceID})
 		time.Sleep(500 * time.Millisecond)
 
@@ -2316,6 +2516,7 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 		Type:         "queue_started",
 		Content:      fmt.Sprintf("Starting scan queue: %d target(s)", totalTargets),
 		TotalTargets: totalTargets,
+		CurrentPhase: firstSelectedPhase(req.Phases),
 	})
 
 	// Discord: scan started
@@ -2420,24 +2621,28 @@ func (s *Server) runSingleTarget(_ context.Context, scanCfg *config.Config, req 
 		AgentID:      filepath.Base(scanDir),
 		TargetIndex:  idx + 1,
 		TotalTargets: total,
+		CurrentPhase: firstSelectedPhase(req.Phases),
 	})
 
 	sess := &scanSession{
-		id:             filepath.Base(scanDir),
-		target:         target,
-		scanDir:        scanDir,
-		cfg:            scanCfg,
-		server:         s,
-		instruction:    buildAutonomousInstruction(target, instruction),
-		severityFilter: req.SeverityFilter,
-		discoveryMode:  false,
-		genReport:      true,
-		resetState:     true,
-		instanceID:     req.InstanceID,
-		scanMode:       "single",
-		companyName:    req.CompanyName,
-		logoPath:       req.LogoPath,
-		phases:         req.Phases,
+		id:              filepath.Base(scanDir),
+		target:          target,
+		scanDir:         scanDir,
+		cfg:             scanCfg,
+		server:          s,
+		instruction:     buildAutonomousInstruction(target, instruction),
+		name:            req.Name,
+		userInstruction: req.Instruction,
+		severityFilter:  req.SeverityFilter,
+		discordWebhook:  req.DiscordWebhook,
+		discoveryMode:   false,
+		genReport:       true,
+		resetState:      true,
+		instanceID:      req.InstanceID,
+		scanMode:        "single",
+		companyName:     req.CompanyName,
+		logoPath:        req.LogoPath,
+		phases:          req.Phases,
 	}
 	s.executeScanSession(sess)
 
@@ -2467,24 +2672,28 @@ func (s *Server) runDASTTarget(_ context.Context, scanCfg *config.Config, req Sc
 		AgentID:      filepath.Base(scanDir),
 		TargetIndex:  idx + 1,
 		TotalTargets: total,
+		CurrentPhase: firstSelectedPhase(req.Phases),
 	})
 
 	sess := &scanSession{
-		id:             filepath.Base(scanDir),
-		target:         target,
-		scanDir:        scanDir,
-		cfg:            scanCfg,
-		server:         s,
-		instruction:    dastInstruction,
-		severityFilter: req.SeverityFilter,
-		discoveryMode:  false,
-		genReport:      true,
-		resetState:     true,
-		instanceID:     req.InstanceID,
-		scanMode:       "dast",
-		companyName:    req.CompanyName,
-		logoPath:       req.LogoPath,
-		phases:         req.Phases,
+		id:              filepath.Base(scanDir),
+		target:          target,
+		scanDir:         scanDir,
+		cfg:             scanCfg,
+		server:          s,
+		instruction:     dastInstruction,
+		name:            req.Name,
+		userInstruction: req.Instruction,
+		severityFilter:  req.SeverityFilter,
+		discordWebhook:  req.DiscordWebhook,
+		discoveryMode:   false,
+		genReport:       true,
+		resetState:      true,
+		instanceID:      req.InstanceID,
+		scanMode:        "dast",
+		companyName:     req.CompanyName,
+		logoPath:        req.LogoPath,
+		phases:          req.Phases,
 	}
 	s.executeScanSession(sess)
 
@@ -2525,6 +2734,7 @@ func (s *Server) runWildcardTarget(_ context.Context, scanCfg *config.Config, re
 		AgentID:      filepath.Base(scanDir),
 		TargetIndex:  idx + 1,
 		TotalTargets: total,
+		CurrentPhase: 1,
 	})
 
 	// Save the discovery session's context ID so we can read notes after cleanup.
@@ -2537,7 +2747,10 @@ func (s *Server) runWildcardTarget(_ context.Context, scanCfg *config.Config, re
 		cfg:              scanCfg,
 		server:           s,
 		instruction:      discoveryInstruction,
+		name:             req.Name,
+		userInstruction:  req.Instruction,
 		severityFilter:   req.SeverityFilter,
+		discordWebhook:   req.DiscordWebhook,
 		discoveryMode:    true,
 		genReport:        false,
 		resetState:       true,
@@ -2638,6 +2851,7 @@ func (s *Server) runWildcardTarget(_ context.Context, scanCfg *config.Config, re
 				SubTargetIndex: j + 1,
 				SubTargetTotal: len(subdomains),
 				ParentTarget:   target,
+				CurrentPhase:   firstSelectedPhase(req.Phases),
 			})
 
 			// Track vulns BEFORE this subdomain scan using the stable parent context
@@ -2651,7 +2865,10 @@ func (s *Server) runWildcardTarget(_ context.Context, scanCfg *config.Config, re
 				cfg:                  scanCfg,
 				server:               s,
 				instruction:          scanInstruction,
+				name:                 req.Name,
+				userInstruction:      req.Instruction,
 				severityFilter:       req.SeverityFilter,
+				discordWebhook:       req.DiscordWebhook,
 				discoveryMode:        false,
 				genReport:            false,
 				resetState:           false, // accumulate vulns across subdomains
@@ -2671,13 +2888,22 @@ func (s *Server) runWildcardTarget(_ context.Context, scanCfg *config.Config, re
 				newVulns := allVulns[vulnCountBefore:]
 				if len(newVulns) > 0 {
 					subScanRecord := ScanRecord{
-						ID:           filepath.Base(subScanDir),
-						Target:       subdomain,
-						ParentTarget: target,
-						StartedAt:    time.Now().Format(time.RFC3339),
-						Status:       "finished",
-						FinishedAt:   time.Now().Format(time.RFC3339),
-						Vulns:        []VulnSummary{},
+						ID:             filepath.Base(subScanDir),
+						Name:           req.Name,
+						Target:         subdomain,
+						ParentTarget:   target,
+						ScanMode:       "wildcard",
+						Instruction:    req.Instruction,
+						SeverityFilter: append([]string(nil), req.SeverityFilter...),
+						DiscordWebhook: req.DiscordWebhook,
+						StartedAt:      time.Now().Format(time.RFC3339),
+						Status:         "finished",
+						FinishedAt:     time.Now().Format(time.RFC3339),
+						Vulns:          []VulnSummary{},
+						CompanyName:    req.CompanyName,
+						LogoPath:       req.LogoPath,
+						Phases:         append([]int(nil), req.Phases...),
+						CurrentPhase:   22,
 					}
 					for _, v := range newVulns {
 						subScanRecord.Vulns = append(subScanRecord.Vulns, vulnToSummary(v))
@@ -3381,6 +3607,45 @@ func (s *Server) findScanByID(scanID string) (string, *ScanRecord) {
 	return "", nil
 }
 
+func scanRecordFromInstance(inst *ScanInstance) *ScanRecord {
+	if inst == nil {
+		return nil
+	}
+	inst.mu.RLock()
+	defer inst.mu.RUnlock()
+
+	events := make([]WSEvent, len(inst.events))
+	copy(events, inst.events)
+	vulns := make([]VulnSummary, len(inst.Vulns))
+	copy(vulns, inst.Vulns)
+	phases := append([]int(nil), inst.Phases...)
+	severityFilter := append([]string(nil), inst.SeverityFilter...)
+
+	return &ScanRecord{
+		ID:             inst.ID,
+		Name:           inst.Name,
+		Target:         inst.Targets,
+		ParentTarget:   inst.ParentTarget,
+		StartedAt:      inst.StartedAt,
+		FinishedAt:     inst.FinishedAt,
+		Status:         inst.Status,
+		StopReason:     inst.StopReason,
+		ScanMode:       inst.ScanMode,
+		Instruction:    inst.Instruction,
+		SeverityFilter: severityFilter,
+		DiscordWebhook: inst.DiscordWebhook,
+		Events:         events,
+		Vulns:          vulns,
+		TotalTokens:    inst.TotalTokens,
+		Iterations:     inst.Iterations,
+		ToolCalls:      inst.ToolCalls,
+		CompanyName:    inst.CompanyName,
+		LogoPath:       inst.LogoPath,
+		Phases:         phases,
+		CurrentPhase:   inst.CurrentPhase,
+	}
+}
+
 // rebuildInstancesFromDisk populates s.instances from all saved scan.json files on disk.
 // This ensures the dashboard shows historical scans immediately after server restart.
 // Skips subdomain scans (those with ParentTarget set) — those are shown under their parent.
@@ -3411,7 +3676,15 @@ func (s *Server) rebuildInstancesFromDisk() {
 			CompanyName:    entry.rec.CompanyName,
 			LogoPath:       entry.rec.LogoPath,
 			DiscordWebhook: entry.rec.DiscordWebhook,
+			Vulns:          entry.rec.Vulns,
+			CurrentPhase:   entry.rec.CurrentPhase,
+			events:         append([]WSEvent(nil), entry.rec.Events...),
 		}
+		if inst.CurrentPhase == 0 {
+			inst.CurrentPhase = firstSelectedPhase(inst.Phases)
+		}
+		chatCfg := *s.cfg
+		inst.chatCfg = &chatCfg
 		// If scan was "running" from a previous server instance, it's no longer active
 		if inst.Status == "running" {
 			inst.Status = "stopped"
@@ -3464,8 +3737,19 @@ func (s *Server) handleDownloadReport(w http.ResponseWriter, r *http.Request) {
 
 	scanDir, rec := s.findScanByID(scanID)
 	if scanDir == "" || rec == nil {
-		http.Error(w, "scan not found", http.StatusNotFound)
-		return
+		s.instancesMu.RLock()
+		inst := s.instances[scanID]
+		s.instancesMu.RUnlock()
+		if inst != nil {
+			rec = scanRecordFromInstance(inst)
+			inst.mu.RLock()
+			scanDir = inst.scanDir
+			inst.mu.RUnlock()
+		}
+		if scanDir == "" || rec == nil {
+			http.Error(w, "scan not found", http.StatusNotFound)
+			return
+		}
 	}
 
 	reportPath := filepath.Join(scanDir, fmt.Sprintf("xalgorix_report_%s.pdf", scanID))
@@ -3690,6 +3974,7 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	req.Message = strings.TrimSpace(req.Message)
 	if req.Message == "" {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
@@ -3697,34 +3982,10 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// BUG FIX: Use the explicitly provided instance_id to route chat messages
-	// to the correct agent. Previously, `s.currentScanID` (a global) was always
-	// used, so chat messages in multi-scan mode always went to the last-started
-	// scan regardless of which instance the user was viewing.
-	targetID := req.InstanceID
-	if targetID == "" {
-		// Fallback to global for single-instance backwards compatibility
-		s.mu.RLock()
-		targetID = s.currentScanID
-		s.mu.RUnlock()
-	}
-
-	// Check if there's an active agent for the target instance
-	s.mu.RLock()
-	agnt := s.currentAgents[targetID]
-	s.mu.RUnlock()
-	if agnt == nil {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(map[string]string{"error": "no active scan"})
-		return
-	}
-
-	// Send the message to the agent
-	response, err := agnt.SendMessage(req.Message)
+	response, err := s.routeChatMessage(strings.TrimSpace(req.InstanceID), req.Message)
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
@@ -3733,6 +3994,193 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]string{
 		"response": response,
 	})
+}
+
+func (s *Server) routeChatMessage(instanceID, message string) (string, error) {
+	if instanceID != "" {
+		s.instancesMu.RLock()
+		inst := s.instances[instanceID]
+		s.instancesMu.RUnlock()
+		if inst == nil {
+			return "", fmt.Errorf("instance not found")
+		}
+
+		inst.mu.RLock()
+		status := inst.Status
+		agnt := inst.agent
+		inst.mu.RUnlock()
+
+		if agnt != nil && status == "running" {
+			return agnt.SendMessage(message)
+		}
+		if status == "saved" || status == "pending" {
+			return "", fmt.Errorf("scan is not active yet")
+		}
+		return s.postScanChat(inst, message)
+	}
+
+	// Fallback for the older single-scan UI path, where chat messages did not
+	// include an instance_id and the currently running session was global.
+	s.mu.RLock()
+	targetID := s.currentScanID
+	agnt := s.currentAgents[targetID]
+	s.mu.RUnlock()
+	if agnt == nil {
+		return "", fmt.Errorf("no active scan")
+	}
+	return agnt.SendMessage(message)
+}
+
+func (s *Server) postScanChat(inst *ScanInstance, message string) (string, error) {
+	inst.mu.Lock()
+	if inst.chatCfg == nil {
+		chatCfg := *s.cfg
+		inst.chatCfg = &chatCfg
+	}
+	chatCfg := *inst.chatCfg
+	if len(inst.chatMessages) == 0 {
+		inst.chatMessages = []llm.Message{{
+			Role:    "system",
+			Content: buildPostScanChatPrompt(inst),
+		}}
+	}
+	messages := append([]llm.Message(nil), inst.chatMessages...)
+	messages = append(messages, llm.Message{Role: "user", Content: message})
+	inst.mu.Unlock()
+
+	response, err := s.postScanChatFn(&chatCfg, messages)
+	if err != nil {
+		return "", err
+	}
+	response = strings.TrimSpace(llm.CleanContent(response))
+	if response == "" {
+		response = "I do not have enough scan context to answer that."
+	}
+
+	inst.mu.Lock()
+	inst.chatMessages = append(messages, llm.Message{Role: "assistant", Content: response})
+	inst.chatMessages = trimPostScanChatHistory(inst.chatMessages)
+	inst.mu.Unlock()
+
+	return response, nil
+}
+
+func buildPostScanChatPrompt(inst *ScanInstance) string {
+	var b strings.Builder
+	if inst.Status == "paused" {
+		b.WriteString("You are Xalgorix in paused-scan chat mode. The scan is paused, so answer follow-up questions using only the scan context captured so far. Do not claim that you are still scanning or that you can run tools in this chat. If the user asks for new testing, explain what the current results show and suggest resuming the scan.\n\n")
+	} else {
+		b.WriteString("You are Xalgorix in post-scan chat mode. The scan has already finished, so answer follow-up questions using only the completed scan context below. Do not claim that you are still scanning or that you can run tools in this chat. If the user asks for new testing, explain what the existing results show and suggest restarting or starting a new scan.\n\n")
+	}
+
+	b.WriteString("## Scan\n")
+	fmt.Fprintf(&b, "Instance ID: %s\n", inst.ID)
+	fmt.Fprintf(&b, "Targets: %s\n", inst.Targets)
+	fmt.Fprintf(&b, "Status: %s\n", inst.Status)
+	if inst.ScanMode != "" {
+		fmt.Fprintf(&b, "Mode: %s\n", inst.ScanMode)
+	}
+	if inst.StartedAt != "" {
+		fmt.Fprintf(&b, "Started: %s\n", inst.StartedAt)
+	}
+	if inst.FinishedAt != "" {
+		fmt.Fprintf(&b, "Finished: %s\n", inst.FinishedAt)
+	}
+	fmt.Fprintf(&b, "Iterations: %d\nTool calls: %d\nVulnerabilities: %d\nTotal tokens: %d\n", inst.Iterations, inst.ToolCalls, inst.VulnCount, inst.TotalTokens)
+	if strings.TrimSpace(inst.Instruction) != "" {
+		fmt.Fprintf(&b, "User instructions: %s\n", truncStr(inst.Instruction, 1200))
+	}
+
+	if len(inst.Vulns) > 0 {
+		b.WriteString("\n## Vulnerabilities\n")
+		for i, v := range inst.Vulns {
+			if i >= 40 {
+				fmt.Fprintf(&b, "- ... %d additional vulnerabilities omitted from prompt context\n", len(inst.Vulns)-i)
+				break
+			}
+			fmt.Fprintf(&b, "- [%s] %s", strings.ToUpper(v.Severity), v.Title)
+			if v.Endpoint != "" {
+				fmt.Fprintf(&b, " at %s", v.Endpoint)
+			}
+			if v.CVSS > 0 {
+				fmt.Fprintf(&b, " (CVSS %.1f)", v.CVSS)
+			}
+			if v.Description != "" {
+				fmt.Fprintf(&b, " - %s", truncStr(v.Description, 500))
+			}
+			b.WriteByte('\n')
+		}
+	}
+
+	if len(inst.events) > 0 {
+		b.WriteString("\n## Recent Scan Events\n")
+		start := 0
+		if len(inst.events) > 80 {
+			start = len(inst.events) - 80
+		}
+		for _, evt := range inst.events[start:] {
+			line := summarizeChatEvent(evt)
+			if line != "" {
+				b.WriteString("- ")
+				b.WriteString(line)
+				b.WriteByte('\n')
+			}
+		}
+	}
+
+	return b.String()
+}
+
+func summarizeChatEvent(evt WSEvent) string {
+	switch evt.Type {
+	case "thinking":
+		return fmt.Sprintf("thinking: %s", truncStr(evt.Content, 160))
+	case "message":
+		return fmt.Sprintf("message: %s", truncStr(evt.Content, 300))
+	case "error":
+		return fmt.Sprintf("error: %s", truncStr(evt.Content, 300))
+	case "tool_call":
+		return fmt.Sprintf("tool_call: %s", evt.ToolName)
+	case "tool_result":
+		body := evt.Output
+		if body == "" {
+			body = evt.Error
+		}
+		if evt.ToolName != "" {
+			return fmt.Sprintf("tool_result: %s: %s", evt.ToolName, truncStr(body, 300))
+		}
+		return fmt.Sprintf("tool_result: %s", truncStr(body, 300))
+	case "finished":
+		return fmt.Sprintf("finished: %s", truncStr(evt.Content, 300))
+	case "target_started", "target_completed", "queue_started", "queue_finished", "report_ready":
+		if evt.Target != "" {
+			return fmt.Sprintf("%s: %s (%s)", evt.Type, truncStr(evt.Content, 220), evt.Target)
+		}
+		return fmt.Sprintf("%s: %s", evt.Type, truncStr(evt.Content, 220))
+	default:
+		return ""
+	}
+}
+
+func trimPostScanChatHistory(messages []llm.Message) []llm.Message {
+	const keepRecent = 40
+	if len(messages) <= keepRecent+1 {
+		return messages
+	}
+	trimmed := make([]llm.Message, 0, keepRecent+1)
+	trimmed = append(trimmed, messages[0])
+	trimmed = append(trimmed, messages[len(messages)-keepRecent:]...)
+	return trimmed
+}
+
+func truncStr(s string, max int) string {
+	if max <= 0 || len(s) <= max {
+		return s
+	}
+	if max <= 3 {
+		return s[:max]
+	}
+	return s[:max-3] + "..."
 }
 
 // handleQueueStatus returns the current queue state for recovery
@@ -3834,6 +4282,18 @@ func (s *Server) handleGetScan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if r.Method == http.MethodGet {
+		s.instancesMu.RLock()
+		inst := s.instances[scanID]
+		s.instancesMu.RUnlock()
+		if rec := scanRecordFromInstance(inst); rec != nil {
+			data, _ := json.Marshal(rec)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(data)
+			return
+		}
+	}
+
 	dir, rec := s.findScanByID(scanID)
 	_ = dir
 	if rec == nil {
@@ -3908,6 +4368,9 @@ func (s *Server) broadcastToInstance(instanceID string, evt WSEvent) {
 		// Also buffer vulns
 		if len(evt.Vulns) > 0 {
 			inst.Vulns = append(inst.Vulns, evt.Vulns...)
+		}
+		if evt.CurrentPhase > 0 {
+			inst.CurrentPhase = evt.CurrentPhase
 		}
 		inst.mu.Unlock()
 	}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -13,7 +13,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/xalgord/xalgorix/v4/internal/agent"
 	"github.com/xalgord/xalgorix/v4/internal/config"
+	"github.com/xalgord/xalgorix/v4/internal/llm"
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
 )
 
 func newTestServer(t *testing.T, cfg *config.Config) *Server {
@@ -146,6 +149,149 @@ func TestScanRequest_InternalFieldsIgnoredFromJSON(t *testing.T) {
 	}
 	if req.InstanceID != "" || req.IsResume {
 		t.Fatalf("internal fields were set from JSON: %#v", req)
+	}
+}
+
+func TestPhaseRestriction_ReconReportOnlyIsStrict(t *testing.T) {
+	instruction := buildPhaseFilterInstruction([]int{1, 22})
+	for _, want := range []string{
+		"RECONNAISSANCE-ONLY SCOPE",
+		"Do NOT run vulnerability scanners",
+		"DNS records",
+		"Open ports",
+		"do not call report_vulnerability",
+	} {
+		if !strings.Contains(instruction, want) {
+			t.Fatalf("phase restriction missing %q:\n%s", want, instruction)
+		}
+	}
+	if !isReconReportOnlyPhaseSelection([]int{1, 22}) {
+		t.Fatal("recon/report-only phase selection was not detected")
+	}
+	if isReconReportOnlyPhaseSelection([]int{1, 6, 22}) {
+		t.Fatal("vulnerability phase selection was incorrectly treated as recon-only")
+	}
+}
+
+func TestHandleGetScan_ReturnsLiveInstanceMetadata(t *testing.T) {
+	s := newTestServer(t, nil)
+	inst := &ScanInstance{
+		ID:             "inst-meta",
+		Name:           "Recon pass",
+		Targets:        "https://meta.test",
+		Status:         "running",
+		StartedAt:      "2026-05-10T10:00:00Z",
+		ScanMode:       "single",
+		Instruction:    "recon only",
+		SeverityFilter: []string{"high"},
+		Phases:         []int{1, 22},
+		CurrentPhase:   1,
+		CompanyName:    "ACME",
+		events: []WSEvent{{
+			Type:         "target_started",
+			Content:      "Scanning target",
+			CurrentPhase: 1,
+		}},
+	}
+	s.instancesMu.Lock()
+	s.instances[inst.ID] = inst
+	s.instancesMu.Unlock()
+
+	rr := httptest.NewRecorder()
+	s.handleGetScan(rr, httptest.NewRequest(http.MethodGet, "/api/scans/inst-meta", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("get scan code = %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	var rec ScanRecord
+	if err := json.Unmarshal(rr.Body.Bytes(), &rec); err != nil {
+		t.Fatalf("decode scan record: %v", err)
+	}
+	if rec.Name != "Recon pass" || rec.Instruction != "recon only" || rec.CurrentPhase != 1 || len(rec.Phases) != 2 {
+		t.Fatalf("live instance metadata not preserved: %#v", rec)
+	}
+}
+
+func TestHandleChat_RoutesRunningInstanceByInstanceID(t *testing.T) {
+	s := newTestServer(t, nil)
+	events := make(chan agent.Event, 4)
+	sctx := scanctx.New("chat-running", t.TempDir())
+	agnt := agent.NewAgent(s.cfg, "test-agent", events, sctx)
+	inst := &ScanInstance{
+		ID:      "inst-running",
+		Targets: "https://running.test",
+		Status:  "running",
+		agent:   agnt,
+	}
+	s.instancesMu.Lock()
+	s.instances[inst.ID] = inst
+	s.instancesMu.Unlock()
+	t.Cleanup(func() {
+		agnt.Stop()
+		sctx.Close()
+	})
+
+	rr := httptest.NewRecorder()
+	body := strings.NewReader(`{"instance_id":"inst-running","message":"continue checking auth"}`)
+	s.handleChat(rr, httptest.NewRequest(http.MethodPost, "/api/chat", body))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("chat status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "next iteration") {
+		t.Fatalf("unexpected running chat response: %s", rr.Body.String())
+	}
+}
+
+func TestHandleChat_AllowsFinishedInstancePostScanChat(t *testing.T) {
+	s := newTestServer(t, &config.Config{RateLimitRequests: 60, RateLimitWindow: 60})
+	var gotMessages []string
+	s.postScanChatFn = func(_ *config.Config, messages []llm.Message) (string, error) {
+		for _, msg := range messages {
+			gotMessages = append(gotMessages, msg.Content)
+		}
+		return "The scan found one high severity issue.", nil
+	}
+	inst := &ScanInstance{
+		ID:          "inst-finished",
+		Targets:     "https://done.test",
+		Status:      "finished",
+		StartedAt:   "2026-05-10T10:00:00Z",
+		FinishedAt:  "2026-05-10T10:30:00Z",
+		ScanMode:    "single",
+		Iterations:  2,
+		ToolCalls:   3,
+		VulnCount:   1,
+		TotalTokens: 100,
+		Vulns: []VulnSummary{{
+			ID:          "v1",
+			Title:       "SQL injection",
+			Severity:    "high",
+			Endpoint:    "/login",
+			Description: "Authentication endpoint reflected SQL errors.",
+		}},
+		events: []WSEvent{
+			{Type: "target_started", Target: "https://done.test", Content: "Scanning https://done.test"},
+			{Type: "finished", Content: "Completed with one finding"},
+		},
+	}
+	s.instancesMu.Lock()
+	s.instances[inst.ID] = inst
+	s.instancesMu.Unlock()
+
+	rr := httptest.NewRecorder()
+	body := strings.NewReader(`{"instance_id":"inst-finished","message":"what did we find?"}`)
+	s.handleChat(rr, httptest.NewRequest(http.MethodPost, "/api/chat", body))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("chat status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "one high severity issue") {
+		t.Fatalf("unexpected post-scan chat response: %s", rr.Body.String())
+	}
+	joinedMessages := strings.Join(gotMessages, "\n")
+	if !strings.Contains(joinedMessages, "post-scan chat mode") ||
+		!strings.Contains(joinedMessages, "SQL injection") ||
+		!strings.Contains(joinedMessages, "what did we find?") {
+		t.Fatalf("LLM prompt missing completed scan context or user message: %s", joinedMessages)
 	}
 }
 

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -150,6 +150,35 @@
         },
     };
 
+    const METHODOLOGY_PHASES = [
+        { id: 1, short: 'Recon', name: 'Recon & Attack Surface' },
+        { id: 2, short: 'Vuln Discovery', name: 'Manual Vulnerability Discovery' },
+        { id: 3, short: 'Dirs', name: 'Directory & File Discovery' },
+        { id: 4, short: 'CORS', name: 'CORS & Cookie Analysis' },
+        { id: 5, short: 'Auth', name: 'Authentication & Session Testing' },
+        { id: 6, short: 'Injection', name: 'Injection Testing' },
+        { id: 7, short: 'SSRF', name: 'SSRF Testing' },
+        { id: 8, short: 'IDOR', name: 'IDOR & Broken Access' },
+        { id: 9, short: 'API', name: 'API & GraphQL Testing' },
+        { id: 10, short: 'Upload', name: 'File Upload Testing' },
+        { id: 11, short: 'RCE', name: 'Deserialization & RCE' },
+        { id: 12, short: 'Logic', name: 'Race Conditions & Logic' },
+        { id: 13, short: 'Takeover', name: 'Subdomain Takeover' },
+        { id: 14, short: 'Redirect', name: 'Open Redirect Testing' },
+        { id: 15, short: 'Email', name: 'Email Security Testing' },
+        { id: 16, short: 'Cloud', name: 'Cloud & Infrastructure' },
+        { id: 17, short: 'WebSocket', name: 'WebSocket Testing' },
+        { id: 18, short: 'CMS', name: 'CMS-Specific Testing' },
+        { id: 19, short: 'Spoofing', name: 'Link Hijack & Spoofing' },
+        { id: 20, short: 'Verify', name: 'Exploit Verification' },
+        { id: 21, short: 'Zero-Day', name: 'Zero-Day Discovery' },
+        { id: 22, short: 'Report', name: 'Final Report' },
+    ];
+
+    let currentScanPhases = [];
+    let currentPhase = 0;
+    let currentScanStatus = 'idle';
+
     // Helper: Replace a <select> with a text <input> (returns the new input element)
     function switchToTextInput(selectEl, placeholder) {
         const input = document.createElement('input');
@@ -367,8 +396,14 @@
 
         hideEmptyState();
 
+        if (evt.current_phase) {
+            setCurrentPhase(evt.current_phase);
+        }
+
         switch (evt.type) {
             case 'queue_started':
+                currentScanStatus = 'running';
+                renderPhaseTimeline(currentScanPhases, currentPhase, currentScanStatus);
                 setStatus('running', 'SCANNING');
                 totalTargets = evt.total_targets || 1;
                 if (totalTargets > 1) showQueueBar();
@@ -394,7 +429,7 @@
                 }
                 if (totalTargets > 1 || totalSubTargets > 0) showQueueBar();
                 addFeedItem(renderTargetBanner(evt.target));
-                if (evt.agent_id) {
+                if (evt.agent_id && !currentInstanceID) {
                     history.pushState(null, '', '/' + evt.agent_id);
                 }
                 break;
@@ -405,10 +440,12 @@
 
             case 'queue_finished':
                 scanRunning = false;
+                currentScanStatus = 'finished';
+                renderPhaseTimeline(currentScanPhases, currentPhase, currentScanStatus);
                 setStatus('finished', 'COMPLETED');
                 toggleButtons(false);
                 hideQueueBar();
-                hideChatInput();
+                showChatInput('Ask follow-up questions about this completed scan');
                 addFeedItem(renderBanner('🏁', evt.content || 'All targets completed', 'success'));
                 showToast('🏁 All targets completed', 'success');
                 break;
@@ -419,6 +456,8 @@
                 break;
 
             case 'scan_started':
+                currentScanStatus = 'running';
+                renderPhaseTimeline(currentScanPhases, currentPhase, currentScanStatus);
                 setStatus('running', 'SCANNING');
                 addFeedItem(renderBanner('🚀', evt.content));
                 break;
@@ -503,9 +542,11 @@
                 // handles the final state transition.
                 if (totalTargets <= 1 && totalSubTargets <= 0) {
                     scanRunning = false;
+                    currentScanStatus = 'finished';
+                    renderPhaseTimeline(currentScanPhases, currentPhase, currentScanStatus);
                     setStatus('finished', 'COMPLETED');
                     toggleButtons(false);
-                    hideChatInput();
+                    showChatInput('Ask follow-up questions about this completed scan');
                     addFeedItem(renderFinished(evt.content));
                     showToast('✅ Scan completed', 'success');
                 }
@@ -513,10 +554,12 @@
 
             case 'stopped':
                 scanRunning = false;
+                currentScanStatus = 'stopped';
+                renderPhaseTimeline(currentScanPhases, currentPhase, currentScanStatus);
                 setStatus('idle', 'STOPPED');
                 toggleButtons(false);
                 hideQueueBar();
-                hideChatInput();
+                showChatInput('Ask follow-up questions about this stopped scan');
                 addFeedItem(renderError(evt.content || 'Scan stopped by user'));
                 showToast('■ Scan stopped', 'warning');
                 break;
@@ -811,6 +854,18 @@
         startBtn.disabled = false;
     }
 
+    function configureStartButtonForInstance(inst) {
+        const startBtn = document.getElementById('start-btn');
+        if (!startBtn) return;
+        if (inst && inst.status === 'saved' && currentInstanceID) {
+            startBtn.innerHTML = '<span>▶</span> Start Saved Scan';
+            startBtn.onclick = () => startSavedInstance(currentInstanceID);
+        } else {
+            startBtn.innerHTML = '<span>▶</span> Start Scan';
+            startBtn.onclick = () => startScan();
+        }
+    }
+
     function showReportButton(url) {
         // Remove existing
         const existing = document.querySelector('.report-btn');
@@ -836,15 +891,113 @@
         return d.innerHTML;
     }
 
+    function normalizePhaseList(phases) {
+        if (!Array.isArray(phases)) return [];
+        return [...new Set(phases.map(Number).filter(p => p >= 1 && p <= 22))].sort((a, b) => a - b);
+    }
+
+    function firstSelectedPhase(phases) {
+        const selected = normalizePhaseList(phases);
+        return selected.length ? selected[0] : 1;
+    }
+
+    function phaseByID(id) {
+        return METHODOLOGY_PHASES.find(p => p.id === Number(id)) || null;
+    }
+
+    function phaseLabel(id) {
+        const phase = phaseByID(id);
+        return phase ? `${phase.id}. ${phase.name}` : '—';
+    }
+
+    function selectedPhaseText(phases) {
+        const selected = normalizePhaseList(phases);
+        if (!selected.length) return 'All phases';
+        return selected.map(id => {
+            const phase = phaseByID(id);
+            return phase ? `${id} ${phase.short}` : String(id);
+        }).join(', ');
+    }
+
+    function renderScanDetails(scan) {
+        currentScanPhases = normalizePhaseList(scan.phases || []);
+        currentPhase = Number(scan.current_phase || currentPhase || firstSelectedPhase(currentScanPhases));
+        currentScanStatus = scan.status || 'idle';
+
+        const nameEl = document.getElementById('scan-detail-name');
+        const targetEl = document.getElementById('scan-detail-target');
+        const modeEl = document.getElementById('scan-detail-mode');
+        const statusEl = document.getElementById('scan-detail-status');
+        const phasesEl = document.getElementById('scan-detail-phases');
+        const activeEl = document.getElementById('scan-detail-active-phase');
+
+        if (nameEl) nameEl.textContent = scan.name || 'Untitled scan';
+        if (targetEl) targetEl.textContent = scan.targets || scan.target || '—';
+        if (modeEl) modeEl.textContent = (scan.scan_mode || 'single').toUpperCase();
+        if (statusEl) statusEl.textContent = (scan.status || 'idle').toUpperCase();
+        if (phasesEl) phasesEl.textContent = selectedPhaseText(currentScanPhases);
+        if (activeEl) activeEl.textContent = phaseLabel(currentPhase);
+
+        renderPhaseTimeline(currentScanPhases, currentPhase, currentScanStatus);
+    }
+
+    function setCurrentPhase(phase) {
+        const parsed = Number(phase);
+        if (!parsed || parsed < 1 || parsed > 22) return;
+        currentPhase = parsed;
+        const activeEl = document.getElementById('scan-detail-active-phase');
+        if (activeEl) activeEl.textContent = phaseLabel(currentPhase);
+        renderPhaseTimeline(currentScanPhases, currentPhase, currentScanStatus);
+    }
+
+    function renderPhaseTimeline(phases, activePhase, status) {
+        const timeline = document.getElementById('phase-timeline');
+        if (!timeline) return;
+
+        const selected = normalizePhaseList(phases);
+        const selectedSet = new Set(selected.length ? selected : METHODOLOGY_PHASES.map(p => p.id));
+        const visible = selected.length ? METHODOLOGY_PHASES.filter(p => selectedSet.has(p.id)) : METHODOLOGY_PHASES;
+        const activeIndex = visible.findIndex(p => p.id === Number(activePhase));
+        const isFinished = status === 'finished';
+
+        timeline.innerHTML = visible.map((phase, index) => {
+            const selectedClass = selectedSet.has(phase.id) ? 'selected' : 'skipped';
+            const activeClass = phase.id === Number(activePhase) && status === 'running' ? 'active' : '';
+            const doneClass = isFinished || (activeIndex >= 0 && index < activeIndex) ? 'done' : '';
+            const state = activeClass ? 'Active' : doneClass ? 'Done' : selectedClass === 'skipped' ? 'Skipped' : 'Queued';
+            return `
+                <div class="phase-step ${selectedClass} ${activeClass} ${doneClass}" data-phase="${phase.id}" title="${escapeHtml(phase.name)}">
+                    ${escapeHtml(phase.short)}
+                    <span class="phase-step-status">${state}</span>
+                </div>`;
+        }).join('');
+    }
+
     // ── Timer ──────────────────────────────────────────────
     function startTimer(startFrom) {
         scanStart = startFrom ? new Date(startFrom).getTime() : Date.now();
-        // Show chat input when scan starts
-        document.getElementById('chat-input-container').style.display = 'block';
+        showChatInput('Chat is active during scans');
+    }
+
+    function showChatInput(hintText) {
+        const container = document.getElementById('chat-input-container');
+        if (container) container.style.display = 'block';
+        const hint = document.getElementById('chat-hint');
+        if (hint && hintText) hint.textContent = hintText;
+        const input = document.getElementById('chat-input');
+        if (input) input.placeholder = scanRunning
+            ? 'Send a message to Xalgorix during scan...'
+            : 'Ask Xalgorix about this scan...';
     }
 
     function hideChatInput() {
         document.getElementById('chat-input-container').style.display = 'none';
+    }
+
+    function currentChatInstanceID() {
+        if (currentInstanceID) return currentInstanceID;
+        const pathID = window.location.pathname.replace(/^\/+/, '').trim();
+        return pathID || '';
     }
 
     // ── Chat Functions ─────────────────────────────────────
@@ -872,12 +1025,19 @@
 
         // Send to server
         try {
+            const payload = { message };
+            const instanceID = currentChatInstanceID();
+            if (instanceID) payload.instance_id = instanceID;
+
             const resp = await fetch('/api/chat', {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({message})
+                body: JSON.stringify(payload)
             });
             const data = await resp.json();
+            if (!resp.ok) {
+                throw new Error(data.error || 'Chat failed');
+            }
 
             // Add Xalgorix response to feed
             const botMsg = document.createElement('div');
@@ -1016,6 +1176,11 @@
 
 
         scanRunning = true;
+        currentScanPhases = [];
+        currentPhase = 1;
+        currentScanStatus = 'running';
+        renderScanDetails({ target: targetVal, scan_mode: scanMode, status: 'running', current_phase: 1 });
+        configureStartButtonForInstance(null);
         toggleButtons(true);
         setStatus('running', 'SCANNING');
         startTimer();
@@ -1109,12 +1274,18 @@
             const statusResp = await fetch('/api/status');
             const status = await statusResp.json();
             
+            if (status.running && status.instance_id) {
+                navigateToInstance(status.instance_id);
+                showChatInput('Chat is active during scans');
+                return;
+            }
+
             if (status.running && status.scan_id) {
                 // There's a running scan, load it
                 history.replaceState(null, '', '/' + status.scan_id);
                 await loadScanById(status.scan_id);
                 // Show chat input when scan is running
-                document.getElementById('chat-input-container').style.display = 'block';
+                showChatInput('Chat is active during scans');
                 return;
             }
         } catch (e) {
@@ -1153,6 +1324,9 @@
             iterCount = scan.iterations || 0;
             toolCount = scan.tool_calls || 0;
             vulnCount = (scan.vulns || []).length;
+            currentPhase = Number(scan.current_phase || firstSelectedPhase(scan.phases || []));
+            currentScanStatus = scan.status || 'idle';
+            renderScanDetails(scan);
             
             const iterEl = document.getElementById('stat-iter');
             const toolsEl = document.getElementById('stat-tools');
@@ -1219,11 +1393,29 @@
                 if (serverStatus.running) {
                     setStatus('running', 'SCANNING');
                     scanRunning = true;
+                    currentScanStatus = 'running';
+                    configureStartButtonForInstance(null);
                     toggleButtons(true);
                     startTimer(scan.started_at ? new Date(scan.started_at) : null);
+                } else if (scan.status === 'saved') {
+                    scanRunning = false;
+                    setStatus('idle', 'SAVED');
+                    toggleButtons(false);
+                    configureStartButtonForInstance(scan);
+                    hideChatInput();
                 } else if (scan.status === 'finished') {
+                    scanRunning = false;
                     setStatus('finished', 'COMPLETED');
+                    toggleButtons(false);
+                    configureStartButtonForInstance(null);
+                    showChatInput('Ask follow-up questions about this completed scan');
                     showReportButton(`/api/report/${encodeURIComponent(scan.id)}`);
+                } else if (scan.status === 'stopped') {
+                    scanRunning = false;
+                    setStatus('idle', 'STOPPED');
+                    toggleButtons(false);
+                    configureStartButtonForInstance(null);
+                    showChatInput('Ask follow-up questions about this stopped scan');
                 }
             } catch (e) {}
 
@@ -1231,9 +1423,8 @@
                 document.getElementById('target-input').value = scan.target;
             }
 
-            // Switch to scan view and render the instance grid so dashboard shows the loaded scan
+            // Switch to scan view for the loaded scan.
             currentView = 'scan';
-            renderInstanceGrid();
 
             feed.scrollTop = feed.scrollHeight;
         } catch (e) {
@@ -1496,7 +1687,7 @@
                 setStatus('finished', 'COMPLETED');
                 toggleButtons(false);
                 hideQueueBar();
-                hideChatInput();
+                showChatInput('Ask follow-up questions about this completed scan');
                 // Add a completion banner if one doesn't already exist
                 const feed = document.getElementById('feed-body');
                 const hasFinished = feed.querySelector('.event-finished');
@@ -1609,6 +1800,7 @@
         document.getElementById('feed-body').innerHTML = '';
         document.getElementById('vuln-list').innerHTML = '<li class="empty-state" style="padding:20px 0"><div class="empty-title">Loading...</div></li>';
         document.getElementById('tools-list').innerHTML = '<li class="empty-state" style="padding:20px 0"><div class="empty-title">Loading...</div></li>';
+        renderScanDetails({ id: instanceId, status: 'loading', targets: 'Loading...' });
         
         // Load instance state
         loadInstanceState(instanceId);
@@ -1619,22 +1811,46 @@
             const resp = await fetch('/api/instances/' + instanceId);
             if (!resp.ok) return;
             const inst = await resp.json();
-            
+            currentPhase = Number(inst.current_phase || firstSelectedPhase(inst.phases || []));
+            currentScanStatus = inst.status || 'idle';
+            renderScanDetails(inst);
+            configureStartButtonForInstance(inst);
+
             // Populate target input
             if (inst.targets) {
                 const targetInput = document.getElementById('target-input');
                 if (targetInput) targetInput.value = inst.targets;
             }
-            
-            if (inst.status === 'running') {
+            const modeInput = document.getElementById('scan-mode');
+            if (modeInput && inst.scan_mode) modeInput.value = inst.scan_mode;
+            const instructionInput = document.getElementById('instruction-input');
+            if (instructionInput) instructionInput.value = inst.instruction || '';
+
+            if (inst.status === 'running' || inst.status === 'pending') {
                 scanRunning = true;
                 toggleButtons(true);
-                setStatus('running', 'SCANNING');
+                setStatus('running', inst.status === 'pending' ? 'PENDING' : 'SCANNING');
                 startTimer();
+            } else if (inst.status === 'saved') {
+                scanRunning = false;
+                toggleButtons(false);
+                setStatus('idle', 'SAVED');
+                hideChatInput();
+            } else if (inst.status === 'paused') {
+                scanRunning = false;
+                toggleButtons(false);
+                setStatus('idle', 'PAUSED');
+                showChatInput('Ask follow-up questions about this paused scan');
             } else {
                 scanRunning = false;
                 toggleButtons(false);
-                setStatus(inst.status === 'stopped' ? 'finished' : 'finished', inst.status.toUpperCase());
+                setStatus(inst.status === 'stopped' ? 'idle' : 'finished', inst.status.toUpperCase());
+                showChatInput(inst.status === 'stopped'
+                    ? 'Ask follow-up questions about this stopped scan'
+                    : 'Ask follow-up questions about this completed scan');
+                if (inst.status === 'finished' || inst.status === 'stopped') {
+                    showReportButton(`/api/report/${encodeURIComponent(inst.id)}`);
+                }
             }
             
             // Update stats — use Math.max to avoid resetting counters
@@ -2127,8 +2343,12 @@
     // Start a saved (queued) instance
     window.startSavedInstance = async function(instanceId) {
         try {
-            await fetch('/api/instances/' + instanceId + '/start', { method: 'POST' });
+            const resp = await fetch('/api/instances/' + instanceId + '/start', { method: 'POST' });
+            const data = await resp.json().catch(() => ({}));
             showToast('▶ Starting saved scan...', 'success');
+            if (data.instance_id) {
+                navigateToInstance(data.instance_id);
+            }
             setTimeout(refreshInstances, 500);
         } catch (e) {
             showToast('Failed to start instance', 'error');
@@ -2159,8 +2379,8 @@
     
     // Pause/Resume from scan detail view
     window.pauseCurrentScan = async function() {
-        if (!currentInstanceId) return;
-        await window.pauseInstance(currentInstanceId);
+        if (!currentInstanceID) return;
+        await window.pauseInstance(currentInstanceID);
         const pauseBtn = document.getElementById('pause-btn');
         const resumeBtn = document.getElementById('resume-btn');
         if (pauseBtn) pauseBtn.classList.add('hidden');
@@ -2168,8 +2388,8 @@
     };
     
     window.resumeCurrentScan = async function() {
-        if (!currentInstanceId) return;
-        await window.resumeInstance(currentInstanceId);
+        if (!currentInstanceID) return;
+        await window.resumeInstance(currentInstanceID);
         const pauseBtn = document.getElementById('pause-btn');
         const resumeBtn = document.getElementById('resume-btn');
         if (resumeBtn) resumeBtn.classList.add('hidden');

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -242,6 +242,34 @@
           <span class="scan-view-instance-id" id="scan-view-instance-id"></span>
         </div>
 
+        <div class="scan-details-card" id="scan-details-card">
+          <div class="scan-details-main">
+            <div>
+              <div class="scan-details-label">Scan</div>
+              <div class="scan-details-title" id="scan-detail-name">Untitled scan</div>
+            </div>
+            <div class="scan-details-meta">
+              <span id="scan-detail-mode">SINGLE</span>
+              <span id="scan-detail-status">IDLE</span>
+            </div>
+          </div>
+          <div class="scan-details-grid">
+            <div>
+              <div class="scan-details-label">Target</div>
+              <div class="scan-details-value" id="scan-detail-target">—</div>
+            </div>
+            <div>
+              <div class="scan-details-label">Selected Phases</div>
+              <div class="scan-details-value" id="scan-detail-phases">All phases</div>
+            </div>
+            <div>
+              <div class="scan-details-label">Active Phase</div>
+              <div class="scan-details-value active-phase-label" id="scan-detail-active-phase">—</div>
+            </div>
+          </div>
+          <div class="phase-timeline" id="phase-timeline"></div>
+        </div>
+
       <!-- Queue Bar -->
       <div class="queue-bar" id="queue-bar">
         <div class="queue-info">
@@ -397,7 +425,7 @@
                   onkeypress="if(event.key==='Enter')sendChatMessage()">
                 <button id="chat-send-btn" onclick="sendChatMessage()" class="chat-send">Send</button>
               </div>
-              <div class="chat-hint">Chat is active during scans</div>
+              <div class="chat-hint" id="chat-hint">Chat is active during scans and after completion</div>
             </div>
           </div>
         </div>

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -796,9 +796,15 @@ a:hover { color: #00ffaa; text-shadow: 0 0 8px rgba(0, 255, 136, 0.5); }
 
 .phase-checkbox:has(input:checked) {
   color: var(--accent);
-  border-color: rgba(0, 255, 136, 0.4);
-  background: rgba(0, 255, 136, 0.08);
-  box-shadow: 0 0 6px rgba(0, 255, 136, 0.15);
+  border-color: var(--accent);
+  background: rgba(0, 255, 136, 0.14);
+  box-shadow: inset 0 0 0 1px rgba(0, 255, 136, 0.35), 0 0 8px rgba(0, 255, 136, 0.2);
+}
+
+.phase-checkbox input:checked + span::before {
+  content: '✓ ';
+  color: var(--accent);
+  font-weight: 900;
 }
 
 .phase-checkbox:hover {
@@ -1780,6 +1786,140 @@ a:hover { color: #00ffaa; text-shadow: 0 0 8px rgba(0, 255, 136, 0.5); }
   letter-spacing: 0.08em;
 }
 
+.scan-details-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  padding: var(--space-4);
+  clip-path: polygon(0 8px, 8px 0, calc(100% - 8px) 0, 100% 8px, 100% calc(100% - 8px), calc(100% - 8px) 100%, 8px 100%, 0 calc(100% - 8px));
+}
+
+.scan-details-main {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin-bottom: var(--space-3);
+}
+
+.scan-details-label {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0;
+  margin-bottom: 2px;
+}
+
+.scan-details-title {
+  font-family: var(--font-heading);
+  font-size: 15px;
+  font-weight: 800;
+  color: var(--accent);
+  letter-spacing: 0;
+  overflow-wrap: anywhere;
+}
+
+.scan-details-meta {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.scan-details-meta span {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--accent-tertiary);
+  border: 1px solid rgba(0, 212, 255, 0.35);
+  padding: 3px 8px;
+  background: rgba(0, 212, 255, 0.08);
+  text-transform: uppercase;
+  letter-spacing: 0;
+}
+
+.scan-details-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr) minmax(0, 1fr);
+  gap: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border);
+}
+
+.scan-details-value {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-primary);
+  overflow-wrap: anywhere;
+}
+
+.active-phase-label {
+  color: var(--accent);
+}
+
+.phase-timeline {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(112px, 1fr));
+  gap: 6px;
+  margin-top: var(--space-3);
+}
+
+.phase-step {
+  position: relative;
+  min-height: 44px;
+  border: 1px solid var(--border);
+  background: rgba(0, 0, 0, 0.16);
+  padding: 7px 8px 6px 28px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  line-height: 1.25;
+  text-transform: uppercase;
+  letter-spacing: 0;
+}
+
+.phase-step::before {
+  content: attr(data-phase);
+  position: absolute;
+  left: 7px;
+  top: 8px;
+  width: 15px;
+  height: 15px;
+  display: grid;
+  place-items: center;
+  border: 1px solid currentColor;
+  font-size: 8px;
+}
+
+.phase-step.selected {
+  color: var(--text-primary);
+  border-color: rgba(0, 255, 136, 0.42);
+  background: rgba(0, 255, 136, 0.07);
+}
+
+.phase-step.done {
+  color: var(--accent);
+}
+
+.phase-step.active {
+  color: #05080a;
+  background: var(--accent);
+  border-color: var(--accent);
+  box-shadow: var(--glow-green);
+}
+
+.phase-step.skipped {
+  opacity: 0.42;
+}
+
+.phase-step-status {
+  display: block;
+  color: inherit;
+  font-size: 8px;
+  opacity: 0.75;
+  margin-top: 3px;
+}
+
 .btn-back { font-size: 11px; padding: 8px var(--space-4); }
 
 /* ── Footer ────────────────────────────────────────────────────────── */
@@ -1878,6 +2018,9 @@ a:hover { color: #00ffaa; text-shadow: 0 0 8px rgba(0, 255, 136, 0.5); }
   .btn-group { flex-direction: column; }
   .btn { width: 100%; }
   .severity-row { flex-wrap: wrap; }
+  .scan-details-main { flex-direction: column; }
+  .scan-details-grid { grid-template-columns: 1fr; }
+  .phase-timeline { grid-template-columns: repeat(auto-fill, minmax(96px, 1fr)); }
 }
 
 @media (max-width: 480px) {

--- a/internal/web/static_test.go
+++ b/internal/web/static_test.go
@@ -30,3 +30,27 @@ func TestStaticApp_ModelSuggestionsStayCurrentAndEditable(t *testing.T) {
 		t.Fatal("Gemini suggestions still prioritize the deprecated Gemini 3 Pro Preview entry")
 	}
 }
+
+func TestStaticApp_ChatRemainsAvailableAfterCompletion(t *testing.T) {
+	data, err := staticFiles.ReadFile("static/app.js")
+	if err != nil {
+		t.Fatalf("read app.js: %v", err)
+	}
+	app := string(data)
+
+	for _, want := range []string{
+		"showChatInput('Ask follow-up questions about this completed scan')",
+		"payload.instance_id = instanceID",
+		"if (evt.agent_id && !currentInstanceID)",
+		"renderPhaseTimeline(currentScanPhases, currentPhase, currentScanStatus)",
+		"Start Saved Scan",
+	} {
+		if !strings.Contains(app, want) {
+			t.Fatalf("app.js missing %q", want)
+		}
+	}
+
+	if strings.Contains(app, "case 'queue_finished':\n                scanRunning = false;\n                setStatus('finished', 'COMPLETED');\n                toggleButtons(false);\n                hideQueueBar();\n                hideChatInput();") {
+		t.Fatal("queue completion still hides the chat input")
+	}
+}


### PR DESCRIPTION
## Summary
- Preserve saved/running scan metadata in scan detail views, including name, instructions, selected phases, and active phase.
- Add a visible phase timeline and stronger selected-phase highlighting in the UI/report.
- Enforce recon/report-only scope in agent instructions and tool execution, and include recon findings in generated reports.
- Keep chat available for completed scans with completed-scan context, and handle paused scans with paused-scan context.

## Tests
- `go test ./internal/web ./internal/agent`
- `go test ./...`