### PR TITLE
release: v4.3.14

### DIFF
--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.3.13"
+var version = "4.3.14"
 
 func main() {
 	// Top-level crash recovery — catches panics that escape all other handlers.


### PR DESCRIPTION
Release v4.3.14.\n\nGenerated by release.sh after v4.3.13.\n\nChanges:\n- Merge pull request #25 from xalgord/fix-scan-details-phase-timeline\n- fix(web): preserve scan details and phase scope