### PR TITLE
fix(web): stabilize scan lifecycle UI

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -2186,7 +2186,7 @@ func inferCurrentPhase(evt WSEvent, allowed []int) int {
 	switch evt.Type {
 	case "queue_started", "target_started", "scan_started":
 		return firstSelectedPhase(allowed)
-	case "finished", "queue_finished", "report_ready":
+	case "queue_finished", "report_ready":
 		if phaseAllowed(allowed, 22) {
 			return 22
 		}
@@ -2195,14 +2195,9 @@ func inferCurrentPhase(evt WSEvent, allowed []int) int {
 	if evt.Type != "tool_call" {
 		return 0
 	}
-	tool := strings.ToLower(evt.ToolName)
 	args := strings.ToLower(strings.Join(mapValues(evt.ToolArgs), " "))
 
 	switch {
-	case tool == "finish" || tool == "report_vulnerability":
-		if phaseAllowed(allowed, 22) {
-			return 22
-		}
 	case strings.Contains(args, "sqlmap") || strings.Contains(args, "dalfox") ||
 		strings.Contains(args, "union select") || strings.Contains(args, "<script") ||
 		strings.Contains(args, "sleep("):

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -173,6 +173,32 @@ func TestPhaseRestriction_ReconReportOnlyIsStrict(t *testing.T) {
 	}
 }
 
+func TestInferCurrentPhase_DoesNotTreatSessionFinishedAsFinalReport(t *testing.T) {
+	allowed := []int{1, 8, 22}
+
+	if got := inferCurrentPhase(WSEvent{Type: "finished", Content: "Agent session complete"}, allowed); got != 0 {
+		t.Fatalf("session finished inferred phase %d, want 0", got)
+	}
+	if got := inferCurrentPhase(WSEvent{Type: "tool_call", ToolName: "finish"}, allowed); got != 0 {
+		t.Fatalf("finish tool inferred phase %d, want 0", got)
+	}
+	if got := inferCurrentPhase(WSEvent{Type: "tool_call", ToolName: "report_vulnerability"}, allowed); got != 0 {
+		t.Fatalf("report_vulnerability inferred phase %d, want 0", got)
+	}
+	if got := inferCurrentPhase(WSEvent{Type: "queue_finished", Content: "Scan queue ended"}, allowed); got != 22 {
+		t.Fatalf("queue_finished inferred phase %d, want 22", got)
+	}
+	if got := inferCurrentPhase(WSEvent{
+		Type:     "tool_call",
+		ToolName: "terminal_execute",
+		ToolArgs: map[string]string{
+			"cmd": "test IDOR authorization bypass on account endpoint",
+		},
+	}, allowed); got != 8 {
+		t.Fatalf("IDOR tool call inferred phase %d, want 8", got)
+	}
+}
+
 func TestHandleGetScan_ReturnsLiveInstanceMetadata(t *testing.T) {
 	s := newTestServer(t, nil)
 	inst := &ScanInstance{

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -361,8 +361,9 @@
 
     // ── Event Handler ──────────────────────────────────────
     function handleEvent(evt, replay) {
+        const isReplay = replay === true;
         // During replay, skip dashboard-level filtering
-        if (!replay) {
+        if (!isReplay) {
             // Dashboard-level events
             if (evt.type === 'instance_started' || evt.type === 'instance_updated') {
                 if (currentView === 'dashboard') refreshInstances();
@@ -396,40 +397,44 @@
 
         hideEmptyState();
 
-        if (evt.current_phase) {
+        if (evt.current_phase && !isReplay) {
             setCurrentPhase(evt.current_phase);
         }
 
         switch (evt.type) {
             case 'queue_started':
-                currentScanStatus = 'running';
-                renderPhaseTimeline(currentScanPhases, currentPhase, currentScanStatus);
-                setStatus('running', 'SCANNING');
-                totalTargets = evt.total_targets || 1;
-                if (totalTargets > 1) showQueueBar();
+                if (!isReplay) {
+                    currentScanStatus = 'running';
+                    renderPhaseTimeline(currentScanPhases, currentPhase, currentScanStatus);
+                    setStatus('running', 'SCANNING');
+                    totalTargets = evt.total_targets || 1;
+                    if (totalTargets > 1) showQueueBar();
+                }
                 addFeedItem(renderBanner('🚀', evt.content));
-                showToast('🚀 Scan started', 'info');
+                if (!isReplay) showToast('🚀 Scan started', 'info');
                 break;
 
             case 'target_started':
-                currentTargetIdx = evt.target_index || 1;
-                // Only update totalTargets from real top-level events (not subdomain events)
-                if (evt.total_targets && evt.total_targets > 0) {
-                    totalTargets = evt.total_targets;
+                if (!isReplay) {
+                    currentTargetIdx = evt.target_index || 1;
+                    // Only update totalTargets from real top-level events (not subdomain events)
+                    if (evt.total_targets && evt.total_targets > 0) {
+                        totalTargets = evt.total_targets;
+                    }
+                    // Track sub-target progress for wildcard scanning
+                    if (evt.sub_target_index && evt.sub_target_total) {
+                        currentSubIdx = evt.sub_target_index;
+                        totalSubTargets = evt.sub_target_total;
+                        updateQueueBar(currentTargetIdx, totalTargets, evt.target, currentSubIdx, totalSubTargets);
+                    } else {
+                        currentSubIdx = 0;
+                        totalSubTargets = 0;
+                        updateQueueBar(currentTargetIdx, totalTargets, evt.target);
+                    }
+                    if (totalTargets > 1 || totalSubTargets > 0) showQueueBar();
                 }
-                // Track sub-target progress for wildcard scanning
-                if (evt.sub_target_index && evt.sub_target_total) {
-                    currentSubIdx = evt.sub_target_index;
-                    totalSubTargets = evt.sub_target_total;
-                    updateQueueBar(currentTargetIdx, totalTargets, evt.target, currentSubIdx, totalSubTargets);
-                } else {
-                    currentSubIdx = 0;
-                    totalSubTargets = 0;
-                    updateQueueBar(currentTargetIdx, totalTargets, evt.target);
-                }
-                if (totalTargets > 1 || totalSubTargets > 0) showQueueBar();
                 addFeedItem(renderTargetBanner(evt.target));
-                if (evt.agent_id && !currentInstanceID) {
+                if (!isReplay && evt.agent_id && !currentInstanceID) {
                     history.pushState(null, '', '/' + evt.agent_id);
                 }
                 break;
@@ -439,15 +444,17 @@
                 break;
 
             case 'queue_finished':
-                scanRunning = false;
-                currentScanStatus = 'finished';
-                renderPhaseTimeline(currentScanPhases, currentPhase, currentScanStatus);
-                setStatus('finished', 'COMPLETED');
-                toggleButtons(false);
-                hideQueueBar();
-                showChatInput('Ask follow-up questions about this completed scan');
+                if (!isReplay) {
+                    scanRunning = false;
+                    currentScanStatus = 'finished';
+                    renderPhaseTimeline(currentScanPhases, currentPhase, currentScanStatus);
+                    setStatus('finished', 'COMPLETED');
+                    toggleButtons(false);
+                    hideQueueBar();
+                    showChatInput('Ask follow-up questions about this completed scan');
+                }
                 addFeedItem(renderBanner('🏁', evt.content || 'All targets completed', 'success'));
-                showToast('🏁 All targets completed', 'success');
+                if (!isReplay) showToast('🏁 All targets completed', 'success');
                 break;
 
             case 'report_ready':
@@ -456,25 +463,31 @@
                 break;
 
             case 'scan_started':
-                currentScanStatus = 'running';
-                renderPhaseTimeline(currentScanPhases, currentPhase, currentScanStatus);
-                setStatus('running', 'SCANNING');
+                if (!isReplay) {
+                    currentScanStatus = 'running';
+                    renderPhaseTimeline(currentScanPhases, currentPhase, currentScanStatus);
+                    setStatus('running', 'SCANNING');
+                }
                 addFeedItem(renderBanner('🚀', evt.content));
                 break;
 
             case 'thinking':
-                iterCount++;
-                const iterEl = document.getElementById('stat-iter');
-                if (iterEl) iterEl.textContent = iterCount;
-                popStat('stat-iter');
+                if (!isReplay) {
+                    iterCount++;
+                    const iterEl = document.getElementById('stat-iter');
+                    if (iterEl) iterEl.textContent = iterCount;
+                    popStat('stat-iter');
+                }
                 addFeedItem(renderThinking(evt.content), true);
                 break;
 
             case 'tool_call':
-                toolCount++;
-                const toolEl = document.getElementById('stat-tools');
-                if (toolEl) toolEl.textContent = toolCount;
-                popStat('stat-tools');
+                if (!isReplay) {
+                    toolCount++;
+                    const toolEl = document.getElementById('stat-tools');
+                    if (toolEl) toolEl.textContent = toolCount;
+                    popStat('stat-tools');
+                }
                 toolUsage[evt.tool_name] = (toolUsage[evt.tool_name] || 0) + 1;
                 updateToolStats();
                 addFeedItem(renderToolCall(evt));
@@ -510,7 +523,7 @@
                     }
                 }
                 // Real-time vuln rendering
-                if (evt.vulns && evt.vulns.length > 0) {
+                if (!isReplay && evt.vulns && evt.vulns.length > 0) {
                     vulnCount += evt.vulns.length;
                     const vulnEl = document.getElementById('stat-vulns');
                     if (vulnEl) vulnEl.textContent = vulnCount;
@@ -528,40 +541,43 @@
 
             case 'error':
                 addFeedItem(renderError(evt.content));
-                showToast('⚠️ ' + (evt.content || 'Error').slice(0, 80), 'error');
+                if (!isReplay) showToast('⚠️ ' + (evt.content || 'Error').slice(0, 80), 'error');
                 break;
 
             case 'finished':
                 if (evt.vulns && evt.vulns.length > 0) {
-                    vulnCount += evt.vulns.length;
-                    popStat('stat-vulns');
-                    renderVulns(evt.vulns);
+                    if (!isReplay) {
+                        vulnCount += evt.vulns.length;
+                        popStat('stat-vulns');
+                        renderVulns(evt.vulns);
+                    }
                 }
-                // Only mark scan as complete if this is a single-target scan
-                // with no queue. For multi-target/wildcard scans, queue_finished
-                // handles the final state transition.
-                if (totalTargets <= 1 && totalSubTargets <= 0) {
+                addFeedItem(renderFinished(evt.content));
+                // Agent "finished" events are session-level. Instance scans finish
+                // only when the queue emits queue_finished.
+                if (!isReplay && !currentInstanceID) {
                     scanRunning = false;
                     currentScanStatus = 'finished';
                     renderPhaseTimeline(currentScanPhases, currentPhase, currentScanStatus);
                     setStatus('finished', 'COMPLETED');
                     toggleButtons(false);
                     showChatInput('Ask follow-up questions about this completed scan');
-                    addFeedItem(renderFinished(evt.content));
                     showToast('✅ Scan completed', 'success');
                 }
                 break;
 
             case 'stopped':
-                scanRunning = false;
-                currentScanStatus = 'stopped';
-                renderPhaseTimeline(currentScanPhases, currentPhase, currentScanStatus);
-                setStatus('idle', 'STOPPED');
-                toggleButtons(false);
-                hideQueueBar();
-                showChatInput('Ask follow-up questions about this stopped scan');
+                if (!isReplay) {
+                    scanRunning = false;
+                    currentScanStatus = 'stopped';
+                    renderPhaseTimeline(currentScanPhases, currentPhase, currentScanStatus);
+                    setStatus('idle', 'STOPPED');
+                    toggleButtons(false);
+                    hideQueueBar();
+                    showChatInput('Ask follow-up questions about this stopped scan');
+                }
                 addFeedItem(renderError(evt.content || 'Scan stopped by user'));
-                showToast('■ Scan stopped', 'warning');
+                if (!isReplay) showToast('■ Scan stopped', 'warning');
                 break;
         }
     }
@@ -1671,6 +1687,69 @@
     // Polling fallback - check status every 5 seconds in case WebSocket fails
     setInterval(async () => {
         try {
+            if (currentView === 'scan' && currentInstanceID) {
+                const resp = await fetch('/api/instances/' + encodeURIComponent(currentInstanceID));
+                if (!resp.ok) return;
+                const inst = await resp.json();
+                const wasRunning = scanRunning;
+                const status = inst.status || 'idle';
+
+                renderScanDetails(inst);
+                configureStartButtonForInstance(inst);
+
+                if (status === 'running' || status === 'pending') {
+                    scanRunning = true;
+                    toggleButtons(true);
+                    setStatus('running', status === 'pending' ? 'PENDING' : 'SCANNING');
+                    if (!scanStart) startTimer(inst.started_at ? new Date(inst.started_at) : null);
+                    return;
+                }
+
+                scanRunning = false;
+                toggleButtons(false);
+                hideQueueBar();
+
+                if (status === 'saved') {
+                    setStatus('idle', 'SAVED');
+                    hideChatInput();
+                    return;
+                }
+
+                if (status === 'paused') {
+                    setStatus('idle', 'PAUSED');
+                    showChatInput('Ask follow-up questions about this paused scan');
+                    return;
+                }
+
+                if (status === 'stopped') {
+                    setStatus('idle', 'STOPPED');
+                    showChatInput('Ask follow-up questions about this stopped scan');
+                    if (wasRunning) showToast('■ Scan stopped', 'warning');
+                    return;
+                }
+
+                if (status === 'finished') {
+                    setStatus('finished', 'COMPLETED');
+                    showChatInput('Ask follow-up questions about this completed scan');
+                    showReportButton(`/api/report/${encodeURIComponent(currentInstanceID)}`);
+                    if (wasRunning) {
+                        const feed = document.getElementById('feed-body');
+                        const hasFinished = feed && feed.querySelector('.event-finished');
+                        if (!hasFinished) {
+                            addFeedItem(renderBanner('🏁', 'Scan completed (recovered from connection loss)', 'success'));
+                        }
+                        showToast('🏁 Scan completed', 'success');
+                    }
+                    return;
+                }
+                return;
+            }
+
+            if (currentView === 'dashboard') {
+                refreshInstances();
+                return;
+            }
+
             const resp = await fetch('/api/status');
             const status = await resp.json();
             if (status.running && !scanRunning) {

--- a/internal/web/static_test.go
+++ b/internal/web/static_test.go
@@ -41,7 +41,7 @@ func TestStaticApp_ChatRemainsAvailableAfterCompletion(t *testing.T) {
 	for _, want := range []string{
 		"showChatInput('Ask follow-up questions about this completed scan')",
 		"payload.instance_id = instanceID",
-		"if (evt.agent_id && !currentInstanceID)",
+		"if (!isReplay && evt.agent_id && !currentInstanceID)",
 		"renderPhaseTimeline(currentScanPhases, currentPhase, currentScanStatus)",
 		"Start Saved Scan",
 	} {
@@ -52,5 +52,29 @@ func TestStaticApp_ChatRemainsAvailableAfterCompletion(t *testing.T) {
 
 	if strings.Contains(app, "case 'queue_finished':\n                scanRunning = false;\n                setStatus('finished', 'COMPLETED');\n                toggleButtons(false);\n                hideQueueBar();\n                hideChatInput();") {
 		t.Fatal("queue completion still hides the chat input")
+	}
+}
+
+func TestStaticApp_ReplayDoesNotTriggerLifecycleSideEffects(t *testing.T) {
+	data, err := staticFiles.ReadFile("static/app.js")
+	if err != nil {
+		t.Fatalf("read app.js: %v", err)
+	}
+	app := string(data)
+
+	for _, want := range []string{
+		"const isReplay = replay === true;",
+		"if (evt.current_phase && !isReplay)",
+		"if (!isReplay) showToast('🚀 Scan started', 'info');",
+		"if (!isReplay && !currentInstanceID)",
+		"Agent \"finished\" events are session-level",
+		"if (currentView === 'scan' && currentInstanceID)",
+		"const inst = await resp.json();",
+		"if (currentView === 'dashboard')",
+		"refreshInstances();",
+	} {
+		if !strings.Contains(app, want) {
+			t.Fatalf("app.js missing replay/state guard %q", want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- treat agent finished events as session-level so wildcard scans do not flash completed mid-run
- prevent replayed buffered events from firing lifecycle side effects or duplicate toasts
- keep dashboard polling on the dashboard instead of redirecting to the latest scan
- narrow phase inference so active phase does not jump to final report from session finish/tool events

## Tests
- go test ./...