### PR TITLE
release: v4.3.15

### DIFF
--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.3.14"
+var version = "4.3.15"
 
 func main() {
 	// Top-level crash recovery — catches panics that escape all other handlers.


### PR DESCRIPTION
## Summary
- release v4.3.15
- includes merged scan lifecycle UI stabilization from PR #27

## Changelog
- 64e2227 Merge pull request #27 from xalgord/fix-scan-ui-state-routing
- b5aceea fix(web): stabilize scan lifecycle UI
- 7ca154c Merge pull request #26 from xalgord/release-v4.3.14

## Tests
- go test ./...
- release.sh build verification