### PR TITLE
Fix duplicate vulnerability broadcasts

### DIFF
--- a/internal/tools/reporting/reporting.go
+++ b/internal/tools/reporting/reporting.go
@@ -181,6 +181,18 @@ func reportVulnWithContextID(contextID string, args map[string]string) (tools.Re
 	proof := strings.TrimSpace(args["exploitation_proof"])
 	method := strings.ToLower(strings.TrimSpace(args["verification_method"]))
 	title := strings.TrimSpace(args["title"])
+	target := strings.TrimSpace(args["target"])
+	endpoint := strings.TrimSpace(args["endpoint"])
+
+	// ── Gate 0: Fast duplicate check before spending effort on report validation ──
+	// This is repeated under the write lock just before append to close races.
+	store := getStoreByID(contextID)
+	store.mu.RLock()
+	if existing, msg, ok := findDuplicateVulnerability(store.vulns, title, args["description"], target, endpoint); ok {
+		store.mu.RUnlock()
+		return duplicateResult(existing, msg), nil
+	}
+	store.mu.RUnlock()
 
 	// ── Gate 1: Validate verification method ──
 	if method == "" || !validVerificationMethods[method] {
@@ -215,32 +227,11 @@ If you cannot exploit it, downgrade severity to 'info' and report as information
 	}
 
 	// ── Gate 4: Smart Deduplication — same vuln type on same endpoint = duplicate ──
-	endpoint := strings.TrimSpace(args["endpoint"])
-	vulnType := extractVulnType(title, args["description"])
-	normalizedEndpoint := normalizeEndpoint(endpoint)
-
-	store := getStoreByID(contextID)
+	store = getStoreByID(contextID)
 	store.mu.RLock()
-	for _, existing := range store.vulns {
-		existingType := extractVulnType(existing.Title, existing.Description)
-		existingNormEndpoint := normalizeEndpoint(existing.Endpoint)
-
-		// Check 1: Exact title + endpoint match
-		if strings.EqualFold(existing.Title, title) && existing.Endpoint == endpoint {
-			store.mu.RUnlock()
-			return tools.Result{
-				Output: fmt.Sprintf("⚠️ DUPLICATE: '%s' at endpoint '%s' already reported as %s. Skipping.", title, endpoint, existing.ID),
-			}, nil
-		}
-
-		// Check 2: Same vulnerability TYPE on same normalized endpoint
-		if vulnType != "" && vulnType == existingType && normalizedEndpoint == existingNormEndpoint && normalizedEndpoint != "" {
-			store.mu.RUnlock()
-			return tools.Result{
-				Output: fmt.Sprintf("⚠️ DUPLICATE: Same vulnerability type '%s' already reported on endpoint '%s' as %s ('%s'). Skipping.\nIf this is genuinely different, use a distinct endpoint or describe how it differs.",
-					vulnType, endpoint, existing.ID, existing.Title),
-			}, nil
-		}
+	if existing, msg, ok := findDuplicateVulnerability(store.vulns, title, args["description"], target, endpoint); ok {
+		store.mu.RUnlock()
+		return duplicateResult(existing, msg), nil
 	}
 	store.mu.RUnlock()
 
@@ -300,6 +291,11 @@ If you cannot exploit it, downgrade severity to 'info' and report as information
 
 	store = getStoreByID(contextID) // re-resolve in case of race
 	store.mu.Lock()
+	if existing, msg, ok := findDuplicateVulnerability(store.vulns, title, args["description"], target, endpoint); ok {
+		store.mu.Unlock()
+		return duplicateResult(existing, msg), nil
+	}
+
 	vuln := Vulnerability{
 		ID:                 fmt.Sprintf("XALG-%d", len(store.vulns)+1),
 		Title:              title,
@@ -307,7 +303,7 @@ If you cannot exploit it, downgrade severity to 'info' and report as information
 		OriginalSeverity:   originalSeverity,
 		Description:        args["description"],
 		Impact:             args["impact"],
-		Target:             args["target"],
+		Target:             target,
 		Endpoint:           endpoint,
 		Method:             args["method"],
 		CVE:                args["cve"],
@@ -335,6 +331,44 @@ If you cannot exploit it, downgrade severity to 'info' and report as information
 		Output:   msg,
 		Metadata: map[string]any{"vuln_id": vuln.ID, "verified": vuln.Verified},
 	}, nil
+}
+
+func duplicateResult(existing Vulnerability, msg string) tools.Result {
+	return tools.Result{
+		Output: msg,
+		Metadata: map[string]any{
+			"duplicate":        true,
+			"existing_vuln_id": existing.ID,
+		},
+	}
+}
+
+func findDuplicateVulnerability(existing []Vulnerability, title, description, target, endpoint string) (Vulnerability, string, bool) {
+	normalizedTitle := normalizeFindingText(title)
+	normalizedTarget := normalizeEndpoint(target)
+	normalizedEndpoint := normalizeEndpoint(endpoint)
+	vulnType := extractVulnType(title, description)
+
+	for _, vuln := range existing {
+		existingTitle := normalizeFindingText(vuln.Title)
+		existingTarget := normalizeEndpoint(vuln.Target)
+		existingEndpoint := normalizeEndpoint(vuln.Endpoint)
+		existingType := extractVulnType(vuln.Title, vuln.Description)
+		sameTarget := normalizedTarget == existingTarget
+
+		// Exact finding match after trimming/case normalization.
+		if sameTarget && normalizedTitle != "" && normalizedTitle == existingTitle && normalizedEndpoint == existingEndpoint {
+			return vuln, fmt.Sprintf("⚠️ DUPLICATE: '%s' at endpoint '%s' already reported as %s. Skipping.", title, endpoint, vuln.ID), true
+		}
+
+		// Same vulnerability class on the same normalized endpoint.
+		if sameTarget && vulnType != "" && vulnType == existingType && normalizedEndpoint != "" && normalizedEndpoint == existingEndpoint {
+			return vuln, fmt.Sprintf("⚠️ DUPLICATE: Same vulnerability type '%s' already reported on endpoint '%s' as %s ('%s'). Skipping.\nIf this is genuinely different, use a distinct endpoint or describe how it differs.",
+				vulnType, endpoint, vuln.ID, vuln.Title), true
+		}
+	}
+
+	return Vulnerability{}, "", false
 }
 
 // checkFalsePositive detects common false positive patterns and rejects them.
@@ -683,8 +717,8 @@ func CleanupContext(contextID string) {
 }
 
 // MergeVulnsToContext copies all vulnerabilities from srcContextID into dstContextID.
-// Duplicates (by vuln ID) are skipped. Used by wildcard scans to accumulate subdomain
-// vulns into a persistent parent context before the subdomain's context is cleaned up.
+// Semantic duplicates are skipped. ID collisions are renumbered because each
+// child context starts its own XALG-1 sequence.
 func MergeVulnsToContext(srcContextID, dstContextID string) int {
 	if srcContextID == "" || dstContextID == "" || srcContextID == dstContextID {
 		return 0
@@ -706,18 +740,29 @@ func MergeVulnsToContext(srcContextID, dstContextID string) int {
 	dstStore.mu.Lock()
 	defer dstStore.mu.Unlock()
 
-	seen := make(map[string]bool, len(dstStore.vulns))
+	seenIDs := make(map[string]bool, len(dstStore.vulns))
 	for _, v := range dstStore.vulns {
-		seen[v.ID] = true
+		seenIDs[v.ID] = true
 	}
 
 	added := 0
 	for _, v := range srcVulns {
-		if !seen[v.ID] {
-			dstStore.vulns = append(dstStore.vulns, v)
-			seen[v.ID] = true
-			added++
+		if _, _, duplicate := findDuplicateVulnerability(dstStore.vulns, v.Title, v.Description, v.Target, v.Endpoint); duplicate {
+			continue
 		}
+		if seenIDs[v.ID] {
+			nextID := len(dstStore.vulns) + 1
+			for {
+				v.ID = fmt.Sprintf("XALG-%d", nextID)
+				if !seenIDs[v.ID] {
+					break
+				}
+				nextID++
+			}
+		}
+		dstStore.vulns = append(dstStore.vulns, v)
+		seenIDs[v.ID] = true
+		added++
 	}
 	return added
 }
@@ -1094,4 +1139,8 @@ func normalizeEndpoint(endpoint string) string {
 	endpoint = strings.TrimRight(endpoint, "/")
 	// Lowercase for consistent comparison
 	return strings.ToLower(endpoint)
+}
+
+func normalizeFindingText(value string) string {
+	return strings.Join(strings.Fields(strings.ToLower(strings.TrimSpace(value))), " ")
 }

--- a/internal/tools/reporting/reporting_test.go
+++ b/internal/tools/reporting/reporting_test.go
@@ -1,15 +1,17 @@
 package reporting
 
 import (
+	"strings"
+	"sync"
 	"testing"
 )
 
 func TestCheckFalsePositive_MissingHeaders(t *testing.T) {
 	tests := []struct {
-		title    string
-		desc     string
-		severity string
-		proof    string
+		title      string
+		desc       string
+		severity   string
+		proof      string
 		wantReject bool
 	}{
 		{"Missing X-Frame-Options Header", "The X-Frame-Options header is not set", "medium", "", true},
@@ -200,6 +202,74 @@ func TestCheckFalsePositive_RealVulns(t *testing.T) {
 		if result != "" {
 			t.Errorf("real vuln %q should NOT be rejected, got: %s", tt.title, result)
 		}
+	}
+}
+
+func TestReportVulnChecksDuplicateBeforeAppending(t *testing.T) {
+	contextID := "test-report-duplicate"
+	CleanupContext(contextID)
+	defer CleanupContext(contextID)
+
+	args := validReportArgs()
+	first, err := reportVulnWithContextID(contextID, args)
+	if err != nil {
+		t.Fatalf("first report error = %v", err)
+	}
+	if _, ok := first.Metadata["vuln_id"].(string); !ok {
+		t.Fatalf("first report metadata = %#v, want vuln_id", first.Metadata)
+	}
+
+	duplicateArgs := validReportArgs()
+	duplicateArgs["endpoint"] = "https://example.com/login?id=2"
+	second, err := reportVulnWithContextID(contextID, duplicateArgs)
+	if err != nil {
+		t.Fatalf("second report error = %v", err)
+	}
+	if !strings.Contains(second.Output, "DUPLICATE") {
+		t.Fatalf("second report output = %q, want duplicate", second.Output)
+	}
+	if got, ok := second.Metadata["duplicate"].(bool); !ok || !got {
+		t.Fatalf("second report metadata = %#v, want duplicate=true", second.Metadata)
+	}
+	if got := len(GetVulnerabilitiesForContext(contextID)); got != 1 {
+		t.Fatalf("stored vulnerabilities = %d, want 1", got)
+	}
+}
+
+func TestReportVulnConcurrentDuplicatesOnlyAppendOnce(t *testing.T) {
+	contextID := "test-report-concurrent-duplicate"
+	CleanupContext(contextID)
+	defer CleanupContext(contextID)
+
+	const attempts = 20
+	var wg sync.WaitGroup
+	wg.Add(attempts)
+	for i := 0; i < attempts; i++ {
+		go func() {
+			defer wg.Done()
+			_, _ = reportVulnWithContextID(contextID, validReportArgs())
+		}()
+	}
+	wg.Wait()
+
+	if got := len(GetVulnerabilitiesForContext(contextID)); got != 1 {
+		t.Fatalf("stored vulnerabilities after concurrent duplicates = %d, want 1", got)
+	}
+}
+
+func validReportArgs() map[string]string {
+	return map[string]string{
+		"title":               "SQL Injection in Login Endpoint",
+		"severity":            "high",
+		"description":         "Union-based SQL injection allows extraction of user records from the login endpoint.",
+		"exploitation_proof":  "sql injection data extraction confirmed; dumped user data including email address records from database",
+		"verification_method": "data_extracted",
+		"impact":              "Unauthorized attackers can extract sensitive user data.",
+		"target":              "https://example.com",
+		"endpoint":            "https://example.com/login?id=1",
+		"method":              "GET",
+		"cvss":                "7.5",
+		"cvss_vector":         "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
 	}
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -229,15 +229,16 @@ func (m *Model) handleEvent(evt agent.Event) {
 		}
 		// Real-time vuln display when report_vulnerability succeeds
 		if evt.ToolName == "report_vulnerability" && evt.ToolResult.Error == "" {
-			vulns := reporting.GetVulnerabilities()
-			if len(vulns) > 0 {
-				m.vulnCount = len(vulns)
-				v := vulns[len(vulns)-1]
-				icon := severityIcon(v.Severity)
-				sev := severityStyle(v.Severity).Render(strings.ToUpper(v.Severity))
-				m.chatLog = append(m.chatLog, "")
-				m.chatLog = append(m.chatLog, titleStyle.Render(fmt.Sprintf("  🐛 VULNERABILITY FOUND — %s", icon)))
-				m.chatLog = append(m.chatLog, fmt.Sprintf("     %s [%s] %s — %s", icon, v.ID, v.Title, sev))
+			if vulnID, ok := metadataString(evt.ToolResult.Metadata, "vuln_id"); ok {
+				vulns := reporting.GetVulnerabilities()
+				if v, found := findReportedVulnerabilityByID(vulns, vulnID); found {
+					m.vulnCount = len(vulns)
+					icon := severityIcon(v.Severity)
+					sev := severityStyle(v.Severity).Render(strings.ToUpper(v.Severity))
+					m.chatLog = append(m.chatLog, "")
+					m.chatLog = append(m.chatLog, titleStyle.Render(fmt.Sprintf("  🐛 VULNERABILITY FOUND — %s", icon)))
+					m.chatLog = append(m.chatLog, fmt.Sprintf("     %s [%s] %s — %s", icon, v.ID, v.Title, sev))
+				}
 			}
 		}
 		m.chatLog = append(m.chatLog, "")
@@ -522,6 +523,31 @@ func FormatVulnSummary() string {
 		b.WriteString("\n")
 	}
 	return b.String()
+}
+
+func metadataString(metadata map[string]any, key string) (string, bool) {
+	if metadata == nil {
+		return "", false
+	}
+	value, ok := metadata[key]
+	if !ok {
+		return "", false
+	}
+	text, ok := value.(string)
+	if !ok {
+		return "", false
+	}
+	text = strings.TrimSpace(text)
+	return text, text != ""
+}
+
+func findReportedVulnerabilityByID(vulns []reporting.Vulnerability, id string) (reporting.Vulnerability, bool) {
+	for _, vuln := range vulns {
+		if vuln.ID == id {
+			return vuln, true
+		}
+	}
+	return reporting.Vulnerability{}, false
 }
 
 // RunInteractive starts the interactive Bubbletea TUI.

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -627,6 +627,7 @@ type VulnSummary struct {
 	ID                 string  `json:"id"`
 	Title              string  `json:"title"`
 	Severity           string  `json:"severity"`
+	Target             string  `json:"target,omitempty"`
 	Endpoint           string  `json:"endpoint"`
 	CVSS               float64 `json:"cvss"`
 	CVSSVector         string  `json:"cvss_vector,omitempty"`
@@ -1935,81 +1936,91 @@ func (s *Server) processEvent(evt agent.Event, sess *scanSession) {
 
 		// Push vuln to UI in real-time when report_vulnerability succeeds
 		if evt.ToolName == "report_vulnerability" && evt.ToolResult.Error == "" {
-			vulns := reporting.GetVulnerabilitiesForContext(sess.sctx.ID)
-			log.Printf("[VULN] report_vulnerability tool succeeded, vulns in list: %d", len(vulns))
-			if len(vulns) > 0 {
-				latest := vulns[len(vulns)-1]
-				vs := vulnToSummary(latest)
-				log.Printf("[VULN] Latest vuln: %s %s (CVSS %.1f)", vs.Severity, vs.Title, vs.CVSS)
-
-				// Severity filter enforcement strictly at the UI layer
-				allowed := true
-				if len(sess.severityFilter) > 0 {
-					allowed = false
-					for _, sev := range sess.severityFilter {
-						if strings.EqualFold(sev, vs.Severity) {
-							allowed = true
-							break
-						}
-					}
-					log.Printf("[VULN] Severity filter active: filter=%v, allowed=%v", sess.severityFilter, allowed)
-				}
-
-				if allowed {
-					wsEvt.Vulns = []VulnSummary{vs}
-					sess.record.Vulns = append(sess.record.Vulns, vs)
-					log.Printf("[VULN] Vuln broadcast real-time: %s %s", vs.Severity, vs.Title)
-
-					// Discord: vulnerability found (respects XALGORIX_DISCORD_MIN_SEVERITY)
-					sevColor := 0xef4444 // red for critical/high
-					switch vs.Severity {
-					case "medium":
-						sevColor = 0xd97706
-					case "low", "info":
-						sevColor = 0x3b82f6
-					}
-					var details strings.Builder
-					details.WriteString(fmt.Sprintf("**%s**\n\n", vs.Title))
-					if vs.Description != "" {
-						details.WriteString(fmt.Sprintf("📝 **Description:**\n%s\n\n", vs.Description))
-					}
-					if vs.Endpoint != "" {
-						details.WriteString(fmt.Sprintf("🔗 **Endpoint:** `%s`\n", vs.Endpoint))
-					}
-					if vs.Method != "" {
-						details.WriteString(fmt.Sprintf("📡 **Method:** `%s`\n", vs.Method))
-					}
-					if vs.CVE != "" {
-						details.WriteString(fmt.Sprintf("🏷️ **CVE:** `%s`\n", vs.CVE))
-					}
-					details.WriteString(fmt.Sprintf("📊 **CVSS:** `%.1f` | **Severity:** `%s`\n\n", vs.CVSS, strings.ToUpper(vs.Severity)))
-					if vs.Impact != "" {
-						details.WriteString(fmt.Sprintf("💥 **Impact:**\n%s\n\n", vs.Impact))
-					}
-					if vs.TechnicalAnalysis != "" {
-						details.WriteString(fmt.Sprintf("🔬 **Technical Analysis:**\n%s\n\n", vs.TechnicalAnalysis))
-					}
-					if vs.PoCDescription != "" {
-						details.WriteString(fmt.Sprintf("🧪 **PoC:**\n%s\n", vs.PoCDescription))
-					}
-					if vs.PoCScript != "" {
-						poc := vs.PoCScript
-						if len(poc) > 800 {
-							poc = poc[:800] + "\n... (truncated)"
-						}
-						details.WriteString(fmt.Sprintf("```\n%s\n```\n\n", poc))
-					}
-					if vs.Remediation != "" {
-						details.WriteString(fmt.Sprintf("🛡️ **Remediation:**\n%s", vs.Remediation))
-					}
-					// Apply Discord minimum severity filter
-					if severityMeetsThreshold(vs.Severity, s.discordMinSeverity) {
-						s.sendDiscord(sevColor, fmt.Sprintf("🐛 %s Vulnerability Found", strings.ToUpper(vs.Severity)), details.String())
-					} else {
-						log.Printf("[DISCORD] Skipping %s vuln notification (min severity: %s)", vs.Severity, s.discordMinSeverity)
-					}
+			vulnID, reported := metadataString(evt.ToolResult.Metadata, "vuln_id")
+			if !reported {
+				log.Printf("[VULN] report_vulnerability returned without a new vuln_id; not broadcasting stored vuln again")
+			} else {
+				vulns := reporting.GetVulnerabilitiesForContext(sess.sctx.ID)
+				log.Printf("[VULN] report_vulnerability tool created %s, vulns in list: %d", vulnID, len(vulns))
+				latest, found := findReportedVulnerabilityByID(vulns, vulnID)
+				if !found {
+					log.Printf("[VULN] report_vulnerability metadata referenced %s, but it was not found in context %s", vulnID, sess.sctx.ID)
 				} else {
-					log.Printf("[VULN] Vuln filtered out by severity: %s (filter: %v)", vs.Severity, sess.severityFilter)
+					vs := vulnToSummary(latest)
+					log.Printf("[VULN] Latest vuln: %s %s (CVSS %.1f)", vs.Severity, vs.Title, vs.CVSS)
+
+					// Severity filter enforcement strictly at the UI layer
+					allowed := true
+					if len(sess.severityFilter) > 0 {
+						allowed = false
+						for _, sev := range sess.severityFilter {
+							if strings.EqualFold(sev, vs.Severity) {
+								allowed = true
+								break
+							}
+						}
+						log.Printf("[VULN] Severity filter active: filter=%v, allowed=%v", sess.severityFilter, allowed)
+					}
+
+					if allowed {
+						if appendVulnSummaryUnique(&sess.record.Vulns, vs) {
+							wsEvt.Vulns = []VulnSummary{vs}
+							log.Printf("[VULN] Vuln broadcast real-time: %s %s", vs.Severity, vs.Title)
+
+							// Discord: vulnerability found (respects XALGORIX_DISCORD_MIN_SEVERITY)
+							sevColor := 0xef4444 // red for critical/high
+							switch vs.Severity {
+							case "medium":
+								sevColor = 0xd97706
+							case "low", "info":
+								sevColor = 0x3b82f6
+							}
+							var details strings.Builder
+							details.WriteString(fmt.Sprintf("**%s**\n\n", vs.Title))
+							if vs.Description != "" {
+								details.WriteString(fmt.Sprintf("📝 **Description:**\n%s\n\n", vs.Description))
+							}
+							if vs.Endpoint != "" {
+								details.WriteString(fmt.Sprintf("🔗 **Endpoint:** `%s`\n", vs.Endpoint))
+							}
+							if vs.Method != "" {
+								details.WriteString(fmt.Sprintf("📡 **Method:** `%s`\n", vs.Method))
+							}
+							if vs.CVE != "" {
+								details.WriteString(fmt.Sprintf("🏷️ **CVE:** `%s`\n", vs.CVE))
+							}
+							details.WriteString(fmt.Sprintf("📊 **CVSS:** `%.1f` | **Severity:** `%s`\n\n", vs.CVSS, strings.ToUpper(vs.Severity)))
+							if vs.Impact != "" {
+								details.WriteString(fmt.Sprintf("💥 **Impact:**\n%s\n\n", vs.Impact))
+							}
+							if vs.TechnicalAnalysis != "" {
+								details.WriteString(fmt.Sprintf("🔬 **Technical Analysis:**\n%s\n\n", vs.TechnicalAnalysis))
+							}
+							if vs.PoCDescription != "" {
+								details.WriteString(fmt.Sprintf("🧪 **PoC:**\n%s\n", vs.PoCDescription))
+							}
+							if vs.PoCScript != "" {
+								poc := vs.PoCScript
+								if len(poc) > 800 {
+									poc = poc[:800] + "\n... (truncated)"
+								}
+								details.WriteString(fmt.Sprintf("```\n%s\n```\n\n", poc))
+							}
+							if vs.Remediation != "" {
+								details.WriteString(fmt.Sprintf("🛡️ **Remediation:**\n%s", vs.Remediation))
+							}
+							// Apply Discord minimum severity filter
+							if severityMeetsThreshold(vs.Severity, s.discordMinSeverity) {
+								s.sendDiscord(sevColor, fmt.Sprintf("🐛 %s Vulnerability Found", strings.ToUpper(vs.Severity)), details.String())
+							} else {
+								log.Printf("[DISCORD] Skipping %s vuln notification (min severity: %s)", vs.Severity, s.discordMinSeverity)
+							}
+						} else {
+							log.Printf("[VULN] Skipping duplicate vuln already present in session record: %s %s", vs.ID, vs.Title)
+						}
+					} else {
+						log.Printf("[VULN] Vuln filtered out by severity: %s (filter: %v)", vs.Severity, sess.severityFilter)
+					}
 				}
 			}
 		}
@@ -2026,16 +2037,16 @@ func (s *Server) processEvent(evt agent.Event, sess *scanSession) {
 		// Build set of vulns already broadcast in real-time to avoid duplicates
 		seen := make(map[string]bool)
 		for _, v := range sess.record.Vulns {
-			seen[v.ID] = true
+			seen[vulnSummaryKey(v)] = true
 		}
 		vulns := reporting.GetVulnerabilitiesForContext(sess.sctx.ID)
 		log.Printf("[VULN] Finished event: total vulns in system: %d, already broadcast: %d", len(vulns), len(seen))
 		for _, v := range vulns {
-			if seen[v.ID] {
+			vs := vulnToSummary(v)
+			if seen[vulnSummaryKey(vs)] {
 				log.Printf("[VULN] Finished: skipping already-broadcast vuln: %s %s", v.ID, v.Title)
 				continue
 			}
-			vs := vulnToSummary(v)
 			allowed := true
 			if len(sess.severityFilter) > 0 {
 				allowed = false
@@ -2048,6 +2059,7 @@ func (s *Server) processEvent(evt agent.Event, sess *scanSession) {
 			}
 			if allowed {
 				wsEvt.Vulns = append(wsEvt.Vulns, vs)
+				seen[vulnSummaryKey(vs)] = true
 				log.Printf("[VULN] Finished: adding new vuln to final broadcast: %s %s", vs.Severity, vs.Title)
 			} else {
 				log.Printf("[VULN] Finished: filtered vuln (not added to broadcast): %s (filter: %v)", vs.Severity, sess.severityFilter)
@@ -3512,6 +3524,7 @@ func vulnToSummary(v reporting.Vulnerability) VulnSummary {
 		ID:                 v.ID,
 		Title:              v.Title,
 		Severity:           v.Severity,
+		Target:             v.Target,
 		Endpoint:           v.Endpoint,
 		CVSS:               v.CVSS,
 		CVSSVector:         v.CVSSVector,
@@ -3526,6 +3539,56 @@ func vulnToSummary(v reporting.Vulnerability) VulnSummary {
 		ExploitationProof:  v.ExploitationProof,
 		VerificationMethod: v.VerificationMethod,
 	}
+}
+
+func metadataString(metadata map[string]any, key string) (string, bool) {
+	if metadata == nil {
+		return "", false
+	}
+	value, ok := metadata[key]
+	if !ok {
+		return "", false
+	}
+	text, ok := value.(string)
+	if !ok {
+		return "", false
+	}
+	text = strings.TrimSpace(text)
+	return text, text != ""
+}
+
+func findReportedVulnerabilityByID(vulns []reporting.Vulnerability, id string) (reporting.Vulnerability, bool) {
+	for _, vuln := range vulns {
+		if vuln.ID == id {
+			return vuln, true
+		}
+	}
+	return reporting.Vulnerability{}, false
+}
+
+func appendVulnSummaryUnique(vulns *[]VulnSummary, vuln VulnSummary) bool {
+	key := vulnSummaryKey(vuln)
+	for _, existing := range *vulns {
+		if vulnSummaryKey(existing) == key {
+			return false
+		}
+	}
+	*vulns = append(*vulns, vuln)
+	return true
+}
+
+func vulnSummaryKey(v VulnSummary) string {
+	return strings.Join([]string{
+		normalizeSummaryPart(v.Title),
+		normalizeSummaryPart(v.Target),
+		normalizeSummaryPart(v.Endpoint),
+		normalizeSummaryPart(v.Method),
+		normalizeSummaryPart(v.CVE),
+	}, "|")
+}
+
+func normalizeSummaryPart(value string) string {
+	return strings.Join(strings.Fields(strings.ToLower(strings.TrimSpace(value))), " ")
 }
 
 // generateReportAt generates a PDF report, saving it to a specific directory.
@@ -4362,7 +4425,9 @@ func (s *Server) broadcastToInstance(instanceID string, evt WSEvent) {
 		}
 		// Also buffer vulns
 		if len(evt.Vulns) > 0 {
-			inst.Vulns = append(inst.Vulns, evt.Vulns...)
+			for _, vuln := range evt.Vulns {
+				appendVulnSummaryUnique(&inst.Vulns, vuln)
+			}
 		}
 		if evt.CurrentPhase > 0 {
 			inst.CurrentPhase = evt.CurrentPhase

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -32,6 +32,7 @@
     let iterCount = 0;
     let toolCount = 0;
     let vulnCount = 0;
+    const vulnKeys = new Set();
     let scanStart = null;
     let autoScroll = true;
     const toolUsage = {};
@@ -524,11 +525,8 @@
                 }
                 // Real-time vuln rendering
                 if (!isReplay && evt.vulns && evt.vulns.length > 0) {
-                    vulnCount += evt.vulns.length;
-                    const vulnEl = document.getElementById('stat-vulns');
-                    if (vulnEl) vulnEl.textContent = vulnCount;
-                    popStat('stat-vulns');
-                    renderVulns(evt.vulns);
+                    const added = renderVulns(evt.vulns);
+                    if (added > 0) popStat('stat-vulns');
                 }
                 break;
             }
@@ -547,9 +545,8 @@
             case 'finished':
                 if (evt.vulns && evt.vulns.length > 0) {
                     if (!isReplay) {
-                        vulnCount += evt.vulns.length;
-                        popStat('stat-vulns');
-                        renderVulns(evt.vulns);
+                        const added = renderVulns(evt.vulns);
+                        if (added > 0) popStat('stat-vulns');
                     }
                 }
                 addFeedItem(renderFinished(evt.content));
@@ -673,22 +670,28 @@
 
     function renderVulns(vulns) {
         const list = document.getElementById('vuln-list');
+        if (!list || !Array.isArray(vulns)) return 0;
+
         const empty = list.querySelector('.empty-state');
         if (empty) list.innerHTML = '';
-        
-        const countEl = document.getElementById('vuln-count');
-        if (countEl) countEl.textContent = vulnCount;
-        
+
+        let added = 0;
         vulns.forEach((v) => {
+            const key = vulnKey(v);
+            if (vulnKeys.has(key)) return;
+            vulnKeys.add(key);
+            added += 1;
+            const severity = normalizeVulnPart(v.severity) || 'info';
+
             const li = document.createElement('li');
-            li.className = `vuln-item ${v.severity.toLowerCase()}`;
+            li.className = `vuln-item ${severity}`;
             li._vulnData = v;
             li.innerHTML = `
                 <div class="vuln-header" style="cursor:pointer">
-                    <span class="vuln-severity-dot ${v.severity.toLowerCase()}"></span>
+                    <span class="vuln-severity-dot ${severity}"></span>
                     <span class="vuln-title-text">${esc(v.title)}</span>
                     <span style="font-family:var(--font-mono);font-size:11px;color:var(--text-muted);margin-left:auto;margin-right:8px">${v.cvss ? v.cvss.toFixed(1) : ''}</span>
-                    <span class="vuln-badge ${v.severity.toLowerCase()}">${v.severity.toUpperCase()}</span>
+                    <span class="vuln-badge ${severity}">${severity.toUpperCase()}</span>
                 </div>
             `;
             // Store vuln data for delegated event handler
@@ -697,6 +700,32 @@
             });
             list.appendChild(li);
         });
+
+        vulnCount = vulnKeys.size;
+        updateVulnCount();
+        return added;
+    }
+
+    function vulnKey(v) {
+        const parts = [
+            normalizeVulnPart(v && v.title),
+            normalizeVulnPart(v && v.target),
+            normalizeVulnPart(v && v.endpoint),
+            normalizeVulnPart(v && v.method),
+            normalizeVulnPart(v && v.cve),
+        ];
+        return parts.join('|');
+    }
+
+    function normalizeVulnPart(value) {
+        return String(value || '').trim().toLowerCase().replace(/\s+/g, ' ');
+    }
+
+    function updateVulnCount() {
+        const statEl = document.getElementById('stat-vulns');
+        const countEl = document.getElementById('vuln-count');
+        if (statEl) statEl.textContent = String(vulnCount);
+        if (countEl) countEl.textContent = String(vulnCount);
     }
 
     // Toggle vuln expand - now opens modal
@@ -1173,12 +1202,14 @@
 
         // Reset state
         iterCount = 0; toolCount = 0; vulnCount = 0;
+        vulnKeys.clear();
         currentTargetIdx = 0; totalTargets = targets.length;
         Object.keys(toolUsage).forEach(k => delete toolUsage[k]);
         
         ['stat-iter', 'stat-tools', 'stat-vulns'].forEach(id => {
             document.getElementById(id).textContent = '0';
         });
+        updateVulnCount();
         
         document.getElementById('feed-body').innerHTML = '';
         document.getElementById('vuln-list').innerHTML = '<li class="empty-state" style="padding:20px 0"><div class="empty-title">Scanning...</div></li>';
@@ -1339,7 +1370,8 @@
             // Reset UI
             iterCount = scan.iterations || 0;
             toolCount = scan.tool_calls || 0;
-            vulnCount = (scan.vulns || []).length;
+            vulnCount = 0;
+            vulnKeys.clear();
             currentPhase = Number(scan.current_phase || firstSelectedPhase(scan.phases || []));
             currentScanStatus = scan.status || 'idle';
             renderScanDetails(scan);
@@ -1351,7 +1383,7 @@
             
             if (iterEl) iterEl.textContent = String(iterCount);
             if (toolsEl) toolsEl.textContent = String(toolCount);
-            if (vulnsEl) vulnsEl.textContent = String(vulnCount);
+            if (vulnsEl) vulnsEl.textContent = '0';
 
             // Tokens
             if (scan.total_tokens > 0 && tokensEl) {
@@ -1366,6 +1398,8 @@
             // Vulns
             if (scan.vulns && scan.vulns.length > 0) {
                 renderVulns(scan.vulns);
+            } else {
+                updateVulnCount();
             }
 
             // Events
@@ -1840,6 +1874,7 @@
         
         // Reset local scan counters so they don't leak into dashboard
         iterCount = 0; toolCount = 0; vulnCount = 0;
+        vulnKeys.clear();
         Object.keys(toolUsage).forEach(k => delete toolUsage[k]);
         
         // Unsubscribe from instance events
@@ -1871,11 +1906,13 @@
         
         // Reset scan view state
         iterCount = 0; toolCount = 0; vulnCount = 0;
+        vulnKeys.clear();
         Object.keys(toolUsage).forEach(k => delete toolUsage[k]);
         ['stat-iter', 'stat-tools', 'stat-vulns'].forEach(id => {
             const el = document.getElementById(id);
             if (el) el.textContent = '0';
         });
+        updateVulnCount();
         document.getElementById('feed-body').innerHTML = '';
         document.getElementById('vuln-list').innerHTML = '<li class="empty-state" style="padding:20px 0"><div class="empty-title">Loading...</div></li>';
         document.getElementById('tools-list').innerHTML = '<li class="empty-state" style="padding:20px 0"><div class="empty-title">Loading...</div></li>';
@@ -1944,10 +1981,9 @@
                 const el = document.getElementById('stat-tools');
                 if (el) el.textContent = toolCount;
             }
-            if (inst.vuln_count) {
+            if (inst.vuln_count && (!inst.vulns || inst.vulns.length === 0)) {
                 vulnCount = Math.max(vulnCount, inst.vuln_count);
-                const el = document.getElementById('stat-vulns');
-                if (el) el.textContent = vulnCount;
+                updateVulnCount();
             }
             if (inst.total_tokens) {
                 const el = document.getElementById('stat-tokens');
@@ -1958,16 +1994,9 @@
             if (inst.vulns && inst.vulns.length > 0) {
                 const vulnList = document.getElementById('vuln-list');
                 vulnList.innerHTML = '';
-                inst.vulns.forEach(v => {
-                    const li = document.createElement('li');
-                    li.className = 'vuln-item';
-                    li.innerHTML = `
-                        <span class="vuln-severity-dot ${(v.severity||'info').toLowerCase()}"></span>
-                        <span class="vuln-title">${esc(v.title)}</span>
-                        <span class="vuln-cvss">${v.cvss || ''}</span>
-                    `;
-                    vulnList.appendChild(li);
-                });
+                vulnKeys.clear();
+                vulnCount = 0;
+                renderVulns(inst.vulns);
             }
             
             // Load buffered events (replay feed)


### PR DESCRIPTION
## Summary
- dedupe report_vulnerability submissions before validation and again under the store lock
- stop web and TUI paths from rebroadcasting existing vulnerabilities when a duplicate report is rejected
- add UI-side deduping for websocket replay/final events and regression coverage for duplicate reports

## Tests
- go test ./...
- node --check internal/web/static/app.js
- git diff --check