### PR TITLE
Release v4.3.16

### DIFF
--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.3.15"
+var version = "4.3.16"
 
 func main() {
 	// Top-level crash recovery — catches panics that escape all other handlers.


### PR DESCRIPTION
## Summary
- bump version to v4.3.16 using release.sh
- include duplicate vulnerability reporting fix from PR #29 in release notes

## Verification
- go test ./...
- ./release.sh completed local bump/build/tag; direct main push was blocked by repository PR rules, so this PR carries the release commit