### PR TITLE
Fix post-scan chat follow-ups

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -4083,10 +4083,58 @@ func (s *Server) routeChatMessage(instanceID, message string) (string, error) {
 	targetID := s.currentScanID
 	agnt := s.currentAgents[targetID]
 	s.mu.RUnlock()
-	if agnt == nil {
-		return "", fmt.Errorf("no active scan")
+	if agnt != nil && s.running.Load() {
+		return agnt.SendMessage(message)
 	}
-	return agnt.SendMessage(message)
+
+	if inst := s.latestChatInstance(); inst != nil {
+		return s.postScanChat(inst, message)
+	}
+
+	return "", fmt.Errorf("no active or completed scan to chat with")
+}
+
+func (s *Server) latestChatInstance() *ScanInstance {
+	s.instancesMu.RLock()
+	defer s.instancesMu.RUnlock()
+
+	var best *ScanInstance
+	var bestTime time.Time
+	for _, inst := range s.instances {
+		inst.mu.RLock()
+		status := inst.Status
+		finishedAt := inst.FinishedAt
+		startedAt := inst.StartedAt
+		inst.mu.RUnlock()
+
+		switch status {
+		case "finished", "stopped", "paused":
+		default:
+			continue
+		}
+
+		t := parseInstanceTime(finishedAt)
+		if t.IsZero() {
+			t = parseInstanceTime(startedAt)
+		}
+		if best == nil || t.After(bestTime) {
+			best = inst
+			bestTime = t
+		}
+	}
+	return best
+}
+
+func parseInstanceTime(value string) time.Time {
+	if value == "" {
+		return time.Time{}
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return parsed
+		}
+	}
+	return time.Time{}
 }
 
 func (s *Server) postScanChat(inst *ScanInstance, message string) (string, error) {
@@ -4128,7 +4176,7 @@ func buildPostScanChatPrompt(inst *ScanInstance) string {
 	if inst.Status == "paused" {
 		b.WriteString("You are Xalgorix in paused-scan chat mode. The scan is paused, so answer follow-up questions using only the scan context captured so far. Do not claim that you are still scanning or that you can run tools in this chat. If the user asks for new testing, explain what the current results show and suggest resuming the scan.\n\n")
 	} else {
-		b.WriteString("You are Xalgorix in post-scan chat mode. The scan has already finished, so answer follow-up questions using only the completed scan context below. Do not claim that you are still scanning or that you can run tools in this chat. If the user asks for new testing, explain what the existing results show and suggest restarting or starting a new scan.\n\n")
+		b.WriteString("You are Xalgorix in post-scan chat mode. The scan has already finished, so answer follow-up questions using only the completed scan context below. Do not claim that you are still scanning or that you can run tools in this chat. If the user asks for new testing, first summarize what the completed scan already found for that topic, then explain that additional live testing requires resuming, restarting, or starting a new scan.\n\n")
 	}
 
 	b.WriteString("## Scan\n")

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -321,6 +321,84 @@ func TestHandleChat_AllowsFinishedInstancePostScanChat(t *testing.T) {
 	}
 }
 
+func TestHandleChat_WithoutInstanceIDUsesLatestCompletedInstance(t *testing.T) {
+	s := newTestServer(t, &config.Config{RateLimitRequests: 60, RateLimitWindow: 60})
+	s.postScanChatFn = func(_ *config.Config, messages []llm.Message) (string, error) {
+		if got := messages[len(messages)-1].Content; got != "test for any api endpoint" {
+			t.Fatalf("chat message = %q", got)
+		}
+		return "The scan is complete; here are the API-related findings from the completed scan.", nil
+	}
+	inst := &ScanInstance{
+		ID:         "inst-latest-finished",
+		Targets:    "https://done.test",
+		Status:     "finished",
+		StartedAt:  "2026-05-10T10:00:00Z",
+		FinishedAt: "2026-05-10T10:30:00Z",
+		ScanMode:   "single",
+		events: []WSEvent{
+			{Type: "queue_finished", Content: "Scan queue ended"},
+		},
+	}
+	s.instancesMu.Lock()
+	s.instances[inst.ID] = inst
+	s.instancesMu.Unlock()
+
+	rr := httptest.NewRecorder()
+	body := strings.NewReader(`{"message":"test for any api endpoint"}`)
+	s.handleChat(rr, httptest.NewRequest(http.MethodPost, "/api/chat", body))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("chat status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "API-related findings") {
+		t.Fatalf("unexpected no-instance post-scan chat response: %s", rr.Body.String())
+	}
+}
+
+func TestHandleChat_WithoutInstanceIDIgnoresStaleFinishedAgent(t *testing.T) {
+	s := newTestServer(t, &config.Config{RateLimitRequests: 60, RateLimitWindow: 60})
+	events := make(chan agent.Event, 4)
+	sctx := scanctx.New("stale-agent", t.TempDir())
+	agnt := agent.NewAgent(s.cfg, "stale-agent", events, sctx)
+	t.Cleanup(func() {
+		agnt.Stop()
+		sctx.Close()
+	})
+
+	s.mu.Lock()
+	s.currentScanID = "stale-scan"
+	s.currentAgents["stale-scan"] = agnt
+	s.mu.Unlock()
+	s.running.Store(false)
+
+	s.postScanChatFn = func(_ *config.Config, _ []llm.Message) (string, error) {
+		return "Post-scan context answer.", nil
+	}
+	inst := &ScanInstance{
+		ID:         "inst-finished-after-stale-agent",
+		Targets:    "https://done.test",
+		Status:     "finished",
+		StartedAt:  "2026-05-10T10:00:00Z",
+		FinishedAt: "2026-05-10T10:30:00Z",
+	}
+	s.instancesMu.Lock()
+	s.instances[inst.ID] = inst
+	s.instancesMu.Unlock()
+
+	rr := httptest.NewRecorder()
+	body := strings.NewReader(`{"message":"what did we find?"}`)
+	s.handleChat(rr, httptest.NewRequest(http.MethodPost, "/api/chat", body))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("chat status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), "next iteration") {
+		t.Fatalf("stale agent handled post-scan chat: %s", rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "Post-scan context answer") {
+		t.Fatalf("unexpected post-scan response: %s", rr.Body.String())
+	}
+}
+
 func TestUploadHandlers_ParseTargetsAndInstructions(t *testing.T) {
 	s := newTestServer(t, nil)
 

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -1175,7 +1175,19 @@
     };
 
     // ── Actions ────────────────────────────────────────────
-    window.startScan = function () {
+    function attachToInstance(instanceID) {
+        if (!instanceID) return;
+        currentInstanceID = instanceID;
+        showScanView();
+        history.pushState(null, '', '/' + instanceID);
+        const label = document.getElementById('scan-view-instance-id');
+        if (label) label.textContent = 'Instance: ' + instanceID;
+        if (ws && ws.readyState === WebSocket.OPEN) {
+            ws.send(JSON.stringify({ subscribe: instanceID }));
+        }
+    }
+
+    window.startScan = async function () {
         const targetVal = document.getElementById('target-input').value.trim();
         if (!targetVal) {
             const targetEl = document.getElementById('target-input');
@@ -1259,14 +1271,27 @@
         const discordWebhook = document.getElementById('discord-webhook')?.value?.trim();
         if (discordWebhook) payload.discord_webhook = discordWebhook;
 
-        if (ws && ws.readyState === WebSocket.OPEN) {
-            ws.send(JSON.stringify(payload));
-        } else {
-            fetch('/api/scan', {
+        try {
+            const resp = await fetch('/api/scan', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(payload),
             });
+            const data = await resp.json();
+            if (!resp.ok) {
+                throw new Error(data.error || 'Failed to start scan');
+            }
+            if (data.instance_id) {
+                attachToInstance(data.instance_id);
+                await loadInstanceState(data.instance_id);
+            }
+        } catch (e) {
+            scanRunning = false;
+            currentScanStatus = 'idle';
+            renderPhaseTimeline(currentScanPhases, currentPhase, currentScanStatus);
+            toggleButtons(false);
+            setStatus('idle', 'IDLE');
+            showToast('Failed to start scan: ' + e.message, 'error');
         }
     };
 


### PR DESCRIPTION
## Summary
- keep UI chat bound to the created scan instance by starting scans through /api/scan and subscribing to the returned instance ID
- route no-instance chat requests to the latest completed/paused/stopped scan instead of stale active-agent state
- make post-scan answers summarize completed scan context before suggesting a new scan

## Tests
- go test ./...
- node --check internal/web/static/app.js
- git diff --check