### PR TITLE
Release v4.3.17

### DIFF
--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.3.16"
+var version = "4.3.17"
 
 func main() {
 	// Top-level crash recovery — catches panics that escape all other handlers.


### PR DESCRIPTION
## Summary
- bump version to v4.3.17 using release.sh
- include post-scan chat follow-up fix from PR #31

## Verification
- go test ./...
- node --check internal/web/static/app.js
- git diff --check
- ./release.sh completed local bump/build/tag; direct main push was blocked by repository PR rules, so this PR carries the release commit