### PR TITLE
docs: cache bust README banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png" alt="Xalgorix" width="860" />
+<img src="assets/banner.png?v=4.4.0" alt="Xalgorix" width="860" />
 
 <br />
 


### PR DESCRIPTION
The banner asset changed in v4.4.0, but GitHub can keep showing the old README image because the path stayed assets/banner.png. Add a version query string to the README image source so the new banner refreshes immediately.