### PR TITLE
fix(webui): mobile responsiveness overhaul

### DIFF
--- a/webui/src/components/scan-status-pill.tsx
+++ b/webui/src/components/scan-status-pill.tsx
@@ -52,7 +52,7 @@ export function ScanStatusPill({
   return (
     <span
       className={cn(
-        "inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide",
+        "inline-flex items-center gap-1.5 whitespace-nowrap rounded-md border px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide",
         meta.className,
         className,
       )}

--- a/webui/src/components/ui/card.tsx
+++ b/webui/src/components/ui/card.tsx
@@ -8,7 +8,7 @@ export const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-md border border-border bg-card text-card-foreground",
+      "overflow-hidden rounded-md border border-border bg-card text-card-foreground",
       className,
     )}
     {...props}

--- a/webui/src/components/ui/dialog.tsx
+++ b/webui/src/components/ui/dialog.tsx
@@ -29,7 +29,7 @@ export const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border border-border bg-card p-6 shadow-lg rounded-lg",
+        "fixed left-1/2 top-1/2 z-50 grid w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border border-border bg-card p-6 shadow-lg rounded-lg",
         className,
       )}
       {...props}

--- a/webui/src/layout/app-shell.tsx
+++ b/webui/src/layout/app-shell.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from "react";
-import { Outlet } from "react-router-dom";
+import { useCallback, useEffect, useState } from "react";
+import { Outlet, useLocation } from "react-router-dom";
 import { Sidebar } from "./sidebar";
 import { Topbar } from "./topbar";
 import { ConnectionBanner } from "@/components/connection-status";
@@ -9,17 +9,45 @@ import { useWSStore } from "@/store/ws";
 export function AppShell() {
   const connect = useWSStore((s) => s.connect);
   const disconnect = useWSStore((s) => s.disconnect);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const location = useLocation();
 
   useEffect(() => {
     connect();
     return () => disconnect();
   }, [connect, disconnect]);
 
+  // Close mobile sidebar on navigation
+  useEffect(() => {
+    setSidebarOpen(false);
+  }, [location.pathname]);
+
+  const handleSidebarToggle = useCallback(() => setSidebarOpen((o) => !o), []);
+  const handleSidebarClose = useCallback(() => setSidebarOpen(false), []);
+
   return (
     <div className="flex h-screen overflow-hidden bg-background text-foreground">
-      <Sidebar />
+      {/* Desktop sidebar */}
+      <div className="hidden md:block">
+        <Sidebar />
+      </div>
+
+      {/* Mobile sidebar overlay */}
+      {sidebarOpen && (
+        <div className="fixed inset-0 z-40 md:hidden">
+          <div
+            className="absolute inset-0 z-40 bg-black/60 backdrop-blur-sm"
+            onClick={handleSidebarClose}
+            aria-hidden
+          />
+          <div className="absolute inset-y-0 left-0 z-50 w-60 animate-in slide-in-from-left duration-200">
+            <Sidebar onNavigate={handleSidebarClose} />
+          </div>
+        </div>
+      )}
+
       <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-        <Topbar />
+        <Topbar onMenuToggle={handleSidebarToggle} />
         <ConnectionBanner />
         <main className="min-h-0 flex-1 overflow-y-auto">
           <div className="mx-auto max-w-7xl px-4 py-4 sm:px-6 sm:py-6">

--- a/webui/src/layout/topbar.tsx
+++ b/webui/src/layout/topbar.tsx
@@ -1,11 +1,11 @@
 import { Link } from "react-router-dom";
-import { Loader2, Plus, Search, StopCircle } from "lucide-react";
+import { Loader2, Menu, Plus, Search, StopCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ConnectionStatus } from "@/components/connection-status";
 import { useStatus, useInstances, useStopAll } from "@/api/queries";
 import { useCommandPalette } from "@/components/command-palette";
 
-export function Topbar() {
+export function Topbar({ onMenuToggle }: { onMenuToggle?: () => void }) {
   const { data: status } = useStatus();
   const { data: instances } = useInstances();
   const stopAll = useStopAll();
@@ -18,16 +18,25 @@ export function Topbar() {
   );
 
   return (
-    <header className="flex h-14 items-center gap-3 border-b border-border bg-background/80 px-4 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+    <header className="flex h-14 items-center gap-2 border-b border-border bg-background/80 px-4 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <button
+        type="button"
+        onClick={onMenuToggle}
+        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:text-foreground md:hidden"
+        aria-label="Toggle menu"
+      >
+        <Menu className="h-5 w-5" />
+      </button>
       <button
         type="button"
         onClick={() => palette.setOpen(true)}
-        className="group inline-flex h-8 items-center gap-2 rounded-md border border-border bg-card px-2.5 text-xs text-muted-foreground hover:text-foreground transition-colors min-w-72"
+        className="group inline-flex h-8 flex-1 items-center gap-2 rounded-md border border-border bg-card px-2.5 text-xs text-muted-foreground hover:text-foreground transition-colors md:flex-none md:min-w-72"
         aria-label="Open command palette"
       >
-        <Search className="h-3.5 w-3.5" />
-        <span>Search scans, findings, actions…</span>
-        <kbd className="ml-auto rounded-sm border border-border bg-muted px-1 py-0.5 text-[10px] mono">
+        <Search className="h-3.5 w-3.5 shrink-0" />
+        <span className="hidden sm:inline truncate">Search scans, findings, actions…</span>
+        <span className="sm:hidden truncate">Search…</span>
+        <kbd className="ml-auto hidden sm:inline rounded-sm border border-border bg-muted px-1 py-0.5 text-[10px] mono">
           Ctrl K
         </kbd>
       </button>
@@ -59,7 +68,7 @@ export function Topbar() {
             size="sm"
             onClick={() => stopAll.mutate()}
             disabled={stopAll.isPending}
-            className="text-red-400 hover:text-red-300"
+            className="hidden sm:inline-flex text-red-400 hover:text-red-300"
           >
             <StopCircle className="h-3.5 w-3.5" />
             Stop all
@@ -67,7 +76,7 @@ export function Topbar() {
         )}
         <Button asChild size="sm">
           <Link to="/scans/new">
-            <Plus className="h-3.5 w-3.5" /> New Scan
+            <Plus className="h-3.5 w-3.5" /> <span className="hidden sm:inline">New Scan</span>
           </Link>
         </Button>
       </div>

--- a/webui/src/pages/email-triage.tsx
+++ b/webui/src/pages/email-triage.tsx
@@ -62,7 +62,7 @@ export default function EmailTriagePage() {
   const configured = !!mail?.pod && !!mail?.hasApiKey;
 
   return (
-    <>
+    <div className="space-y-6">
       <header className="space-y-1">
         <h1 className="font-sans text-2xl font-semibold tracking-tight">
           Email triage
@@ -186,6 +186,6 @@ export default function EmailTriagePage() {
           )}
         </CardContent>
       </Card>
-    </>
+    </div>
   );
 }

--- a/webui/src/pages/instances.tsx
+++ b/webui/src/pages/instances.tsx
@@ -32,7 +32,7 @@ export default function InstancesPage() {
   const { data, isLoading, error, refetch } = useInstances()
 
   return (
-    <>
+    <div className="space-y-6">
       <header className="flex flex-col gap-1">
         <h1 className="font-sans text-2xl font-semibold tracking-tight">Instances</h1>
         <p className="text-sm text-muted-foreground">
@@ -69,7 +69,7 @@ export default function InstancesPage() {
           )}
         </>
       )}
-    </>
+    </div>
   )
 }
 
@@ -161,8 +161,8 @@ function InstanceCard({ instance }: { instance: ScanInstance }) {
   return (
     <Card>
       <CardHeader className="pb-3">
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0">
+        <div className="flex items-start justify-between gap-3 overflow-hidden">
+          <div className="min-w-0 flex-1">
             <CardTitle className="truncate mono text-sm">
               {instance.name || instance.targets || shortId(instance.id)}
             </CardTitle>
@@ -171,7 +171,7 @@ function InstanceCard({ instance }: { instance: ScanInstance }) {
               {instance.scan_mode && <> · {instance.scan_mode}</>}
             </CardDescription>
           </div>
-          <ScanStatusPill status={instance.status} />
+          <ScanStatusPill status={instance.status} className="shrink-0" />
         </div>
       </CardHeader>
       <CardContent className="space-y-3">

--- a/webui/src/pages/live.tsx
+++ b/webui/src/pages/live.tsx
@@ -49,7 +49,7 @@ export default function LivePage() {
   }, [activeInstanceIds, clearedAt, events, historyQueries])
 
   return (
-    <>
+    <div className="space-y-6">
       <header className="flex items-center justify-between gap-3">
         <div>
           <h1 className="font-sans text-2xl font-semibold tracking-tight">Live feed</h1>
@@ -72,7 +72,7 @@ export default function LivePage() {
         emptyTitle="Quiet on the wire"
         emptyDescription="Events from any running instance will appear here in real time."
       />
-    </>
+    </div>
   )
 }
 

--- a/webui/src/pages/scan-detail.tsx
+++ b/webui/src/pages/scan-detail.tsx
@@ -101,7 +101,7 @@ export default function ScanDetailPage() {
   const mergedEvents = mergeFeedEvents(persistedAsFeed, wsForScan)
 
   return (
-    <>
+    <div className="space-y-6">
       <div>
         <Link to="/scans" className="inline-flex items-center text-xs text-muted-foreground hover:text-foreground">
           <ChevronLeft className="mr-1 h-3 w-3" />
@@ -290,7 +290,7 @@ export default function ScanDetailPage() {
           <ConfigTab scan={scan} />
         </TabsContent>
       </Tabs>
-    </>
+    </div>
   )
 }
 

--- a/webui/src/pages/scans.tsx
+++ b/webui/src/pages/scans.tsx
@@ -110,7 +110,7 @@ export default function ScansPage() {
   }
 
   return (
-    <>
+    <div className="space-y-6">
       <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="font-sans text-2xl font-semibold tracking-tight">
@@ -219,7 +219,7 @@ export default function ScansPage() {
       )}
 
       <NewScanDialog open={newOpen} onOpenChange={setNewOpen} />
-    </>
+    </div>
   );
 }
 

--- a/webui/src/pages/settings.tsx
+++ b/webui/src/pages/settings.tsx
@@ -180,7 +180,7 @@ export default function SettingsPage() {
   }
 
   return (
-    <>
+    <div className="space-y-6">
       <header className="space-y-1">
         <h1 className="font-sans text-2xl font-semibold tracking-tight">
           Settings
@@ -742,7 +742,7 @@ export default function SettingsPage() {
           </Card>
         </TabsContent>
       </Tabs>
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
Fixes mobile layout issues across the webui — sidebar, topbar, cards, and page spacing.

## Changes
**Layout**
- Sidebar hidden on mobile (`md:` breakpoint), replaced with hamburger menu + slide-over overlay with backdrop
- Topbar: search bar uses flex-1 on mobile with shortened placeholder, "New Scan" shows as icon-only `+` button, "Stop all" hidden on small screens

**Components**
- `Card`: added `overflow-hidden` so child text truncation works properly
- `DialogContent`: changed `w-full` to `w-[calc(100%-2rem)]` for horizontal breathing room on mobile
- `ScanStatusPill`: added `whitespace-nowrap` to prevent label clipping

**Pages**
- `instances`: wrapped root in `space-y-6`, fixed card header flex overflow for long scan names
- `scans`, `scan-detail`, `live`, `email-triage`, `settings`: replaced bare `<>` fragments with `<div className="space-y-6">` to fix stacked cards having no vertical gap

## Testing
Verified on 375×812 (iPhone X) viewport:
- Overview, Scans, Instances, Live Feed, Settings, Integrations all render without horizontal overflow
- Hamburger menu opens/closes sidebar overlay
- Long instance names truncate with ellipsis
- Status pills remain intact

## Screenshots
<img width="375" height="812" alt="pr-overview" src="https://github.com/user-attachments/assets/35114d05-60da-4c6e-bb41-4bcaa4e48b0b" />
<img width="375" height="812" alt="pr-scans" src="https://github.com/user-attachments/assets/39abbf5c-0d5c-4e92-86d3-c4bf0736bd40" />
<img width="375" height="812" alt="pr-sidebar" src="https://github.com/user-attachments/assets/f6737103-b83b-4235-94a4-77d4cecf0766" />
<img width="375" height="812" alt="pr-instances" src="https://github.com/user-attachments/assets/f40d96bb-bf8a-4095-bbf6-c999aa0ab574" />
