### PR TITLE
release: v4.4.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.4.5
+VERSION=4.4.6
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.4.5" alt="Xalgorix" width="860" />
+<img src="assets/banner.png?v=4.4.6" alt="Xalgorix" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.4.5"
+var version = "4.4.6"
 
 const defaultWebPort = 9137
 

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -194,6 +194,11 @@ type anthropicResponse struct {
 		Text string `json:"text"`
 	} `json:"delta,omitempty"`
 	Index int `json:"index,omitempty"`
+	// Usage at the top level (message_delta events carry final output token count here).
+	Usage struct {
+		InputTokens  int `json:"input_tokens"`
+		OutputTokens int `json:"output_tokens"`
+	} `json:"usage,omitempty"`
 }
 
 // resolveEndpoint returns the full chat completions URL and clean model name.
@@ -545,7 +550,12 @@ func (c *Client) ChatStream(messages []Message) <-chan StreamChunk {
 						ch <- StreamChunk{Content: anResp.Delta.Text}
 					}
 				case "message_delta":
-					// Final usage update if present
+					// Final usage update — output_tokens arrives at the top level here.
+					if anResp.Usage.OutputTokens > 0 {
+						c.mu.Lock()
+						c.totalOut += anResp.Usage.OutputTokens
+						c.mu.Unlock()
+					}
 				case "message_stop":
 					ch <- StreamChunk{Done: true}
 					return
@@ -714,22 +724,23 @@ func (c *Client) doChat(messages []Message) (string, error) {
 	}
 
 	if isAnthropic {
-		var anResp anthropicResponse
-		if err := json.Unmarshal(respBody, &anResp); err != nil {
+		var anMsg anthropicMessage
+		if err := json.Unmarshal(respBody, &anMsg); err != nil {
 			return "", fmt.Errorf("failed to parse Anthropic response: %w", err)
 		}
 		// Track token usage
 		c.mu.Lock()
-		c.totalIn += anResp.Message.Usage.InputTokens
-		c.totalOut += anResp.Message.Usage.OutputTokens
+		c.totalIn += anMsg.Usage.InputTokens
+		c.totalOut += anMsg.Usage.OutputTokens
 		c.mu.Unlock()
 		// Extract text from content blocks
-		for _, block := range anResp.Message.Content {
+		for _, block := range anMsg.Content {
 			if block.Type == "text" && block.Text != "" {
 				return block.Text, nil
 			}
 		}
-		return "", fmt.Errorf("no text content in Anthropic response")
+		log.Printf("[llm] Anthropic response with no text content (stop_reason: %s, content_blocks: %d): %s", anMsg.StopReason, len(anMsg.Content), string(respBody))
+		return "", fmt.Errorf("no text content in Anthropic response (stop_reason: %s, content_blocks: %d)", anMsg.StopReason, len(anMsg.Content))
 	}
 
 	var chatResp chatResponse

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -296,7 +296,7 @@ func TestDoChat_AnthropicAPIBaseWithoutProviderUsesAnthropicProtocol(t *testing.
 			t.Fatalf("Anthropic payload missing messages: %s", string(body))
 		}
 
-		return jsonResponse(http.StatusOK, `{"message":{"content":[{"type":"text","text":"anthropic ok"}],"usage":{"input_tokens":3,"output_tokens":4}}}`), nil
+		return jsonResponse(http.StatusOK, `{"id":"msg_test","type":"message","role":"assistant","content":[{"type":"text","text":"anthropic ok"}],"model":"claude-sonnet-4-20250514","stop_reason":"end_turn","usage":{"input_tokens":3,"output_tokens":4}}`), nil
 	})}
 
 	got, err := c.doChat([]Message{
@@ -312,6 +312,98 @@ func TestDoChat_AnthropicAPIBaseWithoutProviderUsesAnthropicProtocol(t *testing.
 	_, _, total := c.GetTokens()
 	if total != 7 {
 		t.Fatalf("token total = %d, want 7", total)
+	}
+}
+
+func TestDoChat_AnthropicEmptyContentReturnsError(t *testing.T) {
+	c := NewClient(&config.Config{
+		LLM:           "anthropic/claude-sonnet-4-20250514",
+		APIKey:        "anthropic-key",
+		LLMMaxRetries: 1,
+	})
+	c.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusOK, `{"id":"msg_test","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-20250514","stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":0}}`), nil
+	})}
+
+	_, err := c.doChat([]Message{{Role: "user", Content: "hello"}})
+	if err == nil {
+		t.Fatal("expected error for empty content, got nil")
+	}
+	if !strings.Contains(err.Error(), "no text content") {
+		t.Fatalf("expected 'no text content' error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "content_blocks: 0") {
+		t.Fatalf("expected content_blocks: 0 in error, got: %v", err)
+	}
+}
+
+func TestDoChat_AnthropicToolUseOnlyReturnsError(t *testing.T) {
+	c := NewClient(&config.Config{
+		LLM:           "anthropic/claude-sonnet-4-20250514",
+		APIKey:        "anthropic-key",
+		LLMMaxRetries: 1,
+	})
+	c.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusOK, `{"id":"msg_test","type":"message","role":"assistant","content":[{"type":"tool_use","id":"toolu_123","name":"bash","input":{"command":"ls"}}],"model":"claude-sonnet-4-20250514","stop_reason":"tool_use","usage":{"input_tokens":10,"output_tokens":5}}`), nil
+	})}
+
+	_, err := c.doChat([]Message{{Role: "user", Content: "hello"}})
+	if err == nil {
+		t.Fatal("expected error for tool_use-only content, got nil")
+	}
+	if !strings.Contains(err.Error(), "no text content") {
+		t.Fatalf("expected 'no text content' error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "stop_reason: tool_use") {
+		t.Fatalf("expected stop_reason: tool_use in error, got: %v", err)
+	}
+}
+
+func TestDoChat_AnthropicEmptyTextBlockReturnsError(t *testing.T) {
+	c := NewClient(&config.Config{
+		LLM:           "anthropic/claude-sonnet-4-20250514",
+		APIKey:        "anthropic-key",
+		LLMMaxRetries: 1,
+	})
+	c.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusOK, `{"id":"msg_test","type":"message","role":"assistant","content":[{"type":"text","text":""}],"model":"claude-sonnet-4-20250514","stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":1}}`), nil
+	})}
+
+	_, err := c.doChat([]Message{{Role: "user", Content: "hello"}})
+	if err == nil {
+		t.Fatal("expected error for empty text block, got nil")
+	}
+	if !strings.Contains(err.Error(), "no text content") {
+		t.Fatalf("expected 'no text content' error, got: %v", err)
+	}
+}
+
+func TestDoChat_AnthropicTokenUsageTracked(t *testing.T) {
+	c := NewClient(&config.Config{
+		LLM:           "anthropic/claude-sonnet-4-20250514",
+		APIKey:        "anthropic-key",
+		LLMMaxRetries: 1,
+	})
+	c.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusOK, `{"id":"msg_test","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"model":"claude-sonnet-4-20250514","stop_reason":"end_turn","usage":{"input_tokens":50,"output_tokens":25}}`), nil
+	})}
+
+	got, err := c.doChat([]Message{{Role: "user", Content: "hello"}})
+	if err != nil {
+		t.Fatalf("doChat returned error: %v", err)
+	}
+	if got != "ok" {
+		t.Fatalf("doChat = %q, want ok", got)
+	}
+	in, out, total := c.GetTokens()
+	if in != 50 {
+		t.Errorf("input tokens = %d, want 50", in)
+	}
+	if out != 25 {
+		t.Errorf("output tokens = %d, want 25", out)
+	}
+	if total != 75 {
+		t.Errorf("total tokens = %d, want 75", total)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fix Anthropic non-streaming response parsing — unmarshal into `anthropicMessage` directly (the API returns the message at top level, not wrapped in `"message"`)
- Fix `message_delta` streaming event to track `output_tokens` usage
- Add diagnostic logging with raw response body for empty-content errors
- Add tests: empty content, tool_use-only, empty text block, token usage tracking

Fixes #44