### PR TITLE
release: v4.4.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.4.6
+VERSION=4.4.7
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.4.6" alt="Xalgorix" width="860" />
+<img src="assets/banner.png?v=4.4.7" alt="Xalgorix" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.4.6"
+var version = "4.4.7"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.4.7 via release.sh.\n\nValidation:\n- go test ./...\n- /tmp/xalgorix-release/xalgorix-linux-amd64 --version