### PR TITLE
release: v4.4.16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,8 @@ webui/node_modules/
 webui/dist/
 webui/.vite/
 webui/.turbo/
+
+# Local-only ephemeral files used by release/commit tooling
+.commit_msg.tmp
+.pr_body.tmp
+.release_notes.tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ A `[MIGRATION]` warning is emitted at startup when legacy markers (`notes.json`,
 
 ### Added
 - `XALGORIX_LLM_MAX_INFLIGHT`: caps concurrent outbound LLM calls (default: `4 × EffectiveMaxInstances`, minimum 1).
-- Health endpoint counters: `panics_recovered`, `path_rejections`, `watchdog_kills`, `admission_refusals`, `llm_inflight_cap`, `data_dir`, `allow_list`.
+- Health endpoint counters: `panics_recovered`, `path_rejections`, `watchdog_kills`, `admission_refusals`, `llm_inflight_cap`, `data_dir`, `allow_list`, `read_deny`.
 - Path_Policy boundary check: every filesystem-touching tool now writes only into `~/.xalgorix/data/`, `~/.xalgorix/`, or `/tmp/`.
+- Read-policy: filesystem-touching tools may now READ anywhere on the host (system wordlists, payload directories, `/etc/services`, etc.) so agents can use shared assets without copying them into the workspace. A built-in deny-list still rejects reads of sensitive paths (`~/.ssh`, `~/.aws`, `~/.gnupg`, `/etc/shadow`, `/etc/sudoers`, `/proc/kcore`, etc.). Set `XALGORIX_READ_DENY_LIST` (colon-separated) to extend the defaults. The active deny-list is exposed as `read_deny` on `/api/status`.
 - Browser tool now acquires Tool_Leases and applies process memory limits.
 - Recovery for tool panics, scheduler ticks, HTTP handler panics, and ScanContext close panics.
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.4.15
+VERSION=4.4.16
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.4.15" alt="Xalgorix" width="860" />
+<img src="assets/banner.png?v=4.4.16" alt="Xalgorix" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.4.15"
+var version = "4.4.16"
 
 const defaultWebPort = 9137
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,6 +88,15 @@ type Config struct {
 	HomeDir     string // ~/.xalgorix
 	SkillsDir   string // embedded or local skills directory
 	BrowserPath string // XALGORIX_BROWSER_PATH — override auto-download with custom Chrome path
+
+	// Filesystem read deny-list. Reads outside the Allow_List are
+	// permitted by default so tools can use system wordlists, payload
+	// directories, and other shared assets. Entries here are
+	// canonicalized prefix matches that REVOKE that default for
+	// sensitive locations (~/.ssh, ~/.aws, /etc/shadow, etc.). Set
+	// XALGORIX_READ_DENY_LIST to a colon-separated list of additional
+	// roots; defaults are merged in. See sandbox.Policy.CheckRead.
+	ReadDenyList []string // XALGORIX_READ_DENY_LIST
 }
 
 var (
@@ -220,6 +229,10 @@ func load() *Config {
 		HomeDir:     xalgorixHome,
 		SkillsDir:   filepath.Join(xalgorixHome, "skills"),
 		BrowserPath: envOr("XALGORIX_BROWSER_PATH", ""),
+
+		// Filesystem read deny-list. Defaults applied in resolveReadDenyList
+		// (sensitive home and system paths); user list extends them.
+		ReadDenyList: resolveReadDenyList(home, os.Getenv("XALGORIX_READ_DENY_LIST")),
 	}
 
 	// Debug: show loaded config so users can verify correct env was picked up.
@@ -487,4 +500,64 @@ func loadEnvFile(path string) {
 		// Always set — later files override earlier ones
 		os.Setenv(key, value)
 	}
+}
+
+// defaultReadDenyList returns the built-in deny-list applied to every
+// Filesystem_Tool read. Reads outside the Allow_List are permitted by
+// default (so tools can consume /usr/share/wordlists, payload dirs,
+// system binaries, etc.); these entries REVOKE that default for
+// sensitive locations only.
+//
+// Each entry is canonicalized at Policy construction time and treated
+// as a prefix match (entry == path OR entry/ is a prefix of path).
+func defaultReadDenyList(home string) []string {
+	if home == "" {
+		home = "/root"
+	}
+	return []string{
+		// User secrets
+		filepath.Join(home, ".ssh"),
+		filepath.Join(home, ".gnupg"),
+		filepath.Join(home, ".aws"),
+		filepath.Join(home, ".azure"),
+		filepath.Join(home, ".config", "gcloud"),
+		filepath.Join(home, ".kube"),
+		filepath.Join(home, ".docker"),
+		filepath.Join(home, ".netrc"),
+		filepath.Join(home, ".pgpass"),
+		filepath.Join(home, ".bash_history"),
+		filepath.Join(home, ".zsh_history"),
+		// System secrets
+		"/etc/shadow",
+		"/etc/gshadow",
+		"/etc/sudoers",
+		"/etc/sudoers.d",
+		"/etc/ssh",
+		"/root/.ssh",
+		"/root/.aws",
+		"/root/.gnupg",
+		// Process / kernel keyrings & memory
+		"/proc/kcore",
+		"/proc/kallsyms",
+		// Encrypted volume keys
+		"/etc/luks",
+	}
+}
+
+// resolveReadDenyList composes the default deny-list with any extra
+// entries supplied via XALGORIX_READ_DENY_LIST. Entries in the env var
+// are colon-separated (Linux PATH convention); an empty string yields
+// the defaults. Empty tokens are skipped.
+func resolveReadDenyList(home, raw string) []string {
+	out := defaultReadDenyList(home)
+	if raw == "" {
+		return out
+	}
+	for _, entry := range strings.Split(raw, ":") {
+		entry = strings.TrimSpace(entry)
+		if entry != "" {
+			out = append(out, entry)
+		}
+	}
+	return out
 }

--- a/internal/sandbox/policy.go
+++ b/internal/sandbox/policy.go
@@ -19,12 +19,30 @@ import (
 // singleton) for normal callers; tests inject their own roots via New.
 //
 // The zero value is not usable — always go through New or Default.
+//
+// Two boundary semantics are exposed:
+//
+//   - CheckResolve enforces the Allow_List for WRITES (R5.x / R8.x).
+//     Writes must land inside cfg.Workspace, cfg.HomeDir, or /tmp.
+//   - CheckRead enforces only the deny-list for READS. Reads succeed
+//     anywhere on the filesystem unless the canonical path falls
+//     under a deny-list root (~/.ssh, ~/.aws, /etc/shadow, etc.).
+//     Tools that consume system wordlists, payload directories, and
+//     other shared assets call CheckRead so the agent can find them
+//     without having to copy them under the workspace.
 type Policy struct {
-	// roots holds canonical absolute prefixes. Each entry is the result
-	// of filepath.Abs + filepath.Clean, with empty/duplicate entries
-	// dropped, sorted longest-first so the prefix match is deterministic
-	// when one root is nested inside another (e.g. /tmp/xalgorix vs /tmp).
+	// roots holds canonical absolute prefixes used for write checks.
+	// Each entry is the result of filepath.Abs + filepath.Clean, with
+	// empty/duplicate entries dropped, sorted longest-first so the
+	// prefix match is deterministic when one root is nested inside
+	// another (e.g. /tmp/xalgorix vs /tmp).
 	roots []string
+
+	// readDeny holds canonical absolute prefixes that REVOKE the
+	// default-allow read policy. Empty/duplicate entries are dropped
+	// at construction time. Reads are otherwise permitted everywhere
+	// the OS will read (so wordlists in /usr/share/seclists work).
+	readDeny []string
 }
 
 // New constructs a Policy from the supplied Allow_List roots. Each
@@ -35,7 +53,29 @@ type Policy struct {
 //
 // New never touches the filesystem; missing roots are accepted and
 // will simply never match. Use Default() in production code.
+//
+// The deny-list (passed via NewWithReadDeny / Default) is left empty
+// here, which means CheckRead allows reads anywhere. Tests that want
+// the default deny-list behavior should call NewWithReadDeny.
 func New(roots ...string) *Policy {
+	return NewWithReadDeny(roots, nil)
+}
+
+// NewWithReadDeny constructs a Policy with explicit write roots and
+// read deny-list. Both slices are canonicalized + deduplicated +
+// sorted longest-first. See New for the write-roots semantics; see
+// CheckRead for the deny-list semantics.
+func NewWithReadDeny(roots, readDeny []string) *Policy {
+	return &Policy{
+		roots:    canonicalizeRootList(roots),
+		readDeny: canonicalizeRootList(readDeny),
+	}
+}
+
+// canonicalizeRootList canonicalizes, dedups, and sorts a list of
+// path roots. Used for both the write Allow_List and the read
+// deny-list — both share the same lookup semantics.
+func canonicalizeRootList(roots []string) []string {
 	seen := make(map[string]struct{}, len(roots))
 	canonical := make([]string, 0, len(roots))
 	for _, raw := range roots {
@@ -59,7 +99,7 @@ func New(roots ...string) *Policy {
 	sort.SliceStable(canonical, func(i, j int) bool {
 		return len(canonical[i]) > len(canonical[j])
 	})
-	return &Policy{roots: canonical}
+	return canonical
 }
 
 var (
@@ -76,9 +116,14 @@ var (
 //   - cfg.HomeDir (~/.xalgorix),
 //   - "/tmp".
 //
+// The read deny-list comes from cfg.ReadDenyList (sensible defaults
+// merged with XALGORIX_READ_DENY_LIST entries). Reads outside the
+// Allow_List are permitted by default; only deny-list members are
+// rejected.
+//
 // The first call must follow config.Get(); subsequent calls return the
-// memoized instance. Tests that need a different Allow_List should
-// construct their own Policy via New.
+// memoized instance. Tests that need a different policy should
+// construct their own via New / NewWithReadDeny.
 func Default() *Policy {
 	defaultOnce.Do(func() {
 		cfg := config.Get()
@@ -86,7 +131,14 @@ func Default() *Policy {
 		// the field; before that landed it points at the legacy
 		// $CWD-derived workspace). Either way it is the right
 		// resolution root for Filesystem_Tool writes.
-		defaultPolicy = New(cfg.Workspace, cfg.HomeDir, "/tmp")
+		var readDeny []string
+		if cfg != nil {
+			readDeny = cfg.ReadDenyList
+		}
+		defaultPolicy = NewWithReadDeny(
+			[]string{cfg.Workspace, cfg.HomeDir, "/tmp"},
+			readDeny,
+		)
 	})
 	return defaultPolicy
 }
@@ -101,6 +153,18 @@ func (p *Policy) Roots() []string {
 	}
 	out := make([]string, len(p.roots))
 	copy(out, p.roots)
+	return out
+}
+
+// ReadDenyRoots returns a defensive copy of the deny-list used by
+// CheckRead. Returned for the health endpoint and for tests; the
+// Policy's internal state is not mutated by callers.
+func (p *Policy) ReadDenyRoots() []string {
+	if p == nil {
+		return nil
+	}
+	out := make([]string, len(p.readDeny))
+	copy(out, p.readDeny)
 	return out
 }
 
@@ -189,6 +253,9 @@ func (p *Policy) Check(canonical string) error {
 // "python_action") used in both the log line and the returned error.
 // On success the returned string is the canonical, allow-list-cleared
 // path the caller can hand directly to os.Open / os.MkdirAll / etc.
+//
+// CheckResolve is the WRITE entry point. Use CheckRead for read paths
+// — reads are permitted everywhere except deny-list members.
 func (p *Policy) CheckResolve(sc *scanctx.ScanContext, toolName, raw string) (string, error) {
 	canonical, err := p.Resolve(sc, raw)
 	if err != nil {
@@ -213,6 +280,77 @@ func (p *Policy) CheckResolve(sc *scanctx.ScanContext, toolName, raw string) (st
 		return "", rej
 	}
 	return canonical, nil
+}
+
+// CheckRead is the READ entry point used by Filesystem_Tools that need
+// to consume files anywhere on the host (system wordlists, payload
+// dirs, /etc/services, /usr/share/seclists, etc.). It returns the
+// canonical path on success and a *PathRejectError ONLY when the path
+// resolves into a deny-list root.
+//
+// Behavior summary:
+//
+//   - Reads inside the Allow_List succeed (same as CheckResolve).
+//   - Reads outside the Allow_List succeed by default.
+//   - Reads under any deny-list root fail with PathRejectError and
+//     the same counter / log line as CheckResolve.
+//
+// toolName is forwarded to the rejection log line and the typed error.
+// Callers should pass the same namespaced operation name they use for
+// CheckResolve (e.g. "fileedit.view", "terminal_read").
+func (p *Policy) CheckRead(sc *scanctx.ScanContext, toolName, raw string) (string, error) {
+	canonical, err := p.Resolve(sc, raw)
+	if err != nil {
+		return "", err
+	}
+	if err := p.CheckReadCanonical(canonical); err != nil {
+		var rej *PathRejectError
+		if pre, ok := err.(*PathRejectError); ok {
+			rej = pre
+		} else {
+			rej = &PathRejectError{Path: canonical, Roots: p.ReadDenyRoots()}
+		}
+		rej.Tool = toolName
+		rej.ScanCtxID = scanContextID(sc)
+
+		safe.IncPathReject()
+		log.Printf("[path-policy] read-deny tool=%s scan=%s path=%s deny=%v",
+			rej.Tool, rej.ScanCtxID, rej.Path, p.readDeny)
+
+		return "", rej
+	}
+	return canonical, nil
+}
+
+// CheckReadCanonical applies only the deny-list portion of the read
+// policy to an already-canonical path. Returns nil when the path is
+// outside every deny-list root, or *PathRejectError otherwise. The
+// returned error has Path and Roots populated (with the deny-list
+// roots) but Tool / ScanCtxID empty — CheckRead fills those.
+//
+// Side-effect-free: never touches the filesystem, never increments
+// counters, never logs.
+func (p *Policy) CheckReadCanonical(canonical string) error {
+	abs, err := filepath.Abs(canonical)
+	if err != nil {
+		return fmt.Errorf("path policy: abs(%s): %w", canonical, err)
+	}
+	abs = filepath.Clean(abs)
+	for _, deny := range p.readDeny {
+		if abs == deny {
+			return &PathRejectError{
+				Path:  abs,
+				Roots: append([]string(nil), p.readDeny...),
+			}
+		}
+		if strings.HasPrefix(abs, deny+string(filepath.Separator)) {
+			return &PathRejectError{
+				Path:  abs,
+				Roots: append([]string(nil), p.readDeny...),
+			}
+		}
+	}
+	return nil
 }
 
 // resolutionBase picks the directory relative paths resolve against.

--- a/internal/sandbox/policy_read_test.go
+++ b/internal/sandbox/policy_read_test.go
@@ -1,0 +1,159 @@
+package sandbox
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCheckRead_AllowsOutsideAllowList confirms the new read policy:
+// reads outside the write Allow_List succeed by default. This is the
+// whole point of the change — wordlists in /usr/share, payload dirs
+// in /opt, and other read-mostly assets must be reachable without
+// being copied into the workspace.
+func TestCheckRead_AllowsOutsideAllowList(t *testing.T) {
+	// Allow_List intentionally narrow. /etc/hostname is outside it but
+	// is a real read-only file present on every Linux box, so it
+	// exercises the canonicalization path too.
+	p := New("/tmp/xalgorix-write-only")
+
+	canonical, err := p.CheckRead(nil, "test", "/etc/hostname")
+	if err != nil {
+		t.Fatalf("read of /etc/hostname rejected: %v", err)
+	}
+	if !filepath.IsAbs(canonical) {
+		t.Fatalf("canonical path = %q, want absolute", canonical)
+	}
+}
+
+// TestCheckRead_AllowsInsideAllowList confirms reads inside the
+// Allow_List still succeed (the old behavior is preserved).
+func TestCheckRead_AllowsInsideAllowList(t *testing.T) {
+	root := t.TempDir()
+	p := New(root)
+
+	canonical, err := p.CheckRead(nil, "test", filepath.Join(root, "any-file"))
+	if err != nil {
+		t.Fatalf("read inside allow-list rejected: %v", err)
+	}
+	if !strings.HasPrefix(canonical, root) {
+		t.Fatalf("canonical = %q, want prefix %q", canonical, root)
+	}
+}
+
+// TestCheckRead_DenyListBlocks confirms the deny-list portion: reads
+// of paths under a deny-list root are rejected with PathRejectError.
+// errors.Is(err, ErrPathReject) must match for callers that want the
+// generic check.
+func TestCheckRead_DenyListBlocks(t *testing.T) {
+	denyRoot := t.TempDir()
+	p := NewWithReadDeny(
+		[]string{"/tmp/xalgorix-write-only"},
+		[]string{denyRoot},
+	)
+
+	target := filepath.Join(denyRoot, "secret-key")
+	_, err := p.CheckRead(nil, "test", target)
+	if err == nil {
+		t.Fatalf("read of %s should have been rejected", target)
+	}
+	if !errors.Is(err, ErrPathReject) {
+		t.Fatalf("err = %T %v, want errors.Is(ErrPathReject)", err, err)
+	}
+	var rej *PathRejectError
+	if !errors.As(err, &rej) {
+		t.Fatalf("err = %T, want *PathRejectError", err)
+	}
+	if rej.Tool != "test" {
+		t.Fatalf("rej.Tool = %q, want %q", rej.Tool, "test")
+	}
+}
+
+// TestCheckRead_DenyListExactMatch confirms an exact match against a
+// deny-list root (not just a descendant) is rejected. Without this
+// guard, a deny-list entry like "/etc/shadow" would only fire on
+// reads of /etc/shadow/something — which never happens because
+// /etc/shadow is a file.
+func TestCheckRead_DenyListExactMatch(t *testing.T) {
+	denyFile := filepath.Join(t.TempDir(), "shadow")
+	p := NewWithReadDeny(nil, []string{denyFile})
+
+	_, err := p.CheckRead(nil, "test", denyFile)
+	if err == nil {
+		t.Fatalf("read of exact deny-list path %s should have been rejected", denyFile)
+	}
+	if !errors.Is(err, ErrPathReject) {
+		t.Fatalf("err = %T %v, want errors.Is(ErrPathReject)", err, err)
+	}
+}
+
+// TestCheckRead_DenyListSiblingNotBlocked confirms the deny-list
+// boundary uses prefix-with-separator semantics — a sibling path like
+// "/etc/shadow.bak" must NOT be rejected by a "/etc/shadow" deny-list
+// entry. (Naive strings.HasPrefix without the separator check would
+// produce a false positive here.)
+func TestCheckRead_DenyListSiblingNotBlocked(t *testing.T) {
+	dir := t.TempDir()
+	denyFile := filepath.Join(dir, "shadow")
+	siblingFile := filepath.Join(dir, "shadow.bak")
+	p := NewWithReadDeny(nil, []string{denyFile})
+
+	if _, err := p.CheckRead(nil, "test", siblingFile); err != nil {
+		t.Fatalf("sibling path %s should not be denied by entry %s: %v",
+			siblingFile, denyFile, err)
+	}
+}
+
+// TestCheckRead_EmptyDenyListAllowsEverything confirms a Policy
+// constructed with no deny-list (the legacy New behavior) admits every
+// read. This is the behavior tests written before the deny-list
+// addition relied on.
+func TestCheckRead_EmptyDenyListAllowsEverything(t *testing.T) {
+	p := New("/tmp/xalgorix-write-only")
+	if got := len(p.ReadDenyRoots()); got != 0 {
+		t.Fatalf("ReadDenyRoots() len = %d, want 0", got)
+	}
+
+	for _, target := range []string{
+		"/etc/hostname",
+		"/usr/share/wordlists/rockyou.txt",
+		"/opt/some/payload",
+	} {
+		if _, err := p.CheckRead(nil, "test", target); err != nil {
+			t.Fatalf("read of %s rejected with empty deny-list: %v", target, err)
+		}
+	}
+}
+
+// TestCheckResolve_Unchanged confirms the WRITE entry point is
+// untouched by the read-policy work: writes outside the Allow_List
+// remain rejected.
+func TestCheckResolve_Unchanged(t *testing.T) {
+	root := t.TempDir()
+	p := NewWithReadDeny([]string{root}, []string{filepath.Join(root, "secret")})
+
+	// Write inside Allow_List → ok.
+	if _, err := p.CheckResolve(nil, "test", filepath.Join(root, "ok.txt")); err != nil {
+		t.Fatalf("write inside allow-list rejected: %v", err)
+	}
+	// Write outside Allow_List → reject.
+	outside := filepath.Join(t.TempDir(), "elsewhere.txt")
+	if _, err := p.CheckResolve(nil, "test", outside); err == nil {
+		t.Fatalf("write outside allow-list (%s) should have been rejected", outside)
+	}
+}
+
+// TestReadDenyRoots_DefensiveCopy confirms callers cannot mutate
+// the Policy's internal state via the returned slice.
+func TestReadDenyRoots_DefensiveCopy(t *testing.T) {
+	p := NewWithReadDeny(nil, []string{"/secret/one"})
+	got := p.ReadDenyRoots()
+	if len(got) != 1 {
+		t.Fatalf("ReadDenyRoots() len = %d, want 1", len(got))
+	}
+	got[0] = "/mutated"
+	if p.ReadDenyRoots()[0] == "/mutated" {
+		t.Fatal("ReadDenyRoots returned a slice aliased to internal state")
+	}
+}

--- a/internal/tools/fileedit/fileedit.go
+++ b/internal/tools/fileedit/fileedit.go
@@ -152,11 +152,16 @@ func runEditorWithPolicy(sc *scanctx.ScanContext, args map[string]string) (tools
 
 	switch command {
 	case "view":
-		path, err := resolveViewPath(sc, rawPath)
-		if err != nil {
-			return tools.Result{}, err
+		// Reads honor the deny-list but are otherwise permitted
+		// anywhere — agents need access to system wordlists, payload
+		// dirs, /etc/services, etc. CheckRead canonicalizes the path
+		// and rejects only if it lands inside a deny-list root
+		// (~/.ssh, ~/.aws, /etc/shadow, etc.).
+		canonical, rerr := sandbox.Default().CheckRead(sc, "fileedit.view", rawPath)
+		if rerr != nil {
+			return tools.Result{Error: rerr.Error()}, nil
 		}
-		return viewFile(path, args["view_range"])
+		return viewFile(canonical, args["view_range"])
 	case "create":
 		canonical, rerr := sandbox.Default().CheckResolve(sc, "fileedit.create", rawPath)
 		if rerr != nil {
@@ -180,24 +185,10 @@ func runEditorWithPolicy(sc *scanctx.ScanContext, args map[string]string) (tools
 	}
 }
 
-// resolveViewPath keeps the prior scan-workspace containment rule for the
-// read-only view command: it never touches the Path_Policy (writes only)
-// but still resolves relative paths against the active Scan_Context.
-func resolveViewPath(sc *scanctx.ScanContext, rawPath string) (string, error) {
-	contextID := ""
-	if sc != nil {
-		contextID = sc.ID
-	}
-	if contextID == "" {
-		return resolvePath(rawPath), nil
-	}
-	return resolvePathForContext(contextID, rawPath)
-}
-
 // runEditor is intentionally removed: the editor entry point now lives in
 // runEditorWithPolicy, which inlines the dispatch so each write command can
-// route its path through sandbox.Default().CheckResolve with the correct
-// "fileedit.<op>" tool name.
+// route its path through sandbox.Default().CheckResolve (writes) or
+// sandbox.Default().CheckRead (the view read).
 
 func viewFile(path, viewRange string) (tools.Result, error) {
 	data, err := os.ReadFile(path)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -2214,6 +2214,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	// internally consistent (Task 11.4 / R9.5).
 	counters := safe.Snapshot()
 	allowList := sandbox.Default().Roots()
+	readDeny := sandbox.Default().ReadDenyRoots()
 
 	// vulns_persisted: total count from on-disk corpus across every scan
 	// record. Stable across teardown — survives reporting.CleanupContext.
@@ -2237,6 +2238,11 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		"llm_inflight_cap":   resources.LLMInFlightCap(),
 		"data_dir":           s.cfg.DataDir,
 		"allow_list":         allowList,
+		// read_deny is the deny-list applied to Filesystem_Tool reads.
+		// Reads outside allow_list succeed by default; only paths under
+		// these roots are rejected. Set XALGORIX_READ_DENY_LIST
+		// (colon-separated) to extend the defaults.
+		"read_deny": readDeny,
 	})
 }
 


### PR DESCRIPTION
## Summary

Release **v4.4.16** ships a single feature: filesystem tools may now READ anywhere on the host, with a built-in deny-list to protect sensitive paths.

## Why

Agents need access to system wordlists (`/usr/share/seclists/`, `/usr/share/wordlists/rockyou.txt`), payload directories, `/etc/services`, etc. The previous policy rejected every read outside the workspace, forcing agents to copy assets into the workspace before use.

## What changed

### New read policy

- **Reads outside `allow_list` succeed by default.**
- A built-in **deny-list** still rejects sensitive paths:
  - User secrets: `~/.ssh`, `~/.gnupg`, `~/.aws`, `~/.azure`, `~/.config/gcloud`, `~/.kube`, `~/.docker`, `~/.netrc`, `~/.pgpass`, `~/.bash_history`, `~/.zsh_history`
  - System secrets: `/etc/shadow`, `/etc/gshadow`, `/etc/sudoers`, `/etc/sudoers.d`, `/etc/ssh`, `/root/.ssh`, `/root/.aws`, `/root/.gnupg`
  - Process / kernel: `/proc/kcore`, `/proc/kallsyms`
  - Encrypted volume keys: `/etc/luks`
- **Writes are unchanged** — `CheckResolve` still enforces the workspace + `~/.xalgorix/` + `/tmp/` Allow_List.

### Operator-facing additions

- `XALGORIX_READ_DENY_LIST` (colon-separated) — extends the default deny-list.
- `read_deny` field on `/api/status` exposes the active deny-list alongside `allow_list`.

### API additions

- `sandbox.Policy.CheckRead(sc, toolName, raw) (canonical, error)` — read entry point.
- `sandbox.Policy.CheckReadCanonical(canonical) error` — pure deny-list check, side-effect-free.
- `sandbox.Policy.ReadDenyRoots() []string` — defensive-copy accessor.
- `sandbox.NewWithReadDeny(roots, readDeny)` — explicit constructor.
- `config.Config.ReadDenyList []string` — populated from defaults + env.

### First caller

- `fileedit view` now routes through `CheckRead`, gaining deny-list protection while permitting reads of system files.

## Tests

- `internal/sandbox/policy_read_test.go` — 8 cases:
  - Read outside Allow_List allowed
  - Read inside Allow_List allowed
  - Deny-list blocks descendant
  - Deny-list blocks exact match
  - Sibling NOT blocked (separator-aware prefix matching)
  - Empty deny-list allows everything
  - `CheckResolve` write semantics unchanged
  - `ReadDenyRoots` returns a defensive copy

## Verification

- `go vet ./...` clean
- `go build ./...` clean
- `go test ./... -count=1` — all 26 packages pass (browser ~102s)
- `go test -race` on `sandbox/web/fileedit` — no races
- `cd webui && npm run build` clean

## Notes

- `.commit_msg.tmp`, `.pr_body.tmp`, `.release_notes.tmp` added to `.gitignore` to prevent the release tooling's ephemeral files from being committed (one snuck in during the v4.4.15 prep before being amended out).
- No spec was authored for this change since it's a single-feature policy addition; the rationale is captured in the commit message and the CHANGELOG.
