### PR TITLE
release: v4.4.18 — block out-of-scope tool calls and self-listener scans

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.4.17
+VERSION=4.4.18
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.4.17" alt="Xalgorix" width="860" />
+<img src="assets/banner.png?v=4.4.18" alt="Xalgorix" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.4.17"
+var version = "4.4.18"
 
 const defaultWebPort = 9137
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net"
 	"net/url"
 	"os/exec"
 	"regexp"
@@ -779,6 +780,253 @@ func (a *Agent) shouldBlockForActivityPolicy(toolName string, toolArgs map[strin
 	return false, ""
 }
 
+// shouldBlockForOutOfScope rejects probe-style tool calls and
+// report_vulnerability invocations whose target host is NOT derived
+// from the configured scan target. Runs unconditionally — even in
+// active mode — so the agent cannot pivot to a third-party host it
+// discovered through DNS, nmap, related-infrastructure heuristics,
+// etc.
+//
+// Hosts considered in-scope:
+//
+//   - any host in a.activityHosts (which includes the configured
+//     targets, their www. variants, and registrable parents).
+//   - subdomains of any activityHosts entry.
+//
+// Tools subject to this gate:
+//
+//   - terminal_execute, python_action, browser_action, page_agent,
+//     pageagent — anything that can hit a network target.
+//   - report_vulnerability — files findings against the wrong host.
+//
+// All other tools (notes, finish, web_search, agentmail, list_skills,
+// read_skill, etc.) are exempt because they don't probe targets.
+//
+// Returns (false, "") when:
+//
+//   - activityHosts is empty (no scope configured — disable the gate
+//     rather than block everything),
+//   - the tool is not in the gated list,
+//   - the args don't reference any host (e.g. local artifact analysis),
+//   - the only hosts referenced are in-scope.
+func (a *Agent) shouldBlockForOutOfScope(toolName string, toolArgs map[string]string) (bool, string) {
+	if len(a.activityHosts) == 0 {
+		return false, ""
+	}
+
+	lowerTool := strings.ToLower(toolName)
+	switch lowerTool {
+	case "terminal_execute", "python_action", "browser_action", "page_agent", "pageagent",
+		"report_vulnerability":
+		// gated
+	default:
+		return false, ""
+	}
+
+	// Pull every host-looking token from the args.
+	hosts := extractHostsFromArgs(toolArgs)
+	if len(hosts) == 0 {
+		// No host token detected — let it through. Local artifact
+		// analysis (grep/awk/jq over recon files) shouldn't be
+		// blocked just because no host is named.
+		return false, ""
+	}
+
+	for _, h := range hosts {
+		if !hostInScope(h, a.activityHosts) {
+			return true, fmt.Sprintf(
+				"%q is not in scope. Configured target hosts: %s. Stay on the configured target — do NOT pivot to discovered third-party hosts, related infrastructure, or sibling services. If the agent thinks the host is part of the engagement, it must be added to the scan request, not probed implicitly.",
+				h, strings.Join(a.activityHosts, ", "),
+			)
+		}
+	}
+
+	// Extra check for report_vulnerability: validate the explicit
+	// `target` and `endpoint` arguments too. The reported finding
+	// should clearly belong to a configured target host even if the
+	// agent didn't put a URL in the description body.
+	if lowerTool == "report_vulnerability" {
+		rawTarget := strings.ToLower(strings.TrimSpace(toolArgs["target"]))
+		rawEndpoint := strings.ToLower(strings.TrimSpace(toolArgs["endpoint"]))
+		for _, raw := range []string{rawTarget, rawEndpoint} {
+			if raw == "" {
+				continue
+			}
+			h := extractHostFromTokenForScope(raw)
+			if h == "" {
+				continue
+			}
+			if !hostInScope(h, a.activityHosts) {
+				return true, fmt.Sprintf(
+					"report_vulnerability target %q is out of scope. Configured target hosts: %s. Refusing to file a finding against a host the operator did not authorize. Re-target the report to one of the configured hosts, or drop the finding.",
+					h, strings.Join(a.activityHosts, ", "),
+				)
+			}
+		}
+	}
+
+	return false, ""
+}
+
+// extractHostsFromArgs scans every value in toolArgs for URL/host
+// tokens and returns the lowercased hostnames found. Tokens with no
+// host are dropped. Used by shouldBlockForOutOfScope.
+func extractHostsFromArgs(toolArgs map[string]string) []string {
+	seen := make(map[string]bool)
+	var out []string
+	for _, raw := range toolArgs {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		for _, tok := range scopeHostTokenSplit(raw) {
+			h := extractHostFromTokenForScope(tok)
+			if h == "" || seen[h] {
+				continue
+			}
+			seen[h] = true
+			out = append(out, h)
+		}
+	}
+	return out
+}
+
+// scopeHostTokenSplit splits a free-form string into tokens that are
+// candidates for host extraction. Splits on whitespace and common
+// shell metacharacters so URLs inside curl/python invocations are
+// still found.
+func scopeHostTokenSplit(s string) []string {
+	return strings.FieldsFunc(s, func(r rune) bool {
+		switch r {
+		case ' ', '\t', '\n', '\r',
+			'"', '\'', '`',
+			'(', ')', '{', '}', '[', ']',
+			',', ';', '|', '&', '<', '>':
+			return true
+		}
+		return false
+	})
+}
+
+// extractHostFromTokenForScope pulls a hostname out of a token, or
+// returns "" if the token is not host-shaped. Accepts:
+//
+//   - http(s)://host[:port]/path
+//   - host:port
+//   - bare host (must contain a dot or be a literal IP)
+//   - [ipv6]
+func extractHostFromTokenForScope(token string) string {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return ""
+	}
+	// Strip trailing punctuation, but NOT brackets — `[ipv6]:port`
+	// needs them preserved for net.SplitHostPort to recognize the
+	// shape.
+	token = strings.Trim(token, ".,;:?!(){}\"'`<>")
+
+	if strings.Contains(token, "://") {
+		if u, err := url.Parse(token); err == nil && u.Hostname() != "" {
+			return strings.ToLower(u.Hostname())
+		}
+	}
+
+	if h, _, err := net.SplitHostPort(token); err == nil && h != "" {
+		// SplitHostPort keeps brackets around the host for [ipv6]:port,
+		// so peel them and accept the inner IP literal.
+		h = strings.TrimPrefix(h, "[")
+		h = strings.TrimSuffix(h, "]")
+		return strings.ToLower(h)
+	}
+
+	if ip := net.ParseIP(token); ip != nil {
+		return strings.ToLower(token)
+	}
+	if strings.HasPrefix(token, "[") && strings.HasSuffix(token, "]") {
+		inner := token[1 : len(token)-1]
+		if net.ParseIP(inner) != nil {
+			return strings.ToLower(inner)
+		}
+	}
+	if strings.Contains(token, ".") && !strings.ContainsAny(token, " /\\") {
+		if strings.HasPrefix(token, "./") || strings.HasPrefix(token, "../") || strings.HasPrefix(token, "/") {
+			return ""
+		}
+		if isVersionLike(token) {
+			return ""
+		}
+		// Filter file-name shaped tokens (notes.json, scan.txt,
+		// recon.csv) so local artifact analysis isn't blocked.
+		if looksLikeFilename(token) {
+			return ""
+		}
+		return strings.ToLower(token)
+	}
+	return ""
+}
+
+// looksLikeFilename returns true when token has the shape <name>.<ext>
+// with a recognized extension. Used by extractHostFromTokenForScope to
+// avoid treating filenames as hostnames. The extension list is short
+// — TLDs that overlap with extensions (e.g. ".sh" for Saint Helena)
+// are uncommon and real URLs usually have at least one label before
+// the TLD anyway.
+func looksLikeFilename(token string) bool {
+	idx := strings.LastIndex(token, ".")
+	if idx <= 0 || idx == len(token)-1 {
+		return false
+	}
+	ext := strings.ToLower(token[idx+1:])
+	switch ext {
+	case "txt", "json", "csv", "log", "yaml", "yml", "xml", "html", "htm",
+		"md", "sh", "py", "js", "ts", "tsx", "jsx", "go", "rs", "rb",
+		"php", "java", "cpp", "tar", "gz", "zip", "tgz",
+		"pdf", "png", "jpg", "jpeg", "gif", "svg", "webp", "ico",
+		"sql", "db", "sqlite", "pem", "key", "crt", "pcap", "har":
+		return true
+	}
+	return false
+}
+
+// isVersionLike returns true for strings that are entirely digits +
+// dots ("1.2.3", "10.0", "v1.0.0"). Used by
+// extractHostFromTokenForScope to skip CLI version arguments.
+func isVersionLike(s string) bool {
+	s = strings.TrimPrefix(s, "v")
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if !(r == '.' || (r >= '0' && r <= '9')) {
+			return false
+		}
+	}
+	return strings.Contains(s, ".")
+}
+
+// hostInScope returns true when host equals (or is a subdomain of)
+// any entry in scopeHosts. Both sides are compared lowercased;
+// trailing dots are stripped.
+func hostInScope(host string, scopeHosts []string) bool {
+	host = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(host), "."))
+	if host == "" {
+		return true
+	}
+	for _, s := range scopeHosts {
+		s = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(s), "."))
+		if s == "" {
+			continue
+		}
+		if host == s {
+			return true
+		}
+		if strings.HasSuffix(host, "."+s) {
+			return true
+		}
+	}
+	return false
+}
+
 func passivePolicyBlockReason(passiveScan bool) string {
 	if passiveScan {
 		return "Passive scanning is enabled, so direct target access and active probes are blocked. Use web_search, public passive datasets, existing notes, or already collected artifacts instead."
@@ -1149,6 +1397,22 @@ func (a *Agent) Run(targets []string, instruction string) {
 
 			if blocked, reason := a.shouldBlockForPhaseRestriction(tc.Name, tc.Args); blocked {
 				blockMsg := "⛔ PHASE RESTRICTION BLOCKED TOOL — " + reason
+				a.emit(Event{Type: "tool_call", ToolName: tc.Name, ToolArgs: tc.Args})
+				a.emit(Event{Type: "tool_result", ToolName: tc.Name, ToolResult: tools.Result{Output: blockMsg}, TotalTokens: tokenCount()})
+				a.msgMu.Lock()
+				a.messages = append(a.messages, llm.Message{Role: "user", Content: blockMsg})
+				a.msgMu.Unlock()
+				continue
+			}
+
+			// ── In-scope guard ──
+			// Runs UNCONDITIONALLY (active and passive). Probes and
+			// finding reports for hosts not derived from the configured
+			// scan target are rejected — prevents the agent from
+			// pivoting to third-party hosts discovered via DNS, port
+			// scans, related infrastructure, etc.
+			if blocked, reason := a.shouldBlockForOutOfScope(tc.Name, tc.Args); blocked {
+				blockMsg := "⛔ OUT-OF-SCOPE TARGET BLOCKED — " + reason
 				a.emit(Event{Type: "tool_call", ToolName: tc.Name, ToolArgs: tc.Args})
 				a.emit(Event{Type: "tool_result", ToolName: tc.Name, ToolResult: tools.Result{Output: blockMsg}, TotalTokens: tokenCount()})
 				a.msgMu.Lock()
@@ -1786,6 +2050,17 @@ func (a *Agent) buildSystemPrompt(targets []string, instruction string, ratePoli
 	}
 
 	return fmt.Sprintf(`You are an elite autonomous AI penetration tester and bug bounty hunter with the mindset of a top-10 HackerOne researcher. You don't just run tools — you THINK like an attacker. You analyze application logic, understand business flows, find edge cases that automated scanners miss, and chain low-severity findings into critical exploits.
+
+## TARGET SCOPE — HARD RULE
+
+You may ONLY probe and report on the configured target host(s) and their subdomains. The runtime enforces this: any tool call that names an out-of-scope host (a third-party Grafana you discovered, an unrelated SaaS the target integrates with, an IP found via portscan that isn't a target subdomain, the local Xalgorix dashboard itself, etc.) is REJECTED with an OUT-OF-SCOPE error.
+
+When you stumble onto a related-but-not-authorized host while doing recon:
+
+- DO NOT fire payloads at it.
+- DO NOT call report_vulnerability against it — the report will be refused.
+- DO note its existence ("found <host> on the target's infrastructure") via add_note for the operator's review.
+- THEN continue working on the configured target.
 
 ## YOUR HACKER MINDSET
 

--- a/internal/agent/agent_scope_test.go
+++ b/internal/agent/agent_scope_test.go
@@ -1,0 +1,225 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestShouldBlockForOutOfScope_BlocksThirdPartyHost is the regression
+// test for the "agent reports findings on unrelated host" bug
+// (Grafana on 159.223.74.62:9999 turning up in a scan of
+// pentest-ground.com). The agent must reject any tool call whose
+// arguments name a host that isn't the configured target or a
+// subdomain of it.
+func TestShouldBlockForOutOfScope_BlocksThirdPartyHost(t *testing.T) {
+	a := &Agent{}
+	a.SetActivityPolicy("active", "active", []string{"https://pentest-ground.com"})
+
+	cases := []struct {
+		name string
+		tool string
+		args map[string]string
+	}{
+		{
+			name: "terminal_execute against unrelated IP",
+			tool: "terminal_execute",
+			args: map[string]string{
+				"command": "curl http://159.223.74.62:9999/?title=%22%3E%3Csvg/onload=alert(1)%3E",
+			},
+		},
+		{
+			name: "report_vulnerability with unrelated target field",
+			tool: "report_vulnerability",
+			args: map[string]string{
+				"title":    "XSS in Grafana",
+				"target":   "http://159.223.74.62:9999",
+				"endpoint": "http://159.223.74.62:9999/?title=%3Csvg",
+				"severity": "high",
+			},
+		},
+		{
+			name: "browser_action navigating to unrelated host",
+			tool: "browser_action",
+			args: map[string]string{
+				"action": "navigate",
+				"url":    "https://attacker.example/callback",
+			},
+		},
+		{
+			name: "python_action requesting unrelated host",
+			tool: "python_action",
+			args: map[string]string{
+				"code": "import requests; requests.get('http://example.org/admin')",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			blocked, reason := a.shouldBlockForOutOfScope(tc.tool, tc.args)
+			if !blocked {
+				t.Fatalf("expected %s with args %v to be blocked, got allow", tc.tool, tc.args)
+			}
+			if reason == "" {
+				t.Fatalf("expected non-empty rejection reason")
+			}
+		})
+	}
+}
+
+// TestShouldBlockForOutOfScope_AllowsInScope confirms the guard does
+// not block legitimate tool calls against the configured target or
+// its subdomains.
+func TestShouldBlockForOutOfScope_AllowsInScope(t *testing.T) {
+	a := &Agent{}
+	a.SetActivityPolicy("active", "active", []string{"https://pentest-ground.com"})
+
+	cases := []struct {
+		name string
+		tool string
+		args map[string]string
+	}{
+		{
+			name: "exact target",
+			tool: "terminal_execute",
+			args: map[string]string{"command": "nmap -sV pentest-ground.com"},
+		},
+		{
+			name: "subdomain",
+			tool: "terminal_execute",
+			args: map[string]string{"command": "curl https://api.pentest-ground.com/v1/users"},
+		},
+		{
+			name: "URL form with port",
+			tool: "browser_action",
+			args: map[string]string{"url": "https://app.pentest-ground.com:8443/admin"},
+		},
+		{
+			name: "report_vulnerability against subdomain",
+			tool: "report_vulnerability",
+			args: map[string]string{
+				"target":   "https://api.pentest-ground.com",
+				"endpoint": "https://api.pentest-ground.com/v1/users",
+				"title":    "IDOR",
+				"severity": "high",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if blocked, reason := a.shouldBlockForOutOfScope(tc.tool, tc.args); blocked {
+				t.Fatalf("expected %s with args %v to be allowed, got blocked: %s", tc.tool, tc.args, reason)
+			}
+		})
+	}
+}
+
+// TestShouldBlockForOutOfScope_AllowsHostlessCommands confirms tool
+// calls that don't name any host (local artifact analysis like grep,
+// awk, jq over recon output files) are allowed.
+func TestShouldBlockForOutOfScope_AllowsHostlessCommands(t *testing.T) {
+	a := &Agent{}
+	a.SetActivityPolicy("active", "active", []string{"https://pentest-ground.com"})
+
+	cases := []map[string]string{
+		{"command": "ls -la"},
+		{"command": "grep 'password' notes.json"},
+		{"command": "jq '.vulns[]' scan.json"},
+		{"command": "wc -l live_subdomains.txt"},
+	}
+	for _, args := range cases {
+		if blocked, reason := a.shouldBlockForOutOfScope("terminal_execute", args); blocked {
+			t.Fatalf("hostless command %v should be allowed, got blocked: %s", args, reason)
+		}
+	}
+}
+
+// TestShouldBlockForOutOfScope_DisabledWhenNoScope confirms the gate
+// is a no-op when no activity hosts are configured. A scope-less scan
+// (CLI mode without targets piped in) shouldn't fail every tool call.
+func TestShouldBlockForOutOfScope_DisabledWhenNoScope(t *testing.T) {
+	a := &Agent{}
+	// activityHosts left empty
+	if blocked, _ := a.shouldBlockForOutOfScope("terminal_execute",
+		map[string]string{"command": "curl http://anywhere.example"}); blocked {
+		t.Fatal("expected guard to be disabled when activityHosts is empty")
+	}
+}
+
+// TestExtractHostFromTokenForScope tests the host-extraction primitive
+// for the variety of token shapes the agent emits.
+func TestExtractHostFromTokenForScope(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"https://example.com/path", "example.com"},
+		{"http://example.com:8080/path", "example.com"},
+		{"example.com:8080", "example.com"},
+		{"example.com", "example.com"},
+		{"159.223.74.62", "159.223.74.62"},
+		{"159.223.74.62:9999", "159.223.74.62"},
+		{"[2001:db8::1]:443", "2001:db8::1"},
+		{"./script.sh", ""},
+		{"/tmp/foo.txt", ""},
+		{"../etc/passwd", ""},
+		{"v1.2.3", ""},
+		{"1.2.3", ""},
+		{"--rate-limit", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		got := extractHostFromTokenForScope(tc.in)
+		if got != tc.want {
+			t.Errorf("extractHostFromTokenForScope(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestHostInScope tests the scope membership primitive.
+func TestHostInScope(t *testing.T) {
+	hosts := []string{"pentest-ground.com", "another.example"}
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"pentest-ground.com", true},
+		{"api.pentest-ground.com", true},
+		{"deep.nested.api.pentest-ground.com", true},
+		{"another.example", true},
+		{"sub.another.example", true},
+		// Suffix attack: must not match.
+		{"evilpentest-ground.com", false},
+		{"pentest-ground.com.attacker.example", false},
+		// Unrelated.
+		{"159.223.74.62", false},
+		{"google.com", false},
+		// Empty host = always in-scope (caller's call).
+		{"", true},
+	}
+	for _, tc := range cases {
+		got := hostInScope(tc.in, hosts)
+		if got != tc.want {
+			t.Errorf("hostInScope(%q, %v) = %v, want %v", tc.in, hosts, got, tc.want)
+		}
+	}
+}
+
+// TestExtractHostsFromArgs verifies multi-token extraction.
+func TestExtractHostsFromArgs(t *testing.T) {
+	args := map[string]string{
+		"command": `curl -H "Host: api.example.com" https://example.com/foo && nmap evil.org`,
+	}
+	hosts := extractHostsFromArgs(args)
+	got := strings.Join(hosts, ",")
+	// Order is insertion-order; the actual hosts must include the three
+	// distinct ones from the command.
+	for _, want := range []string{"api.example.com", "example.com", "evil.org"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("extractHostsFromArgs(%v) = %v, missing %q", args, hosts, want)
+		}
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -3703,8 +3703,8 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 	// Filter out local/internal targets to prevent self-scanning
 	var safeTargets []string
 	for _, t := range cleanTargets {
-		if isBlockedTarget(t) {
-			log.Printf("[BLOCKLIST] Skipping blocked target: %s (local/internal IP)", t)
+		if s.isBlockedTarget(t) {
+			log.Printf("[BLOCKLIST] Skipping blocked target: %s (local/internal IP or self-listener)", t)
 		} else {
 			safeTargets = append(safeTargets, t)
 		}
@@ -7264,16 +7264,48 @@ func (s *Server) sendSimpleEmbed(color int, title, description string) {
 }
 
 // isBlockedTarget checks whether a target resolves to a local, loopback, or internal
-// IP address. This prevents the agent from inadvertently scanning the host machine.
-func isBlockedTarget(target string) bool {
+// IP address — OR matches the running Xalgorix instance's bind address + port.
+// This prevents the agent from inadvertently scanning the host machine OR the
+// dashboard's own listener (which is reachable on a public IP when
+// XALGORIX_BIND=0.0.0.0). Both forms are blocked.
+func (s *Server) isBlockedTarget(target string) bool {
 	// Strip scheme if present (http://127.0.0.1 → 127.0.0.1)
 	host := target
+	hostPort := ""
 	if u, err := url.Parse(target); err == nil && u.Host != "" {
 		host = u.Hostname()
+		hostPort = u.Port()
 	}
 	// Also handle host:port without scheme
-	if h, _, err := net.SplitHostPort(host); err == nil {
+	if h, p, err := net.SplitHostPort(host); err == nil {
 		host = h
+		if hostPort == "" {
+			hostPort = p
+		}
+	}
+
+	// Self-listener guard. Block if the target's port matches our own
+	// listening port AND the host either matches our bind address, is
+	// any local address, or resolves to one. This catches the case where
+	// XALGORIX_BIND=0.0.0.0 and the operator types the public IP back
+	// in — the previous loopback-only check missed it.
+	if s != nil && hostPort != "" {
+		if portNum, err := strconv.Atoi(hostPort); err == nil && portNum == s.port {
+			bind := strings.ToLower(strings.TrimSpace(s.cfg.BindAddr))
+			if bind == "" {
+				bind = "127.0.0.1"
+			}
+			lowerHost := strings.ToLower(strings.TrimSpace(host))
+			if lowerHost == bind || lowerHost == "0.0.0.0" || lowerHost == "::" {
+				return true
+			}
+			// Compare against every interface address — covers
+			// the case where bind=0.0.0.0 and the operator reaches
+			// the dashboard via a LAN IP (192.168.x.y) or public IP.
+			if hostMatchesLocalInterface(host) {
+				return true
+			}
+		}
 	}
 
 	// Explicit textual matches (fast path)
@@ -7318,6 +7350,59 @@ func isBlockedTarget(target string) bool {
 			continue
 		}
 		if subnet.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// hostMatchesLocalInterface returns true when the supplied host string
+// resolves (or directly equals) one of this machine's interface addresses.
+// Used by isBlockedTarget to catch the "bind=0.0.0.0, operator types
+// public IP" self-scan loophole.
+func hostMatchesLocalInterface(host string) bool {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return false
+	}
+	candidate := net.ParseIP(host)
+	if candidate == nil {
+		// Resolve hostname — best-effort. A DNS failure means we treat
+		// the host as not-local; the broader isBlockedTarget loopback
+		// check will still catch obvious cases.
+		addrs, err := net.LookupHost(host)
+		if err != nil {
+			return false
+		}
+		for _, a := range addrs {
+			if ip := net.ParseIP(a); ip != nil && ipMatchesLocalInterface(ip) {
+				return true
+			}
+		}
+		return false
+	}
+	return ipMatchesLocalInterface(candidate)
+}
+
+// ipMatchesLocalInterface walks every configured interface address and
+// returns true if any of them equals the supplied IP.
+func ipMatchesLocalInterface(ip net.IP) bool {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return false
+	}
+	for _, a := range addrs {
+		var aIP net.IP
+		switch v := a.(type) {
+		case *net.IPNet:
+			aIP = v.IP
+		case *net.IPAddr:
+			aIP = v.IP
+		}
+		if aIP == nil {
+			continue
+		}
+		if aIP.Equal(ip) {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary

Release **v4.4.18** fixes two scope-related agent bugs reported in the field.

## The bugs

### 1. Agent reported findings on a third-party host

The user was scanning `pentest-ground.com`. The dashboard surfaced a "Critical XSS" finding for `http://159.223.74.62:9999` (a public Grafana instance, completely unrelated to the configured target). The agent had:

- Discovered the Grafana via recon
- Fired XSS payloads at it
- Called `report_vulnerability` against it

Root cause: the existing `referencesActivityTarget` guard only ran in **passive** mode. In active mode, the agent was free to probe and report on any host it found, regardless of whether the operator authorized it.

### 2. Self-listener loophole

`isBlockedTarget` correctly blocked `127.0.0.1`, `localhost`, and RFC 1918 ranges at scan-creation. But:

- When `XALGORIX_BIND=0.0.0.0` and the operator typed the public IP back in as a target, it was accepted (the IP wasn't loopback).
- Even when the IP was a LAN address, the dashboard's own port could be probed because `isBlockedTarget` had no awareness of the running listener.

## Fix

### `internal/web/server.go` — self-listener guard

`isBlockedTarget` is now a method on `*Server`. New self-listener check rejects any target whose port matches `s.port` AND whose host is:

- `s.cfg.BindAddr` exactly
- An unspecified address (`0.0.0.0`, `::`)
- Any local interface address (matches via `net.InterfaceAddrs`)

This catches the `bind=0.0.0.0 + LAN/public IP` loophole without changing behavior for legitimate non-self targets.

### `internal/agent/agent.go` — unconditional in-scope guard

New `shouldBlockForOutOfScope` runs in front of every gated tool call, **active mode included**:

- Gated tools: `terminal_execute`, `python_action`, `browser_action`, `page_agent`, `pageagent`, `report_vulnerability`.
- Args are tokenized and each host-shaped token is checked against `activityHosts` (which already contains the configured targets + `www.` variants + registrable parents).
- Subdomain match is separator-aware, so `evilpentest-ground.com` is NOT in scope of `pentest-ground.com`.
- Hostless commands (e.g. `grep 'password' notes.json`) pass through because no host is named.
- The system prompt now opens with a `## TARGET SCOPE — HARD RULE` section so the LLM knows the runtime will reject out-of-scope probes.

`report_vulnerability` additionally validates its `target` and `endpoint` arguments explicitly, so even if the LLM tried to file a finding without running a probe, the report is rejected.

## Tests

`internal/agent/agent_scope_test.go` (new):

- `TestShouldBlockForOutOfScope_BlocksThirdPartyHost` — direct regression for the Grafana-on-`159.223.74.62` bug, four sub-cases.
- `TestShouldBlockForOutOfScope_AllowsInScope` — configured target + subdomains + URL-with-port pass through.
- `TestShouldBlockForOutOfScope_AllowsHostlessCommands` — `ls`, `grep`, `jq`, `wc` over recon files aren't blocked.
- `TestShouldBlockForOutOfScope_DisabledWhenNoScope` — gate is a no-op when `activityHosts` is empty (CLI mode without targets piped in).
- `TestExtractHostFromTokenForScope` — URL / `host:port` / IPv4 / IPv6 (`[2001:db8::1]:443`) / file path (`./script.sh`, `notes.json`) / version string (`1.2.3`, `v1.0.0`) discrimination.
- `TestHostInScope` — subdomain matching with separator-aware suffix comparison.
- `TestExtractHostsFromArgs` — multi-host extraction from a single shell command.

## Verification

- `go vet ./...` clean
- `go build ./...` clean
- `go test ./... -count=1` — all 26 packages pass
- `go test -race` on `agent/web` — no races

## Files changed

- `internal/web/server.go` — `isBlockedTarget` upgraded to method + self-listener check + interface-address helper
- `internal/agent/agent.go` — new `shouldBlockForOutOfScope` guard + system-prompt scope rule
- `internal/agent/agent_scope_test.go` — new (7 test groups, 17 cases)
