### PR TITLE
release: v4.4.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased] — Scope guard hardening v2
+
+### Fixed
+- **URL-in-query-param bypass closed.** `scopeHostTokenSplit` in `internal/agent/agent.go` now also breaks tokens on `=`, `?`, `#`, and `@`, and a new `extractEmbeddedURLs` sweep pulls every `http://` / `https://` substring out of an arg value before the separator pass. An OOS host smuggled inside a redirect query parameter (e.g. `https://in-scope.example/redirect?next=https://oos.example/path`), a userinfo form (`user@oos.example`, `https://user:pass@oos.example/`), or any of the new delimiters now surfaces as a standalone token and the gated tool call is rejected.
+- **Per-arg scan length capped at 8 KiB.** A new `argScanLimitBytes = 8192` constant plus `truncateForScopeScan` helper bound how much of any single Arg_Value the agent-side guard tokenizes. Values ≤ 8 KiB still walk the same path byte-for-byte; values larger than 8 KiB are silently truncated at the largest UTF-8 rune-boundary offset ≤ 8192. The cap never short-circuits to a reject — oversize args fall through to the existing allow path on length alone.
+- **Single DNS lookup per `isBlockedTarget` call.** `isBlockedTarget` in `internal/web/server.go` now parses the host as a `net.IP` literal first, otherwise issues exactly one `net.LookupHost` (via a package-level `lookupHost` shim for testability), and threads the resolved IP slice into both the self-listener check (new internal helper `ipsMatchLocalInterface`) and the private-range check. DNS failure preserves the prior `return false` (allow) verdict.
+- **OOS hostnames in `add_note` are redacted, not leaked.** A new `(*Agent).redactOutOfScopeHosts` method mirrors the gated tokenization path and substitutes the literal marker `[redacted: out-of-scope host]` for every OOS host span in the `key` and `value` arguments of `add_note`. The agent loop applies redaction in place immediately before `shouldBlockForOutOfScope`, so notes can no longer launder OOS hostnames through `read_notes` on the next iteration. Gated tools continue to reject rather than redact.
+
+### See also
+Spec: `.kiro/specs/scope-guard-hardening-v2/requirements.md`
+
 ## [Unreleased]
 
 ### Breaking changes

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.4.18
+VERSION=4.4.19
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.4.18" alt="Xalgorix" width="860" />
+<img src="assets/banner.png?v=4.4.19" alt="Xalgorix" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.4.18"
+var version = "4.4.19"
 
 const defaultWebPort = 9137
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 
 	"github.com/xalgord/xalgorix/v4/internal/config"
 	"github.com/xalgord/xalgorix/v4/internal/llm"
@@ -879,6 +880,15 @@ func extractHostsFromArgs(toolArgs map[string]string) []string {
 		if raw == "" {
 			continue
 		}
+		raw = truncateForScopeScan(raw)
+		for _, span := range extractEmbeddedURLs(raw) {
+			h := extractHostFromTokenForScope(span)
+			if h == "" || seen[h] {
+				continue
+			}
+			seen[h] = true
+			out = append(out, h)
+		}
 		for _, tok := range scopeHostTokenSplit(raw) {
 			h := extractHostFromTokenForScope(tok)
 			if h == "" || seen[h] {
@@ -894,18 +904,11 @@ func extractHostsFromArgs(toolArgs map[string]string) []string {
 // scopeHostTokenSplit splits a free-form string into tokens that are
 // candidates for host extraction. Splits on whitespace and common
 // shell metacharacters so URLs inside curl/python invocations are
-// still found.
+// still found. The separator set is owned by scopeTokenSeparator so
+// extractEmbeddedURLs and redactOutOfScopeHosts agree on token
+// edges.
 func scopeHostTokenSplit(s string) []string {
-	return strings.FieldsFunc(s, func(r rune) bool {
-		switch r {
-		case ' ', '\t', '\n', '\r',
-			'"', '\'', '`',
-			'(', ')', '{', '}', '[', ']',
-			',', ';', '|', '&', '<', '>':
-			return true
-		}
-		return false
-	})
+	return strings.FieldsFunc(s, scopeTokenSeparator)
 }
 
 // extractHostFromTokenForScope pulls a hostname out of a token, or
@@ -1025,6 +1028,209 @@ func hostInScope(host string, scopeHosts []string) bool {
 		}
 	}
 	return false
+}
+
+// argScanLimitBytes caps how many bytes of any single tool-argument
+// value the Agent_Scope_Guard will tokenize when extracting OOS host
+// references. Values larger than this cap are tokenized only over
+// their first argScanLimitBytes bytes; the cap silently bounds CPU
+// and never short-circuits to a reject.
+const argScanLimitBytes = 8192
+
+// truncateForScopeScan returns v truncated to at most
+// argScanLimitBytes bytes, trimmed back to the largest UTF-8 rune
+// boundary at or below the cap so downstream tokenizers never see a
+// partial rune. Values whose byte length is already at or below the
+// cap are returned unchanged.
+func truncateForScopeScan(v string) string {
+	if len(v) <= argScanLimitBytes {
+		return v
+	}
+	end := argScanLimitBytes
+	for end > 0 && !utf8.RuneStart(v[end]) {
+		end--
+	}
+	return v[:end]
+}
+
+// extractEmbeddedURLs scans s for case-insensitive "http://" and
+// "https://" substrings and returns each contiguous URL span. Each
+// span starts at a scheme-prefix occurrence and ends at the first
+// scopeHostTokenSplit separator rune or the end of s, whichever
+// comes first. The helper lets the host-extraction path see URLs
+// embedded inside query-parameter redirects, userinfo wrappers, and
+// other key=value forms before scopeHostTokenSplit's separator pass
+// runs over the same value. When a span cannot be parsed as a URL
+// later, extractHostFromTokenForScope drops it silently and the
+// separator pass still recovers any bare host.
+func extractEmbeddedURLs(s string) []string {
+	if s == "" {
+		return nil
+	}
+	var out []string
+	n := len(s)
+	for i := 0; i < n; {
+		prefixLen := 0
+		switch {
+		case i+7 <= n && strings.EqualFold(s[i:i+7], "http://"):
+			prefixLen = 7
+		case i+8 <= n && strings.EqualFold(s[i:i+8], "https://"):
+			prefixLen = 8
+		}
+		if prefixLen == 0 {
+			i++
+			continue
+		}
+		end := i + prefixLen
+	span:
+		for end < n {
+			r, size := utf8.DecodeRuneInString(s[end:])
+			if size == 0 {
+				size = 1
+			}
+			if scopeTokenSeparator(r) {
+				break span
+			}
+			end += size
+		}
+		out = append(out, s[i:end])
+		i = end
+	}
+	return out
+}
+
+// scopeTokenSeparator reports whether r is one of the runes
+// scopeHostTokenSplit treats as a token boundary. Kept in lockstep
+// with that function's switch so the URL sweep, the separator-pass
+// tokenizer, and the redaction tokenizer agree on token edges.
+func scopeTokenSeparator(r rune) bool {
+	switch r {
+	case ' ', '\t', '\n', '\r',
+		'"', '\'', '`',
+		'(', ')', '{', '}', '[', ']',
+		',', ';', '|', '&', '<', '>',
+		'=', '?', '#', '@':
+		return true
+	}
+	return false
+}
+
+// redactOutOfScopeHosts returns s rewritten with every out-of-scope
+// host span replaced by the literal marker
+// "[redacted: out-of-scope host]", along with the number of
+// substitutions performed. Tokenization mirrors extractHostsFromArgs:
+// the value is first capped at argScanLimitBytes via
+// truncateForScopeScan, embedded http(s):// spans are swept first,
+// and the remainder is split through the same separator set as
+// scopeHostTokenSplit. Each candidate span is classified through
+// extractHostFromTokenForScope and a.activityHosts via hostInScope;
+// only OOS spans are redacted. Bytes beyond the cap (the unredacted
+// tail) are appended to the result unchanged, per Requirement 4.7,
+// so the caller never silently loses data. When a.activityHosts is
+// empty or s is empty, s is returned unchanged with a zero count.
+func (a *Agent) redactOutOfScopeHosts(s string) (string, int) {
+	if s == "" || len(a.activityHosts) == 0 {
+		return s, 0
+	}
+	const marker = "[redacted: out-of-scope host]"
+
+	head := truncateForScopeScan(s)
+	tail := s[len(head):]
+	if head == "" {
+		return s, 0
+	}
+
+	// mask[i]=true marks byte i of head as part of an OOS span.
+	mask := make([]bool, len(head))
+	markIfOOS := func(start, end int) {
+		if start < 0 || end > len(head) || start >= end {
+			return
+		}
+		h := extractHostFromTokenForScope(head[start:end])
+		if h == "" {
+			return
+		}
+		if hostInScope(h, a.activityHosts) {
+			return
+		}
+		for i := start; i < end; i++ {
+			mask[i] = true
+		}
+	}
+
+	n := len(head)
+
+	// URL sweep: find every http(s):// span with positions, mirror
+	// of extractEmbeddedURLs.
+	for i := 0; i < n; {
+		prefixLen := 0
+		switch {
+		case i+7 <= n && strings.EqualFold(head[i:i+7], "http://"):
+			prefixLen = 7
+		case i+8 <= n && strings.EqualFold(head[i:i+8], "https://"):
+			prefixLen = 8
+		}
+		if prefixLen == 0 {
+			i++
+			continue
+		}
+		end := i + prefixLen
+		for end < n {
+			r, size := utf8.DecodeRuneInString(head[end:])
+			if size == 0 {
+				size = 1
+			}
+			if scopeTokenSeparator(r) {
+				break
+			}
+			end += size
+		}
+		markIfOOS(i, end)
+		i = end
+	}
+
+	// Separator-pass tokenizer: same boundary set as
+	// scopeHostTokenSplit, but tracked with positions so OOS tokens
+	// can be redacted in place.
+	start := -1
+	for i := 0; i < n; {
+		r, size := utf8.DecodeRuneInString(head[i:])
+		if size == 0 {
+			size = 1
+		}
+		if scopeTokenSeparator(r) {
+			if start >= 0 {
+				markIfOOS(start, i)
+				start = -1
+			}
+		} else if start < 0 {
+			start = i
+		}
+		i += size
+	}
+	if start >= 0 {
+		markIfOOS(start, n)
+	}
+
+	// Emit head with each contiguous masked region collapsed to a
+	// single marker, then append the unredacted tail unchanged.
+	var b strings.Builder
+	b.Grow(len(head) + len(tail))
+	count := 0
+	for i := 0; i < n; {
+		if mask[i] {
+			b.WriteString(marker)
+			count++
+			for i < n && mask[i] {
+				i++
+			}
+			continue
+		}
+		b.WriteByte(head[i])
+		i++
+	}
+	b.WriteString(tail)
+	return b.String(), count
 }
 
 func passivePolicyBlockReason(passiveScan bool) string {
@@ -1403,6 +1609,23 @@ func (a *Agent) Run(targets []string, instruction string) {
 				a.messages = append(a.messages, llm.Message{Role: "user", Content: blockMsg})
 				a.msgMu.Unlock()
 				continue
+			}
+
+			// ── add_note redaction (pre-gate) ──
+			// add_note is not a gated tool, but its arguments persist
+			// into read_notes on later iterations. Scrub OOS host
+			// references in place so an LLM cannot launder an OOS
+			// hostname through the notes store. Empty activityHosts
+			// short-circuits the path (matches shouldBlockForOutOfScope).
+			if tc.Name == "add_note" && len(a.activityHosts) > 0 {
+				for _, k := range []string{"key", "value"} {
+					if v, ok := tc.Args[k]; ok {
+						if r, n := a.redactOutOfScopeHosts(v); n > 0 {
+							tc.Args[k] = r
+							log.Printf("[scope] redacted %d out-of-scope host(s) from add_note", n)
+						}
+					}
+				}
 			}
 
 			// ── In-scope guard ──

--- a/internal/agent/agent_scope_test.go
+++ b/internal/agent/agent_scope_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 // TestShouldBlockForOutOfScope_BlocksThirdPartyHost is the regression
@@ -222,4 +223,754 @@ func TestExtractHostsFromArgs(t *testing.T) {
 			t.Errorf("extractHostsFromArgs(%v) = %v, missing %q", args, hosts, want)
 		}
 	}
+}
+
+// TestExtractHostsFromArgs_QueryParamRedirect locks in the URL-sweep
+// path. URLs nested inside query parameters, fragments, or bare
+// `key=value` forms must surface their embedded host alongside the
+// outer in-scope host so the gate sees the full set, and a gated
+// tool that names the wrapped OOS host must be rejected.
+//
+// Validates Requirements 1.2, 1.3, 1.5, 1.6.
+func TestExtractHostsFromArgs_QueryParamRedirect(t *testing.T) {
+	extractCases := []struct {
+		name     string
+		args     map[string]string
+		wantAll  []string
+		wantNone []string
+	}{
+		{
+			name:    "redirect param surfaces both hosts",
+			args:    map[string]string{"url": "https://in-scope.example/redirect?next=https://oos.example/path"},
+			wantAll: []string{"in-scope.example", "oos.example"},
+		},
+		{
+			name:    "fragment-embedded URL surfaces both hosts",
+			args:    map[string]string{"url": "https://in-scope.example/page#https://oos.example/p"},
+			wantAll: []string{"in-scope.example", "oos.example"},
+		},
+		{
+			name:    "bare key=value pair splits and extracts host",
+			args:    map[string]string{"url": "next=evil.example"},
+			wantAll: []string{"evil.example"},
+		},
+		{
+			// Req 1.5: in-scope host, OOS host, filename, and
+			// version-like token in one value — the host-classification
+			// rules must apply to each token independently.
+			name:     "mix of in-scope, OOS, filename, and version",
+			args:     map[string]string{"command": "scanner --version v1.2.3 --in pentest-ground.com --out notes.json target=evil.example"},
+			wantAll:  []string{"pentest-ground.com", "evil.example"},
+			wantNone: []string{"notes.json", "v1.2.3", "1.2.3"},
+		},
+		{
+			// Req 1.6: the URL-sweep helper hits "https://user:pass"
+			// (which url.Parse rejects with "invalid port"). The sweep
+			// must drop it silently and the separator pass must still
+			// recover the trailing bare host.
+			name:    "malformed URL then bare host",
+			args:    map[string]string{"url": "https://user:pass evil.example"},
+			wantAll: []string{"evil.example"},
+		},
+	}
+	for _, tc := range extractCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			hosts := extractHostsFromArgs(tc.args)
+			joined := "," + strings.Join(hosts, ",") + ","
+			for _, want := range tc.wantAll {
+				if !strings.Contains(joined, ","+want+",") {
+					t.Errorf("extractHostsFromArgs(%v) = %v, missing %q", tc.args, hosts, want)
+				}
+			}
+			for _, none := range tc.wantNone {
+				if strings.Contains(joined, ","+none+",") {
+					t.Errorf("extractHostsFromArgs(%v) = %v, %q must not appear", tc.args, hosts, none)
+				}
+			}
+		})
+	}
+
+	// Req 1.3: a redirect-style URL whose query parameter wraps an
+	// OOS host must cause a gated tool call to be rejected, with the
+	// rejection reason naming the OOS host.
+	t.Run("gated tool blocked on wrapped OOS host", func(t *testing.T) {
+		a := &Agent{}
+		a.SetActivityPolicy("active", "active", []string{"https://pentest-ground.com"})
+		args := map[string]string{
+			"url": "https://app.pentest-ground.com/redirect?next=https://oos.example/path",
+		}
+		blocked, reason := a.shouldBlockForOutOfScope("browser_action", args)
+		if !blocked {
+			t.Fatalf("expected redirect-style OOS URL to be blocked, got allow")
+		}
+		if !strings.Contains(reason, "oos.example") {
+			t.Errorf("rejection reason should name the OOS host, got %q", reason)
+		}
+	})
+}
+
+// TestExtractHostsFromArgs_UserinfoForm locks in the userinfo-aware
+// extraction path. Both the bare `user@host` shape (caught by the
+// new `@` separator in scopeHostTokenSplit) and the
+// `https://user:pass@host` shape (caught by url.Parse via the URL
+// sweep) must surface the host portion case-insensitively, and a
+// gated tool naming a userinfo-wrapped OOS host must be rejected.
+//
+// Validates Requirement 1.4.
+func TestExtractHostsFromArgs_UserinfoForm(t *testing.T) {
+	extractCases := []struct {
+		name string
+		args map[string]string
+		want string
+	}{
+		{
+			name: "bare user@host",
+			args: map[string]string{"target": "user@oos.example"},
+			want: "oos.example",
+		},
+		{
+			name: "case-insensitive bare user@host",
+			args: map[string]string{"target": "USER@OOS.EXAMPLE"},
+			want: "oos.example",
+		},
+		{
+			name: "userinfo URL",
+			args: map[string]string{"target": "https://user:pass@oos.example"},
+			want: "oos.example",
+		},
+		{
+			name: "case-insensitive userinfo URL",
+			args: map[string]string{"target": "https://USER:PASS@OOS.EXAMPLE"},
+			want: "oos.example",
+		},
+	}
+	for _, tc := range extractCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			hosts := extractHostsFromArgs(tc.args)
+			found := false
+			for _, h := range hosts {
+				if h == tc.want {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("extractHostsFromArgs(%v) = %v, missing %q", tc.args, hosts, tc.want)
+			}
+		})
+	}
+
+	// Gated-tool path: a userinfo-wrapped OOS host inside a
+	// terminal_execute command must be blocked, naming the OOS host.
+	t.Run("gated tool blocked on userinfo OOS host", func(t *testing.T) {
+		a := &Agent{}
+		a.SetActivityPolicy("active", "active", []string{"https://pentest-ground.com"})
+		for _, raw := range []string{
+			"user@oos.example",
+			"https://user:pass@oos.example",
+		} {
+			args := map[string]string{"command": "curl " + raw}
+			blocked, reason := a.shouldBlockForOutOfScope("terminal_execute", args)
+			if !blocked {
+				t.Errorf("expected userinfo OOS form %q to be blocked, got allow", raw)
+				continue
+			}
+			if !strings.Contains(reason, "oos.example") {
+				t.Errorf("rejection reason for %q should name oos.example, got %q", raw, reason)
+			}
+		}
+	})
+}
+
+// TestScopeHostTokenSplit_NewSeparators pins the separator switch to
+// the four runes added in Wave A — `=`, `?`, `#`, and `@` — without
+// regressing the pre-existing whitespace and shell metacharacter
+// boundaries.
+//
+// Validates Requirement 1.1.
+func TestScopeHostTokenSplit_NewSeparators(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{
+			name: "equals splits",
+			in:   "key=evil.example",
+			want: []string{"key", "evil.example"},
+		},
+		{
+			name: "question splits",
+			in:   "host.example?id=1",
+			want: []string{"host.example", "id", "1"},
+		},
+		{
+			name: "fragment splits",
+			in:   "host.example#anchor",
+			want: []string{"host.example", "anchor"},
+		},
+		{
+			name: "at splits",
+			in:   "user@oos.example",
+			want: []string{"user", "oos.example"},
+		},
+		{
+			name: "all four new separators together",
+			in:   "k=v?p#f@h",
+			want: []string{"k", "v", "p", "f", "h"},
+		},
+		{
+			name: "pre-existing separators still split",
+			in:   "a,b;c|d&e<f>g",
+			want: []string{"a", "b", "c", "d", "e", "f", "g"},
+		},
+		{
+			name: "whitespace, brackets, and quotes still split",
+			in:   "a\tb\nc \"d\" 'e' (f) [g] {h}",
+			want: []string{"a", "b", "c", "d", "e", "f", "g", "h"},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := scopeHostTokenSplit(tc.in)
+			if strings.Join(got, "|") != strings.Join(tc.want, "|") {
+				t.Errorf("scopeHostTokenSplit(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExtractHostsFromArgs_LongValueTruncated locks in the 8 KiB
+// per-value scan cap. Host-shaped tokens that sit past the
+// argScanLimitBytes boundary must be ignored, and the gate must not
+// block, deny, or fail a tool call solely because the argument is
+// long.
+//
+// Validates Requirements 2.1, 2.2.
+func TestExtractHostsFromArgs_LongValueTruncated(t *testing.T) {
+	const oosHost = "evil.example"
+	const inScopeHost = "in.example"
+
+	// Build a payload whose first argScanLimitBytes bytes contain an
+	// in-scope host and whose tail (past byte 8192) contains an OOS
+	// host. The OOS host must not surface from extractHostsFromArgs.
+	var b strings.Builder
+	b.WriteString(inScopeHost)
+	b.WriteByte(' ')
+	// Pad with whitespace-separated junk until we are well past the
+	// 8 KiB cap, then append the OOS host.
+	pad := strings.Repeat("x ", argScanLimitBytes)
+	b.WriteString(pad)
+	b.WriteString(oosHost)
+	long := b.String()
+	if len(long) <= argScanLimitBytes {
+		t.Fatalf("test setup: long value should exceed the cap, got %d bytes", len(long))
+	}
+
+	hosts := extractHostsFromArgs(map[string]string{"command": long})
+	joined := "," + strings.Join(hosts, ",") + ","
+	if !strings.Contains(joined, ","+inScopeHost+",") {
+		t.Errorf("in-scope host before cap missing: hosts=%v", hosts)
+	}
+	if strings.Contains(joined, ","+oosHost+",") {
+		t.Errorf("OOS host past the 8 KiB cap must be ignored, got hosts=%v", hosts)
+	}
+
+	// Req 2.2: a gated tool whose OOS reference sits entirely past
+	// the cap must not be blocked.
+	a := &Agent{}
+	a.SetActivityPolicy("active", "active", []string{"https://" + inScopeHost})
+	if blocked, reason := a.shouldBlockForOutOfScope("terminal_execute",
+		map[string]string{"command": long}); blocked {
+		t.Fatalf("OOS reference past the 8 KiB cap must not block, got blocked: %s", reason)
+	}
+
+	// And: a value that is simply long with no host-shaped tokens at
+	// all must produce no hosts and must not raise an error.
+	hostlessLong := strings.Repeat("x ", argScanLimitBytes*2)
+	if got := extractHostsFromArgs(map[string]string{"command": hostlessLong}); len(got) != 0 {
+		t.Errorf("hostless long value should produce no hosts, got %v", got)
+	}
+}
+
+// TestExtractHostsFromArgs_ShortValueUnaffected pins the
+// behavior-preservation guarantee for values whose byte length is
+// at or below the 8 KiB cap: tokenization must walk the entire
+// value and return the same host set the implementation produced
+// before the cap was introduced.
+//
+// Validates Requirement 2.3.
+func TestExtractHostsFromArgs_ShortValueUnaffected(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		want  []string
+	}{
+		{
+			name:  "short value, host at end",
+			value: "scan target evil.example",
+			want:  []string{"evil.example"},
+		},
+		{
+			name:  "two hosts in a short value",
+			value: "curl https://example.com/foo && nmap evil.org",
+			want:  []string{"example.com", "evil.org"},
+		},
+		{
+			name: "value of exactly argScanLimitBytes bytes with host at the end",
+			value: strings.Repeat("x ", (argScanLimitBytes-len("evil.example"))/2) +
+				"evil.example",
+			want: []string{"evil.example"},
+		},
+		{
+			name: "value of argScanLimitBytes-1 bytes with host at the end",
+			value: strings.Repeat("x ", (argScanLimitBytes-1-len("evil.example"))/2) +
+				" evil.example",
+			want: []string{"evil.example"},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if len(tc.value) > argScanLimitBytes {
+				t.Fatalf("test setup: value must be <= cap, got %d bytes", len(tc.value))
+			}
+			hosts := extractHostsFromArgs(map[string]string{"command": tc.value})
+			joined := "," + strings.Join(hosts, ",") + ","
+			for _, want := range tc.want {
+				if !strings.Contains(joined, ","+want+",") {
+					t.Errorf("extractHostsFromArgs(%q) = %v, missing %q", tc.value, hosts, want)
+				}
+			}
+		})
+	}
+}
+
+// TestTruncateForScopeScan_UTF8Boundary pins the rune-boundary trim
+// behavior of truncateForScopeScan. When the 8 KiB cap falls inside
+// a multi-byte UTF-8 sequence, the helper must walk back to the
+// largest byte offset <= argScanLimitBytes that lies on a rune
+// start, and the returned string must be valid UTF-8 so downstream
+// FieldsFunc never sees a partial rune.
+//
+// Validates Requirement 2.4.
+func TestTruncateForScopeScan_UTF8Boundary(t *testing.T) {
+	// "✓" is U+2713, encoded as 3 bytes (0xE2 0x9C 0x93).
+	const checkmark = "\u2713"
+	if utf8.RuneLen('\u2713') != 3 {
+		t.Fatalf("test setup: expected ✓ to be 3 bytes")
+	}
+
+	t.Run("value at or below cap returned unchanged", func(t *testing.T) {
+		short := "https://example.com/path"
+		if got := truncateForScopeScan(short); got != short {
+			t.Errorf("short value should be returned unchanged, got %q", got)
+		}
+		exact := strings.Repeat("a", argScanLimitBytes)
+		if got := truncateForScopeScan(exact); got != exact {
+			t.Errorf("value of exactly cap length should be returned unchanged (len=%d)", len(got))
+		}
+	})
+
+	t.Run("cap inside multi-byte rune walks back to rune start", func(t *testing.T) {
+		// Place an ASCII pad of (cap-2) bytes then a checkmark so the
+		// checkmark's bytes live at offsets cap-2, cap-1, cap. The
+		// cap index argScanLimitBytes itself sits on the trailing
+		// byte of the checkmark, which is a continuation byte.
+		pad := strings.Repeat("a", argScanLimitBytes-2)
+		v := pad + checkmark + checkmark
+		if len(v) <= argScanLimitBytes {
+			t.Fatalf("test setup: v must exceed cap, got %d bytes", len(v))
+		}
+		got := truncateForScopeScan(v)
+		if len(got) > argScanLimitBytes {
+			t.Errorf("truncated length %d exceeds cap %d", len(got), argScanLimitBytes)
+		}
+		if !utf8.ValidString(got) {
+			t.Errorf("truncated string must be valid UTF-8, got %q", got)
+		}
+		// The first checkmark spans bytes [cap-2, cap-1, cap]; since
+		// the cap byte is a continuation, the helper must walk back
+		// to argScanLimitBytes-2 (the rune start of the first
+		// checkmark).
+		if len(got) != argScanLimitBytes-2 {
+			t.Errorf("expected truncation back to cap-2 (%d), got %d", argScanLimitBytes-2, len(got))
+		}
+		if got != pad {
+			t.Errorf("truncated string should equal the ASCII pad, got %q", got)
+		}
+		// And: the truncated string must not panic when fed into the
+		// downstream FieldsFunc-based tokenizer.
+		_ = scopeHostTokenSplit(got)
+	})
+
+	t.Run("cap exactly on rune boundary keeps the prefix", func(t *testing.T) {
+		// Pad with cap bytes of ASCII, then append a checkmark. The
+		// cap index sits on the lead byte of the checkmark, which is
+		// itself a rune start, so the helper returns the prefix
+		// untouched at exactly cap bytes.
+		pad := strings.Repeat("a", argScanLimitBytes)
+		v := pad + checkmark
+		got := truncateForScopeScan(v)
+		if len(got) != argScanLimitBytes {
+			t.Errorf("expected truncation length cap (%d), got %d", argScanLimitBytes, len(got))
+		}
+		if got != pad {
+			t.Errorf("truncated string should equal the ASCII pad")
+		}
+		if !utf8.ValidString(got) {
+			t.Errorf("truncated string must be valid UTF-8")
+		}
+	})
+}
+
+// runAddNoteRedaction mirrors the pre-gate redaction step the agent
+// loop runs at internal/agent/agent.go (~line 1633) before
+// shouldBlockForOutOfScope. It walks `key` and `value` independently,
+// applies redactOutOfScopeHosts, and writes the rewritten string
+// back into args when the substitution count is non-zero. Returning
+// the total count lets the wiring tests assert end-to-end behaviour
+// without booting the full agent loop. Kept tiny on purpose so the
+// production wiring it stands in for stays the source of truth.
+func runAddNoteRedaction(a *Agent, args map[string]string) int {
+	if len(a.activityHosts) == 0 {
+		return 0
+	}
+	total := 0
+	for _, k := range []string{"key", "value"} {
+		if v, ok := args[k]; ok {
+			if r, n := a.redactOutOfScopeHosts(v); n > 0 {
+				args[k] = r
+				total += n
+			}
+		}
+	}
+	return total
+}
+
+// TestRedactOutOfScopeHosts_BasicReplace pins the core behaviour of
+// the redact helper: every OOS host span is replaced in place with
+// the literal marker `[redacted: out-of-scope host]`, the
+// substitution count matches the number of distinct OOS spans, and
+// the rewriter handles the three shapes the URL sweep and separator
+// pass surface (bare host, full URL, userinfo, query-style
+// `key=URL`). Tokenization mirrors extractHostsFromArgs.
+//
+// Validates Requirements 4.1, 4.2, 4.5.
+func TestRedactOutOfScopeHosts_BasicReplace(t *testing.T) {
+	a := &Agent{}
+	a.SetActivityPolicy("active", "active", []string{"https://pentest-ground.com"})
+
+	const marker = "[redacted: out-of-scope host]"
+
+	cases := []struct {
+		name      string
+		in        string
+		wantOut   string
+		wantCount int
+	}{
+		{
+			name:      "bare OOS host",
+			in:        "saw evil.example today",
+			wantOut:   "saw " + marker + " today",
+			wantCount: 1,
+		},
+		{
+			name:      "OOS URL with path",
+			in:        "visit https://oos.example/path now",
+			wantOut:   "visit " + marker + " now",
+			wantCount: 1,
+		},
+		{
+			name:      "userinfo bare form (split on @ separator)",
+			in:        "ssh user@oos.example",
+			wantOut:   "ssh user@" + marker,
+			wantCount: 1,
+		},
+		{
+			name:      "redirect query parameter",
+			in:        "go=https://oos.example/redirect",
+			wantOut:   "go=" + marker,
+			wantCount: 1,
+		},
+		{
+			name:      "two distinct OOS hosts in one value",
+			in:        "first evil.example then evil2.example",
+			wantOut:   "first " + marker + " then " + marker,
+			wantCount: 2,
+		},
+		{
+			name:      "OOS host inside redirect-style URL",
+			in:        "https://app.pentest-ground.com/redirect?next=https://oos.example/path",
+			wantOut:   "https://app.pentest-ground.com/redirect?next=" + marker,
+			wantCount: 1,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, count := a.redactOutOfScopeHosts(tc.in)
+			if got != tc.wantOut {
+				t.Errorf("redactOutOfScopeHosts(%q)\n got = %q\nwant = %q", tc.in, got, tc.wantOut)
+			}
+			if count != tc.wantCount {
+				t.Errorf("redactOutOfScopeHosts(%q) count = %d, want %d", tc.in, count, tc.wantCount)
+			}
+			if !strings.Contains(got, marker) {
+				t.Errorf("redaction marker missing from output %q", got)
+			}
+		})
+	}
+}
+
+// TestRedactOutOfScopeHosts_PreservesInScope locks in the
+// no-mutation guarantee for in-scope inputs: when every host in the
+// value is in-scope (or no host is named at all), the helper must
+// return the input string byte-identical and a zero substitution
+// count. This is the read_notes round-trip safety net — legitimate
+// notes referencing the configured target must not be mangled.
+//
+// Validates Requirements 4.3, 4.4, 4.5, 4.8.
+func TestRedactOutOfScopeHosts_PreservesInScope(t *testing.T) {
+	a := &Agent{}
+	a.SetActivityPolicy("active", "active", []string{"https://pentest-ground.com"})
+
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{
+			name: "configured host bare",
+			in:   "found CSRF token on pentest-ground.com",
+		},
+		{
+			name: "configured host as URL",
+			in:   "visit https://app.pentest-ground.com/login soon",
+		},
+		{
+			name: "subdomain URL with path and query",
+			in:   "GET https://api.pentest-ground.com/v1/users?id=1&role=admin",
+		},
+		{
+			name: "no host tokens at all",
+			in:   "scan completed, see notes.json for output",
+		},
+		{
+			name: "configured host plus filename and version token",
+			in:   "wrote https://pentest-ground.com to scan.txt v1.2.3",
+		},
+		{
+			name: "empty string",
+			in:   "",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, count := a.redactOutOfScopeHosts(tc.in)
+			if got != tc.in {
+				t.Errorf("redactOutOfScopeHosts(%q) mutated string to %q, expected byte-identical passthrough", tc.in, got)
+			}
+			if count != 0 {
+				t.Errorf("redactOutOfScopeHosts(%q) count = %d, want 0", tc.in, count)
+			}
+			if strings.Contains(got, "[redacted: out-of-scope host]") {
+				t.Errorf("in-scope value should not contain the redaction marker, got %q", got)
+			}
+		})
+	}
+
+	// Empty activityHosts → redact path is a no-op even for
+	// host-shaped inputs. Matches the shouldBlockForOutOfScope
+	// short-circuit and keeps scope-less CLI runs from corrupting
+	// notes.
+	t.Run("empty activityHosts is no-op", func(t *testing.T) {
+		bare := &Agent{}
+		got, count := bare.redactOutOfScopeHosts("saw evil.example today")
+		if got != "saw evil.example today" {
+			t.Errorf("no-scope agent should not redact, got %q", got)
+		}
+		if count != 0 {
+			t.Errorf("no-scope agent should report zero redactions, got %d", count)
+		}
+	})
+}
+
+// TestAddNote_RedactsOOSInKeyAndValue exercises the agent loop's
+// add_note pre-gate wiring (internal/agent/agent.go ~line 1633). A
+// ToolCall named `add_note` whose `key` and `value` arguments each
+// reference an OOS host must have both arguments rewritten in place
+// with the redaction marker substituted, the call must be allowed
+// to proceed (shouldBlockForOutOfScope returns allow on the rewritten
+// args because the OOS tokens are gone), and the gated-tool list
+// must remain unchanged.
+//
+// Validates Requirements 4.1, 4.2, 4.3, 4.6, 4.7.
+func TestAddNote_RedactsOOSInKeyAndValue(t *testing.T) {
+	a := &Agent{}
+	a.SetActivityPolicy("active", "active", []string{"https://pentest-ground.com"})
+
+	const marker = "[redacted: out-of-scope host]"
+
+	args := map[string]string{
+		"key":   "leak_from_oos.example",
+		"value": "found at https://evil.example/dump and also tracker.example",
+	}
+
+	total := runAddNoteRedaction(a, args)
+	if total < 2 {
+		t.Errorf("expected at least 2 total redactions across key+value, got %d", total)
+	}
+
+	if !strings.Contains(args["key"], marker) {
+		t.Errorf("key should contain redaction marker, got %q", args["key"])
+	}
+	if strings.Contains(args["key"], "oos.example") {
+		t.Errorf("key still contains OOS host: %q", args["key"])
+	}
+
+	if !strings.Contains(args["value"], marker) {
+		t.Errorf("value should contain redaction marker, got %q", args["value"])
+	}
+	if strings.Contains(args["value"], "evil.example") {
+		t.Errorf("value still contains OOS host evil.example: %q", args["value"])
+	}
+	if strings.Contains(args["value"], "tracker.example") {
+		t.Errorf("value still contains OOS host tracker.example: %q", args["value"])
+	}
+
+	// Req 4.3: post-redaction the gate must allow add_note. (add_note
+	// is not in the gated tool list, so this is a belt-and-braces
+	// check that the OOS-clean rewritten args don't surface any host
+	// that would trip a hypothetical future gate addition.)
+	if blocked, reason := a.shouldBlockForOutOfScope("add_note", args); blocked {
+		t.Errorf("add_note must be allowed after redaction, got blocked: %s", reason)
+	}
+
+	// Req 4.6: the gated reject path must NOT invoke the redactor.
+	// Re-run a Gated_Tool with the same OOS shape and confirm the
+	// args are still byte-identical to the inputs (i.e. the gated
+	// rejection path leaves them alone — only the redact wiring
+	// mutates).
+	gatedArgs := map[string]string{"command": "curl https://evil.example/dump"}
+	want := gatedArgs["command"]
+	blocked, reason := a.shouldBlockForOutOfScope("terminal_execute", gatedArgs)
+	if !blocked {
+		t.Fatalf("gated tool with OOS host should be rejected, got allow")
+	}
+	if !strings.Contains(reason, "evil.example") {
+		t.Errorf("gated rejection reason should name evil.example, got %q", reason)
+	}
+	if gatedArgs["command"] != want {
+		t.Errorf("gated path mutated args (redactor leaked into reject path): %q", gatedArgs["command"])
+	}
+}
+
+// TestAddNote_NoOpWhenAllInScope locks in the byte-identical
+// passthrough guarantee from Requirement 4.4: when neither argument
+// of an add_note call references any OOS host, both arguments must
+// reach the tool handler exactly as the LLM emitted them, and the
+// redaction wiring must not raise an error or mutate the args even
+// when one of the documented arguments is missing or non-host (Req
+// 4.8). Also exercises the empty-activityHosts short-circuit.
+//
+// Validates Requirements 4.4, 4.6, 4.8.
+func TestAddNote_NoOpWhenAllInScope(t *testing.T) {
+	a := &Agent{}
+	a.SetActivityPolicy("active", "active", []string{"https://pentest-ground.com"})
+
+	cases := []struct {
+		name string
+		args map[string]string
+	}{
+		{
+			name: "both args reference in-scope host",
+			args: map[string]string{
+				"key":   "csrf_token_app",
+				"value": "found at https://app.pentest-ground.com/login",
+			},
+		},
+		{
+			name: "neither arg names a host",
+			args: map[string]string{
+				"key":   "phase_done",
+				"value": "recon complete, see notes.json",
+			},
+		},
+		{
+			name: "value reference subdomain via URL with path+query",
+			args: map[string]string{
+				"key":   "user_endpoint",
+				"value": "GET https://api.pentest-ground.com/v1/users?id=1",
+			},
+		},
+		{
+			name: "missing key argument (Req 4.8 passthrough)",
+			args: map[string]string{
+				"value": "ok",
+			},
+		},
+		{
+			name: "missing value argument (Req 4.8 passthrough)",
+			args: map[string]string{
+				"key": "phase_done",
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// Snapshot the original args so the comparison is
+			// byte-identical even if the wiring mutates the map.
+			before := make(map[string]string, len(tc.args))
+			for k, v := range tc.args {
+				before[k] = v
+			}
+
+			total := runAddNoteRedaction(a, tc.args)
+			if total != 0 {
+				t.Errorf("expected zero redactions for in-scope/missing-arg input, got %d", total)
+			}
+			for k, want := range before {
+				if got := tc.args[k]; got != want {
+					t.Errorf("arg %q mutated: got %q, want %q", k, got, want)
+				}
+			}
+			if len(tc.args) != len(before) {
+				t.Errorf("args map size changed: got %d entries, want %d", len(tc.args), len(before))
+			}
+			for _, v := range tc.args {
+				if strings.Contains(v, "[redacted: out-of-scope host]") {
+					t.Errorf("in-scope arg gained a redaction marker: %q", v)
+				}
+			}
+		})
+	}
+
+	// Empty activityHosts: the wiring's `len(a.activityHosts) > 0`
+	// guard short-circuits the path entirely, so even an OOS-rich
+	// arg set passes through untouched.
+	t.Run("empty activityHosts short-circuits the wiring", func(t *testing.T) {
+		bare := &Agent{}
+		args := map[string]string{
+			"key":   "leak_from_oos.example",
+			"value": "saw https://evil.example/dump",
+		}
+		want := map[string]string{
+			"key":   "leak_from_oos.example",
+			"value": "saw https://evil.example/dump",
+		}
+		total := runAddNoteRedaction(bare, args)
+		if total != 0 {
+			t.Errorf("scope-less agent should not redact, got %d", total)
+		}
+		for k, v := range want {
+			if args[k] != v {
+				t.Errorf("scope-less wiring mutated %q: got %q, want %q", k, args[k], v)
+			}
+		}
+	})
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -7263,6 +7263,12 @@ func (s *Server) sendSimpleEmbed(color int, title, description string) {
 	}()
 }
 
+// lookupHost is a package-level indirection over net.LookupHost so tests can
+// swap the resolver out and assert the per-call lookup count. The single call
+// site lives inside isBlockedTarget below; nothing else in this package
+// resolves DNS for self-listener / private-range checks.
+var lookupHost = net.LookupHost
+
 // isBlockedTarget checks whether a target resolves to a local, loopback, or internal
 // IP address — OR matches the running Xalgorix instance's bind address + port.
 // This prevents the agent from inadvertently scanning the host machine OR the
@@ -7289,20 +7295,20 @@ func (s *Server) isBlockedTarget(target string) bool {
 	// any local address, or resolves to one. This catches the case where
 	// XALGORIX_BIND=0.0.0.0 and the operator types the public IP back
 	// in — the previous loopback-only check missed it.
+	//
+	// We capture portMatch here but defer the interface-address comparison
+	// until after the single DNS resolution below, so the same resolved IP
+	// set feeds both the self-listener check and the private-range check.
+	portMatch := false
 	if s != nil && hostPort != "" {
 		if portNum, err := strconv.Atoi(hostPort); err == nil && portNum == s.port {
+			portMatch = true
 			bind := strings.ToLower(strings.TrimSpace(s.cfg.BindAddr))
 			if bind == "" {
 				bind = "127.0.0.1"
 			}
 			lowerHost := strings.ToLower(strings.TrimSpace(host))
 			if lowerHost == bind || lowerHost == "0.0.0.0" || lowerHost == "::" {
-				return true
-			}
-			// Compare against every interface address — covers
-			// the case where bind=0.0.0.0 and the operator reaches
-			// the dashboard via a LAN IP (192.168.x.y) or public IP.
-			if hostMatchesLocalInterface(host) {
 				return true
 			}
 		}
@@ -7314,23 +7320,43 @@ func (s *Server) isBlockedTarget(target string) bool {
 		return true
 	}
 
-	// Parse as IP
-	ip := net.ParseIP(host)
-	if ip == nil {
-		// Try DNS resolution for hostnames that might resolve to local IPs
-		addrs, err := net.LookupHost(host)
+	// Resolve the target host to one or more IPs exactly once for the
+	// remainder of this call. IP literals skip DNS entirely; otherwise a
+	// single net.LookupHost feeds every downstream check. An empty or
+	// failing resolution falls back to "allow" (matching prior behavior)
+	// so that unreachable hostnames are not blocked solely on lookup
+	// failure — the request will fail naturally further down the stack.
+	var resolvedIPs []net.IP
+	if ip := net.ParseIP(host); ip != nil {
+		resolvedIPs = []net.IP{ip}
+	} else {
+		addrs, err := lookupHost(host)
 		if err != nil || len(addrs) == 0 {
 			return false // can't resolve — let it through, will fail naturally
 		}
-		ip = net.ParseIP(addrs[0])
-		if ip == nil {
+		for _, a := range addrs {
+			if parsed := net.ParseIP(a); parsed != nil {
+				resolvedIPs = append(resolvedIPs, parsed)
+			}
+		}
+		if len(resolvedIPs) == 0 {
 			return false
 		}
 	}
 
-	// Check blocked ranges
-	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() {
+	// Self-listener interface check, gated by the port-match flag captured
+	// above. Uses the already-resolved IP set so we never issue a second
+	// DNS lookup. Covers the bind=0.0.0.0 + operator-types-public-IP loophole.
+	if portMatch && ipsMatchLocalInterface(resolvedIPs) {
 		return true
+	}
+
+	// Check blocked ranges across the entire resolved set: a single
+	// loopback/link-local/unspecified hit is enough to block.
+	for _, ip := range resolvedIPs {
+		if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() {
+			return true
+		}
 	}
 
 	// RFC 1918 private ranges: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
@@ -7344,44 +7370,57 @@ func (s *Server) isBlockedTarget(target string) bool {
 		"fc00::/7",  // IPv6 unique local
 		"fe80::/10", // IPv6 link-local
 	}
+	parsedSubnets := make([]*net.IPNet, 0, len(privateCIDRs))
 	for _, cidr := range privateCIDRs {
 		_, subnet, err := net.ParseCIDR(cidr)
 		if err != nil {
 			continue
 		}
-		if subnet.Contains(ip) {
-			return true
+		parsedSubnets = append(parsedSubnets, subnet)
+	}
+	for _, ip := range resolvedIPs {
+		for _, subnet := range parsedSubnets {
+			if subnet.Contains(ip) {
+				return true
+			}
 		}
 	}
 	return false
 }
 
-// hostMatchesLocalInterface returns true when the supplied host string
-// resolves (or directly equals) one of this machine's interface addresses.
-// Used by isBlockedTarget to catch the "bind=0.0.0.0, operator types
-// public IP" self-scan loophole.
-func hostMatchesLocalInterface(host string) bool {
-	host = strings.TrimSpace(host)
-	if host == "" {
+// ipsMatchLocalInterface returns true if any IP in the supplied slice
+// matches one of this machine's interface addresses. Issues a single
+// net.InterfaceAddrs call and walks ips × addrs so callers can resolve
+// a hostname once and reuse the result for every downstream check.
+func ipsMatchLocalInterface(ips []net.IP) bool {
+	if len(ips) == 0 {
 		return false
 	}
-	candidate := net.ParseIP(host)
-	if candidate == nil {
-		// Resolve hostname — best-effort. A DNS failure means we treat
-		// the host as not-local; the broader isBlockedTarget loopback
-		// check will still catch obvious cases.
-		addrs, err := net.LookupHost(host)
-		if err != nil {
-			return false
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return false
+	}
+	for _, ip := range ips {
+		if ip == nil {
+			continue
 		}
 		for _, a := range addrs {
-			if ip := net.ParseIP(a); ip != nil && ipMatchesLocalInterface(ip) {
+			var aIP net.IP
+			switch v := a.(type) {
+			case *net.IPNet:
+				aIP = v.IP
+			case *net.IPAddr:
+				aIP = v.IP
+			}
+			if aIP == nil {
+				continue
+			}
+			if aIP.Equal(ip) {
 				return true
 			}
 		}
-		return false
 	}
-	return ipMatchesLocalInterface(candidate)
+	return false
 }
 
 // ipMatchesLocalInterface walks every configured interface address and

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"image"
 	"image/color"
 	"image/png"
@@ -1971,4 +1972,119 @@ func TestInstanceAction_GetAndStopSpecificInstance(t *testing.T) {
 	if got := s.instances["inst-1"].Status; got != "stopped" {
 		t.Fatalf("instance status = %q, want stopped", got)
 	}
+}
+
+
+// withStubLookupHost swaps the package-level lookupHost shim for the
+// duration of a single test. Restoration runs via t.Cleanup so every
+// test exits with the original net.LookupHost binding in place,
+// regardless of failure or skip. The test functions below MUST NOT call
+// t.Parallel() because lookupHost is package-level state.
+func withStubLookupHost(t *testing.T, stub func(string) ([]string, error)) {
+	t.Helper()
+	prev := lookupHost
+	lookupHost = stub
+	t.Cleanup(func() { lookupHost = prev })
+}
+
+// TestIsBlockedTarget_SingleLookup asserts that isBlockedTarget invokes
+// the test-shimmed lookupHost exactly once per call when the target is a
+// hostname that requires DNS resolution, and that two back-to-back calls
+// each perform one lookup (no caching across calls). Covers Req 3.1 and
+// 3.6.
+func TestIsBlockedTarget_SingleLookup(t *testing.T) {
+	s := newTestServer(t, nil)
+
+	var calls int
+	withStubLookupHost(t, func(host string) ([]string, error) {
+		calls++
+		// Return a public IP so the target threads through every
+		// downstream check (port match, self-iface match, private
+		// CIDR scan) without short-circuiting before the lookup
+		// counter is observed.
+		return []string{"203.0.113.10"}, nil
+	})
+
+	if blocked := s.isBlockedTarget("https://oos.example/"); blocked {
+		t.Fatalf("public-IP-resolving target reported blocked = true")
+	}
+	if calls != 1 {
+		t.Fatalf("lookupHost call count after first call = %d, want 1", calls)
+	}
+
+	// Second call: lookups are not cached across invocations, so the
+	// counter MUST advance by exactly one.
+	if blocked := s.isBlockedTarget("https://oos.example/"); blocked {
+		t.Fatalf("second call to public-IP-resolving target reported blocked = true")
+	}
+	if calls != 2 {
+		t.Fatalf("lookupHost call count after second call = %d, want 2", calls)
+	}
+}
+
+// TestIsBlockedTarget_IPLiteralSkipsLookup asserts that when the target
+// host is already an IP literal, isBlockedTarget never invokes the
+// resolver shim. Covers Req 3.3.
+func TestIsBlockedTarget_IPLiteralSkipsLookup(t *testing.T) {
+	s := newTestServer(t, nil)
+
+	var calls int
+	withStubLookupHost(t, func(host string) ([]string, error) {
+		calls++
+		return nil, errors.New("lookupHost should not be invoked for IP literals")
+	})
+
+	// Public IP literal — should pass through without a lookup and
+	// without being blocked.
+	if blocked := s.isBlockedTarget("https://203.0.113.10/"); blocked {
+		t.Fatalf("public IP literal reported blocked = true")
+	}
+	if calls != 0 {
+		t.Fatalf("lookupHost calls for public IP literal = %d, want 0", calls)
+	}
+
+	// Private RFC1918 IP literal — must be blocked AND must not
+	// resolve. Confirms the private-range check runs against the
+	// parsed IP without re-routing through DNS.
+	if blocked := s.isBlockedTarget("http://10.0.0.5/"); !blocked {
+		t.Fatalf("private IP literal 10.0.0.5 reported blocked = false")
+	}
+	if calls != 0 {
+		t.Fatalf("lookupHost calls for private IP literal = %d, want 0", calls)
+	}
+}
+
+// TestIsBlockedTarget_DNSFailureAllows asserts that lookup failures and
+// empty resolutions result in an allow (return false), without any
+// further blocking signals being applied. Covers Req 3.4.
+func TestIsBlockedTarget_DNSFailureAllows(t *testing.T) {
+	s := newTestServer(t, nil)
+
+	t.Run("lookup error", func(t *testing.T) {
+		var calls int
+		withStubLookupHost(t, func(host string) ([]string, error) {
+			calls++
+			return nil, errors.New("simulated NXDOMAIN")
+		})
+		if blocked := s.isBlockedTarget("https://nope.example/"); blocked {
+			t.Fatalf("DNS-error target reported blocked = true; want false (allow)")
+		}
+		if calls != 1 {
+			t.Fatalf("lookupHost calls = %d, want 1", calls)
+		}
+	})
+
+	t.Run("empty result", func(t *testing.T) {
+		var calls int
+		withStubLookupHost(t, func(host string) ([]string, error) {
+			calls++
+			return []string{}, nil
+		})
+		if blocked := s.isBlockedTarget("https://void.example/"); blocked {
+			t.Fatalf("empty-result target reported blocked = true; want false (allow)")
+		}
+		if calls != 1 {
+			t.Fatalf("lookupHost calls = %d, want 1", calls)
+		}
+	})
 }


### PR DESCRIPTION
Scope guard hardening v2 — four targeted fixes against OOS-host bypass and reliability bugs.

## Summary

- **agent**: `scopeHostTokenSplit` now also splits on `=`, `?`, `#`, `@`; new `extractEmbeddedURLs` sweep pulls every `http(s)://` substring out of arg values before the separator pass. URLs hidden in query params, fragments, or userinfo (`https://in-scope/redirect?next=https://oos.example/...`) now surface as standalone tokens.
- **agent**: `extractHostsFromArgs` caps tokenization at 8 KiB per arg via `truncateForScopeScan` (UTF-8 rune-boundary safe). Oversize args fall through to allow, never reject.
- **agent**: new `(*Agent).redactOutOfScopeHosts` replaces every OOS host span in `add_note` key/value with `[redacted: out-of-scope host]` before the gate runs, so notes can no longer launder OOS hostnames into `read_notes`.
- **web**: `isBlockedTarget` resolves DNS exactly once per call (via package-level `lookupHost` shim) and threads the resolved IP set into both the self-listener check (new `ipsMatchLocalInterface`) and the private-range check. Deleted the dead `hostMatchesLocalInterface` helper.

## Verification

- `go vet ./...` clean
- `go build ./...` clean
- `go test ./internal/agent/... ./internal/web/... -count=1` ok
- `go test -race ./internal/agent/... ./internal/web/...` ok

## Spec

`.kiro/specs/scope-guard-hardening-v2/`