### PR TITLE
release: v4.4.23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.4.22
+VERSION=4.4.23
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.4.22" alt="Xalgorix" width="860" />
+<img src="assets/banner.png?v=4.4.23" alt="Xalgorix" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.4.22"
+var version = "4.4.23"
 
 const defaultWebPort = 9137
 

--- a/internal/tools/terminal/rewrite_repro_test.go
+++ b/internal/tools/terminal/rewrite_repro_test.go
@@ -1,0 +1,77 @@
+package terminal
+
+import (
+	"testing"
+)
+
+// TestRewriteShellSegments_MultiBytePanic reproduces the panic:
+//   runtime error: slice bounds out of range [414:413]
+// when a command contains multi-byte UTF-8 characters (e.g. em-dash,
+// curly quotes, non-ASCII domain characters) before a shell delimiter.
+//
+// In `range command`, `i` is the byte offset of each rune. For multi-byte
+// runes, the byte offset can jump by 2-4 bytes. But the code uses
+// `command[i+1]` (a byte-level peek-ahead of exactly 1) and
+// `command[i : i+delimiterLen]` — these assume every rune occupies
+// exactly 1 byte. After a multi-byte rune, `i` can overshoot the
+// actual byte position, making `i+delimiterLen` exceed `i` by a
+// wrong amount, or producing inverted slice bounds.
+func TestRewriteShellSegments_MultiBytePanic(t *testing.T) {
+	// Simulates the crash scenario: a command with multi-byte characters
+	// followed by a pipe or &&.
+	cases := []struct {
+		name string
+		cmd  string
+	}{
+		{
+			name: "em-dash before pipe",
+			cmd:  "echo 'testing — value' | grep foo",
+		},
+		{
+			name: "curly quotes before semicolon",
+			cmd:  "echo 'it\u2019s a test'; echo done",
+		},
+		{
+			name: "unicode domain before &&",
+			cmd:  "curl https://例え.jp/path && echo done",
+		},
+		{
+			name: "mixed multi-byte with double pipe",
+			cmd:  "echo 'naïve café résumé' || echo fallback",
+		},
+		{
+			name: "emoji in command before ampersand",
+			cmd:  "echo '🔍 scanning' && nuclei -u https://example.test",
+		},
+		{
+			name: "long multi-byte prefix to trigger offset mismatch",
+			// Build a string with enough multi-byte chars that i (byte offset)
+			// significantly exceeds the character count, reproducing [414:413].
+			cmd: buildLongMultiByteCommand(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Should not panic
+			result := rewriteShellSegments(tc.cmd, func(s string) string { return s })
+			if result != tc.cmd {
+				t.Fatalf("identity rewrite changed command:\n  got:  %q\n  want: %q", result, tc.cmd)
+			}
+		})
+	}
+}
+
+func buildLongMultiByteCommand() string {
+	// Each '—' is 3 bytes (U+2014). 140 of them = 420 bytes but only 140 runes.
+	// After all of them, place a pipe. The rune index `i` at the pipe will be
+	// 420 (byte offset), but the previous rune ended at byte 419, so
+	// command[start:i] with start=0 works, but the delimiter peek
+	// command[i+1] can access byte 421 while len might be 422... the real
+	// problem is when the byte offset math for delimiterLen goes wrong.
+	s := ""
+	for j := 0; j < 140; j++ {
+		s += "—"
+	}
+	return s + " | grep test"
+}

--- a/internal/tools/terminal/terminal.go
+++ b/internal/tools/terminal/terminal.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"syscall"
 	"time"
+	"unicode/utf8"
 	"unsafe"
 
 	"github.com/xalgord/xalgorix/v4/internal/config"
@@ -151,23 +152,29 @@ func rewriteShellSegments(command string, rewrite func(string) string) string {
 	start := 0
 	var quote rune
 	escaped := false
-	for i, r := range command {
+	i := 0
+	for i < len(command) {
+		r, size := utf8.DecodeRuneInString(command[i:])
 		if escaped {
 			escaped = false
+			i += size
 			continue
 		}
 		if r == '\\' && quote != '\'' {
 			escaped = true
+			i += size
 			continue
 		}
 		if quote != 0 {
 			if r == quote {
 				quote = 0
 			}
+			i += size
 			continue
 		}
 		if r == '\'' || r == '"' {
 			quote = r
+			i += size
 			continue
 		}
 		delimiterLen := 0
@@ -180,11 +187,13 @@ func rewriteShellSegments(command string, rewrite func(string) string) string {
 			delimiterLen = 2
 		}
 		if delimiterLen == 0 {
+			i += size
 			continue
 		}
 		b.WriteString(rewrite(command[start:i]))
 		b.WriteString(command[i : i+delimiterLen])
 		start = i + delimiterLen
+		i = start
 	}
 	b.WriteString(rewrite(command[start:]))
 	return b.String()


### PR DESCRIPTION
### Changes

- fix: slice bounds panic in rewriteShellSegments with multi-byte UTF-8 commands

### Root Cause
`rewriteShellSegments` used `for i, r := range command` which yields byte offsets, but peek-ahead operations (`command[i+1]`) assumed 1-byte runes. Multi-byte UTF-8 characters (em-dashes, accented chars, emoji, IDN domains) before shell delimiters (`|`, `||`, `&&`, `;`) caused inverted slice bounds → panic.

### Fix
Replaced `range` iteration with explicit byte-index stepping via `utf8.DecodeRuneInString`, ensuring all peek-ahead and slicing use consistent byte offsets.

### Tests
Added 6 regression tests covering em-dashes, curly quotes, IDN domains, accented characters, emoji, and long multi-byte strings.