### PR TITLE
release: v4.4.24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.4.23
+VERSION=4.4.24
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.4.23" alt="Xalgorix" width="860" />
+<img src="assets/banner.png?v=4.4.24" alt="Xalgorix" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.4.23"
+var version = "4.4.24"
 
 const defaultWebPort = 9137
 

--- a/internal/scopeguard/scopeguard.go
+++ b/internal/scopeguard/scopeguard.go
@@ -103,20 +103,12 @@ func IsLocalOrListener(cfg Config, target string) bool {
 		}
 	}
 
-	// Self-listener guard. Block if the target's port matches our own
-	// listening port AND the host either matches our bind address, is
-	// any local address, or resolves to one. This catches the case
-	// where XALGORIX_BIND=0.0.0.0 and the operator types the public IP
-	// back in — the previous loopback-only check missed it.
-	//
-	// We capture portMatch here but defer the interface-address
-	// comparison until after the single DNS resolution below, so the
-	// same resolved IP set feeds both the self-listener check and the
-	// private-range check.
-	portMatch := false
+	// Self-listener textual fast-path. Block if the target's port
+	// matches our own listening port AND the host textually matches
+	// our bind address (or 0.0.0.0 / ::). This fires before DNS
+	// resolution and catches the most common self-probe patterns.
 	if hostPort != "" {
 		if portNum, err := strconv.Atoi(hostPort); err == nil && portNum == cfg.Port {
-			portMatch = true
 			bind := strings.ToLower(strings.TrimSpace(cfg.BindAddr))
 			if bind == "" {
 				bind = "127.0.0.1"
@@ -158,11 +150,15 @@ func IsLocalOrListener(cfg Config, target string) bool {
 		}
 	}
 
-	// Self-listener interface check, gated by the port-match flag
-	// captured above. Uses the already-resolved IP set so we never
-	// issue a second DNS lookup. Covers the bind=0.0.0.0 +
-	// operator-types-public-IP loophole.
-	if portMatch && ipsMatchLocalInterface(resolvedIPs) {
+	// Self-host interface check. Block ANY target whose resolved IP
+	// matches one of this machine's network interface addresses —
+	// regardless of port. This prevents the agent from probing the
+	// operator's own public-facing services (SSH, Grafana, CUPS, etc.)
+	// even when the probed port differs from the dashboard listener.
+	// Without this unconditional check, the agent can self-scan its
+	// host on non-dashboard ports (e.g. :22, :9999) because the
+	// public IP is neither private nor loopback.
+	if ipsMatchLocalInterface(resolvedIPs) {
 		return true
 	}
 

--- a/internal/scopeguard/scopeguard_test.go
+++ b/internal/scopeguard/scopeguard_test.go
@@ -67,7 +67,7 @@ func isLocalOrListenerRows() []isLocalOrListenerRow {
 
 	cfg := Config{BindAddr: "127.0.0.1", Port: listenerPort}
 
-	return []isLocalOrListenerRow{
+	rows := []isLocalOrListenerRow{
 		// ── Local_Or_Listener_Host literals ─────────────────────────
 		{cell: "local-literal", name: "loopback ipv4", cfg: cfg, target: "http://127.0.0.1/admin", wantBlocked: true, wantDNSCheckOn: true, wantDNSCalls: 0},
 		{cell: "local-literal", name: "loopback ipv4 with port", cfg: cfg, target: "http://127.0.0.1:9000/x", wantBlocked: true, wantDNSCheckOn: true, wantDNSCalls: 0},
@@ -209,6 +209,67 @@ func isLocalOrListenerRows() []isLocalOrListenerRow {
 			wantDNSCalls:   1,
 		},
 	}
+
+	// ── Self-host public IP regression (any port) ────────────────
+	// Dynamically discover a non-loopback interface IP so the test
+	// works on any machine. When the resolved IP matches one of the
+	// machine's interfaces, IsLocalOrListener must block regardless
+	// of port — this is the fix for the self-scanning bug where the
+	// agent probed its own SSH/Grafana/CUPS services.
+	if selfIP := firstNonLoopbackInterfaceIP(); selfIP != "" {
+		rows = append(rows,
+			isLocalOrListenerRow{
+				cell:   "self-host-public",
+				name:   "own public IP on SSH port 22 (no port match)",
+				cfg:    cfg,
+				target: "http://" + selfIP + ":22/",
+				stubLookup: func(host string) ([]string, error) {
+					return []string{selfIP}, nil
+				},
+				wantBlocked:    true,
+				wantDNSCheckOn: true,
+				wantDNSCalls:   0, // IP literal → no DNS
+			},
+			isLocalOrListenerRow{
+				cell:   "self-host-public",
+				name:   "own public IP on Grafana port 9999 (no port match)",
+				cfg:    cfg,
+				target: "http://" + selfIP + ":9999/api/users",
+				stubLookup: func(host string) ([]string, error) {
+					return []string{selfIP}, nil
+				},
+				wantBlocked:    true,
+				wantDNSCheckOn: true,
+				wantDNSCalls:   0,
+			},
+			isLocalOrListenerRow{
+				cell:   "self-host-public",
+				name:   "own public IP bare (no port)",
+				cfg:    cfg,
+				target: "http://" + selfIP + "/",
+				stubLookup: func(host string) ([]string, error) {
+					return []string{selfIP}, nil
+				},
+				wantBlocked:    true,
+				wantDNSCheckOn: true,
+				wantDNSCalls:   0,
+			},
+			isLocalOrListenerRow{
+				cell:   "self-host-public",
+				name:   "hostname resolving to own public IP blocks",
+				cfg:    cfg,
+				target: "https://my-server.example.com/",
+				stubLookup: func(host string) ([]string, error) {
+					return []string{selfIP}, nil
+				},
+				wantBlocked:    true,
+				wantDNSCheckOn: true,
+				wantDNSCalls:   1,
+			},
+		)
+	}
+
+	return rows
 }
 
 // TestIsLocalOrListener_Table is the unit test surface for
@@ -282,4 +343,30 @@ func TestIsLocalOrListener_SingleLookupAcrossTwoCalls(t *testing.T) {
 	if calls != 2 {
 		t.Fatalf("LookupHost call count after second call = %d, want 2", calls)
 	}
+}
+
+// firstNonLoopbackInterfaceIP returns the first non-loopback IPv4
+// address found among the machine's network interfaces, or "" if
+// none is available. Used by the self-host-public regression tests
+// so they dynamically adapt to whatever machine runs them.
+func firstNonLoopbackInterfaceIP() string {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return ""
+	}
+	for _, a := range addrs {
+		ipNet, ok := a.(*net.IPNet)
+		if !ok {
+			continue
+		}
+		ip := ipNet.IP
+		if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() {
+			continue
+		}
+		// Prefer IPv4 for simpler test URLs
+		if ip4 := ip.To4(); ip4 != nil {
+			return ip4.String()
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
### Changes

- fix: block agent from self-scanning its own server public IP on any port

### Root Cause
The scope guard (`IsLocalOrListener` in `scopeguard.go`) only checked `ipsMatchLocalInterface` when `portMatch` was true — meaning the probed port had to match the dashboard listener port. When the agent discovered its host's public IP (e.g. `159.223.74.62`) during target enumeration and probed SSH (:22), Grafana (:9999), or CUPS (:631), the guard let the probes through because:

1. The public IP is not private/loopback/link-local (CIDR check passes)
2. The probed port doesn't match the dashboard port (`portMatch = false`)
3. So `ipsMatchLocalInterface` was never called

### Fix
Removed the `portMatch &&` gate from the `ipsMatchLocalInterface` call so it runs unconditionally on every resolved IP. Any IP that matches one of the machine's own network interfaces is now blocked regardless of port.

### Tests
- 4 new regression tests: own public IP on SSH:22, Grafana:9999, bare IP, hostname resolving to own interface IP
- All 26 scopeguard tests pass
- All agent scope tests pass