### PR TITLE
release: v4.4.25

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.4.24
+VERSION=4.4.25
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.4.24" alt="Xalgorix" width="860" />
+<img src="assets/banner.png?v=4.4.25" alt="Xalgorix" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.4.24"
+var version = "4.4.25"
 
 const defaultWebPort = 9137
 

--- a/internal/web/settings_env.go
+++ b/internal/web/settings_env.go
@@ -330,14 +330,29 @@ func (s *Server) applyCatalogLLMSettings(ctx context.Context, req llmSettingsReq
 	}
 
 	// Legacy env-var sync. Always written when the operator
-	// supplied a model so a fresh-out-of-the-tab "openai/gpt-5"
-	// keeps the legacy path runnable even before the catalog
-	// branch picks up.
+	// supplied a model so the legacy path stays runnable.
 	if model := strings.TrimSpace(req.Model); model != "" {
 		updates["XALGORIX_LLM"] = model
 	}
-	if base := strings.TrimSpace(req.APIBase); base != "" {
-		updates["XALGORIX_API_BASE"] = base
+
+	// Legacy env-var sync: XALGORIX_API_BASE.
+	// The WebUI sends apiBase only for the "custom" provider; for
+	// catalog providers it sends apiBaseOverride instead. Fall
+	// through: req.APIBase → req.APIBaseOverride → catalog entry
+	// BaseURL, so switching provider always updates the env file.
+	{
+		base := strings.TrimSpace(req.APIBase)
+		if base == "" {
+			base = strings.TrimSpace(req.APIBaseOverride)
+		}
+		if base == "" && provider != "" && s.catalog != nil {
+			if entry, ok, err := s.catalog.Get(ctx, provider); err == nil && ok {
+				base = strings.TrimSpace(entry.BaseURL)
+			}
+		}
+		if base != "" {
+			updates["XALGORIX_API_BASE"] = base
+		}
 	}
 	if !isMaskedSettingValue(req.APIKey) && strings.TrimSpace(req.APIKey) != "" {
 		updates["XALGORIX_API_KEY"] = strings.TrimSpace(req.APIKey)


### PR DESCRIPTION
### Fix

- **fix: sync XALGORIX_API_BASE from apiBaseOverride when switching providers**

### Root Cause
The legacy env-var sync in `applyCatalogLLMSettings` only wrote `XALGORIX_API_BASE` from `req.APIBase`, but the WebUI only sends `apiBase` for the "custom" provider. For catalog providers (NVIDIA, OpenAI, etc.) it sends `apiBaseOverride` instead — which was saved to the profile correctly but never synced to the `.xalgorix.env` file.

### Fix
Fall through: `req.APIBase` → `req.APIBaseOverride` → catalog entry BaseURL, so switching providers always updates the env file.