### PR TITLE
release: v4.4.26

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.4.25
+VERSION=4.4.26
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.4.25" alt="Xalgorix" width="860" />
+<img src="assets/banner.png?v=4.4.26" alt="Xalgorix" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.4.25"
+var version = "4.4.26"
 
 const defaultWebPort = 9137
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -6135,9 +6135,16 @@ func isChildOfScan(parent, child *ScanRecord) bool {
 	if parent == nil || child == nil || child.ParentTarget == "" {
 		return false
 	}
-	if parent.InstanceID != "" && child.InstanceID == parent.InstanceID {
-		return true
+	// Instance-aware matching: when the parent has an InstanceID (all
+	// multi-instance scans do), the child must belong to the same
+	// instance. Without this gate a new yahoo.com scan would absorb
+	// every subdomain record from *previous* yahoo.com scans on disk,
+	// instantly showing stale vulns and inflated subdomain counts.
+	if parent.InstanceID != "" {
+		return child.InstanceID == parent.InstanceID
 	}
+	// Legacy fallback for scans created before multi-instance mode:
+	// match by target name only.
 	return normalizeScanTarget(child.ParentTarget) == normalizeScanTarget(parent.Target)
 }
 


### PR DESCRIPTION
### Critical Fix

- **fix: prevent cross-scan data leakage in wildcard subdomain matching**

### Bug
Starting a new wildcard scan for a domain that was previously scanned (e.g. yahoo.com) would instantly show all subdomains and findings from **previous** scans. A 1-minute-old yahoo.com scan showed 424 completed subdomains and 16 findings that were actually from old scans.

### Root Cause
`isChildOfScan()` matched children by target name alone (`child.ParentTarget == parent.Target`). When `attachWildcardSubScans()` walked all scan records on disk, any child with `ParentTarget: "yahoo.com"` would be absorbed into the new scan — regardless of which instance it belonged to.

### Fix
When the parent scan has an InstanceID (all multi-instance scans do), require the child's InstanceID to match exactly. The legacy target-name fallback only applies to pre-multi-instance scans.