### PR TITLE
release: v4.4.27

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.4.26
+VERSION=4.4.27
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.4.26" alt="Xalgorix" width="860" />
+<img src="assets/banner.png?v=4.4.27" alt="Xalgorix" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.4.26"
+var version = "4.4.27"
 
 const defaultWebPort = 9137
 

--- a/internal/scopeguard/scopeguard.go
+++ b/internal/scopeguard/scopeguard.go
@@ -8,13 +8,29 @@
 // pulling in the web package. Its single semantic entry point is
 // IsLocalOrListener, which classifies a target string (bare host,
 // host:port, scheme://host[:port][/path], or [ipv6][:port]) against
-// the operator's listener identity (Config) and a fixed table of
-// private/loopback/link-local/ULA CIDRs.
+// the operator's listener identity (Config) and the machine's actual
+// network interfaces.
 //
-// Centralising the classifier here makes Requirement 3.8 of the
-// scope-guard-local-only bugfix structurally true: the web guard and
-// the agent guard literally call the same function, so the verdict
-// for any input is identical by construction.
+// DESIGN PRINCIPLE: only block IPs that provably belong to the
+// operator's own machine. Do NOT blanket-block entire private ranges
+// (RFC1918, link-local) — the agent is a security scanner that needs
+// to test SSRF payloads like 169.254.169.254 (cloud metadata) and
+// internal IPs that belong to the TARGET, not the operator.
+//
+// What we block:
+//   - Loopback addresses (127.0.0.0/8, ::1) — always self
+//   - Unspecified addresses (0.0.0.0, ::) — always self
+//   - "localhost" hostname — always self
+//   - IPs matching any local network interface — the operator's machine
+//   - Self-listener textual match (bind addr + port)
+//
+// What we ALLOW (that the old code incorrectly blocked):
+//   - RFC1918 (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) — unless
+//     they match a local interface
+//   - Link-local (169.254.0.0/16) including 169.254.169.254 cloud
+//     metadata — unless they match a local interface
+//   - IPv6 ULA (fc00::/7) and link-local (fe80::/10) — unless they
+//     match a local interface
 package scopeguard
 
 import (
@@ -41,52 +57,15 @@ type Config struct {
 // indirection that previously lived in internal/web/server.go.
 var LookupHost = net.LookupHost
 
-// privateCIDRListLiterals is the source-of-truth list of CIDR
-// strings the package classifies as Local_Or_Listener_Host. It is
-// kept as a string slice both for documentation and so the unit
-// test in scopeguard_test.go can assert that every parsed entry in
-// privateCIDRs round-trips back to one of these literals.
-var privateCIDRListLiterals = []string{
-	"10.0.0.0/8",
-	"172.16.0.0/12",
-	"192.168.0.0/16",
-	"127.0.0.0/8",
-	"169.254.0.0/16", // link-local
-	"::1/128",
-	"fc00::/7",  // IPv6 unique local
-	"fe80::/10", // IPv6 link-local
-}
-
-// privateCIDRs is the parsed form of privateCIDRListLiterals,
-// initialised once in init() so the per-call body of
-// IsLocalOrListener doesn't re-parse the same eight strings on
-// every invocation. Structural cleanup over the previous
-// per-call parse — verdict on every input is identical.
-var privateCIDRs []*net.IPNet
-
-func init() {
-	privateCIDRs = make([]*net.IPNet, 0, len(privateCIDRListLiterals))
-	for _, cidr := range privateCIDRListLiterals {
-		_, subnet, err := net.ParseCIDR(cidr)
-		if err != nil {
-			continue
-		}
-		privateCIDRs = append(privateCIDRs, subnet)
-	}
-}
-
 // IsLocalOrListener returns true when target — a bare host,
 // host:port, scheme://host[:port][/path], or [ipv6][:port] —
-// classifies as a Local_Or_Listener_Host: literal loopback /
-// link-local / unspecified / RFC1918 IPv4 or IPv6, hostname that
-// resolves to a local-interface address or to a private CIDR, or a
-// host string equal (case-insensitive) to cfg.BindAddr (default
-// "127.0.0.1") or to "0.0.0.0" / "::" when paired with cfg.Port.
+// classifies as pointing at the operator's own machine.
 //
-// Body is the byte-for-byte port of (*Server).isBlockedTarget from
-// internal/web/server.go with s.cfg.BindAddr / s.port replaced by
-// cfg.BindAddr / cfg.Port and the package-local lookupHost
-// indirection replaced by LookupHost.
+// The check is smart: it only blocks loopback, unspecified, and IPs
+// that match one of this machine's network interfaces. It does NOT
+// blanket-block RFC1918 or link-local ranges — those are legitimate
+// SSRF targets (e.g. 169.254.169.254 cloud metadata, internal IPs
+// on the target's network).
 func IsLocalOrListener(cfg Config, target string) bool {
 	// Strip scheme if present (http://127.0.0.1 → 127.0.0.1)
 	host := target
@@ -120,7 +99,7 @@ func IsLocalOrListener(cfg Config, target string) bool {
 		}
 	}
 
-	// Explicit textual matches (fast path)
+	// Explicit textual matches (fast path) — these always mean "self"
 	lower := strings.ToLower(host)
 	if lower == "localhost" || lower == "0.0.0.0" || lower == "[::1]" || lower == "::1" {
 		return true
@@ -150,34 +129,30 @@ func IsLocalOrListener(cfg Config, target string) bool {
 		}
 	}
 
+	// Check each resolved IP against the operator's own machine.
+	// We block ONLY:
+	//   1. Loopback (127.x.x.x, ::1) — always the local machine
+	//   2. Unspecified (0.0.0.0, ::) — binds to all local interfaces
+	//   3. IPs matching a local network interface — the operator's machine
+	//
+	// Everything else is allowed, including RFC1918, link-local,
+	// cloud metadata (169.254.169.254), IPv6 ULA, etc. — these may
+	// be legitimate targets on the scanned host's network.
+	for _, ip := range resolvedIPs {
+		if ip.IsLoopback() || ip.IsUnspecified() {
+			return true
+		}
+	}
+
 	// Self-host interface check. Block ANY target whose resolved IP
 	// matches one of this machine's network interface addresses —
 	// regardless of port. This prevents the agent from probing the
 	// operator's own public-facing services (SSH, Grafana, CUPS, etc.)
 	// even when the probed port differs from the dashboard listener.
-	// Without this unconditional check, the agent can self-scan its
-	// host on non-dashboard ports (e.g. :22, :9999) because the
-	// public IP is neither private nor loopback.
 	if ipsMatchLocalInterface(resolvedIPs) {
 		return true
 	}
 
-	// Check blocked ranges across the entire resolved set: a single
-	// loopback/link-local/unspecified hit is enough to block.
-	for _, ip := range resolvedIPs {
-		if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() {
-			return true
-		}
-	}
-
-	// RFC 1918 private ranges and friends — pre-parsed at init().
-	for _, ip := range resolvedIPs {
-		for _, subnet := range privateCIDRs {
-			if subnet.Contains(ip) {
-				return true
-			}
-		}
-	}
 	return false
 }
 
@@ -186,11 +161,6 @@ func IsLocalOrListener(cfg Config, target string) bool {
 // single net.InterfaceAddrs call and walks ips × addrs so callers
 // can resolve a hostname once and reuse the result for every
 // downstream check.
-//
-// Relocated verbatim from internal/web/server.go as part of the
-// scope-guard-local-only spec (task 3.1). The unused
-// ipMatchesLocalInterface (no callers in the current tree) is NOT
-// relocated — it gets cleaned up incidentally by task 3.2.
 func ipsMatchLocalInterface(ips []net.IP) bool {
 	if len(ips) == 0 {
 		return false

--- a/internal/scopeguard/scopeguard_test.go
+++ b/internal/scopeguard/scopeguard_test.go
@@ -19,47 +19,16 @@ func withStubLookupHost(t *testing.T, stub func(string) ([]string, error)) {
 	t.Cleanup(func() { LookupHost = prev })
 }
 
-// TestPrivateCIDRs_MatchesLiterals asserts that the parsed
-// privateCIDRs slice round-trips back to the literal source-of-truth
-// strings in privateCIDRListLiterals. Pins the structural cleanup
-// (move + memoise) — the parsed CIDR set MUST be identical to the
-// per-call slice the unfixed isBlockedTarget body parsed.
-//
-// Validates: Requirement 3.8 (verdict preservation across the
-// per-call → init() refactor).
-func TestPrivateCIDRs_MatchesLiterals(t *testing.T) {
-	if got, want := len(privateCIDRs), len(privateCIDRListLiterals); got != want {
-		t.Fatalf("privateCIDRs length = %d, want %d", got, want)
-	}
-	for i, lit := range privateCIDRListLiterals {
-		_, want, err := net.ParseCIDR(lit)
-		if err != nil {
-			t.Fatalf("source-of-truth literal %q failed to parse: %v", lit, err)
-		}
-		got := privateCIDRs[i]
-		if got.String() != want.String() {
-			t.Errorf("privateCIDRs[%d] = %q, want %q (from literal %q)",
-				i, got.String(), want.String(), lit)
-		}
-	}
-}
-
-// isLocalOrListenerRow is one row in the table-driven test surface
-// for IsLocalOrListener. The rows mirror every cell the web-side
-// preservation property (internal/web/server_test.go →
-// webPreservationRows) exercises, plus dedicated coverage for the
-// self-listener leg, the localhost / [::1] fast-path, the public
-// hostname allow, the IP-literal-skips-DNS contract, and the
-// DNS-failure-allows fallback.
+// isLocalOrListenerRow is one row in the table-driven test surface.
 type isLocalOrListenerRow struct {
 	cell           string
 	name           string
 	cfg            Config
 	target         string
-	stubLookup     func(string) ([]string, error) // nil = no resolver swap
+	stubLookup     func(string) ([]string, error)
 	wantBlocked    bool
-	wantDNSCalls   int  // expected number of LookupHost invocations
-	wantDNSCheckOn bool // assert wantDNSCalls when true
+	wantDNSCalls   int
+	wantDNSCheckOn bool
 }
 
 func isLocalOrListenerRows() []isLocalOrListenerRow {
@@ -68,145 +37,118 @@ func isLocalOrListenerRows() []isLocalOrListenerRow {
 	cfg := Config{BindAddr: "127.0.0.1", Port: listenerPort}
 
 	rows := []isLocalOrListenerRow{
-		// ── Local_Or_Listener_Host literals ─────────────────────────
-		{cell: "local-literal", name: "loopback ipv4", cfg: cfg, target: "http://127.0.0.1/admin", wantBlocked: true, wantDNSCheckOn: true, wantDNSCalls: 0},
-		{cell: "local-literal", name: "loopback ipv4 with port", cfg: cfg, target: "http://127.0.0.1:9000/x", wantBlocked: true, wantDNSCheckOn: true, wantDNSCalls: 0},
-		{cell: "local-literal", name: "localhost name", cfg: cfg, target: "http://localhost/x", wantBlocked: true, wantDNSCheckOn: true, wantDNSCalls: 0},
-		{cell: "local-literal", name: "ipv6 loopback bracket", cfg: cfg, target: "http://[::1]:8080/", wantBlocked: true, wantDNSCheckOn: true, wantDNSCalls: 0},
-		{cell: "local-literal", name: "rfc1918 10/8", cfg: cfg, target: "http://10.0.0.1/", wantBlocked: true, wantDNSCheckOn: true, wantDNSCalls: 0},
-		{cell: "local-literal", name: "rfc1918 172.16/12", cfg: cfg, target: "http://172.16.5.5/", wantBlocked: true, wantDNSCheckOn: true, wantDNSCalls: 0},
-		{cell: "local-literal", name: "rfc1918 192.168/16", cfg: cfg, target: "http://192.168.1.1/", wantBlocked: true, wantDNSCheckOn: true, wantDNSCalls: 0},
-		{cell: "local-literal", name: "link-local ipv4 169.254", cfg: cfg, target: "http://169.254.169.254/latest/meta-data/", wantBlocked: true, wantDNSCheckOn: true, wantDNSCalls: 0},
-		{cell: "local-literal", name: "ipv6 link-local fe80", cfg: cfg, target: "http://[fe80::1]/", wantBlocked: true, wantDNSCheckOn: true, wantDNSCalls: 0},
-		{cell: "local-literal", name: "ipv6 unique-local fc00", cfg: cfg, target: "http://[fc00::1]/", wantBlocked: true, wantDNSCheckOn: true, wantDNSCalls: 0},
-		{cell: "local-literal", name: "unspecified 0.0.0.0", cfg: cfg, target: "http://0.0.0.0/", wantBlocked: true, wantDNSCheckOn: true, wantDNSCalls: 0},
+		// ── Always-self literals ──────────────────────────────────
+		{cell: "always-self", name: "loopback ipv4", cfg: cfg, target: "http://127.0.0.1/admin", wantBlocked: true, wantDNSCheckOn: true, wantDNSCalls: 0},
+		{cell: "always-self", name: "loopback ipv4 with port", cfg: cfg, target: "http://127.0.0.1:9000/x", wantBlocked: true, wantDNSCheckOn: true, wantDNSCalls: 0},
+		{cell: "always-self", name: "localhost name", cfg: cfg, target: "http://localhost/x", wantBlocked: true, wantDNSCheckOn: true, wantDNSCalls: 0},
+		{cell: "always-self", name: "ipv6 loopback bracket", cfg: cfg, target: "http://[::1]:8080/", wantBlocked: true, wantDNSCheckOn: true, wantDNSCalls: 0},
+		{cell: "always-self", name: "unspecified 0.0.0.0", cfg: cfg, target: "http://0.0.0.0/", wantBlocked: true, wantDNSCheckOn: true, wantDNSCalls: 0},
 
 		// ── Self-listener leg ───────────────────────────────────────
 		{
-			cell:           "self-listener",
-			name:           "0.0.0.0:<listener-port>",
-			cfg:            cfg,
-			target:         "http://0.0.0.0:9000/",
-			wantBlocked:    true,
-			wantDNSCheckOn: true,
-			wantDNSCalls:   0,
+			cell: "self-listener", name: "0.0.0.0:<listener-port>",
+			cfg: cfg, target: "http://0.0.0.0:9000/",
+			wantBlocked: true, wantDNSCheckOn: true, wantDNSCalls: 0,
 		},
 		{
-			cell:           "self-listener",
-			name:           "::: paired with listener port",
-			cfg:            cfg,
-			target:         "http://[::]:9000/",
-			wantBlocked:    true,
-			wantDNSCheckOn: true,
-			wantDNSCalls:   0,
+			cell: "self-listener", name: "::: paired with listener port",
+			cfg: cfg, target: "http://[::]:9000/",
+			wantBlocked: true, wantDNSCheckOn: true, wantDNSCalls: 0,
 		},
 		{
-			cell:           "self-listener",
-			name:           "configured bind addr with listener port",
-			cfg:            cfg,
-			target:         "http://127.0.0.1:9000/",
-			wantBlocked:    true,
-			wantDNSCheckOn: true,
-			wantDNSCalls:   0,
+			cell: "self-listener", name: "configured bind addr with listener port",
+			cfg: cfg, target: "http://127.0.0.1:9000/",
+			wantBlocked: true, wantDNSCheckOn: true, wantDNSCalls: 0,
 		},
 		{
-			// Empty BindAddr → defaults to "127.0.0.1". Asserts the
-			// default-listener branch fires when the operator hasn't
-			// configured an explicit bind address.
-			cell:           "self-listener",
-			name:           "empty BindAddr defaults to 127.0.0.1",
-			cfg:            Config{BindAddr: "", Port: listenerPort},
-			target:         "http://127.0.0.1:9000/",
-			wantBlocked:    true,
-			wantDNSCheckOn: true,
-			wantDNSCalls:   0,
+			cell: "self-listener", name: "empty BindAddr defaults to 127.0.0.1",
+			cfg: Config{BindAddr: "", Port: listenerPort}, target: "http://127.0.0.1:9000/",
+			wantBlocked: true, wantDNSCheckOn: true, wantDNSCalls: 0,
 		},
 
-		// ── Hostname → private IP via LookupHost swap ───────────────
+		// ── RFC1918 / link-local: NOT blocked (smart scope guard) ──
+		// These are legitimate SSRF targets on the scanned host's
+		// network. Only block if they match a local interface.
 		{
-			cell:   "hostname-resolves-private",
-			name:   "hostname resolves to 10.0.0.5",
-			cfg:    cfg,
-			target: "https://internal.example/",
-			stubLookup: func(host string) ([]string, error) {
-				return []string{"10.0.0.5"}, nil
-			},
-			wantBlocked:    true,
-			wantDNSCheckOn: true,
-			wantDNSCalls:   1,
+			cell: "private-allowed", name: "RFC1918 10.0.0.1 allowed (not our interface)",
+			cfg: cfg, target: "http://10.0.0.1/",
+			// Stub: 10.0.0.1 is NOT one of our interfaces
+			stubLookup:     func(string) ([]string, error) { return []string{"10.0.0.1"}, nil },
+			wantBlocked:    false,
+			wantDNSCheckOn: true, wantDNSCalls: 0, // IP literal, no DNS
 		},
 		{
-			cell:   "hostname-resolves-private",
-			name:   "hostname resolves to 169.254.169.254",
-			cfg:    cfg,
-			target: "https://metadata.example/",
-			stubLookup: func(host string) ([]string, error) {
-				return []string{"169.254.169.254"}, nil
-			},
-			wantBlocked:    true,
-			wantDNSCheckOn: true,
-			wantDNSCalls:   1,
+			cell: "private-allowed", name: "RFC1918 192.168.1.1 allowed (not our interface)",
+			cfg: cfg, target: "http://192.168.1.1/",
+			wantBlocked:    false,
+			wantDNSCheckOn: true, wantDNSCalls: 0,
 		},
 		{
-			cell:   "hostname-resolves-private",
-			name:   "hostname resolves to ::1",
-			cfg:    cfg,
-			target: "https://lb6.example/",
-			stubLookup: func(host string) ([]string, error) {
-				return []string{"::1"}, nil
-			},
+			cell: "private-allowed", name: "cloud metadata 169.254.169.254 allowed",
+			cfg: cfg, target: "http://169.254.169.254/latest/meta-data/",
+			wantBlocked:    false,
+			wantDNSCheckOn: true, wantDNSCalls: 0,
+		},
+		{
+			cell: "private-allowed", name: "hostname resolving to 169.254.169.254 allowed",
+			cfg: cfg, target: "https://metadata.example/",
+			stubLookup:     func(string) ([]string, error) { return []string{"169.254.169.254"}, nil },
+			wantBlocked:    false,
+			wantDNSCheckOn: true, wantDNSCalls: 1,
+		},
+		{
+			cell: "private-allowed", name: "hostname resolving to RFC1918 allowed",
+			cfg: cfg, target: "https://internal.target.com/",
+			stubLookup:     func(string) ([]string, error) { return []string{"10.0.0.5"}, nil },
+			wantBlocked:    false,
+			wantDNSCheckOn: true, wantDNSCalls: 1,
+		},
+
+		// ── Hostname → loopback: STILL blocked ─────────────────────
+		{
+			cell: "hostname-loopback", name: "hostname resolves to 127.0.0.1 blocked",
+			cfg: cfg, target: "https://evil.example/",
+			stubLookup:     func(string) ([]string, error) { return []string{"127.0.0.1"}, nil },
 			wantBlocked:    true,
-			wantDNSCheckOn: true,
-			wantDNSCalls:   1,
+			wantDNSCheckOn: true, wantDNSCalls: 1,
+		},
+		{
+			cell: "hostname-loopback", name: "hostname resolves to ::1 blocked",
+			cfg: cfg, target: "https://lb6.example/",
+			stubLookup:     func(string) ([]string, error) { return []string{"::1"}, nil },
+			wantBlocked:    true,
+			wantDNSCheckOn: true, wantDNSCalls: 1,
 		},
 
 		// ── Public host (allow) ─────────────────────────────────────
 		{
-			cell:   "public-host",
-			name:   "hostname resolves to public IP",
-			cfg:    cfg,
-			target: "https://example.com/",
-			stubLookup: func(host string) ([]string, error) {
-				return []string{"93.184.216.34"}, nil
-			},
+			cell: "public-host", name: "hostname resolves to public IP",
+			cfg: cfg, target: "https://example.com/",
+			stubLookup:     func(string) ([]string, error) { return []string{"93.184.216.34"}, nil },
 			wantBlocked:    false,
-			wantDNSCheckOn: true,
-			wantDNSCalls:   1,
+			wantDNSCheckOn: true, wantDNSCalls: 1,
 		},
 		{
-			cell:           "public-host",
-			name:           "public IP literal skips DNS",
-			cfg:            cfg,
-			target:         "http://203.0.113.10/",
+			cell: "public-host", name: "public IP literal skips DNS",
+			cfg: cfg, target: "http://203.0.113.10/",
 			wantBlocked:    false,
-			wantDNSCheckOn: true,
-			wantDNSCalls:   0,
+			wantDNSCheckOn: true, wantDNSCalls: 0,
 		},
 
 		// ── DNS failure → allow ─────────────────────────────────────
 		{
-			cell:   "dns-failure",
-			name:   "lookup error falls back to allow",
-			cfg:    cfg,
-			target: "https://nope.example/",
-			stubLookup: func(host string) ([]string, error) {
-				return nil, errors.New("simulated NXDOMAIN")
-			},
+			cell: "dns-failure", name: "lookup error falls back to allow",
+			cfg: cfg, target: "https://nope.example/",
+			stubLookup:     func(string) ([]string, error) { return nil, errors.New("simulated NXDOMAIN") },
 			wantBlocked:    false,
-			wantDNSCheckOn: true,
-			wantDNSCalls:   1,
+			wantDNSCheckOn: true, wantDNSCalls: 1,
 		},
 		{
-			cell:   "dns-failure",
-			name:   "empty result falls back to allow",
-			cfg:    cfg,
-			target: "https://void.example/",
-			stubLookup: func(host string) ([]string, error) {
-				return []string{}, nil
-			},
+			cell: "dns-failure", name: "empty result falls back to allow",
+			cfg: cfg, target: "https://void.example/",
+			stubLookup:     func(string) ([]string, error) { return []string{}, nil },
 			wantBlocked:    false,
-			wantDNSCheckOn: true,
-			wantDNSCalls:   1,
+			wantDNSCheckOn: true, wantDNSCalls: 1,
 		},
 	}
 
@@ -214,57 +156,33 @@ func isLocalOrListenerRows() []isLocalOrListenerRow {
 	// Dynamically discover a non-loopback interface IP so the test
 	// works on any machine. When the resolved IP matches one of the
 	// machine's interfaces, IsLocalOrListener must block regardless
-	// of port — this is the fix for the self-scanning bug where the
-	// agent probed its own SSH/Grafana/CUPS services.
+	// of port — this is the fix for the self-scanning bug.
 	if selfIP := firstNonLoopbackInterfaceIP(); selfIP != "" {
 		rows = append(rows,
 			isLocalOrListenerRow{
-				cell:   "self-host-public",
-				name:   "own public IP on SSH port 22 (no port match)",
-				cfg:    cfg,
-				target: "http://" + selfIP + ":22/",
-				stubLookup: func(host string) ([]string, error) {
-					return []string{selfIP}, nil
-				},
+				cell: "self-host-public", name: "own public IP on SSH port 22 blocked",
+				cfg: cfg, target: "http://" + selfIP + ":22/",
 				wantBlocked:    true,
-				wantDNSCheckOn: true,
-				wantDNSCalls:   0, // IP literal → no DNS
+				wantDNSCheckOn: true, wantDNSCalls: 0,
 			},
 			isLocalOrListenerRow{
-				cell:   "self-host-public",
-				name:   "own public IP on Grafana port 9999 (no port match)",
-				cfg:    cfg,
-				target: "http://" + selfIP + ":9999/api/users",
-				stubLookup: func(host string) ([]string, error) {
-					return []string{selfIP}, nil
-				},
+				cell: "self-host-public", name: "own public IP on Grafana port 9999 blocked",
+				cfg: cfg, target: "http://" + selfIP + ":9999/api/users",
 				wantBlocked:    true,
-				wantDNSCheckOn: true,
-				wantDNSCalls:   0,
+				wantDNSCheckOn: true, wantDNSCalls: 0,
 			},
 			isLocalOrListenerRow{
-				cell:   "self-host-public",
-				name:   "own public IP bare (no port)",
-				cfg:    cfg,
-				target: "http://" + selfIP + "/",
-				stubLookup: func(host string) ([]string, error) {
-					return []string{selfIP}, nil
-				},
+				cell: "self-host-public", name: "own public IP bare (no port) blocked",
+				cfg: cfg, target: "http://" + selfIP + "/",
 				wantBlocked:    true,
-				wantDNSCheckOn: true,
-				wantDNSCalls:   0,
+				wantDNSCheckOn: true, wantDNSCalls: 0,
 			},
 			isLocalOrListenerRow{
-				cell:   "self-host-public",
-				name:   "hostname resolving to own public IP blocks",
-				cfg:    cfg,
-				target: "https://my-server.example.com/",
-				stubLookup: func(host string) ([]string, error) {
-					return []string{selfIP}, nil
-				},
+				cell: "self-host-public", name: "hostname resolving to own public IP blocks",
+				cfg: cfg, target: "https://my-server.example.com/",
+				stubLookup:     func(string) ([]string, error) { return []string{selfIP}, nil },
 				wantBlocked:    true,
-				wantDNSCheckOn: true,
-				wantDNSCalls:   1,
+				wantDNSCheckOn: true, wantDNSCalls: 1,
 			},
 		)
 	}
@@ -272,14 +190,7 @@ func isLocalOrListenerRows() []isLocalOrListenerRow {
 	return rows
 }
 
-// TestIsLocalOrListener_Table is the unit test surface for
-// IsLocalOrListener. Carries every row from the current
-// isBlockedTarget table in internal/web/server_test.go (the
-// webPreservationRows partition) plus self-listener and DNS-edge
-// rows. Covers both literal targets and LookupHost swap cases per
-// design.md → "Unit Tests" final bullet.
-//
-// Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.8.
+// TestIsLocalOrListener_Table covers the smart scope guard behavior.
 func TestIsLocalOrListener_Table(t *testing.T) {
 	for _, row := range isLocalOrListenerRows() {
 		row := row
@@ -292,10 +203,6 @@ func TestIsLocalOrListener_Table(t *testing.T) {
 					return stub(host)
 				})
 			} else {
-				// Even rows that should NOT trigger DNS still install a
-				// counter-only stub. If the production code regresses
-				// and starts looking up an IP literal, the assertion
-				// catches it.
 				withStubLookupHost(t, func(host string) ([]string, error) {
 					calls++
 					return nil, errors.New("DNS should not have been invoked for this row")
@@ -316,11 +223,7 @@ func TestIsLocalOrListener_Table(t *testing.T) {
 }
 
 // TestIsLocalOrListener_SingleLookupAcrossTwoCalls asserts that two
-// back-to-back calls each perform exactly one DNS lookup (no
-// caching across calls). Mirrors
-// TestIsBlockedTarget_SingleLookup in internal/web/server_test.go.
-//
-// Validates: Requirement 3.3 (single DNS lookup per call).
+// back-to-back calls each perform exactly one DNS lookup.
 func TestIsLocalOrListener_SingleLookupAcrossTwoCalls(t *testing.T) {
 	cfg := Config{BindAddr: "127.0.0.1", Port: 9000}
 
@@ -345,10 +248,45 @@ func TestIsLocalOrListener_SingleLookupAcrossTwoCalls(t *testing.T) {
 	}
 }
 
+// TestCloudMetadataAllowed verifies that common SSRF targets are
+// NOT blocked by the scope guard.
+func TestCloudMetadataAllowed(t *testing.T) {
+	cfg := Config{BindAddr: "127.0.0.1", Port: 9137}
+
+	targets := []string{
+		"http://169.254.169.254/latest/meta-data/",
+		"http://169.254.169.254/computeMetadata/v1/",
+		"http://169.254.169.254/metadata/instance",
+	}
+	for _, target := range targets {
+		if IsLocalOrListener(cfg, target) {
+			t.Errorf("cloud metadata target %q was blocked — SSRF testing broken", target)
+		}
+	}
+}
+
+// TestDifferentPrivateIPsAllowed verifies that RFC1918 IPs that
+// don't match local interfaces are allowed through.
+func TestDifferentPrivateIPsAllowed(t *testing.T) {
+	cfg := Config{BindAddr: "127.0.0.1", Port: 9137}
+
+	// These are private IPs but they DON'T belong to our machine
+	// (unless you happen to have exactly these IPs, very unlikely)
+	targets := []string{
+		"http://10.255.255.1/",
+		"http://172.31.255.254/",
+		"http://192.168.254.254/",
+	}
+	for _, target := range targets {
+		got := IsLocalOrListener(cfg, target)
+		// We can't guarantee these aren't on a local interface,
+		// but on a typical machine they shouldn't be
+		_ = got // just test that it doesn't panic
+	}
+}
+
 // firstNonLoopbackInterfaceIP returns the first non-loopback IPv4
-// address found among the machine's network interfaces, or "" if
-// none is available. Used by the self-host-public regression tests
-// so they dynamically adapt to whatever machine runs them.
+// address found among the machine's network interfaces.
 func firstNonLoopbackInterfaceIP() string {
 	addrs, err := net.InterfaceAddrs()
 	if err != nil {
@@ -363,7 +301,6 @@ func firstNonLoopbackInterfaceIP() string {
 		if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() {
 			continue
 		}
-		// Prefer IPv4 for simpler test URLs
 		if ip4 := ip.To4(); ip4 != nil {
 			return ip4.String()
 		}

--- a/internal/web/scope_oracle_test.go
+++ b/internal/web/scope_oracle_test.go
@@ -1,26 +1,16 @@
 package web
 
-// Frozen oracle snapshot of the web-side scope guard
-// (isBlockedTarget) as it exists before the
-// scope-guard-local-only fix. The names here are intentionally
-// unexported and prefixed with `oracle` so they cannot be confused
-// with the production symbols. The bodies below MUST remain
-// byte-frozen for the duration of the spec — they are the pre-fix
-// `F` against which the post-fix `F'` is compared in preservation
-// property tests (task 2 of the scope-guard-local-only spec).
+// Updated oracle snapshot of the web-side scope guard (isBlockedTarget)
+// matching the smart scope guard rewrite. The smart guard only blocks:
+//   - Loopback (127.0.0.0/8, ::1) — always self
+//   - Unspecified (0.0.0.0, ::) — always self
+//   - "localhost" — always self
+//   - IPs matching local network interfaces — operator's machine
+//   - Self-listener textual match (bind addr + port)
 //
-// Captured from internal/web/server.go as of the unfixed baseline:
-//   - (*Server).isBlockedTarget        → oracleIsBlockedTarget
-//   - ipsMatchLocalInterface           → oracleIPsMatchLocalInterface
-//   - lookupHost                       → oracleLookupHost
-//
-// Resolver indirection is deliberately oracle-local
-// (oracleLookupHost) so when task 3.3 migrates the production
-// resolver to scopeguard.LookupHost the oracle keeps reading from
-// its own var. Tests inject a stub by overwriting oracleLookupHost
-// directly. The oracle reproduces the per-call private-CIDR parse
-// the unfixed implementation does — that's a structural quirk of
-// the baseline `F` and the property tests pin it.
+// It does NOT blanket-block RFC1918, link-local, or ULA ranges.
+// Those are legitimate SSRF targets (e.g. 169.254.169.254 cloud
+// metadata, internal IPs on the target's network).
 
 import (
 	"net"
@@ -29,15 +19,10 @@ import (
 	"strings"
 )
 
-// oracleLookupHost is the web oracle's frozen resolver indirection.
-// Tests overwrite this var to feed deterministic resolutions
-// without depending on the production package-level lookupHost.
+// oracleLookupHost is the web oracle's resolver indirection.
 var oracleLookupHost = net.LookupHost
 
-// oracleIsBlockedTarget is the byte-frozen pre-fix copy of
-// (*Server).isBlockedTarget. It accepts a non-nil *Server so the
-// test surface mirrors the production call site (s.cfg.BindAddr
-// and s.port are read directly).
+// oracleIsBlockedTarget mirrors the smart scope guard behavior.
 func oracleIsBlockedTarget(s *Server, target string) bool {
 	host := target
 	hostPort := ""
@@ -52,10 +37,9 @@ func oracleIsBlockedTarget(s *Server, target string) bool {
 		}
 	}
 
-	portMatch := false
+	// Self-listener textual fast-path.
 	if s != nil && hostPort != "" {
 		if portNum, err := strconv.Atoi(hostPort); err == nil && portNum == s.port {
-			portMatch = true
 			bind := strings.ToLower(strings.TrimSpace(s.cfg.BindAddr))
 			if bind == "" {
 				bind = "127.0.0.1"
@@ -67,11 +51,13 @@ func oracleIsBlockedTarget(s *Server, target string) bool {
 		}
 	}
 
+	// Always-self textual fast-path.
 	lower := strings.ToLower(host)
 	if lower == "localhost" || lower == "0.0.0.0" || lower == "[::1]" || lower == "::1" {
 		return true
 	}
 
+	// Resolve IPs.
 	var resolvedIPs []net.IP
 	if ip := net.ParseIP(host); ip != nil {
 		resolvedIPs = []net.IP{ip}
@@ -90,47 +76,22 @@ func oracleIsBlockedTarget(s *Server, target string) bool {
 		}
 	}
 
-	if portMatch && oracleIPsMatchLocalInterface(resolvedIPs) {
-		return true
-	}
-
+	// Only block loopback and unspecified — NOT link-local or RFC1918.
 	for _, ip := range resolvedIPs {
-		if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() {
+		if ip.IsLoopback() || ip.IsUnspecified() {
 			return true
 		}
 	}
 
-	privateCIDRs := []string{
-		"10.0.0.0/8",
-		"172.16.0.0/12",
-		"192.168.0.0/16",
-		"127.0.0.0/8",
-		"169.254.0.0/16",
-		"::1/128",
-		"fc00::/7",
-		"fe80::/10",
+	// Block IPs matching local interfaces (operator's own machine).
+	if oracleIPsMatchLocalInterface(resolvedIPs) {
+		return true
 	}
-	parsedSubnets := make([]*net.IPNet, 0, len(privateCIDRs))
-	for _, cidr := range privateCIDRs {
-		_, subnet, err := net.ParseCIDR(cidr)
-		if err != nil {
-			continue
-		}
-		parsedSubnets = append(parsedSubnets, subnet)
-	}
-	for _, ip := range resolvedIPs {
-		for _, subnet := range parsedSubnets {
-			if subnet.Contains(ip) {
-				return true
-			}
-		}
-	}
+
 	return false
 }
 
-// oracleIPsMatchLocalInterface mirrors the byte-frozen pre-fix
-// copy of ipsMatchLocalInterface. Walks net.InterfaceAddrs once
-// and checks ips × addrs.
+// oracleIPsMatchLocalInterface checks if any IP matches a local interface.
 func oracleIPsMatchLocalInterface(ips []net.IP) bool {
 	if len(ips) == 0 {
 		return false

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -2190,12 +2190,12 @@ func TestIsBlockedTarget_IPLiteralSkipsLookup(t *testing.T) {
 		t.Fatalf("lookupHost calls for public IP literal = %d, want 0", calls)
 	}
 
-	// Private RFC1918 IP literal — must be blocked AND must not
-	// resolve. Confirms the private-range check runs against the
-	// parsed IP without re-routing through DNS.
-	if blocked := s.isBlockedTarget("http://10.0.0.5/"); !blocked {
-		t.Fatalf("private IP literal 10.0.0.5 reported blocked = false")
-	}
+	// RFC1918 IP literal — with smart scope guard, this is NOT blocked
+	// unless it matches a local interface. 10.0.0.5 is unlikely to be
+	// on our interfaces.
+	// NOTE: We can't guarantee 10.0.0.5 isn't on a local interface,
+	// so just verify no DNS lookup is performed for IP literals.
+	_ = s.isBlockedTarget("http://10.0.0.5/")
 	if calls != 0 {
 		t.Fatalf("lookupHost calls for private IP literal = %d, want 0", calls)
 	}
@@ -2290,18 +2290,12 @@ type webPreservationRow struct {
 // and the empty-host edge case isBlockedTarget already handles).
 func webPreservationRows() []webPreservationRow {
 	return []webPreservationRow{
-		// ── Cell 1 (a): Local_Or_Listener_Host literal ────────────
-		{cell: "local-literal", name: "loopback ipv4", target: "http://127.0.0.1/admin"},
-		{cell: "local-literal", name: "loopback ipv4 with port", target: "http://127.0.0.1:9000/x"},
-		{cell: "local-literal", name: "localhost name", target: "http://localhost/x"},
-		{cell: "local-literal", name: "ipv6 loopback bracket", target: "http://[::1]:8080/"},
-		{cell: "local-literal", name: "rfc1918 10/8", target: "http://10.0.0.1/"},
-		{cell: "local-literal", name: "rfc1918 172.16/12", target: "http://172.16.5.5/"},
-		{cell: "local-literal", name: "rfc1918 192.168/16", target: "http://192.168.1.1/"},
-		{cell: "local-literal", name: "link-local ipv4 169.254", target: "http://169.254.169.254/latest/meta-data/"},
-		{cell: "local-literal", name: "ipv6 link-local fe80", target: "http://[fe80::1]/"},
-		{cell: "local-literal", name: "ipv6 unique-local fc00", target: "http://[fc00::1]/"},
-		{cell: "local-literal", name: "unspecified 0.0.0.0", target: "http://0.0.0.0/"},
+		// ── Cell 1 (a): Always-self literals ────────────────────
+		{cell: "always-self", name: "loopback ipv4", target: "http://127.0.0.1/admin"},
+		{cell: "always-self", name: "loopback ipv4 with port", target: "http://127.0.0.1:9000/x"},
+		{cell: "always-self", name: "localhost name", target: "http://localhost/x"},
+		{cell: "always-self", name: "ipv6 loopback bracket", target: "http://[::1]:8080/"},
+		{cell: "always-self", name: "unspecified 0.0.0.0", target: "http://0.0.0.0/"},
 
 		// ── Cell 1 (b): hostname → private IP ─────────────────────
 		{


### PR DESCRIPTION
### Smart Scope Guard

- **fix: smart scope guard — only block operator's own IPs, not entire RFC1918/link-local**

### Bug
The scope guard was blanket-blocking all RFC1918 (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16), link-local (169.254.0.0/16), and IPv6 ULA/link-local ranges. This prevented the scanner from testing SSRF targets like `169.254.169.254` (AWS/GCP/Azure cloud metadata endpoint) and internal IPs on the target's network.

### Fix
Rewrote the scope guard to be smart — only block IPs that provably belong to the **operator's own machine**:
- Loopback (127.0.0.0/8, ::1)
- Unspecified (0.0.0.0, ::)
- `localhost` hostname
- IPs matching local network interfaces (the operator's machine)
- Self-listener textual match (bind addr + port)

Everything else is now allowed, including RFC1918 and link-local IPs that don't match local interfaces. If a target subdomain resolves to a DigitalOcean or AWS private IP, the scanner can now reach it.