### PR TITLE
release: v4.4.33

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.4.32
+VERSION=4.4.33
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.4.32" alt="Xalgorix" width="860" />
+<img src="assets/banner.png?v=4.4.33" alt="Xalgorix" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.4.32"
+var version = "4.4.33"
 
 const defaultWebPort = 9137
 

--- a/internal/llm/resolver.go
+++ b/internal/llm/resolver.go
@@ -196,6 +196,20 @@ func (c *compositeResolver) Resolve(ctx context.Context) (Endpoint, error) {
 		cr := &catalogResolver{cat: c.cat, prof: c.prof, pick: c.pick}
 		ep, err := cr.Resolve(ctx)
 		if err == nil {
+			// Custom Provider and LiteLLM catalog entries have
+			// empty Models lists, so BuildCatalogEndpoint returns
+			// an endpoint with Model="". Fall back to the
+			// operator's configured model (XALGORIX_LLM) stripped
+			// of any "provider/" prefix — mirrors the same logic
+			// in scan_resolve.go legacyOrCatalogDefaultEndpoint
+			// Branch 0.
+			if ep.Model == "" && c.cfg.LLM != "" {
+				model := c.cfg.LLM
+				if idx := strings.Index(model, "/"); idx >= 0 {
+					model = model[idx+1:]
+				}
+				ep.Model = strings.TrimSpace(model)
+			}
 			return ep, nil
 		}
 		// On catalog-branch failure (unknown profile, missing


### PR DESCRIPTION
fix: populate model from cfg.LLM when catalog entry has empty Models list (#82)

The compositeResolver's catalog branch called BuildCatalogEndpoint with no preferModel. For Custom Provider and LiteLLM entries (which have empty Models lists), the endpoint came back with model="" — causing 400 errors from upstream proxies.

Closes #82