### PR TITLE
release: v4.4.34

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.4.33
+VERSION=4.4.34
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.4.33" alt="Xalgorix" width="860" />
+<img src="assets/banner.png?v=4.4.34" alt="Xalgorix" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.4.33"
+var version = "4.4.34"
 
 const defaultWebPort = 9137
 

--- a/internal/providers/builtin.go
+++ b/internal/providers/builtin.go
@@ -215,11 +215,11 @@ var builtinList = []Entry{
 	{
 		ID:          "litellm",
 		DisplayName: "LiteLLM",
-		BaseURL:     "",
+		BaseURL:     "http://localhost:4000/v1",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
 		Models:      []string{"gpt-4o"},
-		Notes:       "Point base URL at your LiteLLM proxy via Custom Provider (commonly http://localhost:4000).",
+		Notes:       "Default base URL points at the standard LiteLLM proxy (http://localhost:4000). Override via API Base if your proxy runs on a different host or port.",
 	},
 	{
 		ID:          "lmstudio",


### PR DESCRIPTION
fix: set default LiteLLM base URL to http://localhost:4000/v1