### PR TITLE
release: v4.5.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.1
+VERSION=4.5.2
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.1" alt="Xalgorix" width="860" />
+<img src="assets/banner.png?v=4.5.2" alt="Xalgorix" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.1"
+var version = "4.5.2"
 
 const defaultWebPort = 9137
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -2037,6 +2037,73 @@ func TestLLMSettings_CatalogShape_RejectsUnknownProvider(t *testing.T) {
 	}
 }
 
+// TestLLMSettings_CatalogShape_ProviderSwitchWithMaskedKey is a regression
+// test for the "provider reverts after refresh" bug: switching the provider
+// while leaving the API key masked (**** — the UI tells the operator to keep
+// it to preserve the saved key) must still persist the new provider by moving
+// the XALGORIX_LLM_PROFILE pointer. Previously the api_key branch was gated on
+// a freshly-typed key, so only the model env var changed and the provider
+// derived back to the stale profile on the next GET.
+func TestLLMSettings_CatalogShape_ProviderSwitchWithMaskedKey(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.WriteFile(filepath.Join(home, ".xalgorix.env"), []byte(""), 0o644); err != nil {
+		t.Fatalf("seed env file: %v", err)
+	}
+
+	s := newTestServer(t, &config.Config{
+		ReasoningEffort:   "high",
+		RateLimitRequests: 60,
+		RateLimitWindow:   60,
+	})
+
+	// 1) Initial save under litellm with a real key.
+	rr := httptest.NewRecorder()
+	body := strings.NewReader(`{"provider":"litellm","authMethod":"api_key","profileId":"default","apiKey":"sk-real-key","model":"minimax/MiniMax-M2.7"}`)
+	s.handleLLMSettings(rr, httptest.NewRequest(http.MethodPost, "/api/settings/llm", body))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("POST #1 code = %d body=%s", rr.Code, rr.Body.String())
+	}
+	if s.cfg.LLMProfile != "litellm:default" {
+		t.Fatalf("after POST #1 LLMProfile = %q, want litellm:default", s.cfg.LLMProfile)
+	}
+
+	// 2) Switch the provider to minimax but KEEP the masked key.
+	rr = httptest.NewRecorder()
+	body = strings.NewReader(`{"provider":"minimax","authMethod":"api_key","profileId":"default","apiKey":"****-key","model":"minimax/MiniMax-M2.7"}`)
+	s.handleLLMSettings(rr, httptest.NewRequest(http.MethodPost, "/api/settings/llm", body))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("POST #2 code = %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	// The active profile pointer must have moved to minimax.
+	if s.cfg.LLMProfile != "minimax:default" {
+		t.Fatalf("after provider switch LLMProfile = %q, want minimax:default", s.cfg.LLMProfile)
+	}
+	// A minimax profile must exist, carrying over the previously-saved key.
+	prof, ok, err := s.profiles.Get(context.Background(), "minimax:default")
+	if err != nil {
+		t.Fatalf("profile get: %v", err)
+	}
+	if !ok {
+		t.Fatalf("minimax:default profile not persisted after switch")
+	}
+	if prof.APIKey != "sk-real-key" {
+		t.Fatalf("minimax profile APIKey = %q, want carried-over sk-real-key", prof.APIKey)
+	}
+
+	// 3) GET must now report minimax — the symptom the user saw (reverting
+	// to litellm on refresh) is fixed.
+	rr = httptest.NewRecorder()
+	s.handleLLMSettings(rr, httptest.NewRequest(http.MethodGet, "/api/settings/llm", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET code = %d body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"provider":"minimax"`) {
+		t.Fatalf("GET provider did not persist as minimax; body=%s", rr.Body.String())
+	}
+}
+
 func TestEnvironmentSettings_RejectsUnknownAndUpdatesRuntime(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/web/settings_env.go
+++ b/internal/web/settings_env.go
@@ -299,25 +299,72 @@ func (s *Server) applyCatalogLLMSettings(ctx context.Context, req llmSettingsReq
 	// legacy XALGORIX_LLM / XALGORIX_API_KEY / XALGORIX_API_BASE
 	// trio so anyone still consuming those env vars (legacy
 	// scripts, the legacyResolver fallback) keeps working.
-	if authMethod == "api_key" && provider != "" && !isMaskedSettingValue(req.APIKey) && strings.TrimSpace(req.APIKey) != "" {
+	//
+	// The pointer must move whenever the operator switches provider —
+	// even if they leave the masked **** key in place (the UI tells them
+	// to keep it to preserve the saved key). Previously this whole branch
+	// was gated on a freshly-typed key, so switching provider with a
+	// masked key updated only the model env var and the provider reverted
+	// to the stale profile on reload.
+	if authMethod == "api_key" && provider != "" {
 		if s.profiles == nil {
 			return fmt.Errorf("profile store not initialized")
 		}
-		baseOverride := strings.TrimSpace(req.APIBaseOverride)
-		if baseOverride == "" {
-			baseOverride = strings.TrimSpace(req.APIBase)
+		typedKey := strings.TrimSpace(req.APIKey)
+		hasTypedKey := typedKey != "" && !isMaskedSettingValue(req.APIKey)
+		if hasTypedKey {
+			// New key supplied: create/update the profile for this provider.
+			baseOverride := strings.TrimSpace(req.APIBaseOverride)
+			if baseOverride == "" {
+				baseOverride = strings.TrimSpace(req.APIBase)
+			}
+			prof := auth.Profile{
+				Provider:        provider,
+				ProfileID:       profileID,
+				Type:            auth.APIKey,
+				APIKey:          typedKey,
+				APIBaseOverride: baseOverride,
+			}
+			if err := s.profiles.Put(ctx, prof); err != nil {
+				return fmt.Errorf("save profile: %w", err)
+			}
+			activeProfileKey = prof.Key()
+		} else if activeProfileKey == "" {
+			// Masked/empty key and no explicit profile selected. Persist the
+			// provider switch without rewriting any credential:
+			//   1. If a profile already exists for <provider>:<profileId>,
+			//      point at it (preserving its stored key/base).
+			//   2. Otherwise carry over the current saved key (the masked
+			//      value the UI is showing == cfg.APIKey, or the active
+			//      profile's key) into a new profile for this provider so the
+			//      selection sticks.
+			target := auth.Profile{Provider: provider, ProfileID: profileID}
+			if existing, ok, err := s.profiles.Get(ctx, target.Key()); err != nil {
+				return fmt.Errorf("look up profile %q: %w", target.Key(), err)
+			} else if ok {
+				activeProfileKey = existing.Key()
+			} else {
+				carry := strings.TrimSpace(s.cfg.APIKey)
+				if carry == "" && strings.TrimSpace(s.cfg.LLMProfile) != "" {
+					if prof, ok, err := s.profiles.Get(ctx, strings.TrimSpace(s.cfg.LLMProfile)); err == nil && ok {
+						carry = strings.TrimSpace(prof.APIKey)
+					}
+				}
+				if carry != "" {
+					prof := auth.Profile{
+						Provider:        provider,
+						ProfileID:       profileID,
+						Type:            auth.APIKey,
+						APIKey:          carry,
+						APIBaseOverride: strings.TrimSpace(req.APIBaseOverride),
+					}
+					if err := s.profiles.Put(ctx, prof); err != nil {
+						return fmt.Errorf("save profile: %w", err)
+					}
+					activeProfileKey = prof.Key()
+				}
+			}
 		}
-		prof := auth.Profile{
-			Provider:        provider,
-			ProfileID:       profileID,
-			Type:            auth.APIKey,
-			APIKey:          strings.TrimSpace(req.APIKey),
-			APIBaseOverride: baseOverride,
-		}
-		if err := s.profiles.Put(ctx, prof); err != nil {
-			return fmt.Errorf("save profile: %w", err)
-		}
-		activeProfileKey = prof.Key()
 	}
 
 	// activeProfileKey wins as the source of truth for


### PR DESCRIPTION
### Changes (v4.5.2)

**fix(settings): persist LLM provider switch when API key left masked**

Switching the LLM provider (e.g. LiteLLM → MiniMax) and saving without retyping the API key (the UI tells you to keep the masked `****` value) previously updated only the model env var — the active credential pointer (`XALGORIX_LLM_PROFILE`) never moved, so the provider reverted to the old one after a page refresh.

The `api_key` save path now moves the pointer even with a masked key:
- new key typed → create/point at the profile (unchanged);
- masked key + existing profile for the selected provider → point at it;
- masked key + no profile yet → carry over the currently-saved key into a new profile for that provider.

Adds regression test `TestLLMSettings_CatalogShape_ProviderSwitchWithMaskedKey`. Verified: `go build/vet/test` clean, `golangci-lint` 0 issues. Tag: v4.5.2.
