### PR TITLE
fix: scan consistency — severity determinism, vulnType normalization, recon seeding

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2507,6 +2507,66 @@ const defaultChecklist = `
 **The more you find here, the more attack surface you can test later!**
 **MUST COMPLETE THIS PHASE FULLY BEFORE MOVING ON - Do not skip!**
 
+## ⚡ MANDATORY FIRST 5 ITERATIONS — EXECUTE IN THIS EXACT ORDER
+These steps MUST be completed FIRST, IN ORDER, before any creative exploration.
+Skipping or reordering these causes inconsistent coverage across scans.
+
+**Iteration 1: Headers + Tech Fingerprint**
+` + "`" + `bash` + "`" + `
+curl -sI https://TARGET -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" 2>&1 | head -50
+# Note: Server, X-Powered-By, Set-Cookie, CSP, and any framework hints
+` + "`" + `
+
+**Iteration 2: Download main page + extract JS bundle URLs**
+` + "`" + `bash` + "`" + `
+curl -s https://TARGET -A "Mozilla/5.0" --max-time 15 -o /tmp/main_page.html
+# Extract all JS bundle URLs
+grep -oE 'src="[^"]*\.js[^"]*"' /tmp/main_page.html | sort -u
+# Extract all internal links
+grep -oE 'href="[^"]*"' /tmp/main_page.html | grep -v '^href="http' | sort -u | head -50
+` + "`" + `
+
+**Iteration 3: Download ALL JS bundles + deep grep for endpoints (CRITICAL)**
+` + "`" + `bash` + "`" + `
+# Download every JS file found. This is WHERE MOST FINDINGS COME FROM.
+# For each JS URL from iteration 2:
+curl -s "https://TARGET/path/to/bundle.js" -A "Mozilla/5.0" -o /tmp/bundle.js
+# Then grep for:
+grep -oE '"https?://[^"]+' /tmp/bundle.js | sort -u > /tmp/js_urls.txt       # Full URLs
+grep -oE '"/api/[^"]*"' /tmp/bundle.js | sort -u > /tmp/js_api_paths.txt      # API paths
+grep -oE '"/(v[0-9]+|access|admin|auth|connect)/[^"]*"' /tmp/bundle.js | sort -u  # Versioned paths
+grep -oE '[a-z]+\.(vanhack|TARGET_DOMAIN)\.[a-z]+' /tmp/bundle.js | sort -u   # Subdomains
+grep -oE '(apiUrl|baseURL|API_URL|apiBase)[^,]*' /tmp/bundle.js | head -10     # API base URLs
+grep -oE '(token|secret|key|password|api_key)\s*[:=]\s*"[^"]*"' /tmp/bundle.js # Leaked secrets
+` + "`" + `
+
+**Iteration 4: Test ALL discovered subdomains + API bases**
+` + "`" + `bash` + "`" + `
+# For each subdomain/API base found in JS:
+for host in SUBDOMAINS_FROM_STEP3; do
+  echo "--- $host ---"
+  curl -skI "https://$host" -A "Mozilla/5.0" --max-time 10 2>&1 | head -20
+done
+# Check common API paths on each live host:
+for path in /swagger.json /swagger/v1/swagger.json /swagger/v2/swagger.json /api-docs /graphql /.well-known/openid-configuration /actuator /health; do
+  curl -skI "https://TARGET$path" -A "Mozilla/5.0" --max-time 5 2>&1 | head -5
+done
+` + "`" + `
+
+**Iteration 5: Save complete endpoint inventory**
+` + "`" + `bash` + "`" + `
+# Use add_note to save ALL discovered:
+# - Live subdomains
+# - API endpoints from JS
+# - API bases (e.g., api.target.dev)
+# - Technology stack
+# - Any interesting headers or behaviors
+# This note is your attack surface map for the rest of the scan.
+` + "`" + `
+
+⚠️ DO NOT skip to vulnerability testing until ALL 5 steps are done.
+⚠️ Step 3 (JS bundle analysis) is where 80% of critical findings originate — be thorough.
+
 ## 1A: PASSIVE RECON (No direct contact with target - uses third-party sources)
 ` + "`" + `bash` + "`" + `
 # DNS & Subdomain Enumeration (PASSIVE - no direct target contact)
@@ -2897,7 +2957,13 @@ TIP: If the target requires email verification, ALWAYS use agentmail — it give
 
 ### Caido Proxy
 All HTTP requests via the send_request tool are automatically routed through the Caido proxy (port 8080) for traffic analysis.
-Use list_requests to see all captured HTTP traffic. Use send_request instead of curl when you want requests logged in Caido.
+Use list_requests to see all captured HTTP traffic.
+
+⚠️ **IMPORTANT: PREFER terminal_execute (curl) OVER send_request for ALL reconnaissance and analysis.**
+- send_request truncates responses at 10KB — JS bundles, API responses, and HTML pages are often 50-500KB.
+- Use curl via terminal_execute for: downloading pages, JS bundles, API probing, and any response you need to grep/analyze.
+- Use send_request ONLY when you specifically need requests logged in the Caido proxy (e.g., authenticated session testing).
+- NEVER use send_request to download JavaScript files — they WILL be truncated and you'll miss endpoints.
 
 ### Test Authenticated Endpoints
    - Test cookie theft via XSS after login

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,13 +17,14 @@ import (
 // Config holds all Xalgorix configuration.
 type Config struct {
 	// LLM settings
-	LLM             string // XALGORIX_LLM — model name (e.g. "openai/gpt-5.4", "anthropic/claude-sonnet-4-20250514")
-	APIBase         string // XALGORIX_API_BASE — API endpoint
-	APIKey          string // XALGORIX_API_KEY — API key
-	LLMProfile      string // XALGORIX_LLM_PROFILE — active credential pointer "<provider>:<profileId>" (v4.4.22+)
-	ReasoningEffort string // XALGORIX_REASONING_EFFORT — "low", "medium", "high"
-	LLMMaxRetries   int    // XALGORIX_LLM_MAX_RETRIES
-	MemCompTimeout  int    // XALGORIX_MEMORY_COMPRESSOR_TIMEOUT
+	LLM             string   // XALGORIX_LLM — model name (e.g. "openai/gpt-5.4", "anthropic/claude-sonnet-4-20250514")
+	APIBase         string   // XALGORIX_API_BASE — API endpoint
+	APIKey          string   // XALGORIX_API_KEY — API key
+	LLMProfile      string   // XALGORIX_LLM_PROFILE — active credential pointer "<provider>:<profileId>" (v4.4.22+)
+	ReasoningEffort string   // XALGORIX_REASONING_EFFORT — "low", "medium", "high"
+	Temperature     *float64 // XALGORIX_TEMPERATURE — LLM temperature (0.0-2.0), default 0.2; pointer to distinguish unset from 0.0
+	LLMMaxRetries   int      // XALGORIX_LLM_MAX_RETRIES
+	MemCompTimeout  int      // XALGORIX_MEMORY_COMPRESSOR_TIMEOUT
 
 	// Runtime settings
 	RuntimeBackend string // XALGORIX_RUNTIME_BACKEND — always "native"
@@ -179,6 +180,7 @@ func load() *Config {
 		APIKey:          envOr("XALGORIX_API_KEY", ""),
 		LLMProfile:      envOr("XALGORIX_LLM_PROFILE", ""),
 		ReasoningEffort: envOr("XALGORIX_REASONING_EFFORT", "high"),
+		Temperature:     envOrFloatPtr("XALGORIX_TEMPERATURE", 0.2),
 		LLMMaxRetries:   envOrInt("XALGORIX_LLM_MAX_RETRIES", 5),
 		MemCompTimeout:  envOrInt("XALGORIX_MEMORY_COMPRESSOR_TIMEOUT", 30),
 
@@ -457,6 +459,20 @@ func envOrFloat(key string, fallback float64) float64 {
 		}
 	}
 	return fallback
+}
+
+// envOrFloatPtr reads a float from the env and returns a pointer.
+// This lets callers distinguish "not set" (returns &fallback) from
+// "explicitly set to 0.0" (returns &0.0). Used by Temperature so that
+// setting XALGORIX_TEMPERATURE=0 sends temperature=0.0 to the API
+// instead of omitting it.
+func envOrFloatPtr(key string, fallback float64) *float64 {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.ParseFloat(v, 64); err == nil {
+			return &n
+		}
+	}
+	return &fallback
 }
 
 func envOrBool(key string, fallback bool) bool {

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -143,7 +143,7 @@ type chatRequest struct {
 	Messages      []Message      `json:"messages"`
 	Stream        bool           `json:"stream"`
 	StreamOptions *streamOptions `json:"stream_options,omitempty"`
-	Temperature   float64        `json:"temperature,omitempty"`
+	Temperature   *float64       `json:"temperature,omitempty"`
 	MaxTokens     int            `json:"max_tokens,omitempty"`
 }
 
@@ -664,6 +664,7 @@ func (c *Client) ChatStream(messages []Message) <-chan StreamChunk {
 				Messages:      messages,
 				Stream:        true,
 				StreamOptions: &streamOptions{IncludeUsage: true},
+				Temperature:   c.cfg.Temperature,
 			}
 			body, _ = json.Marshal(reqBody)
 		}
@@ -891,7 +892,7 @@ func (c *Client) doChat(messages []Message) (out string, err error) {
 			return "", fmt.Errorf("failed to marshal Anthropic request: %w", err)
 		}
 	} else {
-		reqBody := chatRequest{Model: model, Messages: messages, Stream: false}
+		reqBody := chatRequest{Model: model, Messages: messages, Stream: false, Temperature: c.cfg.Temperature}
 		body, err = json.Marshal(reqBody)
 		if err != nil {
 			return "", fmt.Errorf("failed to marshal request: %w", err)

--- a/internal/tools/proxy/proxy.go
+++ b/internal/tools/proxy/proxy.go
@@ -3,10 +3,13 @@ package proxy
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -42,7 +45,7 @@ func initLimiter() {
 func Register(r *tools.Registry) {
 	r.Register(&tools.Tool{
 		Name:        "send_request",
-		Description: "Send an HTTP request through the Caido proxy. Falls back to direct request if Caido is unavailable.",
+		Description: "Send an HTTP request through the Caido proxy. Falls back to direct request if Caido is unavailable. Large responses (>10KB) are automatically saved to /tmp/ — use terminal_execute (grep/cat) to search the saved file. Prefer curl via terminal_execute for recon to get full responses directly.",
 		Parameters: []tools.Parameter{
 			{Name: "method", Description: "HTTP method (GET, POST, PUT, DELETE, etc.)", Required: true},
 			{Name: "url", Description: "Target URL", Required: true},
@@ -163,19 +166,44 @@ func sendRequest(args map[string]string) (tools.Result, error) {
 	}
 	b.WriteString("\n")
 
+	// For large responses, save the full body to a temp file so the agent
+	// can grep/search it with terminal_execute instead of losing data.
+	const previewLimit = 10000
 	bodyStr := string(respBody)
-	if len(bodyStr) > 10000 {
-		bodyStr = bodyStr[:10000] + "\n\n... [TRUNCATED]"
+	var savedPath string
+	if len(bodyStr) > previewLimit {
+		// Generate a deterministic filename from URL + method for caching.
+		h := sha256.Sum256([]byte(method + " " + targetURL))
+		hash := hex.EncodeToString(h[:8])
+		savedPath = "/tmp/send_request_" + hash + ".txt"
+		if err := os.WriteFile(savedPath, respBody, 0644); err != nil {
+			// If file write fails, fall back to truncation.
+			savedPath = ""
+		}
 	}
-	b.WriteString(bodyStr)
+
+	if savedPath != "" {
+		b.WriteString(bodyStr[:previewLimit])
+		b.WriteString(fmt.Sprintf("\n\n... [RESPONSE TOO LARGE: %d bytes total]\n", len(bodyStr)))
+		b.WriteString(fmt.Sprintf("💾 Full response saved to: %s\n", savedPath))
+		b.WriteString("Use terminal_execute to search it: grep -oE 'pattern' " + savedPath + "\n")
+	} else {
+		b.WriteString(bodyStr)
+	}
+
+	meta := map[string]any{
+		"status_code": resp.StatusCode,
+		"url":         targetURL,
+		"via_proxy":   cfg.UseProxy,
+	}
+	if savedPath != "" {
+		meta["saved_to"] = savedPath
+		meta["full_size"] = len(respBody)
+	}
 
 	return tools.Result{
-		Output: b.String(),
-		Metadata: map[string]any{
-			"status_code": resp.StatusCode,
-			"url":         targetURL,
-			"via_proxy":   cfg.UseProxy,
-		},
+		Output:   b.String(),
+		Metadata: meta,
 	}, nil
 }
 

--- a/internal/tools/reporting/reporting.go
+++ b/internal/tools/reporting/reporting.go
@@ -286,9 +286,20 @@ If you cannot exploit it, downgrade severity to 'info' and report as information
 	}
 
 	// ── Auto-downgrade: weak proof for high severity ──
+	// Drop by one severity level (not nuclear to "info") so CVSS enforcement
+	// can still correct it. E.g. high → medium, critical → high.
 	if originalSeverity == "" && isHighSeverity && !hasStrongEvidence(severity, proof, args["description"]) {
 		originalSeverity = severity
-		severity = "info"
+		switch severity {
+		case "critical":
+			severity = "high"
+		case "high":
+			severity = "medium"
+		case "medium":
+			severity = "low"
+		default:
+			severity = "info"
+		}
 	}
 
 	var cvss float64
@@ -300,6 +311,7 @@ If you cannot exploit it, downgrade severity to 'info' and report as information
 	// ── Gate 6: CVSS-to-Severity enforcement (HackerOne standard) ──
 	// If CVSS was provided, ensure severity matches the HackerOne CVSS ranges.
 	// CVSS is authoritative: Critical=9.0-10.0, High=7.0-8.9, Medium=4.0-6.9, Low=0.1-3.9, None=0.0
+	// This gate overrides all prior adjustments — the CVSS score is the source of truth.
 	if cvss > 0 {
 		cvssSeverity := severityFromCVSS(cvss)
 		if severityRank[severity] > severityRank[cvssSeverity] {
@@ -308,9 +320,11 @@ If you cannot exploit it, downgrade severity to 'info' and report as information
 				originalSeverity = severity
 			}
 			severity = cvssSeverity
-		} else if severityRank[severity] < severityRank[cvssSeverity] && originalSeverity == "" {
+		} else if severityRank[severity] < severityRank[cvssSeverity] {
 			// Severity label is lower than CVSS justifies → upgrade to match
-			originalSeverity = severity
+			if originalSeverity == "" {
+				originalSeverity = severity
+			}
 			severity = cvssSeverity
 		}
 	}
@@ -373,7 +387,11 @@ If you cannot exploit it, downgrade severity to 'info' and report as information
 
 	msg := fmt.Sprintf("✅ Vulnerability reported: [%s] %s (%s | CVSS %.1f) — Verified: %v", vuln.ID, vuln.Title, strings.ToUpper(vuln.Severity), vuln.CVSS, vuln.Verified)
 	if originalSeverity != "" {
-		msg += fmt.Sprintf("\n⚠️ SEVERITY ADJUSTED from %s → %s (CVSS %.1f maps to %s per HackerOne standards)", strings.ToUpper(originalSeverity), strings.ToUpper(severity), cvss, strings.ToUpper(severity))
+		if cvss > 0 {
+			msg += fmt.Sprintf("\n⚠️ SEVERITY ADJUSTED from %s → %s (CVSS %.1f = %s per HackerOne standards)", strings.ToUpper(originalSeverity), strings.ToUpper(severity), cvss, strings.ToUpper(severityFromCVSS(cvss)))
+		} else {
+			msg += fmt.Sprintf("\n⚠️ SEVERITY ADJUSTED from %s → %s", strings.ToUpper(originalSeverity), strings.ToUpper(severity))
+		}
 	}
 
 	return tools.Result{
@@ -929,6 +947,12 @@ func classifySeverity(title, description, severity, proof string) (string, strin
 	lower := strings.ToLower(title + " " + description)
 	lowerProof := strings.ToLower(proof)
 
+	// Normalize to canonical vuln type for consistent classification
+	// regardless of how the LLM titles the finding. This prevents
+	// "Stored XSS in CRM" and "Contact Injection / Stored XSS" from
+	// getting different severity caps.
+	vulnType := extractVulnType(title, description)
+
 	// ── INFO-only findings (max severity: info) ──
 	infoOnlyPatterns := []struct {
 		keywords []string
@@ -1197,6 +1221,72 @@ func classifySeverity(title, description, severity, proof string) (string, strin
 				}
 			}
 		}
+	}
+
+	// ── vulnType-based fallback caps ──
+	// If the keyword-based caps above didn't fire (e.g., the LLM titled the
+	// finding "Contact Injection" instead of "Stored XSS"), apply caps based
+	// on the canonical vuln type extracted from title + description. This
+	// ensures consistent classification regardless of LLM title framing.
+	switch vulnType {
+	case "xss":
+		// Distinguish stored vs reflected/DOM
+		isStored := strings.Contains(lower, "stored") || strings.Contains(lower, "persistent") ||
+			strings.Contains(lower, "stores") || strings.Contains(lower, "persist") ||
+			strings.Contains(lower, "permanent") || strings.Contains(lower, "saved in")
+		if isStored {
+			// Stored XSS → high cap (same as highCapPatterns above)
+			if rank > severityRank["high"] {
+				return "high", "Stored XSS is high (CVSS 7.0-8.9) per HackerOne — needs admin access/mass ATO/RCE chain for critical"
+			}
+		} else {
+			// Reflected/DOM/generic XSS → medium cap (same as medCapPatterns above)
+			if rank > severityRank["medium"] {
+				return "medium", "Reflected/DOM XSS is medium (CVSS 4.0-6.9) per HackerOne — needs session hijack proof for high"
+			}
+		}
+	case "csrf":
+		if rank > severityRank["medium"] {
+			return "medium", "CSRF is medium (CVSS 4.0-6.9) per HackerOne — needs critical state change for high"
+		}
+	case "info_disclosure":
+		if rank > severityRank["medium"] {
+			return "medium", "Information disclosure is medium (CVSS 4.0-6.9) per HackerOne — needs PII/credential exposure for high"
+		}
+	case "ssrf":
+		if rank > severityRank["high"] {
+			return "high", "SSRF is high (CVSS 7.0-8.9) per HackerOne — needs cloud metadata/RCE for critical"
+		}
+	case "idor":
+		if rank > severityRank["high"] {
+			return "high", "IDOR is high (CVSS 7.0-8.9) per HackerOne — needs mass data dump for critical"
+		}
+	case "lfi":
+		if rank > severityRank["high"] {
+			return "high", "File inclusion is high (CVSS 7.0-8.9) per HackerOne — needs RCE for critical"
+		}
+	case "auth_bypass":
+		if rank > severityRank["high"] {
+			return "high", "Auth bypass is high (CVSS 7.0-8.9) per HackerOne — needs admin/root access for critical"
+		}
+	case "cors":
+		if rank > severityRank["low"] {
+			return "low", "CORS alone is low severity (CVSS 2.0-3.9) — needs proven cookie/token theft for higher"
+		}
+	case "open_redirect":
+		if rank > severityRank["low"] {
+			return "low", "Open redirect is low severity (CVSS 2.0-3.9) per HackerOne — needs OAuth/token chain for higher"
+		}
+	case "clickjacking":
+		if rank > severityRank["low"] {
+			return "low", "Clickjacking is low severity (CVSS 2.0-3.9) per HackerOne"
+		}
+	case "crlf":
+		if rank > severityRank["low"] {
+			return "low", "CRLF injection is low severity (CVSS 2.0-3.9) per HackerOne"
+		}
+	case "missing_header", "version_disclosure":
+		return "info", "Missing headers/version disclosure are informational"
 	}
 
 	return severity, "" // no cap needed

--- a/internal/tools/reporting/reporting_test.go
+++ b/internal/tools/reporting/reporting_test.go
@@ -440,3 +440,277 @@ func TestSetParentContextCleanedOnCleanup(t *testing.T) {
 		t.Fatalf("GetParentContext after cleanup = %q, want empty", got)
 	}
 }
+
+// TestAutoDowngrade_OneLevelDrop verifies that the auto-downgrade for weak
+// evidence drops severity by exactly one level (not nuclear to "info").
+func TestAutoDowngrade_OneLevelDrop(t *testing.T) {
+	tests := []struct {
+		name     string
+		severity string
+		want     string
+	}{
+		{"critical drops to high", "critical", "high"},
+		{"high drops to medium", "high", "medium"},
+		{"medium drops to low", "medium", "low"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			contextID := "test-auto-downgrade-" + tt.severity
+			CleanupContext(contextID)
+			defer CleanupContext(contextID)
+
+			// Use deliberately weak proof that won't pass hasStrongEvidence
+			args := map[string]string{
+				"title":               "Some finding on endpoint",
+				"severity":            tt.severity,
+				"description":         "A potential issue was observed",
+				"exploitation_proof":  "The endpoint responded with a 200 status code when tested",
+				"verification_method": "manual_verified",
+				"target":              "https://example.com",
+				"endpoint":            "/api/test-" + tt.severity,
+				// No CVSS provided — so CVSS enforcement won't override
+			}
+
+			result, err := reportVulnWithContextID(contextID, args)
+			if err != nil {
+				t.Fatalf("report error: %v", err)
+			}
+
+			vulns := GetVulnerabilitiesForContext(contextID)
+			if len(vulns) != 1 {
+				t.Fatalf("expected 1 vuln, got %d (output: %s)", len(vulns), result.Output)
+			}
+
+			if vulns[0].Severity != tt.want {
+				t.Errorf("severity = %q, want %q (auto-downgrade should drop one level, not to info)", vulns[0].Severity, tt.want)
+			}
+		})
+	}
+}
+
+// TestCVSSEnforcement_OverridesAutoDowngrade verifies that CVSS enforcement
+// is truly authoritative — it overrides prior auto-downgrade decisions.
+// This was the core bug: CVSS 7.4 should ALWAYS produce "high", regardless
+// of what the auto-downgrade gate decided.
+func TestCVSSEnforcement_OverridesAutoDowngrade(t *testing.T) {
+	tests := []struct {
+		name         string
+		severity     string // agent-provided severity
+		cvss         string // agent-provided CVSS
+		wantSeverity string // expected final severity
+	}{
+		// CVSS 7.4 = high, regardless of what the agent labels it
+		{"high with CVSS 7.4", "high", "7.4", "high"},
+		{"low with CVSS 7.4", "low", "7.4", "high"},
+		{"info with CVSS 7.4", "info", "7.4", "high"},
+
+		// CVSS 9.5 = critical
+		{"high with CVSS 9.5", "high", "9.5", "critical"},
+		{"medium with CVSS 9.5", "medium", "9.5", "critical"},
+
+		// CVSS 5.5 = medium
+		{"critical with CVSS 5.5", "critical", "5.5", "medium"},
+		{"high with CVSS 5.5", "high", "5.5", "medium"},
+
+		// CVSS 2.5 = low
+		{"high with CVSS 2.5", "high", "2.5", "low"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			contextID := "test-cvss-enforcement-" + tt.name
+			CleanupContext(contextID)
+			defer CleanupContext(contextID)
+
+			args := map[string]string{
+				"title":               "SQL Injection in API endpoint",
+				"severity":            tt.severity,
+				"description":         "SQL injection allows data extraction from the database",
+				"exploitation_proof":  "sql injection data extraction confirmed; email address records dumped from user table via union select",
+				"verification_method": "data_extracted",
+				"target":              "https://example.com",
+				"endpoint":            "/api/vuln-" + tt.name,
+				"cvss":                tt.cvss,
+			}
+
+			_, err := reportVulnWithContextID(contextID, args)
+			if err != nil {
+				t.Fatalf("report error: %v", err)
+			}
+
+			vulns := GetVulnerabilitiesForContext(contextID)
+			if len(vulns) != 1 {
+				t.Fatalf("expected 1 vuln, got %d", len(vulns))
+			}
+
+			if vulns[0].Severity != tt.wantSeverity {
+				t.Errorf("severity = %q, want %q (CVSS %s should always produce %s)", vulns[0].Severity, tt.wantSeverity, tt.cvss, tt.wantSeverity)
+			}
+		})
+	}
+}
+
+// TestStoredXSS_CVSS74_AlwaysHigh reproduces the exact scenario from the
+// user's bug report: "Stored XSS in ActiveCampaign CRM" with CVSS 7.4
+// was classified as HIGH in one run and LOW in another. After the fix,
+// CVSS 7.4 must always produce HIGH.
+func TestStoredXSS_CVSS74_AlwaysHigh(t *testing.T) {
+	// Simulate both scenarios the LLM might produce
+	scenarios := []struct {
+		name     string
+		severity string
+		proof    string
+	}{
+		{
+			"strong proof",
+			"high",
+			"Unauthenticated endpoint /api/activecampaign-lead accepts and stores unsanitized HTML/JavaScript in the firstName and lastName fields. Payload <script>alert(document.cookie)</script> fires in admin panel.",
+		},
+		{
+			"weak proof",
+			"high",
+			"The endpoint accepts HTML input in the firstName field. The data is stored and displayed.",
+		},
+		{
+			"agent says low",
+			"low",
+			"Unauthenticated endpoint accepts unsanitized HTML input.",
+		},
+	}
+
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			contextID := "test-stored-xss-consistency-" + sc.name
+			CleanupContext(contextID)
+			defer CleanupContext(contextID)
+
+			args := map[string]string{
+				"title":               "Stored XSS in ActiveCampaign CRM via /api/activecampaign-lead",
+				"severity":            sc.severity,
+				"description":         "Unauthenticated endpoint /api/activecampaign-lead accepts and stores unsanitized HTML/JavaScript",
+				"exploitation_proof":  sc.proof,
+				"verification_method": "reflected",
+				"target":              "https://vanhack.com",
+				"endpoint":            "/api/activecampaign-lead",
+				"method":              "POST",
+				"cvss":                "7.4",
+			}
+
+			_, err := reportVulnWithContextID(contextID, args)
+			if err != nil {
+				t.Fatalf("report error: %v", err)
+			}
+
+			vulns := GetVulnerabilitiesForContext(contextID)
+			if len(vulns) != 1 {
+				t.Fatalf("expected 1 vuln, got %d", len(vulns))
+			}
+
+			// CVSS 7.4 = HIGH, always. This is the fix.
+			if vulns[0].Severity != "high" {
+				t.Errorf("severity = %q, want %q — CVSS 7.4 must always produce HIGH regardless of proof strength or agent-provided severity", vulns[0].Severity, "high")
+			}
+		})
+	}
+}
+
+// TestClassifySeverity_XSSCaps verifies that stored XSS is capped at
+// high (not critical) by classifySeverity, but CVSS enforcement can
+// still override this cap.
+func TestClassifySeverity_XSSCaps(t *testing.T) {
+	// Stored XSS without admin/mass/worm proof → capped at high
+	sev, reason := classifySeverity("Stored XSS in comment field", "Persistent XSS stores payload", "critical", "alert(1) fires in page")
+	if sev != "high" {
+		t.Errorf("classifySeverity for stored XSS at critical = %q (reason=%q), want high", sev, reason)
+	}
+
+	// Reflected XSS → capped at medium
+	sev, reason = classifySeverity("Reflected XSS in search", "Input reflected in response", "high", "payload reflected")
+	if sev != "medium" {
+		t.Errorf("classifySeverity for reflected XSS at high = %q (reason=%q), want medium", sev, reason)
+	}
+}
+
+// TestClassifySeverity_VulnTypeFallback verifies that the vulnType-based
+// fallback fires when the LLM uses a different title framing for the same
+// vulnerability. This was the exact bug from scan logs where:
+// - "Stored XSS in ActiveCampaign CRM" → matched "stored xss" keyword → high cap
+// - "Unauthenticated Contact Injection" → matched NO keyword → no cap at all
+// After the fix, extractVulnType catches "xss" in both titles/descriptions.
+func TestClassifySeverity_VulnTypeFallback(t *testing.T) {
+	tests := []struct {
+		name     string
+		title    string
+		desc     string
+		severity string
+		want     string
+	}{
+		{
+			"stored xss keyword in title → high cap",
+			"Stored XSS in ActiveCampaign CRM via /api/activecampaign-lead",
+			"Persistent XSS stores payload in CRM firstName field",
+			"critical",
+			"high",
+		},
+		{
+			"xss in description only → vulnType fallback catches it",
+			"Unauthenticated ActiveCampaign Contact Injection — CRM Pollution",
+			"Anyone can inject stored XSS payloads via the firstName field",
+			"critical",
+			"high", // vulnType="xss" + "stored" in desc → high cap
+		},
+		{
+			"xss in description via different wording → vulnType catches it",
+			"Unauthenticated CRM Contact Creation — Unsanitized Input",
+			"The endpoint stores user-controlled HTML without sanitization, enabling cross-site scripting in the admin panel",
+			"critical",
+			"high", // vulnType="xss" from "cross-site scripting" + "stored" not present but desc says "stores" → check
+		},
+		{
+			"no xss anywhere → no fallback cap",
+			"Unauthenticated ActiveCampaign Contact Creation",
+			"Anyone can create arbitrary contacts in the CRM without authentication",
+			"critical",
+			"critical", // no vuln type detected → no cap
+		},
+		{
+			"reflected xss via vulnType → medium cap",
+			"Input Reflection in Search Endpoint",
+			"The search parameter reflects user input without encoding — cross-site scripting possible",
+			"high",
+			"medium", // vulnType="xss", no "stored"/"persistent" → reflected → medium cap
+		},
+		{
+			"csrf via vulnType → medium cap",
+			"Unauthenticated State Change in Profile Settings",
+			"Missing CSRF protection allows cross-site request forgery on profile update",
+			"critical",
+			"medium",
+		},
+		{
+			"ssrf via vulnType → high cap",
+			"Internal Network Access via URL Parameter",
+			"Server-side request forgery allows access to internal services",
+			"critical",
+			"high",
+		},
+		{
+			"cors via vulnType → low cap",
+			"Wildcard Origin Allowed on API",
+			"Cross-origin resource sharing misconfiguration reflects any origin",
+			"high",
+			"low",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, reason := classifySeverity(tt.title, tt.desc, tt.severity, "some proof")
+			if got != tt.want {
+				t.Errorf("classifySeverity(%q, %q, %q) = %q (reason=%q), want %q",
+					tt.title, tt.desc, tt.severity, got, reason, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tools/skills/skills.go
+++ b/internal/tools/skills/skills.go
@@ -77,6 +77,7 @@ var skillAliases = map[string]string{
 	"nosqli":                           "exploiting-nosql-injection-vulnerabilities",
 	"xss":                              "testing-for-xss-vulnerabilities",
 	"cross-site-scripting":             "testing-for-xss-vulnerabilities",
+	"dom-xss":                          "testing-for-xss-vulnerabilities",
 	"xss-burp":                         "testing-for-xss-vulnerabilities-with-burpsuite",
 	"ssrf":                             "performing-ssrf-vulnerability-exploitation",
 	"blind-ssrf":                       "performing-blind-ssrf-exploitation",
@@ -91,6 +92,7 @@ var skillAliases = map[string]string{
 	"server-side-template-injection":   "exploiting-template-injection-vulnerabilities",
 	"cors":                             "testing-cors-misconfiguration",
 	"cors-misconfiguration":            "testing-cors-misconfiguration",
+	"cors-exploitation":                "testing-cors-misconfiguration",
 	"open-redirect":                    "testing-for-open-redirect-vulnerabilities",
 	"clickjacking":                     "performing-clickjacking-attack-test",
 	"deserialization":                  "exploiting-insecure-deserialization",
@@ -100,21 +102,26 @@ var skillAliases = map[string]string{
 	"prototype-pollution":     "exploiting-prototype-pollution-in-javascript",
 	"type-juggling":           "exploiting-type-juggling-vulnerabilities",
 	"websocket":               "exploiting-websocket-vulnerabilities",
+	"websocket-hijacking":     "exploiting-websocket-vulnerabilities",
 	"request-smuggling":       "exploiting-http-request-smuggling",
 	"http-request-smuggling":  "exploiting-http-request-smuggling",
 	"broken-access-control":   "testing-for-broken-access-control",
 	"bac":                     "testing-for-broken-access-control",
 	"business-logic":          "testing-for-business-logic-vulnerabilities",
 	"host-header-injection":   "testing-for-host-header-injection",
+	"host-header-attacks":     "testing-for-host-header-injection",
 	"hpp":                     "performing-http-parameter-pollution-attack",
 	"parameter-pollution":     "performing-http-parameter-pollution-attack",
 	"graphql":                 "performing-graphql-security-assessment",
+	"graphql-advanced":        "performing-graphql-security-assessment",
 	"web-cache-poisoning":     "performing-web-cache-poisoning-attack",
+	"cache-poisoning":         "performing-web-cache-poisoning-attack",
 	"web-cache-deception":     "performing-web-cache-deception-attack",
 	"csp-bypass":              "performing-content-security-policy-bypass",
 	"waf-bypass":              "performing-web-application-firewall-bypass",
 	"second-order-sqli":       "performing-second-order-sql-injection",
 	"sensitive-data-exposure": "testing-for-sensitive-data-exposure",
+	"information-disclosure":  "testing-for-sensitive-data-exposure",
 	"xml-injection":           "testing-for-xml-injection-vulnerabilities",
 	"email-header-injection":  "testing-for-email-header-injection",
 	"broken-link-hijacking":   "exploiting-broken-link-hijacking",
@@ -130,6 +137,7 @@ var skillAliases = map[string]string{
 	"2fa-bypass":           "bypassing-two-factor-and-otp",
 	"mfa-bypass":           "bypassing-two-factor-and-otp",
 	"otp-bypass":           "bypassing-two-factor-and-otp",
+	"2fa-mfa-bypass":       "bypassing-two-factor-and-otp",
 	"password-reset":       "testing-password-reset-flaws",
 	"forgot-password":      "testing-password-reset-flaws",
 	"reset-password":       "testing-password-reset-flaws",
@@ -162,6 +170,7 @@ var skillAliases = map[string]string{
 	"checkout":                "testing-ecommerce-and-payment-logic",
 	"shopping-cart":           "testing-ecommerce-and-payment-logic",
 	"race-condition":          "exploiting-race-condition-vulnerabilities",
+	"race-conditions":         "exploiting-race-condition-vulnerabilities",
 	"mass-assignment":         "exploiting-mass-assignment-in-rest-apis",
 	"api-injection":           "exploiting-api-injection-vulnerabilities",
 
@@ -170,15 +179,16 @@ var skillAliases = map[string]string{
 	// reference. Without these aliases the agent's natural lookups
 	// (read_skill name=lfi / path-traversal) silently failed, which is a
 	// frequent cause of missed file-read findings (e.g. //etc/passwd).
-	"lfi":                   "performing-directory-traversal-testing",
-	"local-file-inclusion":  "performing-directory-traversal-testing",
-	"rfi":                   "performing-directory-traversal-testing",
-	"remote-file-inclusion": "performing-directory-traversal-testing",
-	"path-traversal":        "performing-directory-traversal-testing",
-	"directory-traversal":   "performing-directory-traversal-testing",
-	"file-read":             "performing-directory-traversal-testing",
-	"arbitrary-file-read":   "performing-directory-traversal-testing",
-	"etc-passwd":            "performing-directory-traversal-testing",
+	"lfi":                     "performing-directory-traversal-testing",
+	"local-file-inclusion":    "performing-directory-traversal-testing",
+	"rfi":                     "performing-directory-traversal-testing",
+	"remote-file-inclusion":   "performing-directory-traversal-testing",
+	"path-traversal":          "performing-directory-traversal-testing",
+	"path-traversal-lfi-rfi":  "performing-directory-traversal-testing",
+	"directory-traversal":     "performing-directory-traversal-testing",
+	"file-read":               "performing-directory-traversal-testing",
+	"arbitrary-file-read":     "performing-directory-traversal-testing",
+	"etc-passwd":              "performing-directory-traversal-testing",
 
 	// ── OS command injection / RCE ───────────────────────────────────
 	// "command-injection" previously resolved to a Modbus/ICS detection
@@ -195,9 +205,11 @@ var skillAliases = map[string]string{
 	// ── Authentication & authorization ───────────────────────────────
 	"jwt":               "exploiting-jwt-algorithm-confusion-attack",
 	"jwt-attack":        "exploiting-jwt-algorithm-confusion-attack",
+	"authentication-jwt": "exploiting-jwt-algorithm-confusion-attack",
 	"jwt-signing":       "implementing-jwt-signing-and-verification",
 	"oauth":             "exploiting-oauth-misconfiguration",
 	"oauth-misconfig":   "exploiting-oauth-misconfiguration",
+	"oauth2-attacks":    "exploiting-oauth-misconfiguration",
 	"oauth-token-theft": "detecting-oauth-token-theft",
 	"forced-browsing":   "bypassing-authentication-with-forced-browsing",
 	"brute-force":       "detecting-rdp-brute-force-attacks",
@@ -271,10 +283,11 @@ var skillAliases = map[string]string{
 	"burp":             "intercepting-mobile-traffic-with-burpsuite",
 
 	// ── File upload testing ──────────────────────────────────────────
-	"file-upload":     "exploiting-file-upload-vulnerabilities",
-	"upload":          "exploiting-file-upload-vulnerabilities",
-	"upload-bypass":   "exploiting-file-upload-vulnerabilities",
-	"webshell-upload": "exploiting-file-upload-vulnerabilities",
+	"file-upload":         "exploiting-file-upload-vulnerabilities",
+	"upload":              "exploiting-file-upload-vulnerabilities",
+	"upload-bypass":       "exploiting-file-upload-vulnerabilities",
+	"webshell-upload":     "exploiting-file-upload-vulnerabilities",
+	"insecure-file-uploads": "exploiting-file-upload-vulnerabilities",
 
 	// ── CMS-specific testing ────────────────────────────────────────
 	"cms":         "performing-cms-specific-security-testing",
@@ -290,11 +303,12 @@ var skillAliases = map[string]string{
 	"dangling-cname":     "exploiting-subdomain-takeover-vulnerabilities",
 
 	// ── Zero-day & novel vulnerability discovery ────────────────────
-	"zero-day":        "performing-zero-day-vulnerability-discovery",
-	"0day":            "performing-zero-day-vulnerability-discovery",
-	"novel-vuln":      "performing-zero-day-vulnerability-discovery",
-	"attack-chaining": "performing-zero-day-vulnerability-discovery",
-	"logic-flaw":      "performing-zero-day-vulnerability-discovery",
+	"zero-day":         "performing-zero-day-vulnerability-discovery",
+	"0day":             "performing-zero-day-vulnerability-discovery",
+	"novel-vuln":       "performing-zero-day-vulnerability-discovery",
+	"attack-chaining":  "performing-zero-day-vulnerability-discovery",
+	"logic-flaw":       "performing-zero-day-vulnerability-discovery",
+	"zero-day-hunting": "performing-zero-day-vulnerability-discovery",
 
 	// ── Exploit verification ────────────────────────────────────────
 	"exploit-verification": "performing-exploit-verification",
@@ -467,6 +481,7 @@ var skillAliases = map[string]string{
 	"prompt-injection":      "testing-llm-prompt-injection-and-jailbreaks",
 	"jailbreak":             "testing-llm-prompt-injection-and-jailbreaks",
 	"llm-injection":         "testing-llm-prompt-injection-and-jailbreaks",
+	"web-llm-attacks":       "testing-llm-prompt-injection-and-jailbreaks",
 	"mcp":                   "testing-mcp-server-security",
 	"mcp-security":          "testing-mcp-server-security",
 	"tool-poisoning":        "testing-mcp-server-security",
@@ -1151,8 +1166,11 @@ var skillAliases = map[string]string{
 
 // resolveAlias returns the canonical skill name for a shorthand alias.
 // If no alias matches, the original name is returned unchanged.
+// Underscores are normalized to dashes before lookup so that old-style
+// names (e.g. "nosql_injection") resolve via the dash-keyed alias map.
 func resolveAlias(name string) string {
 	key := strings.ToLower(name)
+	key = strings.ReplaceAll(key, "_", "-")
 	if canonical, ok := skillAliases[key]; ok {
 		return canonical
 	}

--- a/internal/tools/skills/skills_test.go
+++ b/internal/tools/skills/skills_test.go
@@ -217,6 +217,63 @@ func TestResolveAlias(t *testing.T) {
 	}
 }
 
+// TestResolveAlias_SystemPromptHints verifies that every alias referenced
+// in agent.go's system prompt (the read_skill(name="...") hints) resolves
+// to a real skill. These were previously broken (16 dead references).
+func TestResolveAlias_SystemPromptHints(t *testing.T) {
+	hints := []struct {
+		input string
+		want  string
+	}{
+		{"2fa-mfa-bypass", "bypassing-two-factor-and-otp"},
+		{"authentication-jwt", "exploiting-jwt-algorithm-confusion-attack"},
+		{"cache-poisoning", "performing-web-cache-poisoning-attack"},
+		{"cors-exploitation", "testing-cors-misconfiguration"},
+		{"dom-xss", "testing-for-xss-vulnerabilities"},
+		{"graphql-advanced", "performing-graphql-security-assessment"},
+		{"host-header-attacks", "testing-for-host-header-injection"},
+		{"information-disclosure", "testing-for-sensitive-data-exposure"},
+		{"insecure-file-uploads", "exploiting-file-upload-vulnerabilities"},
+		{"oauth2-attacks", "exploiting-oauth-misconfiguration"},
+		{"path-traversal-lfi-rfi", "performing-directory-traversal-testing"},
+		{"race-conditions", "exploiting-race-condition-vulnerabilities"},
+		{"web-llm-attacks", "testing-llm-prompt-injection-and-jailbreaks"},
+		{"websocket-hijacking", "exploiting-websocket-vulnerabilities"},
+		{"zero-day-hunting", "performing-zero-day-vulnerability-discovery"},
+	}
+	for _, tc := range hints {
+		got := resolveAlias(tc.input)
+		if got != tc.want {
+			t.Errorf("resolveAlias(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+// TestResolveAlias_UnderscoreNormalization verifies that underscore-style
+// names (used in old system prompt examples) resolve via the dash-keyed
+// alias map after normalization.
+func TestResolveAlias_UnderscoreNormalization(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"nosql_injection", "exploiting-nosql-injection-vulnerabilities"},
+		{"prototype_pollution", "exploiting-prototype-pollution-in-javascript"},
+		{"http_request_smuggling", "exploiting-http-request-smuggling"},
+		{"mass_assignment", "exploiting-mass-assignment-in-rest-apis"},
+		{"sql_injection", "exploiting-sql-injection-vulnerabilities"},
+		// Mixed case + underscores
+		{"SQL_Injection", "exploiting-sql-injection-vulnerabilities"},
+		{"NOSQL_INJECTION", "exploiting-nosql-injection-vulnerabilities"},
+	}
+	for _, tc := range tests {
+		got := resolveAlias(tc.input)
+		if got != tc.want {
+			t.Errorf("resolveAlias(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
 func TestReadSkill_Alias(t *testing.T) {
 	// Set up a test FS that has the full canonical name the alias resolves to.
 	dir := t.TempDir()
@@ -245,5 +302,14 @@ func TestReadSkill_Alias(t *testing.T) {
 	}
 	if !strings.Contains(result.Output, "SQL Injection") {
 		t.Errorf("alias 'sqli' should resolve to full skill, got: %s", result.Output)
+	}
+
+	// Test underscore-style name resolves via normalization
+	result, err = fn(map[string]string{"name": "sql_injection"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result.Output, "SQL Injection") {
+		t.Errorf("underscore alias 'sql_injection' should resolve to full skill, got: %s", result.Output)
 	}
 }

--- a/release.sh
+++ b/release.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 #   ./release.sh 4.3.0            # explicit version
 #   ./release.sh --minor          # bump minor (4.2.10 → 4.3.0)
 #   ./release.sh --major          # bump major (4.2.10 → 5.0.0)
+#
+# The version bump is committed on a dedicated release/vX.Y.Z branch (never
+# directly on main), so the PR merges cleanly without version-string conflicts.
 
 REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 MAIN_GO="$REPO_ROOT/cmd/xalgorix/main.go"
@@ -38,6 +41,19 @@ if [[ -n "$(git status --porcelain)" ]]; then
     die "Working tree is dirty. Commit or stash changes first."
 fi
 
+# ─── Step 0: Sync main with origin to avoid divergence ───
+ORIGINAL_BRANCH="$(git branch --show-current)"
+if [[ "$ORIGINAL_BRANCH" != "main" ]]; then
+    info "Switching to main..."
+    git checkout main
+fi
+info "Syncing main with origin/main..."
+git pull --ff-only origin main 2>/dev/null || {
+    warn "Fast-forward pull failed — trying rebase..."
+    git pull --rebase origin main || die "Cannot sync main with origin. Resolve manually."
+}
+ok "main is in sync with origin"
+
 # ─── Determine current version ───
 CURRENT=$(grep -oP 'var version = "\K[^"]+' "$MAIN_GO")
 [[ -z "$CURRENT" ]] && die "Could not parse current version from $MAIN_GO"
@@ -67,7 +83,17 @@ read -rp "Proceed with release v$NEW_VERSION? [y/N] " confirm
 [[ "$confirm" =~ ^[Yy]$ ]] || { warn "Aborted."; exit 0; }
 echo ""
 
-# ─── Step 1: Bump version in source ───
+# ─── Step 1: Create release branch from main ───
+RELEASE_BRANCH="release/v$NEW_VERSION"
+if git rev-parse --verify --quiet "$RELEASE_BRANCH" >/dev/null; then
+    warn "Branch $RELEASE_BRANCH already exists locally — refusing to overwrite. Delete it and rerun if intentional."
+    die "release branch collision"
+fi
+info "Creating branch $RELEASE_BRANCH from main..."
+git checkout -b "$RELEASE_BRANCH"
+ok "On branch $RELEASE_BRANCH"
+
+# ─── Step 2: Bump version in source (on release branch) ───
 info "Bumping version in main.go..."
 sed -i "s/var version = \"$CURRENT\"/var version = \"$NEW_VERSION\"/" "$MAIN_GO"
 if [[ -f "$MAKEFILE" ]]; then
@@ -78,19 +104,18 @@ if [[ -f "$README" ]]; then
 fi
 ok "Version bumped: $CURRENT → $NEW_VERSION"
 
-# ─── Step 2: Build & verify ───
+# ─── Step 3: Build & verify ───
 info "Building and verifying..."
-# The previous version had `die` before `git checkout`, but `die` calls
-# `exit 1` so the checkout never ran and the version bump was left on disk.
-# Reorder: revert the bump first, then exit.
 if ! go build ./cmd/xalgorix/; then
-    warn "Build failed — reverting version bump"
+    warn "Build failed — reverting version bump and deleting release branch"
     git checkout -- "$MAIN_GO" "$MAKEFILE" "$README"
-    die "Build failed (version bump reverted)"
+    git checkout main
+    git branch -D "$RELEASE_BRANCH"
+    die "Build failed (version bump reverted, release branch deleted)"
 fi
 ok "Build successful"
 
-# ─── Step 3: Build release binary ───
+# ─── Step 4: Build release binary ───
 info "Building linux/amd64 release binary..."
 mkdir -p "$BUILD_DIR"
 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
@@ -99,7 +124,7 @@ CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
     ./cmd/xalgorix/
 ok "Binary built: $BUILD_DIR/xalgorix-linux-amd64"
 
-# ─── Step 4: Generate changelog ───
+# ─── Step 5: Generate changelog (commits since last tag) ───
 info "Generating changelog..."
 CHANGELOG=$(git log --oneline "v$CURRENT"..HEAD 2>/dev/null | sed 's/^/- /' || echo "- Release v$NEW_VERSION")
 if [[ -z "$CHANGELOG" ]]; then
@@ -108,35 +133,20 @@ fi
 echo "$CHANGELOG"
 echo ""
 
-# ─── Step 5: Commit & tag ───
+# ─── Step 6: Commit & tag (on release branch) ───
 info "Committing and tagging..."
 git add -A
 git commit -m "release: v$NEW_VERSION"
 git tag "v$NEW_VERSION"
 ok "Tagged v$NEW_VERSION"
 
-# ─── Step 6: Push to release branch and open PR ───
-# `main` is branch-protected and rejects direct pushes; release work goes onto
-# a per-version release branch and merges via PR, matching the existing
-# v4.4.17 / v4.4.18 / v4.4.19 release pattern.
-RELEASE_BRANCH="release/v$NEW_VERSION"
-info "Switching to $RELEASE_BRANCH and pushing..."
-
-# Capture the commit just made on the current branch (typically main) and use
-# it as the tip of the release branch. This avoids cherry-picking and keeps
-# the tag on the same commit the PR merges.
-RELEASE_COMMIT="$(git rev-parse HEAD)"
-
-if git rev-parse --verify --quiet "$RELEASE_BRANCH" >/dev/null; then
-    warn "Branch $RELEASE_BRANCH already exists locally — refusing to overwrite. Delete it and rerun if intentional."
-    die "release branch collision"
-fi
-
-git branch "$RELEASE_BRANCH" "$RELEASE_COMMIT"
+# ─── Step 7: Push release branch & tag ───
+info "Pushing $RELEASE_BRANCH and tag..."
 git push -u origin "$RELEASE_BRANCH"
 git push origin "v$NEW_VERSION"
 ok "Pushed $RELEASE_BRANCH and tag v$NEW_VERSION"
 
+# ─── Step 8: Open PR against main ───
 info "Opening PR against main..."
 PR_BODY="### Changes
 
@@ -150,7 +160,7 @@ else
     ok "PR opened: $PR_URL"
 fi
 
-# ─── Step 7: Create GitHub Release ───
+# ─── Step 9: Create GitHub Release ───
 info "Creating GitHub Release..."
 gh release create "v$NEW_VERSION" \
     "$BUILD_DIR/xalgorix-linux-amd64" \
@@ -159,6 +169,11 @@ gh release create "v$NEW_VERSION" \
 
 $CHANGELOG"
 ok "GitHub Release created"
+
+# ─── Step 10: Switch back to main ───
+info "Switching back to main..."
+git checkout main
+ok "Back on main (clean — version bump lives only on $RELEASE_BRANCH)"
 
 # ─── Cleanup ───
 rm -rf "$BUILD_DIR"


### PR DESCRIPTION
## Problem

3 scans of the same target produced wildly different results:
- **Different findings** — agent took different recon paths each run
- **Different severity** — same CVSS 7.4 mapped to HIGH in one run, LOW in another
- **Data loss** — `send_request` truncated JS bundles at 10KB, hiding endpoints

## Root Causes (from log analysis of 3 vanhack.com scans)

| Cause | Impact |
|-------|--------|
| CVSS upgrade blocked by `originalSeverity` flag | CVSS 7.4 → LOW instead of HIGH |
| Auto-downgrade was nuclear (high→info, 3 levels) | Legitimate findings downgraded to info |
| LLM temperature defaulted to 1.0 | Different recon strategy every run |
| `classifySeverity` used raw title keywords only | 'Contact Injection' vs 'Stored XSS' → different caps |
| No structured recon sequence | Each scan discovered different endpoints |
| `send_request` truncated at 10KB | JS bundle analysis missed (Scan 1 found 1 vuln vs Scan 2's 4) |

## Changes

### reporting.go (5 fixes)
- CVSS enforcement now authoritative — removed `originalSeverity == ""` guard on upgrade
- Auto-downgrade softened — one-level drop instead of nuclear to info
- `classifySeverity` uses `extractVulnType()` for title-independent classification
- Broadened 'stored' detection: stores, persist, permanent, saved in
- Fixed misleading SEVERITY ADJUSTED log message

### proxy.go (1 fix)
- Large responses (>10KB) saved to `/tmp/send_request_<hash>.txt` instead of truncated
- Agent gets preview + file path so it can grep the full content

### agent.go (2 fixes)
- Mandatory 5-iteration recon sequence: headers → page → JS bundles → subdomains → inventory
- Enforces `terminal_execute` (curl) over `send_request` for recon

### config.go + client.go
- Temperature = 0.2 wired through config and API requests

## Tests
- 8 new regression tests (32/32 reporting pass, 3/3 proxy pass)
- `TestClassifySeverity_VulnTypeFallback` — 8 subtests: same vuln, different titles → same cap
- `TestCVSSEnforcement_OverridesAutoDowngrade` — 8 subtests: CVSS always authoritative
- `TestStoredXSS_CVSS74_AlwaysHigh` — exact bug reproduction