### PR TITLE
release: v4.5.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.5
+VERSION=4.5.6
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.5" alt="Xalgorix" width="860" />
+<img src="assets/banner.png?v=4.5.6" alt="Xalgorix" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.5"
+var version = "4.5.6"
 
 const defaultWebPort = 9137
 

--- a/internal/tools/proxy/proxy.go
+++ b/internal/tools/proxy/proxy.go
@@ -176,7 +176,7 @@ func sendRequest(args map[string]string) (tools.Result, error) {
 		h := sha256.Sum256([]byte(method + " " + targetURL))
 		hash := hex.EncodeToString(h[:8])
 		savedPath = "/tmp/send_request_" + hash + ".txt"
-		if err := os.WriteFile(savedPath, respBody, 0644); err != nil {
+		if err := os.WriteFile(savedPath, respBody, 0600); err != nil {
 			// If file write fails, fall back to truncation.
 			savedPath = ""
 		}


### PR DESCRIPTION
### Changes

- 09ddbd4 fix: scan consistency — severity determinism, vulnType normalization, recon seeding (#97)
- 548c3e8 release: v4.5.5 (#96)
- 09e062a release: v4.5.4 (#95)
- 46c7e0f release: v4.5.3 (#94)
- b01ca24 release: v4.5.2 (#93)