### PR TITLE
feat: coverage-based finish gating — proportional endpoint testing, 50-iteration floor

### DIFF
--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -35,9 +35,6 @@ type ScanState struct {
 	SkillsLoaded               int
 	UniqueToolsUsed            map[string]bool
 	ReconDone                  bool
-	InjectionTested            bool
-	DirBustingDone             bool
-	AccessControlTested        bool
 	ScannerUsed                bool
 	FinishAttempts             int
 	DiscoveryMode              bool
@@ -46,6 +43,21 @@ type ScanState struct {
 	PassiveReconGuardActive    bool
 	PassiveReconPassiveLookups int
 	PassiveReconBlockedActive  int
+
+	// Coverage counters — track UNIQUE endpoints per test category.
+	// These replace the old boolean flags (InjectionTested, etc.) which
+	// fired after a single command, allowing the agent to finish after
+	// testing only 1 out of 20 discovered endpoints.
+	InjectionEndpoints     map[string]bool // unique endpoints with injection payloads
+	AccessControlEndpoints map[string]bool // unique endpoints with auth/IDOR tests
+	DirBustingHosts        map[string]bool // unique hosts/paths fuzzed
+	EndpointsTested        map[string]bool // all unique URL paths tested with any tool
+	EndpointInventorySaved bool            // add_note called (recon checklist step 5)
+
+	// Backward-compat booleans — derived from map lengths in hookWorkTracker
+	InjectionTested     bool
+	DirBustingDone      bool
+	AccessControlTested bool
 
 	// Stuck-loop detection
 	StuckDomain        string
@@ -73,8 +85,12 @@ type ScanState struct {
 // NewScanState creates a zero-value ScanState with initialized maps.
 func NewScanState() *ScanState {
 	return &ScanState{
-		UniqueToolsUsed: make(map[string]bool),
-		DetectedTechs:   make(map[string]bool),
+		UniqueToolsUsed:        make(map[string]bool),
+		DetectedTechs:          make(map[string]bool),
+		InjectionEndpoints:     make(map[string]bool),
+		AccessControlEndpoints: make(map[string]bool),
+		DirBustingHosts:        make(map[string]bool),
+		EndpointsTested:        make(map[string]bool),
 	}
 }
 
@@ -183,6 +199,12 @@ func hookWorkTracker(state *ScanState, args map[string]string) HookResult {
 		state.TerminalCalls++
 		cmd := strings.ToLower(args["command"])
 
+		// Extract endpoint from curl/httpx commands for coverage tracking
+		endpoint := extractEndpointFromCmd(cmd)
+		if endpoint != "" {
+			state.EndpointsTested[endpoint] = true
+		}
+
 		// Detect recon commands
 		if strings.Contains(cmd, "nmap") || strings.Contains(cmd, "whatweb") ||
 			strings.Contains(cmd, "curl -si") || strings.Contains(cmd, "curl -sk") ||
@@ -193,32 +215,44 @@ func hookWorkTracker(state *ScanState, args map[string]string) HookResult {
 			state.ReconDone = true
 		}
 
-		// Detect directory busting
+		// Detect directory busting — track unique hosts/paths
 		if strings.Contains(cmd, "ffuf") || strings.Contains(cmd, "gobuster") ||
 			strings.Contains(cmd, "dirsearch") || strings.Contains(cmd, "feroxbuster") ||
 			strings.Contains(cmd, "dirb ") {
+			host := extractHostFromCmd(cmd)
+			if host != "" {
+				state.DirBustingHosts[host] = true
+			}
 			state.DirBustingDone = true
 		}
 
-		// Detect injection testing
-		if strings.Contains(cmd, "sqlmap") || strings.Contains(cmd, "dalfox") ||
+		// Detect injection testing — track unique endpoints
+		isInjection := strings.Contains(cmd, "sqlmap") || strings.Contains(cmd, "dalfox") ||
 			strings.Contains(cmd, "sleep(") || strings.Contains(cmd, "alert(") ||
 			strings.Contains(cmd, "<script>") || strings.Contains(cmd, "' or ") ||
 			strings.Contains(cmd, "' and ") || strings.Contains(cmd, "{{7*7}}") ||
 			strings.Contains(cmd, "etc/passwd") || strings.Contains(cmd, "xalg0r1x") ||
 			strings.Contains(cmd, "$ne") || strings.Contains(cmd, "$gt") ||
 			strings.Contains(cmd, "__proto__") || strings.Contains(cmd, "%0d%0a") ||
-			(strings.Contains(cmd, "content-length") && strings.Contains(cmd, "transfer-encoding")) {
+			(strings.Contains(cmd, "content-length") && strings.Contains(cmd, "transfer-encoding"))
+		if isInjection {
+			if endpoint != "" {
+				state.InjectionEndpoints[endpoint] = true
+			}
 			state.InjectionTested = true
 		}
 
-		// Detect access control testing (IDOR, auth bypass)
-		if strings.Contains(cmd, "/user/1") || strings.Contains(cmd, "/user/2") ||
+		// Detect access control testing — track unique endpoints
+		isAccessControl := strings.Contains(cmd, "/user/1") || strings.Contains(cmd, "/user/2") ||
 			strings.Contains(cmd, "id=1") || strings.Contains(cmd, "id=2") ||
 			strings.Contains(cmd, "role=admin") || strings.Contains(cmd, "isadmin") ||
 			strings.Contains(cmd, "x-forwarded-for") || strings.Contains(cmd, "x-original-url") ||
 			(strings.Contains(cmd, "admin") && strings.Contains(cmd, "curl")) ||
-			strings.Contains(cmd, "authorization") {
+			strings.Contains(cmd, "authorization")
+		if isAccessControl {
+			if endpoint != "" {
+				state.AccessControlEndpoints[endpoint] = true
+			}
 			state.AccessControlTested = true
 		}
 
@@ -235,7 +269,53 @@ func hookWorkTracker(state *ScanState, args map[string]string) HookResult {
 		state.SkillsLoaded++
 	}
 
+	// Track endpoint inventory saved (mandatory recon checklist step 5)
+	if toolName == "add_note" {
+		noteContent := strings.ToLower(args["content"])
+		if strings.Contains(noteContent, "endpoint") || strings.Contains(noteContent, "api") ||
+			strings.Contains(noteContent, "subdomain") || strings.Contains(noteContent, "inventory") ||
+			strings.Contains(noteContent, "discovered") {
+			state.EndpointInventorySaved = true
+		}
+	}
+
 	return HookResult{}
+}
+
+// extractEndpointFromCmd extracts a URL path from curl/httpx commands.
+// Returns a normalized endpoint like "/api/users" or "" if not found.
+func extractEndpointFromCmd(cmd string) string {
+	for _, prefix := range []string{"curl ", "httpx ", "wget "} {
+		if !strings.Contains(cmd, prefix) {
+			continue
+		}
+		for _, token := range strings.Fields(cmd) {
+			if strings.HasPrefix(token, "http://") || strings.HasPrefix(token, "https://") {
+				token = strings.Trim(token, "\"'")
+				if parsed, err := url.Parse(token); err == nil && parsed.Host != "" {
+					path := parsed.Path
+					if path == "" || path == "/" {
+						path = "/"
+					}
+					return parsed.Host + path
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// extractHostFromCmd extracts the target host from a command for dirbusting tracking.
+func extractHostFromCmd(cmd string) string {
+	for _, token := range strings.Fields(cmd) {
+		token = strings.Trim(token, "\"'")
+		if strings.HasPrefix(token, "http://") || strings.HasPrefix(token, "https://") {
+			if parsed, err := url.Parse(token); err == nil && parsed.Host != "" {
+				return parsed.Host
+			}
+		}
+	}
+	return ""
 }
 
 // ── hookStuckTracker ─────────────────────────────────────────────────────────
@@ -423,7 +503,9 @@ func hookTechDetector(state *ScanState, args map[string]string) HookResult {
 }
 
 // ── hookFinishGatekeeper ─────────────────────────────────────────────────────
-// Replaces canFinish() closure. Decides if the agent has done enough work.
+// Decides if the agent has done enough work. Uses proportional coverage
+// tracking: the gate checks how many UNIQUE endpoints were tested per
+// vuln class, not just "did you run sqlmap once?".
 func hookFinishGatekeeper(state *ScanState, args map[string]string) HookResult {
 	state.FinishAttempts++
 
@@ -445,6 +527,10 @@ func hookFinishGatekeeper(state *ScanState, args map[string]string) HookResult {
 	}
 
 	iter := state.Iteration
+	totalEndpoints := len(state.EndpointsTested)
+	injectionCount := len(state.InjectionEndpoints)
+	accessControlCount := len(state.AccessControlEndpoints)
+	dirBustingCount := len(state.DirBustingHosts)
 
 	// Absolute minimum: at least 3 iterations (sanity floor)
 	if iter < 3 {
@@ -470,77 +556,99 @@ func hookFinishGatekeeper(state *ScanState, args map[string]string) HookResult {
 		}
 	}
 
-	// After basic threshold, evaluate work quality
-	if state.TerminalCalls >= 10 && state.ReconDone {
-		if iter < 15 {
-			missing := []string{}
-			if !state.InjectionTested {
-				missing = append(missing, "manual injection testing (SQLi, XSS, SSRF, NoSQL, SSTI)")
-			}
-			if !state.DirBustingDone {
-				missing = append(missing, "directory brute-forcing (ffuf/gobuster/dirsearch)")
-			}
-			if !state.AccessControlTested {
-				missing = append(missing, "access control testing (IDOR, auth bypass, role testing)")
-			}
-			if len(missing) > 0 {
-				return HookResult{
-					Block:       true,
-					BlockReason: fmt.Sprintf("Recon is done but you haven't completed: %s. Continue testing before finishing.", strings.Join(missing, ", ")),
-				}
-			}
+	// ── Coverage-based gating ──
+	// Instead of "did you run sqlmap once?", check how many unique
+	// endpoints were tested per category. This prevents shallow scans
+	// that test 1 out of 20 discovered endpoints.
+
+	// Gate: Endpoint inventory must be saved (mandatory recon step 5)
+	if !state.EndpointInventorySaved && iter < 50 {
+		return HookResult{
+			Block:       true,
+			BlockReason: "You haven't saved your endpoint inventory with add_note yet. Complete the mandatory recon checklist: save ALL discovered endpoints, subdomains, and API bases to notes before finishing.",
 		}
-		// Work quality is acceptable — check iteration floor and first-attempt nudge below
-	} else if iter < 35 {
-		// Between threshold with < 10 commands: nudge to do more
+	}
+
+	// Gate: Proportional coverage — require testing multiple endpoints
+	if iter < 50 {
 		missing := []string{}
-		if !state.InjectionTested {
-			missing = append(missing, "manual parameter testing (SQLi, XSS, SSRF, NoSQL, SSTI, CRLF)")
+
+		// Injection: require at least 3 unique endpoints tested (or all if < 3 exist)
+		minInjection := minInt(3, maxInt(1, totalEndpoints/3))
+		if injectionCount < minInjection {
+			missing = append(missing, fmt.Sprintf("injection testing on %d more endpoints (tested %d/%d — try SQLi, XSS, SSRF, SSTI on different endpoints)",
+				minInjection-injectionCount, injectionCount, totalEndpoints))
 		}
-		if !state.DirBustingDone {
-			missing = append(missing, "directory discovery (ffuf/gobuster/dirsearch)")
+
+		// Directory busting: require at least 1 host
+		if dirBustingCount < 1 {
+			missing = append(missing, "directory brute-forcing (ffuf/gobuster/dirsearch on at least 1 target)")
 		}
-		if !state.AccessControlTested {
-			missing = append(missing, "access control testing (IDOR, privilege escalation, auth bypass)")
+
+		// Access control: require at least 2 unique endpoints tested
+		minAccessControl := minInt(2, maxInt(1, totalEndpoints/4))
+		if accessControlCount < minAccessControl {
+			missing = append(missing, fmt.Sprintf("access control testing on %d more endpoints (tested %d — try IDOR, auth bypass, privilege escalation)",
+				minAccessControl-accessControlCount, accessControlCount))
 		}
+
 		if len(missing) > 0 {
 			return HookResult{
 				Block:       true,
-				BlockReason: fmt.Sprintf("Still missing: %s. Continue testing before finishing.", strings.Join(missing, ", ")),
+				BlockReason: fmt.Sprintf("Coverage gap: you've tested %d unique endpoints total but still need: %s", totalEndpoints, strings.Join(missing, "; ")),
 			}
 		}
 	}
 
-	// Generous allowance after 35 iterations regardless
-	// (iter >= 35 always passes through to first-attempt check below)
-
-	// First finish attempt nudge: reconsider if < 35 iterations
-	if state.FinishAttempts == 1 && iter < 35 {
-		scannerNote := ""
-		if !state.ScannerUsed {
-			scannerNote = "\n- You haven't used any automated scanners (nuclei/ffuf) yet — consider running them on promising endpoints"
-		}
-		skillNote := ""
-		if state.SkillsLoaded == 0 {
-			skillNote = "\n- ⚠️ You haven't loaded ANY deep knowledge skills (read_skill). Load skills for the target's tech stack to get expert-level payloads and bypass techniques!"
-		}
-		nudgeMsg := fmt.Sprintf(`⚠️ Are you SURE you want to finish? You still have capacity to test more.
+	// ── Iteration floor: 50 ──
+	// Matches the system prompt: "Minimum 50 iterations for a thorough assessment"
+	if iter < 50 {
+		if state.FinishAttempts <= 2 {
+			scannerNote := ""
+			if !state.ScannerUsed {
+				scannerNote = "\n- You haven't used any automated scanners (nuclei/ffuf) yet — consider running them on promising endpoints"
+			}
+			skillNote := ""
+			if state.SkillsLoaded == 0 {
+				skillNote = "\n- ⚠️ You haven't loaded ANY deep knowledge skills (read_skill). Load skills for the target's tech stack to get expert-level payloads and bypass techniques!"
+			}
+			coverageNote := fmt.Sprintf("\n- Endpoints tested: %d (injection: %d, access control: %d, dirbusting hosts: %d)",
+				totalEndpoints, injectionCount, accessControlCount, dirBustingCount)
+			nudgeMsg := fmt.Sprintf(`⚠️ Only %d/50 iterations completed. You still have capacity to test more.
 
 Before finishing, verify you have covered:
 - All discovered endpoints and parameters tested MANUALLY
 - Common vulnerability classes (SQLi, XSS, SSRF, IDOR, broken auth)
 - Technology-specific CVEs
-- API endpoints found in JavaScript files%s%s
+- API endpoints found in JavaScript files%s%s%s
 
-If you have truly covered everything, call finish again. Otherwise, continue testing.`, scannerNote, skillNote)
+Continue testing. Call finish again after iteration 50.`, iter, coverageNote, scannerNote, skillNote)
 
-		return HookResult{
-			Block:       true,
-			BlockReason: nudgeMsg,
+			return HookResult{
+				Block:       true,
+				BlockReason: nudgeMsg,
+			}
 		}
 	}
 
+	// After 50 iterations with coverage met: allow finish
 	return HookResult{}
+}
+
+// maxInt returns the larger of two ints.
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// minInt returns the smaller of two ints.
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 // ── hookEmptyResponseHandler ─────────────────────────────────────────────────

--- a/internal/agent/hooks_test.go
+++ b/internal/agent/hooks_test.go
@@ -1,0 +1,321 @@
+package agent
+
+import (
+	"testing"
+)
+
+// ── extractEndpointFromCmd tests ─────────────────────────────────────────────
+
+func TestExtractEndpointFromCmd(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{"curl with https", `curl -sk https://example.com/api/users`, "example.com/api/users"},
+		{"curl with http", `curl http://example.com/login`, "example.com/login"},
+		{"curl root path", `curl https://example.com/`, "example.com/"},
+		{"curl no path", `curl https://example.com`, "example.com/"},
+		{"curl with quotes", `curl https://example.com/v1/token`, "example.com/v1/token"},
+		{"curl with flags", `curl -si -H "Host: evil" https://target.com/admin/panel`, "target.com/admin/panel"},
+		{"httpx command", `httpx -u https://target.com/api/v2/health`, "target.com/api/v2/health"},
+		{"wget command", `wget https://cdn.example.com/bundle.js`, "cdn.example.com/bundle.js"},
+		{"no url", `nmap -sV target.com`, ""},
+		{"sqlmap no url prefix", `sqlmap -r request.txt`, ""},
+		{"strips query params", `curl https://api.example.com/search?q=test`, "api.example.com/search"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractEndpointFromCmd(tt.cmd)
+			if got != tt.want {
+				t.Errorf("extractEndpointFromCmd(%q) = %q, want %q", tt.cmd, got, tt.want)
+			}
+		})
+	}
+}
+
+// ── extractHostFromCmd tests ─────────────────────────────────────────────────
+
+func TestExtractHostFromCmd(t *testing.T) {
+	tests := []struct {
+		cmd  string
+		want string
+	}{
+		{`ffuf -u https://target.com/FUZZ -w wordlist.txt`, "target.com"},
+		{`gobuster dir -u https://sub.target.com/ -w list.txt`, "sub.target.com"},
+		{`dirsearch -u http://10.0.0.1:8080/api`, "10.0.0.1:8080"},
+		{`nmap target.com`, ""},
+	}
+
+	for _, tt := range tests {
+		name := tt.cmd
+		if len(name) > 30 {
+			name = name[:30]
+		}
+		t.Run(name, func(t *testing.T) {
+			got := extractHostFromCmd(tt.cmd)
+			if got != tt.want {
+				t.Errorf("extractHostFromCmd(%q) = %q, want %q", tt.cmd, got, tt.want)
+			}
+		})
+	}
+}
+
+// ── hookWorkTracker tests ────────────────────────────────────────────────────
+
+func TestWorkTracker_TracksUniqueEndpoints(t *testing.T) {
+	state := NewScanState()
+
+	// First curl — should track endpoint
+	hookWorkTracker(state, map[string]string{
+		"tool_name": "terminal_execute",
+		"command":   `curl -sk https://example.com/api/users`,
+	})
+	if len(state.EndpointsTested) != 1 {
+		t.Errorf("Expected 1 endpoint tracked, got %d", len(state.EndpointsTested))
+	}
+
+	// Same endpoint again — no duplicate
+	hookWorkTracker(state, map[string]string{
+		"tool_name": "terminal_execute",
+		"command":   `curl -sk https://example.com/api/users -H "X-Test: 1"`,
+	})
+	if len(state.EndpointsTested) != 1 {
+		t.Errorf("Expected still 1 endpoint (deduped), got %d", len(state.EndpointsTested))
+	}
+
+	// Different endpoint
+	hookWorkTracker(state, map[string]string{
+		"tool_name": "terminal_execute",
+		"command":   `curl https://example.com/api/login`,
+	})
+	if len(state.EndpointsTested) != 2 {
+		t.Errorf("Expected 2 endpoints, got %d", len(state.EndpointsTested))
+	}
+}
+
+func TestWorkTracker_InjectionEndpoints(t *testing.T) {
+	state := NewScanState()
+
+	// SQLi on /api/users — realistic curl with injection in data flag
+	hookWorkTracker(state, map[string]string{
+		"tool_name": "terminal_execute",
+		"command":   `curl -d "id=1' or 1=1--" https://target.com/api/users`,
+	})
+	if len(state.InjectionEndpoints) != 1 {
+		t.Errorf("Expected 1 injection endpoint, got %d", len(state.InjectionEndpoints))
+	}
+	if !state.InjectionTested {
+		t.Error("InjectionTested should be true")
+	}
+
+	// XSS on /search — realistic curl with script in parameter
+	hookWorkTracker(state, map[string]string{
+		"tool_name": "terminal_execute",
+		"command":   `curl -d "q=<script>alert(1)</script>" https://target.com/search`,
+	})
+	if len(state.InjectionEndpoints) != 2 {
+		t.Errorf("Expected 2 injection endpoints, got %d", len(state.InjectionEndpoints))
+	}
+}
+
+func TestWorkTracker_AccessControlEndpoints(t *testing.T) {
+	state := NewScanState()
+
+	hookWorkTracker(state, map[string]string{
+		"tool_name": "terminal_execute",
+		"command":   `curl https://target.com/api/user/1`,
+	})
+	if len(state.AccessControlEndpoints) != 1 {
+		t.Errorf("Expected 1 access control endpoint, got %d", len(state.AccessControlEndpoints))
+	}
+
+	hookWorkTracker(state, map[string]string{
+		"tool_name": "terminal_execute",
+		"command":   `curl -H "x-forwarded-for: 127.0.0.1" https://target.com/admin/dashboard`,
+	})
+	if len(state.AccessControlEndpoints) != 2 {
+		t.Errorf("Expected 2 access control endpoints, got %d", len(state.AccessControlEndpoints))
+	}
+}
+
+func TestWorkTracker_EndpointInventory(t *testing.T) {
+	state := NewScanState()
+
+	// Non-inventory note
+	hookWorkTracker(state, map[string]string{
+		"tool_name": "add_note",
+		"content":   "Target uses CloudFlare WAF",
+	})
+	if state.EndpointInventorySaved {
+		t.Error("Should not be saved for non-inventory note")
+	}
+
+	// Inventory note
+	hookWorkTracker(state, map[string]string{
+		"tool_name": "add_note",
+		"content":   "## Discovered Endpoints\n- /api/users\n- /api/login",
+	})
+	if !state.EndpointInventorySaved {
+		t.Error("Should be saved for inventory note")
+	}
+}
+
+// ── hookFinishGatekeeper tests ───────────────────────────────────────────────
+
+func TestFinishGatekeeper_BlocksLowIteration(t *testing.T) {
+	state := NewScanState()
+	state.Iteration = 2
+	state.TerminalCalls = 10
+	state.ReconDone = true
+
+	result := hookFinishGatekeeper(state, nil)
+	if !result.Block {
+		t.Error("Should block at iteration < 3")
+	}
+}
+
+func TestFinishGatekeeper_BlocksLowCommands(t *testing.T) {
+	state := NewScanState()
+	state.Iteration = 10
+	state.TerminalCalls = 3
+
+	result := hookFinishGatekeeper(state, nil)
+	if !result.Block {
+		t.Error("Should block with < 5 terminal commands")
+	}
+}
+
+func TestFinishGatekeeper_BlocksNoRecon(t *testing.T) {
+	state := NewScanState()
+	state.Iteration = 10
+	state.TerminalCalls = 10
+	state.ReconDone = false
+
+	result := hookFinishGatekeeper(state, nil)
+	if !result.Block {
+		t.Error("Should block without recon")
+	}
+}
+
+func TestFinishGatekeeper_BlocksNoInventory(t *testing.T) {
+	state := NewScanState()
+	state.Iteration = 30
+	state.TerminalCalls = 15
+	state.ReconDone = true
+	state.EndpointInventorySaved = false
+
+	result := hookFinishGatekeeper(state, nil)
+	if !result.Block {
+		t.Error("Should block without endpoint inventory saved")
+	}
+}
+
+func TestFinishGatekeeper_BlocksLowCoverage(t *testing.T) {
+	state := NewScanState()
+	state.Iteration = 30
+	state.TerminalCalls = 15
+	state.ReconDone = true
+	state.EndpointInventorySaved = true
+	// Only 1 injection endpoint out of 10 tested
+	state.EndpointsTested["a"] = true
+	state.EndpointsTested["b"] = true
+	state.EndpointsTested["c"] = true
+	state.EndpointsTested["d"] = true
+	state.EndpointsTested["e"] = true
+	state.EndpointsTested["f"] = true
+	state.EndpointsTested["g"] = true
+	state.EndpointsTested["h"] = true
+	state.EndpointsTested["i"] = true
+	state.EndpointsTested["j"] = true
+	state.InjectionEndpoints["a"] = true // only 1
+
+	result := hookFinishGatekeeper(state, nil)
+	if !result.Block {
+		t.Error("Should block with only 1/10 injection endpoints tested")
+	}
+}
+
+func TestFinishGatekeeper_AllowsAfter50WithCoverage(t *testing.T) {
+	state := NewScanState()
+	state.Iteration = 55
+	state.TerminalCalls = 30
+	state.ReconDone = true
+	state.EndpointInventorySaved = true
+	state.InjectionEndpoints["a"] = true
+	state.InjectionEndpoints["b"] = true
+	state.InjectionEndpoints["c"] = true
+	state.AccessControlEndpoints["a"] = true
+	state.AccessControlEndpoints["b"] = true
+	state.DirBustingHosts["target.com"] = true
+	state.EndpointsTested["a"] = true
+	state.EndpointsTested["b"] = true
+	state.EndpointsTested["c"] = true
+	state.FinishAttempts = 2 // not first attempt (already incremented in the function)
+
+	result := hookFinishGatekeeper(state, nil)
+	if result.Block {
+		t.Errorf("Should allow finish after 50 iterations with good coverage, but got blocked: %s", result.BlockReason)
+	}
+}
+
+func TestFinishGatekeeper_BlocksBelow50EvenWithCoverage(t *testing.T) {
+	state := NewScanState()
+	state.Iteration = 40
+	state.TerminalCalls = 30
+	state.ReconDone = true
+	state.EndpointInventorySaved = true
+	state.InjectionEndpoints["a"] = true
+	state.InjectionEndpoints["b"] = true
+	state.InjectionEndpoints["c"] = true
+	state.AccessControlEndpoints["a"] = true
+	state.AccessControlEndpoints["b"] = true
+	state.DirBustingHosts["target.com"] = true
+	state.EndpointsTested["a"] = true
+
+	result := hookFinishGatekeeper(state, nil)
+	if !result.Block {
+		t.Error("Should block below 50 iterations even with good coverage (first 2 attempts)")
+	}
+}
+
+func TestFinishGatekeeper_DiscoveryModeAllowsEarly(t *testing.T) {
+	state := NewScanState()
+	state.DiscoveryMode = true
+	state.TerminalCalls = 5
+	state.Iteration = 8
+
+	result := hookFinishGatekeeper(state, nil)
+	if result.Block {
+		t.Error("Discovery mode should allow finish after 3+ terminal calls")
+	}
+}
+
+func TestFinishGatekeeper_DiscoveryModeBlocksTooFew(t *testing.T) {
+	state := NewScanState()
+	state.DiscoveryMode = true
+	state.TerminalCalls = 2
+
+	result := hookFinishGatekeeper(state, nil)
+	if !result.Block {
+		t.Error("Discovery mode should block with < 3 terminal calls")
+	}
+}
+
+// ── minInt / maxInt tests ────────────────────────────────────────────────────
+
+func TestMinMaxInt(t *testing.T) {
+	if minInt(3, 5) != 3 {
+		t.Error("minInt(3,5) should be 3")
+	}
+	if minInt(5, 3) != 3 {
+		t.Error("minInt(5,3) should be 3")
+	}
+	if maxInt(3, 5) != 5 {
+		t.Error("maxInt(3,5) should be 5")
+	}
+	if maxInt(5, 3) != 5 {
+		t.Error("maxInt(5,3) should be 5")
+	}
+}


### PR DESCRIPTION
## Problem

The finish gatekeeper used **boolean flags** that fired after a single command. Running one `sqlmap` set `InjectionTested=true` — even if only 1 out of 20 discovered endpoints was tested. This allowed shallow scans to pass the gate.

## Changes

### hooks.go — ScanState (coverage counters replace booleans)

| Old (boolean) | New (counter map) | Tracks |
|---|---|---|
| `InjectionTested` | `InjectionEndpoints map[string]bool` | Unique endpoints with SQLi/XSS/SSRF payloads |
| `DirBustingDone` | `DirBustingHosts map[string]bool` | Unique hosts fuzzed with ffuf/gobuster |
| `AccessControlTested` | `AccessControlEndpoints map[string]bool` | Unique endpoints with IDOR/auth tests |
| *(new)* | `EndpointsTested map[string]bool` | All unique URL paths tested |
| *(new)* | `EndpointInventorySaved bool` | add_note called with endpoint data |

### hooks.go — hookWorkTracker (endpoint extraction)
- `extractEndpointFromCmd()` — extracts host+path from curl/httpx/wget
- `extractHostFromCmd()` — extracts target host for dirbusting
- Tracks `add_note` calls for endpoint inventory detection

### hooks.go — hookFinishGatekeeper (proportional gates)
- **Iteration floor**: 35 → 50 (matches system prompt)
- **Injection**: min(3, totalEndpoints/3) unique endpoints required
- **Access control**: min(2, totalEndpoints/4) unique endpoints required
- **Dirbusting**: at least 1 host fuzzed
- **Inventory**: endpoint inventory must be saved via add_note
- Coverage stats shown in rejection messages

### hooks_test.go — 20 new tests
- 11 endpoint extraction subtests
- 4 work tracker tests
- 7 finish gatekeeper tests (all gate conditions)