### PR TITLE
release: v4.5.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.7
+VERSION=4.5.8
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.7" alt="Xalgorix" width="860" />
+<img src="assets/banner.png?v=4.5.8" alt="Xalgorix" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.7"
+var version = "4.5.8"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
### Changes

- 12f6c11 feat: per-role LLM temperature — scanner 0.2, validator 0.0, reporter 0.3 (#101)
- 9d4ee0d release: v4.5.7 (#100)