### PR TITLE
feat: adaptive surface-area-aware finish gating with test depth tracking

### DIFF
--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -582,7 +582,28 @@ func hookFinishGatekeeper(state *ScanState, args map[string]string) HookResult {
 		}
 	}
 
-	// Gate: Proportional coverage — require testing multiple endpoints
+	// Compute test depth: average vuln-class tests per endpoint.
+	// A depth of 1.0 means each endpoint was tested with 1 category on avg.
+	// A depth of 3.0 means each endpoint had injection + access control + dirbusting.
+	depth := testDepthRatio(totalEndpoints, injectionCount, accessControlCount, dirBustingCount)
+
+	// ── Adaptive surface area detection ──
+	// Static/small targets shouldn't burn 50+ iterations doing nothing.
+	// Allow early finish if the surface area is small AND test depth is high.
+	if state.ReconDone && state.EndpointInventorySaved && dirBustingCount >= 1 {
+		// Small surface (< 5 endpoints): allow finish at 25+ iterations with deep testing
+		if totalEndpoints < 5 && iter >= 25 && depth >= 2.0 {
+			// Verified small target with thorough testing — allow finish
+			return HookResult{}
+		}
+
+		// Medium surface (5-15 endpoints): allow finish at 40+ iterations with good testing
+		if totalEndpoints >= 5 && totalEndpoints <= 15 && iter >= 40 && depth >= 1.5 {
+			return HookResult{}
+		}
+	}
+
+	// ── Proportional coverage gates (for targets below 50 iterations) ──
 	if iter < 50 {
 		missing := []string{}
 
@@ -608,13 +629,14 @@ func hookFinishGatekeeper(state *ScanState, args map[string]string) HookResult {
 		if len(missing) > 0 {
 			return HookResult{
 				Block:       true,
-				BlockReason: fmt.Sprintf("Coverage gap: you've tested %d unique endpoints total but still need: %s", totalEndpoints, strings.Join(missing, "; ")),
+				BlockReason: fmt.Sprintf("Coverage gap (depth: %.1f tests/endpoint): you've tested %d unique endpoints but still need: %s", depth, totalEndpoints, strings.Join(missing, "; ")),
 			}
 		}
 	}
 
 	// ── Iteration floor: 50 ──
 	// Matches the system prompt: "Minimum 50 iterations for a thorough assessment"
+	// Only applies to large surface areas (> 15 endpoints) or when depth is low.
 	if iter < 50 {
 		if state.FinishAttempts <= 2 {
 			scannerNote := ""
@@ -625,8 +647,8 @@ func hookFinishGatekeeper(state *ScanState, args map[string]string) HookResult {
 			if state.SkillsLoaded == 0 {
 				skillNote = "\n- ⚠️ You haven't loaded ANY deep knowledge skills (read_skill). Load skills for the target's tech stack to get expert-level payloads and bypass techniques!"
 			}
-			coverageNote := fmt.Sprintf("\n- Endpoints tested: %d (injection: %d, access control: %d, dirbusting hosts: %d)",
-				totalEndpoints, injectionCount, accessControlCount, dirBustingCount)
+			coverageNote := fmt.Sprintf("\n- Endpoints tested: %d (injection: %d, access control: %d, dirbusting hosts: %d, depth: %.1f/endpoint)",
+				totalEndpoints, injectionCount, accessControlCount, dirBustingCount, depth)
 			nudgeMsg := fmt.Sprintf(`⚠️ Only %d/50 iterations completed. You still have capacity to test more.
 
 Before finishing, verify you have covered:
@@ -646,6 +668,17 @@ Continue testing. Call finish again after iteration 50.`, iter, coverageNote, sc
 
 	// After 50 iterations with coverage met: allow finish
 	return HookResult{}
+}
+
+// testDepthRatio computes the average number of vuln-class tests per endpoint.
+// A ratio of 1.0 means each endpoint was tested with 1 category on average.
+// Higher is better — it means the agent tested each endpoint more thoroughly.
+func testDepthRatio(totalEndpoints, injectionCount, accessControlCount, dirBustingCount int) float64 {
+	if totalEndpoints == 0 {
+		return 0.0
+	}
+	totalTests := injectionCount + accessControlCount + dirBustingCount
+	return float64(totalTests) / float64(totalEndpoints)
 }
 
 // maxInt returns the larger of two ints.

--- a/internal/agent/hooks_test.go
+++ b/internal/agent/hooks_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -261,22 +262,26 @@ func TestFinishGatekeeper_AllowsAfter50WithCoverage(t *testing.T) {
 }
 
 func TestFinishGatekeeper_BlocksBelow50EvenWithCoverage(t *testing.T) {
+	// Large surface area (> 15 endpoints): 50-iteration floor always applies
 	state := NewScanState()
 	state.Iteration = 40
 	state.TerminalCalls = 30
 	state.ReconDone = true
 	state.EndpointInventorySaved = true
-	state.InjectionEndpoints["a"] = true
-	state.InjectionEndpoints["b"] = true
-	state.InjectionEndpoints["c"] = true
-	state.AccessControlEndpoints["a"] = true
-	state.AccessControlEndpoints["b"] = true
+	// 20 endpoints — large surface, adaptive early finish doesn't apply
+	for i := range 20 {
+		state.EndpointsTested[fmt.Sprintf("ep%d", i)] = true
+	}
+	state.InjectionEndpoints["ep0"] = true
+	state.InjectionEndpoints["ep1"] = true
+	state.InjectionEndpoints["ep2"] = true
+	state.AccessControlEndpoints["ep0"] = true
+	state.AccessControlEndpoints["ep1"] = true
 	state.DirBustingHosts["target.com"] = true
-	state.EndpointsTested["a"] = true
 
 	result := hookFinishGatekeeper(state, nil)
 	if !result.Block {
-		t.Error("Should block below 50 iterations even with good coverage (first 2 attempts)")
+		t.Error("Large surface (20 endpoints) should block below 50 iterations even with good coverage")
 	}
 }
 
@@ -356,5 +361,127 @@ func TestFloatPtr(t *testing.T) {
 	p0 := floatPtr(0.0)
 	if p0 == nil || *p0 != 0.0 {
 		t.Error("floatPtr(0.0) should return pointer to 0.0, not nil")
+	}
+}
+
+// ── testDepthRatio tests ─────────────────────────────────────────────────────
+
+func TestTestDepthRatio(t *testing.T) {
+	tests := []struct {
+		name                                                  string
+		total, injection, accessControl, dirbusting           int
+		want                                                  float64
+	}{
+		{"no endpoints", 0, 0, 0, 0, 0.0},
+		{"3 endpoints, full coverage", 3, 3, 3, 3, 3.0},
+		{"10 endpoints, partial", 10, 3, 2, 1, 0.6},
+		{"1 endpoint, all classes", 1, 1, 1, 1, 3.0},
+		{"5 endpoints, shallow", 5, 1, 0, 0, 0.2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := testDepthRatio(tt.total, tt.injection, tt.accessControl, tt.dirbusting)
+			if got != tt.want {
+				t.Errorf("testDepthRatio(%d,%d,%d,%d) = %f, want %f",
+					tt.total, tt.injection, tt.accessControl, tt.dirbusting, got, tt.want)
+			}
+		})
+	}
+}
+
+// ── Adaptive surface area tests ──────────────────────────────────────────────
+
+func TestFinishGatekeeper_SmallSurfaceEarlyFinish(t *testing.T) {
+	// Small target (3 endpoints), deep testing (depth 2.0+), iter 30 → allow
+	state := NewScanState()
+	state.Iteration = 30
+	state.TerminalCalls = 12
+	state.ReconDone = true
+	state.EndpointInventorySaved = true
+	// 3 endpoints, all tested with injection + access control + dirbusting
+	state.EndpointsTested["a"] = true
+	state.EndpointsTested["b"] = true
+	state.EndpointsTested["c"] = true
+	state.InjectionEndpoints["a"] = true
+	state.InjectionEndpoints["b"] = true
+	state.InjectionEndpoints["c"] = true
+	state.AccessControlEndpoints["a"] = true
+	state.AccessControlEndpoints["b"] = true
+	state.DirBustingHosts["target.com"] = true
+	// depth = (3 + 2 + 1) / 3 = 2.0
+
+	result := hookFinishGatekeeper(state, nil)
+	if result.Block {
+		t.Errorf("Small surface with depth 2.0 at iter 30 should allow early finish, got blocked: %s", result.BlockReason)
+	}
+}
+
+func TestFinishGatekeeper_SmallSurfaceShallowBlocked(t *testing.T) {
+	// Small target (3 endpoints), shallow testing (depth 0.3), iter 30 → block
+	state := NewScanState()
+	state.Iteration = 30
+	state.TerminalCalls = 12
+	state.ReconDone = true
+	state.EndpointInventorySaved = true
+	state.EndpointsTested["a"] = true
+	state.EndpointsTested["b"] = true
+	state.EndpointsTested["c"] = true
+	state.InjectionEndpoints["a"] = true // only 1 injection test
+	state.DirBustingHosts["target.com"] = true
+	// depth = (1 + 0 + 1) / 3 = 0.67 — too shallow
+
+	result := hookFinishGatekeeper(state, nil)
+	if !result.Block {
+		t.Error("Small surface with shallow depth should still block")
+	}
+}
+
+func TestFinishGatekeeper_MediumSurfaceEarlyFinish(t *testing.T) {
+	// Medium target (8 endpoints), good depth (1.5+), iter 42 → allow
+	state := NewScanState()
+	state.Iteration = 42
+	state.TerminalCalls = 20
+	state.ReconDone = true
+	state.EndpointInventorySaved = true
+	for i := range 8 {
+		state.EndpointsTested[fmt.Sprintf("ep%d", i)] = true
+	}
+	// 4 injection + 4 access control + 4 dirbusting hosts = 12 tests / 8 endpoints = 1.5
+	for i := range 4 {
+		state.InjectionEndpoints[fmt.Sprintf("ep%d", i)] = true
+		state.AccessControlEndpoints[fmt.Sprintf("ep%d", i)] = true
+	}
+	state.DirBustingHosts["target.com"] = true
+	state.DirBustingHosts["sub.target.com"] = true
+	state.DirBustingHosts["api.target.com"] = true
+	state.DirBustingHosts["admin.target.com"] = true
+	// depth = (4 + 4 + 4) / 8 = 1.5
+
+	result := hookFinishGatekeeper(state, nil)
+	if result.Block {
+		t.Errorf("Medium surface with depth 1.5 at iter 42 should allow finish, got blocked: %s", result.BlockReason)
+	}
+}
+
+func TestFinishGatekeeper_LargeSurfaceNoEarlyFinish(t *testing.T) {
+	// Large target (20 endpoints), good depth, iter 35 → still blocked (> 15 endpoints)
+	state := NewScanState()
+	state.Iteration = 35
+	state.TerminalCalls = 25
+	state.ReconDone = true
+	state.EndpointInventorySaved = true
+	for i := range 20 {
+		state.EndpointsTested[fmt.Sprintf("ep%d", i)] = true
+	}
+	for i := range 10 {
+		state.InjectionEndpoints[fmt.Sprintf("ep%d", i)] = true
+		state.AccessControlEndpoints[fmt.Sprintf("ep%d", i)] = true
+	}
+	state.DirBustingHosts["target.com"] = true
+	// depth = (10 + 10 + 1) / 20 = 1.05 — but > 15 endpoints, no early finish
+
+	result := hookFinishGatekeeper(state, nil)
+	if !result.Block {
+		t.Error("Large surface (20 endpoints) should not get early finish at iter 35")
 	}
 }


### PR DESCRIPTION
## Problem

Setting maxIter to 120 wastes tokens on static/small targets. A simple HTML site with 2 endpoints doesn't need 120 iterations. But we also can't let the agent do a basic test on each endpoint and move on.

## Solution: Adaptive finish + test depth

### Surface Area Tiers
| Surface | Endpoints | Min Iterations | Required Depth |
|---------|----------|----------------|----------------|
| Small | < 5 | 25 | ≥ 2.0 tests/endpoint |
| Medium | 5-15 | 40 | ≥ 1.5 tests/endpoint |
| Large | > 15 | 50 (unchanged) | proportional |

### Test Depth Ratio
`depth = (injection_endpoints + access_control_endpoints + dirbusting_hosts) / total_endpoints`

- Depth 1.0 = each endpoint tested with 1 vuln class on average
- Depth 2.0 = each endpoint tested with 2 vuln classes (e.g. injection + access control)
- Prevents the 'basic test and move on' pattern

### Example: Static site (3 endpoints)
```
Iteration 30: finish attempt
Endpoints: /index.html, /about, /contact  (3 total)
Injection: all 3 tested → depth contribution = 3
Access control: 2 tested → depth contribution = 2
Dirbusting: 1 host → depth contribution = 1
Depth = (3+2+1)/3 = 2.0 ≥ 2.0 → ALLOW EARLY FINISH ✅
```

### Tests: 9 new/updated
- `TestTestDepthRatio` (5 subtests)
- 4 adaptive surface area tests (small+deep, small+shallow, medium, large)