### PR TITLE
fix: address audit concerns — prevent depth gaming and tighten inventory check

### DIFF
--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -285,9 +285,21 @@ func hookWorkTracker(state *ScanState, args map[string]string) HookResult {
 	// Track endpoint inventory saved (mandatory recon checklist step 5)
 	if toolName == "add_note" {
 		noteContent := strings.ToLower(args["content"])
-		if strings.Contains(noteContent, "endpoint") || strings.Contains(noteContent, "api") ||
-			strings.Contains(noteContent, "subdomain") || strings.Contains(noteContent, "inventory") ||
-			strings.Contains(noteContent, "discovered") {
+		hasKeyword := strings.Contains(noteContent, "endpoint") || strings.Contains(noteContent, "inventory") ||
+			strings.Contains(noteContent, "discovered") || strings.Contains(noteContent, "subdomain")
+		// Require URL-like patterns (at least 3) to prevent false positives
+		// from notes like "the WAF blocks our API calls"
+		urlPatterns := 0
+		for _, marker := range []string{"/api/", "/api", "http://", "https://", "/v1/", "/v2/", "/admin", "/login", "/user", "/auth"} {
+			if strings.Contains(noteContent, marker) {
+				urlPatterns++
+			}
+		}
+		if hasKeyword && urlPatterns >= 2 {
+			state.EndpointInventorySaved = true
+		}
+		// Also allow if note has many lines (likely a real inventory list)
+		if hasKeyword && strings.Count(noteContent, "\n") >= 5 {
 			state.EndpointInventorySaved = true
 		}
 	}
@@ -590,7 +602,20 @@ func hookFinishGatekeeper(state *ScanState, args map[string]string) HookResult {
 	// ── Adaptive surface area detection ──
 	// Static/small targets shouldn't burn 50+ iterations doing nothing.
 	// Allow early finish if the surface area is small AND test depth is high.
-	if state.ReconDone && state.EndpointInventorySaved && dirBustingCount >= 1 {
+	// Require at least 2 of 3 vuln categories to have non-zero coverage
+	// to prevent gaming via dirbusting inflation (audit concern #4).
+	categoriesCovered := 0
+	if injectionCount > 0 {
+		categoriesCovered++
+	}
+	if accessControlCount > 0 {
+		categoriesCovered++
+	}
+	if dirBustingCount > 0 {
+		categoriesCovered++
+	}
+
+	if state.ReconDone && state.EndpointInventorySaved && dirBustingCount >= 1 && categoriesCovered >= 2 {
 		// Small surface (< 5 endpoints): allow finish at 25+ iterations with deep testing
 		if totalEndpoints < 5 && iter >= 25 && depth >= 2.0 {
 			// Verified small target with thorough testing — allow finish

--- a/internal/agent/hooks_test.go
+++ b/internal/agent/hooks_test.go
@@ -144,7 +144,7 @@ func TestWorkTracker_AccessControlEndpoints(t *testing.T) {
 func TestWorkTracker_EndpointInventory(t *testing.T) {
 	state := NewScanState()
 
-	// Non-inventory note
+	// Non-inventory note — no keywords at all
 	hookWorkTracker(state, map[string]string{
 		"tool_name": "add_note",
 		"content":   "Target uses CloudFlare WAF",
@@ -153,13 +153,32 @@ func TestWorkTracker_EndpointInventory(t *testing.T) {
 		t.Error("Should not be saved for non-inventory note")
 	}
 
-	// Inventory note
+	// False positive — has "api" in text but no URL patterns (audit fix #2)
 	hookWorkTracker(state, map[string]string{
 		"tool_name": "add_note",
-		"content":   "## Discovered Endpoints\n- /api/users\n- /api/login",
+		"content":   "Discovered that the WAF blocks API calls",
+	})
+	if state.EndpointInventorySaved {
+		t.Error("Should not be saved for note with just keyword 'discovered' without URL patterns")
+	}
+
+	// Real inventory note — keyword + multiple URL-like patterns
+	hookWorkTracker(state, map[string]string{
+		"tool_name": "add_note",
+		"content":   "## Discovered Endpoints\n- /api/users\n- /api/login\n- /admin/dashboard",
 	})
 	if !state.EndpointInventorySaved {
-		t.Error("Should be saved for inventory note")
+		t.Error("Should be saved for inventory note with keyword + URL patterns")
+	}
+
+	// Reset and test multi-line fallback
+	state2 := NewScanState()
+	hookWorkTracker(state2, map[string]string{
+		"tool_name": "add_note",
+		"content":   "Discovered endpoints:\n/page1\n/page2\n/page3\n/page4\n/page5\n/page6",
+	})
+	if !state2.EndpointInventorySaved {
+		t.Error("Should be saved for note with keyword + 5+ lines")
 	}
 }
 
@@ -483,5 +502,29 @@ func TestFinishGatekeeper_LargeSurfaceNoEarlyFinish(t *testing.T) {
 	result := hookFinishGatekeeper(state, nil)
 	if !result.Block {
 		t.Error("Large surface (20 endpoints) should not get early finish at iter 35")
+	}
+}
+
+func TestFinishGatekeeper_DirBustingOnlyGamingBlocked(t *testing.T) {
+	// Audit fix: agent inflates dirbusting hosts to game depth ratio
+	// 3 endpoints, 0 injection, 0 access control, 4 dirbusting hosts
+	// depth = (0 + 0 + 4) / 3 = 1.33 — looks okay but only 1 category covered
+	state := NewScanState()
+	state.Iteration = 30
+	state.TerminalCalls = 12
+	state.ReconDone = true
+	state.EndpointInventorySaved = true
+	state.EndpointsTested["a"] = true
+	state.EndpointsTested["b"] = true
+	state.EndpointsTested["c"] = true
+	state.DirBustingHosts["target.com"] = true
+	state.DirBustingHosts["sub1.target.com"] = true
+	state.DirBustingHosts["sub2.target.com"] = true
+	state.DirBustingHosts["sub3.target.com"] = true
+	// categoriesCovered = 1 (only dirbusting) → early finish blocked
+
+	result := hookFinishGatekeeper(state, nil)
+	if !result.Block {
+		t.Error("Should block early finish when only 1 of 3 vuln categories covered (dirbusting-only gaming)")
 	}
 }


### PR DESCRIPTION
## Self-audit fixes

Addresses 2 of 4 concerns from the v4.5.7-v4.5.9 code audit.

### Fix 1: Depth ratio gaming (audit concern #4)

**Problem:** Agent could inflate `dirBustingHosts` by running `ffuf` on 4 subdomain variants, achieving depth 2.0+ with zero injection or access control testing.

**Fix:** Adaptive early finish now requires `categoriesCovered >= 2`:
```go
categoriesCovered := 0
if injectionCount > 0 { categoriesCovered++ }
if accessControlCount > 0 { categoriesCovered++ }
if dirBustingCount > 0 { categoriesCovered++ }
// Must test at least 2 of 3 vuln classes
```

### Fix 2: Inventory check false positives (audit concern #2)

**Problem:** Any note containing 'api' (e.g., 'the WAF blocks API calls') set `EndpointInventorySaved = true`.

**Fix:** Now requires keyword + 2 URL-like patterns OR keyword + 5+ newlines:
```
✅ 'Discovered Endpoints:\n- /api/users\n- /admin/panel'  (keyword + 2 URL patterns)
✅ 'Discovered:\n/p1\n/p2\n/p3\n/p4\n/p5\n/p6'              (keyword + 6 lines)
❌ 'Discovered that the WAF blocks API calls'                 (keyword only, no patterns)
```

### Tests
- Updated `TestWorkTracker_EndpointInventory` with false positive case
- New `TestFinishGatekeeper_DirBustingOnlyGamingBlocked`