### PR TITLE
feat: curl preference enforcement + wire all 4 temperatures + better endpoint extraction

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1630,6 +1630,9 @@ func (a *Agent) Run(targets []string, instruction string) {
 					a.msgMu.Lock()
 					a.messages = append(a.messages, llm.Message{Role: "user", Content: rejectMsg})
 					a.msgMu.Unlock()
+					// Finish was rejected — switch to validator temperature (0.0)
+					// for deterministic re-verification of coverage gaps
+					a.client.SetTemperature(TempValidator)
 					continue
 				}
 				a.emit(Event{Type: "finished", Content: result.Output, TotalTokens: tokenCount()})
@@ -1648,6 +1651,9 @@ func (a *Agent) Run(targets []string, instruction string) {
 			case "report_vulnerability":
 				// Next response will write/refine a vulnerability report
 				a.client.SetTemperature(TempReporter)
+			case "add_note", "read_notes":
+				// Next response involves analysis/reasoning about findings
+				a.client.SetTemperature(TempReasoner)
 			default:
 				// Default scanning temperature for all other tools
 				a.client.SetTemperature(TempScanner)

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -59,6 +59,10 @@ type ScanState struct {
 	DirBustingDone      bool
 	AccessControlTested bool
 
+	// Tool preference tracking
+	SendRequestCalls   int  // total send_request uses (should be low)
+	BrowserAuthContext bool // true after browser login/auth detected — justifies browser use
+
 	// Stuck-loop detection
 	StuckDomain        string
 	StuckIterations    int
@@ -191,6 +195,7 @@ func RegisterDefaultHooks(reg *HookRegistry) {
 	// Order matters: tracking → detection → policy → reset
 	reg.Register(OnToolCall, hookWorkTracker)
 	reg.Register(OnToolCall, hookStuckTracker)
+	reg.Register(OnToolCall, hookCurlPreference)
 	reg.Register(OnStuckCheck, hookStuckNudge)
 	reg.Register(OnToolResult, hookWAFDetector)
 	reg.Register(OnToolResult, hookTechDetector)
@@ -307,28 +312,34 @@ func hookWorkTracker(state *ScanState, args map[string]string) HookResult {
 	return HookResult{}
 }
 
-// extractEndpointFromCmd extracts a URL path from curl/httpx commands.
-// Returns a normalized endpoint like "/api/users" or "" if not found.
+// extractEndpointFromCmd extracts a URL path from any command containing an HTTP URL.
+// Returns a normalized endpoint like "example.com/api/users" or "" if not found.
+// Handles: curl, httpx, wget, sqlmap -u, nuclei -u, piped commands, and any
+// command containing an HTTP(S) URL as a token.
 func extractEndpointFromCmd(cmd string) string {
-	for _, prefix := range []string{"curl ", "httpx ", "wget "} {
-		if !strings.Contains(cmd, prefix) {
-			continue
-		}
-		for _, token := range strings.Fields(cmd) {
-			if strings.HasPrefix(token, "http://") || strings.HasPrefix(token, "https://") {
-				token = strings.Trim(token, "\"'")
-				if parsed, err := url.Parse(token); err == nil && parsed.Host != "" {
-					path := parsed.Path
-					if path == "" || path == "/" {
-						path = "/"
-					}
-					return parsed.Host + path
+	// Strategy: find ANY http:// or https:// URL in the command tokens.
+	// This handles all tools (curl, wget, sqlmap, nuclei, ffuf, etc.)
+	// and piped commands (echo "..." | curl -d @- https://target.com).
+
+	// Split on pipes first — extract from each segment
+	for _, segment := range strings.Split(cmd, "|") {
+		for _, token := range strings.Fields(segment) {
+			token = strings.Trim(token, "\"'`,;)(}{[]")
+			if !strings.HasPrefix(token, "http://") && !strings.HasPrefix(token, "https://") {
+				continue
+			}
+			if parsed, err := url.Parse(token); err == nil && parsed.Host != "" {
+				path := parsed.Path
+				if path == "" || path == "/" {
+					path = "/"
 				}
+				return parsed.Host + path
 			}
 		}
 	}
 	return ""
 }
+
 
 // extractHostFromCmd extracts the target host from a command for dirbusting tracking.
 func extractHostFromCmd(cmd string) string {
@@ -341,6 +352,83 @@ func extractHostFromCmd(cmd string) string {
 		}
 	}
 	return ""
+}
+
+// ── hookCurlPreference ───────────────────────────────────────────────────────
+// Enforces the policy: prefer curl (via terminal_execute) for all HTTP requests.
+// send_request truncates responses at 10KB and doesn't track endpoints.
+// browser_action is slow and heavyweight — only justified for auth flows,
+// dynamic JS rendering, or form interaction.
+func hookCurlPreference(state *ScanState, args map[string]string) HookResult {
+	toolName := args["tool_name"]
+
+	// Track browser auth context: if browser is used for login/auth, it's justified
+	if toolName == "browser_action" {
+		action := strings.ToLower(args["action"])
+		textArg := strings.ToLower(args["text"])
+		urlArg := strings.ToLower(args["url"])
+		// Detect auth-related browser actions (login forms, session handling)
+		isAuth := strings.Contains(action, "type") && (strings.Contains(textArg, "password") ||
+			strings.Contains(textArg, "admin") || strings.Contains(textArg, "login"))
+		isAuth = isAuth || strings.Contains(urlArg, "login") || strings.Contains(urlArg, "auth") ||
+			strings.Contains(urlArg, "signin") || strings.Contains(urlArg, "oauth") ||
+			strings.Contains(urlArg, "sso")
+		if isAuth || strings.Contains(action, "get_cookies") || strings.Contains(action, "load_session") {
+			state.BrowserAuthContext = true
+		}
+
+		// If no auth context and not the first navigation, nudge
+		if !state.BrowserAuthContext && state.ConsecutiveBrowser > 2 {
+			return HookResult{
+				Nudge: `⚠️ TOOL PREFERENCE: You're using browser_action for testing that curl can handle faster.
+Use browser ONLY for:
+- Login/authentication flows (forms, OAuth, SSO)
+- JavaScript-rendered content that curl can't see
+- Dynamic interactions (clicking buttons, filling forms)
+
+For ALL other HTTP requests, use: curl -sk <URL> | head -200
+Switch to curl now — it's faster and gives you full response bodies.`,
+			}
+		}
+	}
+
+	// Track send_request usage
+	if toolName == "send_request" {
+		state.SendRequestCalls++
+
+		// Check if this is justified (authenticated session testing with cookies)
+		method := strings.ToUpper(args["method"])
+		headers := strings.ToLower(args["headers"])
+		hasAuthHeaders := strings.Contains(headers, "cookie") || strings.Contains(headers, "authorization") ||
+			strings.Contains(headers, "x-csrf") || strings.Contains(headers, "bearer")
+
+		// First use: soft nudge (unless it's auth-related)
+		if !hasAuthHeaders && state.SendRequestCalls == 1 {
+			return HookResult{
+				Nudge: fmt.Sprintf(`💡 TIP: Prefer curl over send_request for %s requests.
+send_request truncates responses at 10KB — JS bundles, API responses, and HTML pages are often 50-500KB.
+Use instead: curl -sk -X %s <URL> -H "header: value"
+Reserve send_request ONLY for authenticated requests that need Caido proxy logging.`, method, method),
+			}
+		}
+
+		// 3+ uses without auth context: stronger warning
+		if !hasAuthHeaders && state.SendRequestCalls >= 3 {
+			return HookResult{
+				Nudge: fmt.Sprintf(`⛔ STOP using send_request (%d calls) — you are missing data due to 10KB truncation.
+Switch to curl immediately:
+  curl -sk -X %s <URL> -H "Content-Type: application/json" -d '{"key":"value"}'
+  curl -sk <URL> -o /tmp/response.html && wc -c /tmp/response.html
+
+send_request is ONLY for:
+✅ Requests with session cookies after browser login (authenticated testing)
+✅ Requests that must appear in the Caido proxy log
+❌ Everything else → use curl`, state.SendRequestCalls, method),
+			}
+		}
+	}
+
+	return HookResult{}
 }
 
 // ── hookStuckTracker ─────────────────────────────────────────────────────────

--- a/internal/agent/hooks_test.go
+++ b/internal/agent/hooks_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -24,6 +25,16 @@ func TestExtractEndpointFromCmd(t *testing.T) {
 		{"no url", `nmap -sV target.com`, ""},
 		{"sqlmap no url prefix", `sqlmap -r request.txt`, ""},
 		{"strips query params", `curl https://api.example.com/search?q=test`, "api.example.com/search"},
+		// New: piped commands (audit fix #1)
+		{"piped curl", `echo '{"id":1}' | curl -d @- https://target.com/api/users`, "target.com/api/users"},
+		{"piped with grep", `curl -sk https://target.com/api/v2/config | grep secret`, "target.com/api/v2/config"},
+		// New: tools the old extractor missed (audit fix #1)
+		{"sqlmap with url", `sqlmap -u https://target.com/api/search?q=test --batch`, "target.com/api/search"},
+		{"nuclei with url", `nuclei -u https://target.com/api/health -t cves/`, "target.com/api/health"},
+		{"dalfox", `dalfox url https://target.com/search?q=xss`, "target.com/search"},
+		// Edge cases
+		{"url in quotes", `curl "https://target.com/api/v1/data"`, "target.com/api/v1/data"},
+		{"ncat no url", `echo "GET / HTTP/1.1" | ncat target.com 80`, ""},
 	}
 
 	for _, tt := range tests {
@@ -526,5 +537,102 @@ func TestFinishGatekeeper_DirBustingOnlyGamingBlocked(t *testing.T) {
 	result := hookFinishGatekeeper(state, nil)
 	if !result.Block {
 		t.Error("Should block early finish when only 1 of 3 vuln categories covered (dirbusting-only gaming)")
+	}
+}
+
+// ── hookCurlPreference tests ─────────────────────────────────────────────────
+
+func TestCurlPreference_SendRequestFirstUseNudge(t *testing.T) {
+	state := NewScanState()
+	result := hookCurlPreference(state, map[string]string{
+		"tool_name": "send_request",
+		"method":    "GET",
+		"headers":   "",
+	})
+	if result.Nudge == "" {
+		t.Error("Should nudge on first send_request without auth headers")
+	}
+	if state.SendRequestCalls != 1 {
+		t.Errorf("SendRequestCalls = %d, want 1", state.SendRequestCalls)
+	}
+}
+
+func TestCurlPreference_SendRequestEscalatesAfter3(t *testing.T) {
+	state := NewScanState()
+	state.SendRequestCalls = 2 // already used twice
+
+	result := hookCurlPreference(state, map[string]string{
+		"tool_name": "send_request",
+		"method":    "POST",
+		"headers":   "Content-Type: application/json",
+	})
+	if result.Nudge == "" {
+		t.Error("Should escalate warning after 3+ send_request calls")
+	}
+	if !strings.Contains(result.Nudge, "STOP") {
+		t.Error("Escalated warning should contain 'STOP'")
+	}
+}
+
+func TestCurlPreference_SendRequestAllowsWithAuth(t *testing.T) {
+	state := NewScanState()
+	state.SendRequestCalls = 4 // would normally trigger strong warning
+
+	result := hookCurlPreference(state, map[string]string{
+		"tool_name": "send_request",
+		"method":    "GET",
+		"headers":   "Cookie: session=abc123; Authorization: Bearer xyz",
+	})
+	if result.Nudge != "" {
+		t.Errorf("Should NOT nudge send_request with auth headers, got: %s", result.Nudge)
+	}
+}
+
+func TestCurlPreference_BrowserNudgeWithoutAuth(t *testing.T) {
+	state := NewScanState()
+	state.ConsecutiveBrowser = 3 // already used 3 times
+	state.BrowserAuthContext = false
+
+	result := hookCurlPreference(state, map[string]string{
+		"tool_name": "browser_action",
+		"action":    "navigate",
+		"url":       "https://target.com/api/users",
+		"text":      "",
+	})
+	if result.Nudge == "" {
+		t.Error("Should nudge browser usage without auth context after 2+ consecutive uses")
+	}
+}
+
+func TestCurlPreference_BrowserAllowsAuthContext(t *testing.T) {
+	state := NewScanState()
+	state.ConsecutiveBrowser = 5
+
+	// Login page navigation sets auth context
+	result := hookCurlPreference(state, map[string]string{
+		"tool_name": "browser_action",
+		"action":    "navigate",
+		"url":       "https://target.com/login",
+		"text":      "",
+	})
+	if !state.BrowserAuthContext {
+		t.Error("Login URL should set BrowserAuthContext = true")
+	}
+	if result.Nudge != "" {
+		t.Errorf("Should NOT nudge browser on login page, got: %s", result.Nudge)
+	}
+}
+
+func TestCurlPreference_IgnoresOtherTools(t *testing.T) {
+	state := NewScanState()
+	result := hookCurlPreference(state, map[string]string{
+		"tool_name": "terminal_execute",
+		"command":   "curl https://target.com",
+	})
+	if result.Nudge != "" {
+		t.Error("Should not nudge for terminal_execute (curl)")
+	}
+	if state.SendRequestCalls != 0 {
+		t.Error("SendRequestCalls should remain 0 for non-send_request tools")
 	}
 }


### PR DESCRIPTION
## Three changes completing all audit items

### 1. Curl Preference Hook (`hookCurlPreference`)
Enforces `curl` over `send_request`/`browser_action`:

| Scenario | Action |
|----------|--------|
| First send_request without auth | Soft tip: prefer curl |
| 3+ send_request without auth | ⛔ STOP warning |
| send_request with Cookie/Auth headers | ✅ Allowed |
| Browser without auth context (3+ uses) | ⚠️ Use curl instead |
| Browser on login/auth/SSO URL | ✅ Allowed (sets auth context) |

### 2. Wire All 4 Temperatures (audit #3)

| Trigger | Temperature | Role |
|---------|------------|------|
| `report_vulnerability` | 0.3 | Reporter |
| `add_note`, `read_notes` | 0.2 | Reasoner |
| Finish rejected | 0.0 | Validator |
| Everything else | 0.2 | Scanner |

### 3. Improved Endpoint Extraction (audit #1)
- Now extracts URLs from ANY command, not just curl/httpx/wget
- Handles piped commands, sqlmap -u, nuclei -u, dalfox
- 7 new test cases for edge patterns

### Tests: 13 new tests total
- 6 curl preference tests
- 7 endpoint extraction edge cases