### PR TITLE
fix: critical — inventory check used wrong arg key (content → key+value)

### DIFF
--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -289,7 +289,11 @@ func hookWorkTracker(state *ScanState, args map[string]string) HookResult {
 
 	// Track endpoint inventory saved (mandatory recon checklist step 5)
 	if toolName == "add_note" {
-		noteContent := strings.ToLower(args["content"])
+		// add_note uses "key" and "value" args, NOT "content"
+		noteKey := strings.ToLower(args["key"])
+		noteValue := strings.ToLower(args["value"])
+		noteContent := noteKey + " " + noteValue // combine both for matching
+
 		hasKeyword := strings.Contains(noteContent, "endpoint") || strings.Contains(noteContent, "inventory") ||
 			strings.Contains(noteContent, "discovered") || strings.Contains(noteContent, "subdomain") ||
 			strings.Contains(noteContent, "api") || strings.Contains(noteContent, "routes")
@@ -309,7 +313,7 @@ func hookWorkTracker(state *ScanState, args map[string]string) HookResult {
 			state.EndpointInventorySaved = true
 		}
 		// Also accept if note has 3+ lines with a keyword (likely a real list)
-		if hasKeyword && strings.Count(noteContent, "\n") >= 3 {
+		if hasKeyword && strings.Count(noteValue, "\n") >= 3 {
 			state.EndpointInventorySaved = true
 		}
 	}

--- a/internal/agent/hooks_test.go
+++ b/internal/agent/hooks_test.go
@@ -158,16 +158,18 @@ func TestWorkTracker_EndpointInventory(t *testing.T) {
 	// Non-inventory note — no keywords at all
 	hookWorkTracker(state, map[string]string{
 		"tool_name": "add_note",
-		"content":   "Target uses CloudFlare WAF",
+		"key":       "waf_info",
+		"value":     "Target uses CloudFlare WAF",
 	})
 	if state.EndpointInventorySaved {
 		t.Error("Should not be saved for non-inventory note")
 	}
 
-	// False positive — has keyword but only 1 path-like token (too few)
+	// False positive — keyword in key but only 1 path-like token (too few)
 	hookWorkTracker(state, map[string]string{
 		"tool_name": "add_note",
-		"content":   "Discovered that the WAF blocks /api calls",
+		"key":       "discovery_notes",
+		"value":     "Discovered that the WAF blocks /api calls",
 	})
 	if state.EndpointInventorySaved {
 		t.Error("Should not be saved for note with just 1 path token")
@@ -176,7 +178,8 @@ func TestWorkTracker_EndpointInventory(t *testing.T) {
 	// Real inventory note — keyword + 3 path-like tokens
 	hookWorkTracker(state, map[string]string{
 		"tool_name": "add_note",
-		"content":   "## Discovered Endpoints\n- /api/users\n- /api/login\n- /admin/dashboard",
+		"key":       "endpoint_inventory",
+		"value":     "## Discovered Endpoints\n- /api/users\n- /api/login\n- /admin/dashboard",
 	})
 	if !state.EndpointInventorySaved {
 		t.Error("Should be saved for inventory note with keyword + 3 path tokens")
@@ -186,7 +189,8 @@ func TestWorkTracker_EndpointInventory(t *testing.T) {
 	state2 := NewScanState()
 	hookWorkTracker(state2, map[string]string{
 		"tool_name": "add_note",
-		"content":   "Discovered endpoints:\n/page1\n/page2\n/page3\n/page4",
+		"key":       "endpoints",
+		"value":     "Discovered endpoints:\n/page1\n/page2\n/page3\n/page4",
 	})
 	if !state2.EndpointInventorySaved {
 		t.Error("Should be saved for note with keyword + 3+ lines")
@@ -196,7 +200,8 @@ func TestWorkTracker_EndpointInventory(t *testing.T) {
 	state3 := NewScanState()
 	hookWorkTracker(state3, map[string]string{
 		"tool_name": "add_note",
-		"content":   "API Endpoints discovered:\n- /api/candidates\n- /api/jobs\n- /api/events\n- /api/candidate-stories\n- /v1/auth/refreshtoken",
+		"key":       "endpoint_inventory",
+		"value":     "Discovered Endpoints:\n- /api/candidates (VULNERABLE - unauthenticated access)\n- /api/jobs (public job listings)\n- /api/testimonials (public)\n- /api/candidate-stories\n- /v1/auth/refreshtoken",
 	})
 	if !state3.EndpointInventorySaved {
 		t.Error("Should be saved for vanhack-style endpoint inventory")


### PR DESCRIPTION
## CRITICAL BUG: inventory gate could NEVER pass

### Root Cause
`add_note` tool uses `key` and `value` args:
```
add_note(key='endpoint_inventory', value='Discovered Endpoints:\n- /api/users...')
```

But `hookWorkTracker` was checking `args["content"]`:
```go
noteContent := strings.ToLower(args["content"])  // BUG: always empty string!
```

The inventory gate checked an empty string every time — it could **never** pass.

### Impact
- vanhack scan #1 (v4.5.10): 4 rejections, 20 wasted iterations
- vanhack scan #2 (v4.5.12): **11 rejections**, agent saved 9 perfect notes but none recognized
- Tests passed because they also used `args["content"]` — both code and tests had the same bug

### Fix
```go
noteKey := strings.ToLower(args["key"])
noteValue := strings.ToLower(args["value"])
noteContent := noteKey + " " + noteValue
```

### Why tests didn't catch it
Tests used `"content": "..."]` which matched the buggy code. Now fixed to use `"key": "...", "value": "..."`.