### PR TITLE
release: v4.5.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.12
+VERSION=4.5.13
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.12" alt="Xalgorix" width="860" />
+<img src="assets/banner.png?v=4.5.13" alt="Xalgorix" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.12"
+var version = "4.5.13"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
### Changes

- 0519dbd fix: critical — inventory check used wrong arg key (content → key+value) (#112)
- 824c48c fix: inventory gate thrashing — path-counting instead of marker matching (#110)
- 06075f7 release: v4.5.8 (#102)
- c75838c feat: curl preference enforcement + wire all 4 temperatures + better endpoint extraction (#107)
- 6a32206 fix: address audit concerns — prevent depth gaming and tighten inventory check (#105)
- bdcfc6c feat: adaptive surface-area-aware finish gating with test depth tracking (#103)