### PR TITLE
release: v4.5.14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.13
+VERSION=4.5.14
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.13" alt="Xalgorix" width="860" />
+<img src="assets/banner.png?v=4.5.14" alt="Xalgorix" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.13"
+var version = "4.5.14"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
### Changes

- 52a070a feat: vuln class coverage tracking + finish nudge for missing classes (#115)
- cf9aa8f chore: bump version to 4.5.13 on main (#114)
- 09f9097 release: v4.5.12 (#111)