### PR TITLE
fix: close python_action loophole — nudge toward curl + track vuln payloads

### DIFF
--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -329,6 +329,41 @@ func hookWorkTracker(state *ScanState, args map[string]string) HookResult {
 		}
 	}
 
+	// ── python_action vuln class tracking ──
+	// The agent sometimes uses python requests.get() instead of curl.
+	// Track vuln payloads in python code so coverage tracking still works.
+	if toolName == "python_action" {
+		code := strings.ToLower(args["code"])
+		if code == "" {
+			code = strings.ToLower(args["script"])
+		}
+		if strings.Contains(code, "sqlmap") || strings.Contains(code, "' or ") ||
+			strings.Contains(code, "union select") || strings.Contains(code, "sleep(") {
+			state.VulnClassesTested["sqli"] = true
+		}
+		if strings.Contains(code, "<script") || strings.Contains(code, "alert(") ||
+			strings.Contains(code, "onerror") {
+			state.VulnClassesTested["xss"] = true
+		}
+		if strings.Contains(code, "{{7*7}}") || strings.Contains(code, "${7*7}") ||
+			strings.Contains(code, "ssti") {
+			state.VulnClassesTested["ssti"] = true
+		}
+		if strings.Contains(code, "%0d%0a") || strings.Contains(code, "crlf") {
+			state.VulnClassesTested["crlf"] = true
+		}
+		if strings.Contains(code, "; id") || strings.Contains(code, "| id") ||
+			strings.Contains(code, "$(id)") {
+			state.VulnClassesTested["cmdi"] = true
+		}
+		if strings.Contains(code, "../") || strings.Contains(code, "etc/passwd") {
+			state.VulnClassesTested["path_traversal"] = true
+		}
+		if strings.Contains(code, "169.254") || strings.Contains(code, "ssrf") {
+			state.VulnClassesTested["ssrf"] = true
+		}
+	}
+
 	if toolName == "read_skill" {
 		state.SkillsLoaded++
 	}
@@ -479,6 +514,37 @@ send_request is ONLY for:
 ✅ Requests with session cookies after browser login (authenticated testing)
 ✅ Requests that must appear in the Caido proxy log
 ❌ Everything else → use curl`, state.SendRequestCalls, method),
+			}
+		}
+	}
+
+	// Track python_action usage for HTTP requests
+	if toolName == "python_action" {
+		code := strings.ToLower(args["code"])
+		if code == "" {
+			code = strings.ToLower(args["script"])
+		}
+		// Detect HTTP requests via requests/urllib/http.client
+		isHTTP := strings.Contains(code, "requests.get") || strings.Contains(code, "requests.post") ||
+			strings.Contains(code, "requests.put") || strings.Contains(code, "requests.delete") ||
+			strings.Contains(code, "urllib") || strings.Contains(code, "http.client")
+		if isHTTP {
+			state.SendRequestCalls++ // reuse counter — conceptually the same issue
+			if state.SendRequestCalls <= 2 {
+				return HookResult{
+					Nudge: `💡 TIP: Use curl instead of python requests for HTTP testing.
+python_action HTTP calls bypass endpoint tracking and don't log to proxy.
+Use instead: curl -sk <URL> -H "header: value" -d '{"payload": "{{7*7}}"}'
+Reserve python only for complex logic (parsing, loops, multi-step chains).`,
+				}
+			}
+			if state.SendRequestCalls >= 5 {
+				return HookResult{
+					Nudge: fmt.Sprintf(`⛔ STOP using python requests for HTTP calls (%d times). This bypasses:
+- Endpoint tracking (your coverage stats are wrong)
+- Proxy logging (findings won't have request/response evidence)
+Switch to curl NOW: curl -sk -X POST <URL> -H "Content-Type: application/json" -d '{}'`, state.SendRequestCalls),
+				}
 			}
 		}
 	}

--- a/internal/agent/hooks_test.go
+++ b/internal/agent/hooks_test.go
@@ -209,6 +209,50 @@ func TestWorkTracker_VulnClassTracking(t *testing.T) {
 	}
 }
 
+func TestWorkTracker_PythonActionVulnTracking(t *testing.T) {
+	state := NewScanState()
+
+	// Python code with SSTI and CRLF payloads
+	hookWorkTracker(state, map[string]string{
+		"tool_name": "python_action",
+		"code":      `import requests; r = requests.get("https://target.com/search?q={{7*7}}")`,
+	})
+	if !state.VulnClassesTested["ssti"] {
+		t.Error("SSTI should be detected from python_action code")
+	}
+
+	hookWorkTracker(state, map[string]string{
+		"tool_name": "python_action",
+		"code":      `r = requests.get("https://target.com/r?url=%0d%0aX-Injected:true")`,
+	})
+	if !state.VulnClassesTested["crlf"] {
+		t.Error("CRLF should be detected from python_action code")
+	}
+}
+
+func TestCurlPreference_PythonRequestsNudge(t *testing.T) {
+	state := NewScanState()
+
+	// First python HTTP call — soft nudge
+	result := hookCurlPreference(state, map[string]string{
+		"tool_name": "python_action",
+		"code":      `import requests; r = requests.get("https://target.com/api/test")`,
+	})
+	if result.Nudge == "" {
+		t.Error("Should nudge on first python requests.get() call")
+	}
+
+	// Non-HTTP python code — no nudge
+	state2 := NewScanState()
+	result2 := hookCurlPreference(state2, map[string]string{
+		"tool_name": "python_action",
+		"code":      `print("hello world"); x = 1 + 2`,
+	})
+	if result2.Nudge != "" {
+		t.Error("Should NOT nudge on python code without HTTP calls")
+	}
+}
+
 func TestWorkTracker_EndpointInventory(t *testing.T) {
 	state := NewScanState()
 


### PR DESCRIPTION
Agent was using python requests instead of curl, bypassing endpoint tracking and proxy logging. Now nudges toward curl and tracks vuln payloads from python code as fallback.