### PR TITLE
fix(agent): break endless loops on repeated identical tool calls (#158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [Unreleased] — Loop-breaker for repeated identical tool calls
+
+### Fixed
+- **Endless loop on repeated identical tool calls (#158).** The agent could spin indefinitely, regenerating the same tool call (most commonly `terminal_execute`) with identical arguments and an identical failing result — observed reaching iteration 2106+ with no progress. Stuck detection in `internal/agent/hooks.go` only accumulated for `browser_action` and `web_search`; the default branch of `hookStuckTracker` reset all stuck counters for every other tool, so a loop on `terminal_execute` (or any non-browser/search tool) never tripped a nudge or force-skip and ran until `MaxIterations` (default 0 = unlimited) or process kill.
+  - New `ScanState` fields track consecutive identical `(tool, args)` and consecutive byte-identical tool outputs; these counters are deliberately NOT reset by `OnHealthyResponse` (a "healthy" response re-issuing the same call is exactly the loop).
+  - New thresholds `RepeatCallSoftNudge=3`, `RepeatCallHardSkip=5`, `RepeatResultHardSkip=4`.
+  - `hashToolArgs()` (order-independent FNV-64a) and `resultFingerprint()` detect identical `(tool, args)` and identical output across iterations.
+  - `hookStuckTracker`'s default branch now counts consecutive identical calls; `add_note`/`read_notes` are excluded so legitimate note-taking between identical test calls doesn't reset the counter.
+  - New `hookResultRepeatTracker` on `OnToolResult` counts byte-identical outputs (ignores `add_note`/`read_notes`/`finish`).
+  - `hookStuckNudge` force-skips + nudges ahead of the browser hard-limit on repeated identical call (soft/hard) and repeated identical output; counters reset after firing.
+
+### Notes
+- No change to `agent.go` (existing `ForceSkip`→skip / `Nudge`→user-message machinery already consumes the result) and no change to the `MaxIterations` default (legitimate wildcard scans run thousands of iterations).
+- Known follow-up, not fixed here: the three block branches in `agent.go` (`shouldBlockForActivityPolicy` / `shouldBlockForPhaseRestriction` / `shouldBlockForOutOfScope`, ~L1547-1581) still do not increment any stuck counter.
+
 ## [Unreleased]
 
 ### Added

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -6,6 +6,7 @@ package agent
 
 import (
 	"fmt"
+	"hash/fnv"
 	"net/url"
 	"sort"
 	"strings"
@@ -77,6 +78,19 @@ type ScanState struct {
 	EmptyResponseCount int
 	NoToolCount        int
 	RefusalCount       int // consecutive responses that look like a model-side safety refusal
+
+	// Repeated-call loop detection (orthogonal to the browser/search stuck
+	// tracking above). Catches the agent regenerating the same tool call with
+	// identical args — e.g. looping on terminal_execute with the same failing
+	// command (issue #158). Only applied to tools NOT already covered by the
+	// browser/search stuck logic, so it cannot conflict with StuckDomain.
+	// These counters are NOT reset by OnHealthyResponse: a "healthy" response
+	// that re-issues the same call is exactly the loop we want to catch.
+	LastToolName          string
+	LastToolArgsHash      string
+	ConsecutiveSameCall   int // same (tool, normalized args) called back-to-back
+	LastResultFP          string
+	ConsecutiveSameResult int // same result-output fingerprint back-to-back
 
 	// CumulativeRateLimitWait tracks the total time spent parked in the
 	// provider-rate-limit backoff loop across the whole scan. It bounds an
@@ -180,6 +194,14 @@ const (
 	StuckBrowserThreshold = 60 // browser actions before nudge
 	StuckSearchThreshold  = 45 // web searches before nudge
 	StuckHardLimit        = 80 // total stuck iterations before force-skip
+
+	// Repeated-call detection — fires on any non-browser/search tool that is
+	// re-issued with identical args (or produces identical output) across
+	// consecutive iterations. Thresholds are intentionally low: a genuinely
+	// identical call is never productive, so we nudge fast and skip fast.
+	RepeatCallSoftNudge  = 3 // identical (tool,args) → soft pivot nudge + skip
+	RepeatCallHardSkip   = 5 // identical (tool,args) → strong force-skip nudge
+	RepeatResultHardSkip = 4 // identical result output across calls → force-skip
 )
 
 // ── Per-Role Temperatures ────────────────────────────────────────────────────
@@ -206,6 +228,7 @@ func RegisterDefaultHooks(reg *HookRegistry) {
 	reg.Register(OnStuckCheck, hookStuckNudge)
 	reg.Register(OnToolResult, hookWAFDetector)
 	reg.Register(OnToolResult, hookTechDetector)
+	reg.Register(OnToolResult, hookResultRepeatTracker)
 	reg.Register(OnFinishAttempt, hookFinishGatekeeper)
 	reg.Register(OnEmptyResponse, hookEmptyResponseHandler)
 	reg.Register(OnNoToolResponse, hookNoToolHandler)
@@ -552,6 +575,39 @@ Switch to curl NOW: curl -sk -X POST <URL> -H "Content-Type: application/json" -
 	return HookResult{}
 }
 
+// hashToolArgs returns a stable hash of (toolName, args) so two calls with
+// the same tool and the same argument values collide regardless of map
+// iteration order. Arg keys are sorted before hashing. The hash is a short
+// hex string — collision-tolerant for loop detection, not security.
+func hashToolArgs(name string, args map[string]string) string {
+	keys := make([]string, 0, len(args))
+	for k := range args {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	h := fnv.New64a()
+	h.Write([]byte(name))
+	h.Write([]byte{0}) // separator so ("ab","c") != ("a","bc")
+	for _, k := range keys {
+		h.Write([]byte(k))
+		h.Write([]byte{0})
+		h.Write([]byte(args[k]))
+		h.Write([]byte{0})
+	}
+	return fmt.Sprintf("%016x", h.Sum64())
+}
+
+// resultFingerprint returns a short, stable fingerprint of a tool result so
+// we can detect the agent getting the same output across consecutive calls
+// (even when the args differ slightly). Uses the error string (if any) plus
+// a truncated FNV of the output.
+func resultFingerprint(output, errStr string) string {
+	h := fnv.New64a()
+	h.Write([]byte(output))
+	return fmt.Sprintf("%s|%016x", errStr, h.Sum64())
+}
+
 // ── hookStuckTracker ─────────────────────────────────────────────────────────
 // Tracks consecutive browser/search actions and domain stickiness.
 // Updates counters on ScanState — the actual nudge/force-skip is in hookStuckNudge.
@@ -592,15 +648,54 @@ func hookStuckTracker(state *ScanState, args map[string]string) HookResult {
 			state.StuckIterations++
 		}
 	default:
-		// A non-browser, non-search tool call = real progress, reset counters
+		// A non-browser, non-search tool call = real progress for the
+		// browser/search stuck counters, so reset those. But track whether
+		// the agent is re-issuing the *same* call (issue #158): a loop on
+		// terminal_execute with identical args never touches the browser
+		// counters above, so without this it runs until MaxIterations.
 		if toolName != "add_note" && toolName != "read_notes" {
 			state.ConsecutiveBrowser = 0
 			state.ConsecutiveSearch = 0
 			state.StuckIterations = 0
 			state.StuckDomain = ""
+
+			// Repeated-call tracking. add_note/read_notes are excluded so
+			// legitimate note-taking between identical test calls doesn't
+			// itself count as a "different" call that resets the counter.
+			argsHash := hashToolArgs(toolName, args)
+			if toolName == state.LastToolName && argsHash == state.LastToolArgsHash {
+				state.ConsecutiveSameCall++
+			} else {
+				state.LastToolName = toolName
+				state.LastToolArgsHash = argsHash
+				state.ConsecutiveSameCall = 1
+			}
 		}
 	}
 
+	return HookResult{}
+}
+
+// ── hookResultRepeatTracker ──────────────────────────────────────────────────
+// Fires on OnToolResult. Fingerprints the result output and counts how many
+// consecutive tool results have been identical — a signal that the agent is
+// not making progress even if it varies its arguments slightly (issue #158).
+// The actual nudge/force-skip is issued by hookStuckNudge on the next
+// OnStuckCheck. Note-readers/note-writers are ignored: an add_note result is
+// not a "test result" and must not feed this counter.
+func hookResultRepeatTracker(state *ScanState, args map[string]string) HookResult {
+	toolName := args["tool_name"]
+	if toolName == "add_note" || toolName == "read_notes" || toolName == "finish" {
+		return HookResult{}
+	}
+
+	fp := resultFingerprint(args["output"], args["error"])
+	if fp == state.LastResultFP {
+		state.ConsecutiveSameResult++
+	} else {
+		state.LastResultFP = fp
+		state.ConsecutiveSameResult = 1
+	}
 	return HookResult{}
 }
 
@@ -610,6 +705,54 @@ func hookStuckTracker(state *ScanState, args map[string]string) HookResult {
 func hookStuckNudge(state *ScanState, args map[string]string) HookResult {
 	if state.ReconOnlyMode {
 		return HookResult{}
+	}
+
+	// ── Repeated identical tool call (issue #158) ──
+	// The agent re-issued the same tool with the same args across consecutive
+	// iterations. This is never productive — repeating an identical action
+	// cannot yield a different result — so nudge hard and force-skip the
+	// redundant call. Checked BEFORE the browser hard-limit so a terminal/
+	// http/other-tool loop is caught regardless of StuckIterations.
+	if state.ConsecutiveSameCall >= RepeatCallSoftNudge {
+		hard := state.ConsecutiveSameCall >= RepeatCallHardSkip
+		verb := "repeated"
+		if hard {
+			verb = "repeatedly re-issued"
+		}
+		msg := fmt.Sprintf(`⛔ REPEATED CALL: You have %s %q with identical arguments %d times in a row and received the same failing result. Repeating an identical action will NOT produce a different outcome.
+
+DO NOT call %q with those same arguments again. Instead:
+1. Re-read the tool's last output — it is failing for a specific reason (exit code 1, command not found, permission denied, bad quoting, wrong path). Fix the ROOT CAUSE.
+2. Try a genuinely different command or a different tool (e.g. switch between terminal_execute / send_request / browser_action).
+3. If you have exhausted this line of testing, add_note what you tried and move to the next target or call finish.
+
+Your next tool call MUST differ from the last one.`, verb, state.LastToolName, state.ConsecutiveSameCall, state.LastToolName)
+
+		// Reset so the nudge doesn't fire every iteration; a new identical
+		// run will re-accumulate.
+		state.ConsecutiveSameCall = 0
+		return HookResult{
+			Nudge:       msg,
+			ForceSkip:   true,
+			EmitMessage: msg,
+		}
+	}
+
+	// ── Repeated identical tool OUTPUT across calls (issue #158) ──
+	// Args vary but the result is byte-identical several times in a row — the
+	// agent is spinning without progress. Force a pivot.
+	if state.ConsecutiveSameResult >= RepeatResultHardSkip {
+		msg := fmt.Sprintf(`⛔ NO PROGRESS: Your last %d tool calls produced byte-identical output. You are looping without making progress.
+
+Change your approach: target a different endpoint, use a different payload/technique, or consult a skill (read_skill). If this avenue is exhausted, add_note your findings and move on.
+
+Do not repeat the action that produced this output.`, state.ConsecutiveSameResult)
+		state.ConsecutiveSameResult = 0
+		return HookResult{
+			Nudge:       msg,
+			ForceSkip:   true,
+			EmitMessage: msg,
+		}
 	}
 
 	// Hard limit: force-skip after too many stuck iterations

--- a/internal/agent/hooks_test.go
+++ b/internal/agent/hooks_test.go
@@ -752,3 +752,188 @@ func TestCurlPreference_IgnoresOtherTools(t *testing.T) {
 		t.Error("SendRequestCalls should remain 0 for non-send_request tools")
 	}
 }
+
+// ── repeat-detector tests (issue #158) ───────────────────────────────────────
+
+// fireRepeat simulates one iteration's hook sequence for a tool call:
+// OnToolCall (tracking) → OnStuckCheck (nudge/force-skip decision).
+func fireRepeat(state *ScanState, toolName string, args map[string]string) HookResult {
+	callArgs := map[string]string{"tool_name": toolName}
+	for k, v := range args {
+		callArgs[k] = v
+	}
+	hookStuckTracker(state, callArgs)
+	return hookStuckNudge(state, callArgs)
+}
+
+func TestRepeatDetector_SameCallForceSkipsAfterThreshold(t *testing.T) {
+	state := NewScanState()
+	args := map[string]string{"command": "curl -sk https://example.com/csp"}
+
+	// Iterations 1..2: below soft-nudge threshold → no skip.
+	for i := 1; i <= RepeatCallSoftNudge-1; i++ {
+		res := fireRepeat(state, "terminal_execute", args)
+		if res.ForceSkip {
+			t.Fatalf("iteration %d: did not expect ForceSkip yet", i)
+		}
+		if state.ConsecutiveSameCall != i {
+			t.Fatalf("iteration %d: ConsecutiveSameCall = %d, want %d", i, state.ConsecutiveSameCall, i)
+		}
+	}
+
+	// Iteration RepeatCallSoftNudge: should force-skip + nudge, then reset.
+	res := fireRepeat(state, "terminal_execute", args)
+	if !res.ForceSkip {
+		t.Fatal("expected ForceSkip at soft-nudge threshold")
+	}
+	if res.Nudge == "" {
+		t.Fatal("expected a non-empty pivot nudge")
+	}
+	if !strings.Contains(res.Nudge, "REPEATED CALL") {
+		t.Errorf("nudge should mention REPEATED CALL, got: %s", res.Nudge)
+	}
+	if state.ConsecutiveSameCall != 0 {
+		t.Errorf("ConsecutiveSameCall should reset to 0 after nudge, got %d", state.ConsecutiveSameCall)
+	}
+
+	// Hard-skip threshold should also fire and reset.
+	state.ConsecutiveSameCall = RepeatCallHardSkip - 1
+	res = fireRepeat(state, "terminal_execute", args)
+	if !res.ForceSkip || !strings.Contains(res.Nudge, "repeatedly re-issued") {
+		t.Errorf("expected hard-skip nudge at %d, got ForceSkip=%v nudge=%q", RepeatCallHardSkip, res.ForceSkip, res.Nudge)
+	}
+	if state.ConsecutiveSameCall != 0 {
+		t.Errorf("ConsecutiveSameCall should reset after hard skip, got %d", state.ConsecutiveSameCall)
+	}
+}
+
+func TestRepeatDetector_DifferentCallResets(t *testing.T) {
+	state := NewScanState()
+
+	fireRepeat(state, "terminal_execute", map[string]string{"command": "curl https://a.example.com"})
+	fireRepeat(state, "terminal_execute", map[string]string{"command": "curl https://b.example.com"})
+
+	if state.ConsecutiveSameCall != 1 {
+		t.Fatalf("alternating commands must reset counter to 1, got %d", state.ConsecutiveSameCall)
+	}
+	// Two different calls must never trip the detector.
+	res := fireRepeat(state, "terminal_execute", map[string]string{"command": "curl https://c.example.com"})
+	if res.ForceSkip {
+		t.Fatal("different calls must not trigger ForceSkip")
+	}
+}
+
+func TestRepeatDetector_ArgOrderIndependent(t *testing.T) {
+	// Same key/values, different map iteration order must hash identically.
+	a := map[string]string{"command": "nmap -sV example.com", "timeout": "30"}
+	b := map[string]string{"timeout": "30", "command": "nmap -sV example.com"}
+	if hashToolArgs("terminal_execute", a) != hashToolArgs("terminal_execute", b) {
+		t.Fatal("hashToolArgs must be insensitive to arg insertion order")
+	}
+	if hashToolArgs("terminal_execute", a) == hashToolArgs("send_request", a) {
+		t.Fatal("different tool names must hash differently")
+	}
+}
+
+func TestRepeatDetector_NotesDoNotResetCounter(t *testing.T) {
+	state := NewScanState()
+	args := map[string]string{"command": "curl https://example.com/csp"}
+
+	// Two identical terminal calls to build the counter.
+	fireRepeat(state, "terminal_execute", args)
+	fireRepeat(state, "terminal_execute", args)
+	if state.ConsecutiveSameCall != 2 {
+		t.Fatalf("expected ConsecutiveSameCall=2, got %d", state.ConsecutiveSameCall)
+	}
+
+	// An add_note call between iterations must NOT reset the terminal-loop
+	// counter (notes are not progress on the test itself).
+	hookStuckTracker(state, map[string]string{"tool_name": "add_note", "content": "tried csp"})
+	if state.ConsecutiveSameCall != 2 {
+		t.Errorf("add_note must not reset ConsecutiveSameCall, got %d", state.ConsecutiveSameCall)
+	}
+
+	// Third identical terminal call trips the detector.
+	res := fireRepeat(state, "terminal_execute", args)
+	if !res.ForceSkip {
+		t.Fatal("identical call after an intervening note must still force-skip")
+	}
+}
+
+func TestRepeatDetector_IdenticalResultForceSkips(t *testing.T) {
+	state := NewScanState()
+	out := "[exit code: 1]\nbash: foobar: command not found"
+
+	for i := 1; i < RepeatResultHardSkip; i++ {
+		hookResultRepeatTracker(state, map[string]string{
+			"tool_name": "terminal_execute",
+			"output":    out,
+			"error":     "",
+		})
+		if state.ConsecutiveSameResult != i {
+			t.Fatalf("iter %d: ConsecutiveSameResult=%d, want %d", i, state.ConsecutiveSameResult, i)
+		}
+		// No force-skip until threshold reached (checked via hookStuckNudge).
+		if nudge := hookStuckNudge(state, map[string]string{"tool_name": "terminal_execute"}); nudge.ForceSkip {
+			t.Fatalf("did not expect force-skip before %d", RepeatResultHardSkip)
+		}
+	}
+
+	// Reach the threshold.
+	hookResultRepeatTracker(state, map[string]string{
+		"tool_name": "terminal_execute",
+		"output":    out,
+		"error":     "",
+	})
+	res := hookStuckNudge(state, map[string]string{"tool_name": "terminal_execute"})
+	if !res.ForceSkip {
+		t.Fatal("expected ForceSkip on identical-output threshold")
+	}
+	if !strings.Contains(res.Nudge, "NO PROGRESS") {
+		t.Errorf("expected NO PROGRESS nudge, got: %s", res.Nudge)
+	}
+	if state.ConsecutiveSameResult != 0 {
+		t.Errorf("ConsecutiveSameResult should reset after nudge, got %d", state.ConsecutiveSameResult)
+	}
+}
+
+func TestRepeatDetector_ResultTrackerIgnoresNotesAndFinish(t *testing.T) {
+	state := NewScanState()
+	for _, tool := range []string{"add_note", "read_notes", "finish"} {
+		before := state.ConsecutiveSameResult
+		hookResultRepeatTracker(state, map[string]string{
+			"tool_name": tool,
+			"output":    "anything",
+			"error":     "",
+		})
+		if state.ConsecutiveSameResult != before {
+			t.Errorf("%q must not feed the result-repeat counter (was %d, now %d)", tool, before, state.ConsecutiveSameResult)
+		}
+	}
+}
+
+func TestRepeatDetector_ResetOnSuccessLeavesRepeatCounters(t *testing.T) {
+	state := NewScanState()
+	state.ConsecutiveSameCall = 3
+	state.ConsecutiveSameResult = 4
+	state.LastToolName = "terminal_execute"
+	state.LastResultFP = "abc"
+
+	// A "healthy" response that re-issues the same call is exactly the loop
+	// we want to keep detecting, so OnHealthyResponse must NOT reset these.
+	hookResetOnSuccess(state, nil)
+
+	if state.ConsecutiveSameCall != 3 {
+		t.Errorf("ConsecutiveSameCall must survive OnHealthyResponse, got %d", state.ConsecutiveSameCall)
+	}
+	if state.ConsecutiveSameResult != 4 {
+		t.Errorf("ConsecutiveSameResult must survive OnHealthyResponse, got %d", state.ConsecutiveSameResult)
+	}
+	if state.LastToolName != "terminal_execute" || state.LastResultFP != "abc" {
+		t.Error("LastToolName/LastResultFP must survive OnHealthyResponse")
+	}
+	// Sanity: the error counters ARE reset by OnHealthyResponse.
+	if state.ConsecutiveErrors != 0 || state.NoToolCount != 0 {
+		t.Error("ConsecutiveErrors/NoToolCount should be reset by OnHealthyResponse")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #158.

The agent could spin indefinitely, regenerating the same tool call (most commonly `terminal_execute`) with identical arguments and an identical failing result — observed reaching iteration 2106+ with no progress.

## Root cause

Stuck detection in `internal/agent/hooks.go` only accumulated for `browser_action` and `web_search`. The default branch of `hookStuckTracker` reset **all** stuck counters to zero for every other tool, so a loop on `terminal_execute` (or any non-browser/search tool) never reached any nudge/force-skip threshold and ran until `MaxIterations` (default 0 = unlimited) or the process was killed. `hookNoToolHandler` didn't help because a tool *was* being called, and `hookResetOnSuccess` actively reset the error counters since the response was "healthy" (non-empty + had tool calls).

## Fix

Add an orthogonal repeat-detector mirroring the existing tracker→nudge pattern (track in `OnToolCall`/`OnToolResult`, act in `OnStuckCheck`), restricted to tools not already covered by the browser/search logic.

- `ScanState`: `LastToolName`, `LastToolArgsHash`, `ConsecutiveSameCall`, `LastResultFP`, `ConsecutiveSameResult` — **not** reset by `OnHealthyResponse` (a healthy response re-issuing the same call is the loop).
- Thresholds: `RepeatCallSoftNudge=3`, `RepeatCallHardSkip=5`, `RepeatResultHardSkip=4`.
- `hashToolArgs()` (order-independent FNV-64a) + `resultFingerprint()` detect identical `(tool, args)` and identical output across iterations.
- `hookStuckTracker` default branch now counts consecutive identical calls; `add_note`/`read_notes` excluded so legitimate note-taking doesn't reset the counter.
- New `hookResultRepeatTracker` on `OnToolResult` counts byte-identical outputs (ignores `add_note`/`read_notes`/`finish`).
- `hookStuckNudge` force-skips + nudges ahead of the browser hard-limit on repeated identical call (soft/hard) and repeated identical output; counters reset after firing.

No change to `agent.go` (existing `ForceSkip`→skip / `Nudge`→user-message machinery already consumes the result). No change to `MaxIterations` default (legitimate wildcard scans run thousands of iterations).

## Verification

- `go vet ./...` / `go build ./...` — clean
- `go test ./internal/agent/ -run TestRepeatDetector -v` — 7/7 pass
- `go test ./...` — 29 packages ok, 0 fail

## Out of scope

Known follow-up, not fixed here: the three block branches in `agent.go` (`shouldBlockForActivityPolicy` / `shouldBlockForPhaseRestriction` / `shouldBlockForOutOfScope`, ~L1547-1581) still do not increment any stuck counter.
