### PR TITLE
fix(agent): satisfy golangci-lint on the #158 repeat-detector

### DIFF
--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -189,16 +189,17 @@ func (r *HookRegistry) Fire(event string, state *ScanState, args map[string]stri
 }
 
 // ── Thresholds ───────────────────────────────────────────────────────────────
+//
+// Repeat-call thresholds (RepeatCallSoftNudge / RepeatCallHardSkip /
+// RepeatResultHardSkip) are intentionally low: a genuinely identical tool call
+// is never productive, so we nudge and force-skip fast. See hookStuckNudge,
+// hookStuckTracker and hookResultRepeatTracker for how they're consumed.
 
 const (
 	StuckBrowserThreshold = 60 // browser actions before nudge
 	StuckSearchThreshold  = 45 // web searches before nudge
 	StuckHardLimit        = 80 // total stuck iterations before force-skip
 
-	// Repeated-call detection — fires on any non-browser/search tool that is
-	// re-issued with identical args (or produces identical output) across
-	// consecutive iterations. Thresholds are intentionally low: a genuinely
-	// identical call is never productive, so we nudge fast and skip fast.
 	RepeatCallSoftNudge  = 3 // identical (tool,args) → soft pivot nudge + skip
 	RepeatCallHardSkip   = 5 // identical (tool,args) → strong force-skip nudge
 	RepeatResultHardSkip = 4 // identical result output across calls → force-skip

--- a/internal/agent/hooks_test.go
+++ b/internal/agent/hooks_test.go
@@ -514,9 +514,9 @@ func TestFloatPtr(t *testing.T) {
 
 func TestTestDepthRatio(t *testing.T) {
 	tests := []struct {
-		name                                                  string
-		total, injection, accessControl, dirbusting           int
-		want                                                  float64
+		name                                        string
+		total, injection, accessControl, dirbusting int
+		want                                        float64
 	}{
 		{"no endpoints", 0, 0, 0, 0, 0.0},
 		{"3 endpoints, full coverage", 3, 3, 3, 3, 3.0},


### PR DESCRIPTION
Follow-up to #159 (merged as `010a877`), which carried a lint failure that made `main` red.

## Problem
- `revive exported`: the repeat-detector consts had a group doc comment not starting with the first identifier name.
- `gofmt`: the pre-existing `TestTestDepthRatio` struct (from the #155 wip merge) was committed unformatted and golangci-lint v2's `gofmt` formatter now flags it.

## Fix
- Removed the preceding const doc comment; inline comments only (matches the existing `Stuck*` consts). Rationale moved to the detached section header above `const (` (revive ignores non-attached comments).
- `gofmt`-formatted `TestTestDepthRatio` (whitespace only).

## Verification
- `golangci-lint v2.5.0` (prebuilt CI-identical binary): **0 issues**
- `go vet ./...` / `go build ./...`: clean
- `go test ./internal/agent/`: pass

Refs: #158