### PR TITLE
release: v4.5.34

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.33
+VERSION=4.5.34
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.33" alt="Xalgorix" width="860" />
+<img src="assets/banner.png?v=4.5.34" alt="Xalgorix" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.33"
+var version = "4.5.34"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
### Changes

- cc6e7a3 fix(agent): satisfy golangci-lint on the #158 repeat-detector (#160)
- 010a877 fix(agent): break endless loops on repeated identical tool calls (#158)
- 6ce0576 release: v4.5.33 (#156)