### PR TITLE
release: v4.5.42

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.41
+VERSION=4.5.42
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.41" alt="Xalgorix" width="860" />
+<img src="assets/banner.png?v=4.5.42" alt="Xalgorix" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.41"
+var version = "4.5.42"
 
 const defaultWebPort = 9137
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -3776,6 +3776,41 @@ func (a *Agent) redactSecrets(s string) string {
 	return s
 }
 
+// credentialsInURL extracts embedded clone credentials from a git/HTTP URL of
+// the form scheme://userinfo@host/path — e.g. a GitHub token in
+// https://x-access-token:<TOKEN>@github.com/org/repo.git. It returns the
+// full userinfo ("user:pass") and, separately, the password/token component,
+// so they can be registered as redaction secrets. Returns nil when the URL
+// carries no credentials. Values shorter than 4 chars are skipped to avoid
+// redacting trivially-common substrings.
+func credentialsInURL(raw string) []string {
+	i := strings.Index(raw, "://")
+	if i < 0 {
+		return nil
+	}
+	rest := raw[i+3:]
+	at := strings.Index(rest, "@")
+	if at < 0 {
+		return nil
+	}
+	// The host part may itself contain no '@'; take the userinfo up to the
+	// FIRST '@' (credentials cannot contain an unescaped '@').
+	userinfo := rest[:at]
+	if userinfo == "" {
+		return nil
+	}
+	var out []string
+	if len(userinfo) >= 4 {
+		out = append(out, userinfo)
+	}
+	if c := strings.Index(userinfo, ":"); c >= 0 {
+		if pw := userinfo[c+1:]; len(pw) >= 4 {
+			out = append(out, pw)
+		}
+	}
+	return out
+}
+
 // SetTargetAuth sets per-scan authenticated-session credentials, overriding
 // the global default. Call before Run(). Empty string clears it.
 func (a *Agent) SetTargetAuth(s string) { a.targetAuth = strings.TrimSpace(s) }
@@ -3824,10 +3859,16 @@ func (a *Agent) prepareScanEnvironment() {
 			dest = os.TempDir()
 		}
 		dest = filepath.Join(dest, "source")
-		a.emit(Event{Type: "message", Content: fmt.Sprintf("📦 Whitebox: resolving source (%s)…", a.sourceRepo)})
+		// A private-repo clone URL may embed a token
+		// (https://x-access-token:<TOKEN>@github.com/...). Register those
+		// credentials as redaction secrets BEFORE any emit/log so the token
+		// never leaks into telemetry, the scan log, PDF reports, or git's
+		// own "authentication failed for <url>" error output.
+		a.secretValues = append(a.secretValues, credentialsInURL(a.sourceRepo)...)
+		a.emit(Event{Type: "message", Content: fmt.Sprintf("📦 Whitebox: resolving source (%s)…", a.redactSecrets(a.sourceRepo))})
 		if root, err := codesearch.ResolveSource(a.sourceRepo, dest); err != nil {
-			a.emit(Event{Type: "error", Content: "Whitebox source unavailable: " + err.Error() + " — continuing black-box."})
-			log.Printf("[agent] whitebox source unavailable (%s): %v", a.sourceRepo, err)
+			a.emit(Event{Type: "error", Content: "Whitebox source unavailable: " + a.redactSecrets(err.Error()) + " — continuing black-box."})
+			log.Printf("[agent] whitebox source unavailable (%s): %v", a.redactSecrets(a.sourceRepo), a.redactSecrets(err.Error()))
 		} else if root != "" {
 			codesearch.SetSourceRoot(a.scanCtx.ID, root)
 			a.emit(Event{Type: "message", Content: "📦 Whitebox source ready — use code_search to hunt sinks."})

--- a/internal/agent/budget_auth_test.go
+++ b/internal/agent/budget_auth_test.go
@@ -109,6 +109,34 @@ func TestRedactSecrets_SkipsEmptySecretEntry(t *testing.T) {
 	}
 }
 
+func TestCredentialsInURL(t *testing.T) {
+	// A tokenized GitHub clone URL must yield the userinfo AND the token so
+	// both are redacted from telemetry/logs/git errors.
+	creds := credentialsInURL("https://x-access-token:ghp_abcd1234efgh@github.com/org/repo.git")
+	joined := strings.Join(creds, "|")
+	if !strings.Contains(joined, "ghp_abcd1234efgh") {
+		t.Fatalf("token not extracted for redaction: %v", creds)
+	}
+	if !strings.Contains(joined, "x-access-token:ghp_abcd1234efgh") {
+		t.Fatalf("full userinfo not extracted: %v", creds)
+	}
+
+	// A plain (public) URL has no credentials to redact.
+	if got := credentialsInURL("https://github.com/org/repo.git"); got != nil {
+		t.Fatalf("public URL must yield no credentials, got %v", got)
+	}
+	// A bare path / non-URL yields nothing.
+	if got := credentialsInURL("/local/path/to/source"); got != nil {
+		t.Fatalf("local path must yield no credentials, got %v", got)
+	}
+	// A short token is skipped (avoids redacting trivial substrings), but the
+	// combined userinfo is still long enough to register.
+	creds = credentialsInURL("https://u:xy@host/r.git")
+	if strings.Contains(strings.Join(creds, "|"), "|xy") {
+		t.Fatalf("short token should be skipped, got %v", creds)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Per-scan setters
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Changes

- 7bd4185 security(whitebox): redact embedded clone-URL credentials from telemetry + logs
- 4e0e91f release: v4.5.41 (#171)