### PR TITLE
release: v4.5.48

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.47
+VERSION=4.5.48
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.47" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.48" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.47"
+var version = "4.5.48"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
### Changes

- 019e71c fix(scan): expand phase inference to detect phases 8-21 from tool calls (#181)
- a4b9e1b README: add Why Xalgorix differentiator + comparison table; add social preview image (#180)
- ba2c7d9 docs(seo): optimize README for search discovery (#179)
- ee68124 release: v4.5.47 (#178)