### PR TITLE
Growth: one-line install, Docker, developer-first README

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+build
+tmp
+research
+docs
+node_modules
+webui/node_modules
+webui/dist
+*.md
+!README.md
+.kiro
+proxies.txt
+*.log

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,63 @@
+# Build and publish the Xalgorix container image to GitHub Container Registry.
+#
+# Triggers on version tags (vX.Y.Z, pushed by release.sh) and can be run
+# manually. Publishes multi-arch (amd64 + arm64) images tagged with the
+# version and `latest`.
+name: Docker
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,58 @@
+# Xalgorix — AI autonomous penetration testing platform.
+#
+# Build:  docker build -t xalgorix .
+# Run:    docker run --rm -p 9137:9137 \
+#           -e XALGORIX_LLM=minimax/MiniMax-M2.7 \
+#           -e XALGORIX_API_KEY=your_provider_api_key \
+#           xalgorix
+#
+# Then open http://127.0.0.1:9137
+#
+# The binary binds to 127.0.0.1 by default; inside the container we set
+# XALGORIX_BIND=0.0.0.0 so the published port is reachable. External access
+# without dashboard auth is refused, so set XALGORIX_USERNAME / XALGORIX_PASSWORD
+# when exposing this beyond localhost.
+
+# ── Stage 1: build the React web UI ──────────────────────────────────────────
+FROM node:20-bookworm-slim AS webui
+WORKDIR /src
+COPY webui/package.json webui/package-lock.json* ./webui/
+RUN cd webui && npm install --no-audit --no-fund
+COPY webui ./webui
+COPY internal/web ./internal/web
+RUN cd webui && npm run build
+
+# ── Stage 2: build the Go binary (embeds the UI from stage 1) ────────────────
+FROM golang:1.25-bookworm AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+# Bring in the freshly built static assets so //go:embed picks them up.
+COPY --from=webui /src/internal/web/static ./internal/web/static
+ARG VERSION=docker
+RUN CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=${VERSION}" \
+    -o /out/xalgorix ./cmd/xalgorix/
+
+# ── Stage 3: runtime ─────────────────────────────────────────────────────────
+FROM debian:bookworm-slim
+# chromium for browser-assisted DAST; ca-certificates for outbound TLS.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends chromium ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV XALGORIX_BIND=0.0.0.0 \
+    XALGORIX_BROWSER_PATH=/usr/bin/chromium \
+    XALGORIX_DATA_DIR=/data
+
+COPY --from=build /out/xalgorix /usr/local/bin/xalgorix
+
+# Non-root runtime user; /data holds scan output and reports (mount a volume).
+RUN useradd --create-home --uid 10001 xalgorix \
+    && mkdir -p /data && chown xalgorix:xalgorix /data
+USER xalgorix
+VOLUME ["/data"]
+EXPOSE 9137
+
+ENTRYPOINT ["xalgorix"]
+CMD ["--web"]

--- a/README.md
+++ b/README.md
@@ -12,16 +12,19 @@
 [![GitHub forks](https://img.shields.io/github/forks/xalgord/xalgorix?style=for-the-badge&logo=github&color=blue)](https://github.com/xalgord/xalgorix/network/members)
 [![GitHub release](https://img.shields.io/github/v/release/xalgord/xalgorix?style=for-the-badge&logo=github&color=green)](https://github.com/xalgord/xalgorix/releases)
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/xalgord/xalgorix)
+
 </div>
 
-<h1 align="center">Xalgorix — AI Autonomous Penetration Testing</h1>
+<h1 align="center">Xalgorix — Open-source AI pentester that <em>proves</em> vulnerabilities</h1>
 
 <p align="center">
-  <strong>Self-hosted AI pentesting platform</strong> with an LLM-driven agent, browser automation, a 22-phase testing methodology, live WebSocket telemetry, verified findings, and branded PDF reports. Built in Go and TypeScript. Runs on your infrastructure — no cloud dependency, no data leaves your machine.
+  <strong>Most scanners detect. Xalgorix proves.</strong> An autonomous LLM agent works a full pentest methodology, then an <strong>independent verifier re-exploits every finding</strong> before it's reported — so you get proof, not a pile of maybes to triage. Self-hosted, private, and bring-your-own-LLM. Built in Go + TypeScript.
 </p>
 
 <p align="center">
   <a href="#quick-start">Quick Start</a> ·
+  <a href="#why-xalgorix">Why Xalgorix</a> ·
   <a href="#features">Features</a> ·
   <a href="#use-cases">Use Cases</a> ·
   <a href="https://www.xalgorix.com/">Hosted Cloud</a> ·
@@ -32,6 +35,37 @@
 
 ## Quick Start
 
+**Install (one line):**
+
+```bash
+curl -sSL https://www.xalgorix.com/install | bash
+```
+
+This downloads the prebuilt binary for your platform (Linux amd64/arm64) from the latest release. Then point it at your LLM provider in `~/.xalgorix.env`:
+
+```bash
+XALGORIX_LLM=minimax/MiniMax-M2.7
+XALGORIX_API_KEY=your_provider_api_key
+```
+
+Launch the dashboard and open `http://127.0.0.1:9137`:
+
+```bash
+xalgorix --web
+```
+
+**Or run with Docker — no toolchain needed:**
+
+```bash
+docker run --rm -p 9137:9137 \
+  -e XALGORIX_LLM=minimax/MiniMax-M2.7 \
+  -e XALGORIX_API_KEY=your_provider_api_key \
+  -v xalgorix-data:/data \
+  ghcr.io/xalgord/xalgorix:latest
+```
+
+**Or build from source** (needs Go 1.25+ and Node.js):
+
 ```bash
 git clone https://github.com/xalgord/xalgorix.git
 cd xalgorix
@@ -39,20 +73,8 @@ make build
 sudo install -m 755 build/xalgorix /usr/local/bin/xalgorix
 ```
 
-Create `~/.xalgorix.env`:
-
-```bash
-XALGORIX_LLM=minimax/MiniMax-M2.7
-XALGORIX_API_KEY=your_provider_api_key
-```
-
-Start the dashboard:
-
-```bash
-xalgorix --web
-```
-
-Open `http://127.0.0.1:9137`.
+> [!TIP]
+> Prefer zero setup? A fully managed version runs at [www.xalgorix.com](https://www.xalgorix.com/) — click-to-scan, no install or API keys required.
 
 > [!IMPORTANT]
 > Use Xalgorix only on systems you own or have explicit permission to test.
@@ -155,12 +177,34 @@ If Xalgorix saves you a triage cycle, please **[⭐ star the repo](https://githu
 
 ## Installation
 
-### Requirements
+The fastest paths need no toolchain at all.
+
+### One-line install (prebuilt binary)
+
+```bash
+curl -sSL https://www.xalgorix.com/install | bash
+```
+
+Downloads the latest release binary for your platform (Linux `amd64`/`arm64`) and installs it to `/usr/local/bin` (or `~/.local/bin` without sudo). Override with `XALGORIX_INSTALL_DIR` or pin a version with `XALGORIX_VERSION=vX.Y.Z`.
+
+### Docker
+
+```bash
+docker run --rm -p 9137:9137 \
+  -e XALGORIX_LLM=minimax/MiniMax-M2.7 \
+  -e XALGORIX_API_KEY=your_provider_api_key \
+  -v xalgorix-data:/data \
+  ghcr.io/xalgord/xalgorix:latest
+```
+
+The image bundles Chromium for browser-assisted DAST and persists scan data to the `/data` volume. It binds to `0.0.0.0` inside the container; set `XALGORIX_USERNAME`/`XALGORIX_PASSWORD` before exposing it beyond localhost.
+
+### Requirements (build from source)
 
 | Requirement    | Notes                                                        |
 | -------------- | ------------------------------------------------------------ |
 | Linux          | Primary supported platform.                                  |
-| Go             | `1.24.2` or newer.                                           |
+| Go             | `1.25` or newer.                                             |
 | Node.js + npm  | Required when building the bundled React Web UI from source. |
 | Security tools | Installed on demand only when auto-install is enabled.       |
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# Xalgorix installer — one-line install of the latest release binary.
+#
+#   curl -sSL https://raw.githubusercontent.com/xalgord/xalgorix/main/install.sh | bash
+#
+# What it does:
+#   1. Detects your OS and CPU architecture.
+#   2. Downloads the matching prebuilt binary from the latest GitHub Release.
+#   3. Installs it to /usr/local/bin (falls back to ~/.local/bin without sudo).
+#
+# Env overrides:
+#   XALGORIX_INSTALL_DIR   target directory (default: /usr/local/bin)
+#   XALGORIX_VERSION       specific version tag, e.g. v4.5.48 (default: latest)
+#
+set -euo pipefail
+
+REPO="xalgord/xalgorix"
+BINARY="xalgorix"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+info() { echo -e "${CYAN}==>${NC} $*"; }
+ok()   { echo -e "${GREEN}==>${NC} $*"; }
+warn() { echo -e "${YELLOW}==>${NC} $*"; }
+die()  { echo -e "${RED}error:${NC} $*" >&2; exit 1; }
+
+command -v curl >/dev/null 2>&1 || die "curl is required but not installed."
+
+# ── Detect platform ────────────────────────────────────────────────────────
+OS="$(uname -s)"
+case "$OS" in
+  Linux) OS="linux" ;;
+  *) die "Unsupported OS '$OS'. Xalgorix ships Linux binaries; build from source for other platforms (see README)." ;;
+esac
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64|amd64) ARCH="amd64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+  *) die "Unsupported architecture '$ARCH'. Build from source (see README)." ;;
+esac
+
+ASSET="${BINARY}-${OS}-${ARCH}"
+info "Platform: ${OS}/${ARCH} → asset '${ASSET}'"
+
+# ── Resolve version ─────────────────────────────────────────────────────────
+VERSION="${XALGORIX_VERSION:-}"
+if [[ -z "$VERSION" ]]; then
+  info "Resolving latest release…"
+  VERSION="$(curl -sSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    | grep -o '"tag_name":[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
+  [[ -n "$VERSION" ]] || die "Could not resolve the latest release tag from GitHub."
+fi
+ok "Installing ${BINARY} ${VERSION}"
+
+URL="https://github.com/${REPO}/releases/download/${VERSION}/${ASSET}"
+
+# ── Download ────────────────────────────────────────────────────────────────
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+info "Downloading ${URL}"
+if ! curl -fSL --progress-bar "$URL" -o "$TMP/$BINARY"; then
+  die "Download failed. This release may not include a ${OS}/${ARCH} binary — check https://github.com/${REPO}/releases"
+fi
+chmod +x "$TMP/$BINARY"
+
+# ── Install ─────────────────────────────────────────────────────────────────
+DEST="${XALGORIX_INSTALL_DIR:-/usr/local/bin}"
+install_to() { mkdir -p "$1" && mv "$TMP/$BINARY" "$1/$BINARY"; }
+
+if [[ -w "$DEST" ]]; then
+  install_to "$DEST"
+elif command -v sudo >/dev/null 2>&1; then
+  info "Installing to ${DEST} (needs sudo)…"
+  sudo mkdir -p "$DEST"
+  sudo mv "$TMP/$BINARY" "$DEST/$BINARY"
+else
+  DEST="$HOME/.local/bin"
+  warn "No write access to system path and sudo unavailable — installing to ${DEST}"
+  install_to "$DEST"
+  case ":$PATH:" in
+    *":$DEST:"*) : ;;
+    *) warn "Add ${DEST} to your PATH:  export PATH=\"\$PATH:${DEST}\"" ;;
+  esac
+fi
+
+ok "Installed ${BINARY} → ${DEST}/${BINARY}"
+echo ""
+echo "  Next steps:"
+echo "    1. Set your LLM provider in ~/.xalgorix.env:"
+echo "         XALGORIX_LLM=minimax/MiniMax-M2.7"
+echo "         XALGORIX_API_KEY=your_provider_api_key"
+echo "    2. Launch the dashboard:"
+echo "         ${BINARY} --web"
+echo "    3. Open http://127.0.0.1:9137"
+echo ""
+echo "  Prefer zero setup? Try the hosted version: https://www.xalgorix.com"

--- a/release.sh
+++ b/release.sh
@@ -192,14 +192,22 @@ if ! go build ./cmd/xalgorix/; then
 fi
 ok "Build successful"
 
-# ─── Step 4: Build release binary ───
-info "Building linux/amd64 release binary..."
+# ─── Step 4: Build release binaries (multi-arch) ───
+# Build both linux/amd64 and linux/arm64 so the one-line installer
+# (install.sh) can serve the right binary for each host. Asset names must
+# match the `${BINARY}-${OS}-${ARCH}` pattern install.sh downloads.
 mkdir -p "$BUILD_DIR"
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-    -ldflags "-s -w -X main.version=$NEW_VERSION" \
-    -o "$BUILD_DIR/xalgorix-linux-amd64" \
-    ./cmd/xalgorix/
-ok "Binary built: $BUILD_DIR/xalgorix-linux-amd64"
+RELEASE_ASSETS=()
+for arch in amd64 arm64; do
+    info "Building linux/$arch release binary..."
+    out="$BUILD_DIR/xalgorix-linux-$arch"
+    CGO_ENABLED=0 GOOS=linux GOARCH="$arch" go build \
+        -ldflags "-s -w -X main.version=$NEW_VERSION" \
+        -o "$out" \
+        ./cmd/xalgorix/
+    RELEASE_ASSETS+=("$out")
+    ok "Binary built: $out"
+done
 
 # ─── Step 5: Generate changelog (commits since last tag) ───
 info "Generating changelog..."
@@ -240,7 +248,7 @@ fi
 # ─── Step 9: Create GitHub Release ───
 info "Creating GitHub Release..."
 gh release create "v$NEW_VERSION" \
-    "$BUILD_DIR/xalgorix-linux-amd64" \
+    "${RELEASE_ASSETS[@]}" \
     --title "v$NEW_VERSION" \
     --notes "### Changes
 


### PR DESCRIPTION
Closes the biggest adoption-friction gaps vs comparable tools (e.g. Strix).

## What changed

### 1. Zero-friction install (biggest lever)
- **`install.sh`** — `curl -sSL https://www.xalgorix.com/install | bash` fetches the latest release binary for the host platform (Linux amd64/arm64) and installs to `/usr/local/bin` (or `~/.local/bin` without sudo). Env overrides: `XALGORIX_INSTALL_DIR`, `XALGORIX_VERSION`.
- **`Dockerfile`** + `.dockerignore` — multi-stage build (React UI -> Go binary -> Debian-slim runtime with Chromium). Non-root user, `/data` volume, binds `0.0.0.0` in-container (refuses external access without dashboard auth).
- **`.github/workflows/docker.yml`** — publishes a multi-arch image to `ghcr.io/xalgord/xalgorix` on version tags.
- **`release.sh`** — now builds **both** linux/amd64 and linux/arm64 release assets so the installer works on both.

> The branded `https://www.xalgorix.com/install` endpoint (302 -> this repo's install.sh) is added on the SaaS side and is already deployed.

### 2. Developer-first README
- New hero: *'Open-source AI pentester that proves vulnerabilities'* — leads with the independent-verifier differentiator ("most scanners detect, Xalgorix proves") instead of the 22-phase framing.
- One-line install and Docker are now the **first** Quick Start options; build-from-source moved below.
- Added **DeepWiki** badge.

## Notes
- No Go code touched — docs + packaging only.
- The GHCR image referenced in the README goes live once this merges and the first tagged release runs the Docker workflow.

## Not included (needs a design decision)
- **Code/repo-only scanning** (scan a local directory with no live target, the way Strix defaults). This is an engine-core change touching the scope guard/verifier and shouldn't be blind-shipped — happy to scope it separately.