### PR TITLE
Code-first scanning: scan a repo/upload/path with no live target

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,35 @@ If the process is listening but the page still does not load remotely, allow TCP
 | Wildcard / multi | Enumerating related targets and scanning the discovered attack surface.         |
 | DAST             | Browser-assisted testing for web apps, auth flows, forms, and runtime behavior. |
 
+## Scan Your Code (no target needed)
+
+Point Xalgorix at a codebase — a Git URL, a local path, or an uploaded zip — and
+it scans the source directly. No deployed URL, no infrastructure to stand up.
+
+```bash
+# Source review (SAST): audit the code, no running target required
+xalgorix --source ./my-app --code-scan review
+
+# Provision + DAST: build & run the app locally, then pentest the running instance
+xalgorix --source https://github.com/org/app.git --code-scan provision
+```
+
+| Code-scan mode | What it does | Verification level |
+| -------------- | ------------ | ------------------ |
+| `review` | Reads the source, traces user input from entry point → dangerous sink, and reports reachable vulnerabilities. No live target. | **Source-verified** — proven reachable in code (clearly labeled as not runtime-exploited). |
+| `provision` | Inspects the repo, builds and runs the app on a loopback port, then runs whitebox-guided DAST against the running instance. Falls back to `review` if the app can't be built. | **Exploit-verified** — reproduced against the running app. |
+
+- `--source` accepts a Git URL (shallow-cloned), a local directory, or a path to
+  an uploaded/extracted archive. In the Web UI / hosted app you can also upload a
+  `.zip` of your codebase (`POST /api/upload-source`).
+- You can still combine a repo **and** a live target for classic whitebox
+  augmentation — that path is unchanged. Code-scan modes are for when the
+  codebase is the whole subject.
+
+> Provision mode runs your app's build/start commands in the agent's sandbox and
+> only pentests the single loopback port it stood the app up on — the dashboard
+> and everything else on the machine stay out of scope.
+
 ## Methodology
 
 Xalgorix organizes autonomous testing into 22 phases.

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -250,9 +250,21 @@ func main() {
 		return
 	}
 
-	// CLI/TUI mode — target required
-	if len(args.targets) == 0 {
-		fmt.Fprintf(os.Stderr, "Error: at least one --target is required (or use --web for Web UI)\n\n")
+	// A code-first scan (--code-scan review|provision) makes the source the
+	// subject, so --target is not required — but --source (or
+	// XALGORIX_SOURCE_REPO) must supply the codebase.
+	codeScan := strings.ToLower(strings.TrimSpace(args.codeScan))
+	if args.source != "" {
+		cfg.SourceRepo = args.source
+	}
+	if codeScan != "" && strings.TrimSpace(cfg.SourceRepo) == "" {
+		fmt.Fprintf(os.Stderr, "Error: --code-scan requires --source <git URL or local path>\n\n")
+		os.Exit(1)
+	}
+
+	// CLI/TUI mode — a live target is required unless this is a code-first scan.
+	if len(args.targets) == 0 && codeScan == "" {
+		fmt.Fprintf(os.Stderr, "Error: at least one --target is required (or use --code-scan with --source, or --web for Web UI)\n\n")
 		printUsage()
 		os.Exit(1)
 	}
@@ -265,13 +277,15 @@ func main() {
 	}
 
 	// Default to CLI mode (no TUI)
-	tui.RunCLI(cfg, args.targets, args.instruction)
+	tui.RunCLI(cfg, args.targets, args.instruction, codeScan)
 }
 
 type cliArgs struct {
 	targets     []string
 	instruction string
 	model       string
+	source      string // --source: git URL or local path for code-first scans
+	codeScan    string // --code-scan: "review" or "provision"
 	bind        string
 	version     bool
 	update      bool
@@ -299,6 +313,16 @@ func parseArgs() cliArgs {
 			if i+1 < len(osArgs) {
 				i++
 				args.instruction = osArgs[i]
+			}
+		case "--source", "-s":
+			if i+1 < len(osArgs) {
+				i++
+				args.source = osArgs[i]
+			}
+		case "--code-scan":
+			if i+1 < len(osArgs) {
+				i++
+				args.codeScan = osArgs[i]
 			}
 		case "--model", "-m":
 			if i+1 < len(osArgs) {
@@ -344,6 +368,10 @@ func parseArgs() cliArgs {
 				args.targets = append(args.targets, strings.TrimPrefix(osArgs[i], "--target="))
 			} else if strings.HasPrefix(osArgs[i], "--instruction=") {
 				args.instruction = strings.TrimPrefix(osArgs[i], "--instruction=")
+			} else if strings.HasPrefix(osArgs[i], "--source=") {
+				args.source = strings.TrimPrefix(osArgs[i], "--source=")
+			} else if strings.HasPrefix(osArgs[i], "--code-scan=") {
+				args.codeScan = strings.TrimPrefix(osArgs[i], "--code-scan=")
 			} else if strings.HasPrefix(osArgs[i], "--model=") {
 				args.model = strings.TrimPrefix(osArgs[i], "--model=")
 			} else if strings.HasPrefix(osArgs[i], "--port=") {
@@ -383,6 +411,9 @@ func printUsage() {
 	fmt.Println("CLI Flags:")
 	fmt.Println("  -t, --target <url>        Target URL, IP, or local path (repeatable)")
 	fmt.Println("  -i, --instruction <text>  Custom instructions for the agent")
+	fmt.Println("  -s, --source <repo|path>  Codebase to scan (git URL or local path)")
+	fmt.Println("      --code-scan <mode>    Code-first scan: 'review' (SAST, no target)")
+	fmt.Println("                            or 'provision' (build+run source, then DAST)")
 	fmt.Println("  -m, --model <name>        LLM model (overrides XALGORIX_LLM)")
 	fmt.Println("  -v, --version             Show version")
 	fmt.Println("  -up, --update             Update to latest version")
@@ -402,6 +433,8 @@ func printUsage() {
 	fmt.Println("  xalgorix --web --port 8080")
 	fmt.Println("  xalgorix --target https://example.com")
 	fmt.Println("  xalgorix --target https://example.com --instruction \"Focus on auth\"")
+	fmt.Println("  xalgorix --source ./my-app --code-scan review")
+	fmt.Println("  xalgorix --source https://github.com/org/app.git --code-scan provision")
 	fmt.Println()
 	fmt.Println("Service Commands:")
 	fmt.Println("  xalgorix --start      Start Web UI in background")

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -127,8 +127,9 @@ type Agent struct {
 	targetAuth   string
 	targetAuthB  string // optional SECOND account, for horizontal IDOR/BOLA proof
 	sourceRepo   string
-	scanContext  string   // path to OpenAPI/HAR/Postman artifact(s) seeding the attack surface
-	secretValues []string // auth values to redact from emitted telemetry
+	scanContext  string       // path to OpenAPI/HAR/Postman artifact(s) seeding the attack surface
+	codeScanMode CodeScanMode // code-first scan mode (source review / provision), see SetCodeScanMode
+	secretValues []string     // auth values to redact from emitted telemetry
 
 	// scanContextBriefing is built from scanContext in prepareScanEnvironment
 	// and injected as a high-priority user message at the start of Run.
@@ -291,6 +292,7 @@ func NewAgent(cfg *config.Config, name string, events chan Event, localGuard sco
 		subAgent.SetTargetAuthSecondary(a.targetAuthB)
 		subAgent.SetSourceRepo(a.sourceRepo)
 		subAgent.SetScanContext(a.scanContext)
+		subAgent.SetCodeScanMode(a.codeScanMode)
 		if a.discoveryMode {
 			subAgent.SetDiscoveryMode(true)
 		}
@@ -1212,6 +1214,28 @@ func (a *Agent) SetTargetAuth(s string) { a.targetAuth = strings.TrimSpace(s) }
 // SetTargetAuthSecondary sets a per-scan SECOND account's credentials (for
 // horizontal IDOR/BOLA proof). Call before Run(). Empty string clears it.
 func (a *Agent) SetTargetAuthSecondary(s string) { a.targetAuthB = strings.TrimSpace(s) }
+
+// CodeScanMode selects a code-first scanning strategy where the primary
+// subject is the target's source (a repo/path), not a live URL.
+type CodeScanMode int
+
+const (
+	// CodeScanNone is the default: black-box or whitebox-augmented testing
+	// against a live target URL.
+	CodeScanNone CodeScanMode = iota
+	// CodeScanReview is source review / SAST with NO live target: the agent
+	// reads the code, traces source→sink→reachable-route, and reports
+	// source-verified findings. Findings are clearly labeled as statically
+	// verified (not runtime-exploited), since there is no running target.
+	CodeScanReview
+	// CodeScanProvision builds and runs the target's source locally (in the
+	// agent's sandbox, on a loopback port the orchestrator allowlists), then
+	// pentests the running instance for exploit-verified findings.
+	CodeScanProvision
+)
+
+// SetCodeScanMode sets the code-first scan strategy. Call before Run().
+func (a *Agent) SetCodeScanMode(m CodeScanMode) { a.codeScanMode = m }
 
 // SetSourceRepo sets the per-scan whitebox source (git URL or local path),
 // overriding the global default. Call before Run().

--- a/internal/agent/agent_prompt.go
+++ b/internal/agent/agent_prompt.go
@@ -2,6 +2,9 @@ package agent
 
 import (
 	"fmt"
+	"net"
+	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/xalgord/xalgorix/v4/internal/config"
@@ -1461,6 +1464,44 @@ func (a *Agent) whiteboxGuidance() string {
 	if root == "" {
 		return ""
 	}
+
+	switch a.codeScanMode {
+	case CodeScanReview:
+		// Option 1 — source review / SAST with NO live target. Findings are
+		// statically verified: proven reachable in code, not runtime-exploited.
+		return fmt.Sprintf(`
+## SOURCE REVIEW MODE — code-only assessment (source at %s), NO live target
+There is NO running target to exploit. Do NOT attempt network requests against a target; there is none. Your job is a rigorous source audit that proves vulnerabilities by CODE REACHABILITY. Methodology:
+1. MAP: identify the framework, routing, entry points (route handlers, params, body, headers, CLI args, deserialized input, env/config).
+2. HUNT SINKS: use the code_search tool (sinks=rce|cmdi|sqli|deserialization|ssrf|fileio|template|secrets|auth|redirect|crypto) to locate dangerous calls; grep for hardcoded secrets/keys/tokens.
+3. TRACE REACHABILITY: for each sink, trace BACKWARD to a user-reachable entry point and confirm tainted input reaches the sink WITHOUT sanitization. Record the exact file:line, the route/entry, and the untrusted parameter.
+4. VERIFY STATICALLY: read the surrounding code to rule out mitigations (validation, parameterization, escaping, authz checks). Only report when the data flow is genuinely exploitable.
+5. PRIORITIZE: RCE / command & template injection / insecure deserialization / hardcoded secrets / SSRF / auth bypass / SQLi.
+When you report_vulnerability, set the PoC to the concrete source-level data-flow trace (file:line → sink, the untrusted input, why it's reachable). These are SOURCE-VERIFIED findings — state clearly that runtime exploitation was not performed (no live target). Be precise and conservative: no speculative findings.
+`, root)
+
+	case CodeScanProvision:
+		// Option 2 — build & run from source, then DAST the running instance.
+		port := 0
+		if len(a.activityHosts) > 0 {
+			port = portFromTarget(a.activityHosts[0])
+		}
+		bind := "127.0.0.1"
+		hostport := bind
+		if port > 0 {
+			hostport = fmt.Sprintf("%s:%d", bind, port)
+		}
+		return fmt.Sprintf(`
+## PROVISION + DAST MODE — build the target from source (at %s), run it, then pentest it
+You have the source AND you must stand the app up locally, then attack the RUNNING instance for exploit-verified findings. Methodology:
+1. INSPECT: read README, Dockerfile/compose, package manifest, and start scripts to learn how to build and run this app.
+2. BUILD & RUN: use terminal_execute to install dependencies and start the app. BIND IT TO %s (this exact loopback host:port is the only one you are permitted to reach). Prefer Docker/compose when present; otherwise the native run command. Run it in the background and confirm it's listening (curl -sI http://%s).
+3. WHITEBOX-GUIDED DAST: use code_search to find sinks (sinks=rce|cmdi|sqli|deserialization|ssrf|fileio|template|secrets|auth|redirect|crypto), trace each to a reachable route, then EXPLOIT it against http://%s and prove impact (extracted data, oob_callback hit, state change, command output).
+4. If the app cannot be built/run after reasonable effort, fall back to SOURCE REVIEW: report source-verified findings from the data-flow trace and say runtime provisioning failed.
+Report findings with a working PoC against the running instance (the verifier will re-test). Source proves the bug EXISTS; the live PoC proves it's EXPLOITABLE — get both when the app runs.
+`, root, hostport, hostport, hostport)
+	}
+
 	return fmt.Sprintf(`
 ## WHITEBOX MODE — you have the target's SOURCE CODE (at %s)
 This is your biggest advantage: you can SEE the vulnerable code, not just guess from responses. Methodology:
@@ -1471,4 +1512,23 @@ This is your biggest advantage: you can SEE the vulnerable code, not just guess 
 5. Prioritize: RCE / command & template injection / insecure deserialization / hardcoded secrets / SSRF / auth bypass — the classes source access finds that black-box misses.
 Report findings ONLY with a working live-target PoC (the verifier will re-test).
 `, root)
+}
+
+// portFromTarget extracts the port from a target like "http://127.0.0.1:3000"
+// or "127.0.0.1:3000". Returns 0 when no port is present.
+func portFromTarget(target string) int {
+	t := strings.TrimSpace(target)
+	if u, err := url.Parse(t); err == nil && u.Host != "" {
+		if p := u.Port(); p != "" {
+			if n, err := strconv.Atoi(p); err == nil {
+				return n
+			}
+		}
+	}
+	if _, p, err := net.SplitHostPort(t); err == nil {
+		if n, err := strconv.Atoi(p); err == nil {
+			return n
+		}
+	}
+	return 0
 }

--- a/internal/scopeguard/allowloopback_test.go
+++ b/internal/scopeguard/allowloopback_test.go
@@ -1,0 +1,50 @@
+package scopeguard
+
+import "testing"
+
+// TestAllowLoopbackPorts covers the per-scan provisioned-target exception used
+// by "provision" code scans (Option 2). A loopback host on an explicitly
+// allowlisted port is NOT classified as self; everything else — including the
+// dashboard listener port and non-allowlisted loopback ports — stays blocked.
+func TestAllowLoopbackPorts(t *testing.T) {
+	const dashboardPort = 9137
+	const provisionPort = 3000
+
+	base := Config{BindAddr: "127.0.0.1", Port: dashboardPort}
+	allow := Config{BindAddr: "127.0.0.1", Port: dashboardPort, AllowLoopbackPorts: []int{provisionPort}}
+
+	cases := []struct {
+		name        string
+		cfg         Config
+		target      string
+		wantBlocked bool
+	}{
+		// Without an allowlist, loopback is always self.
+		{"loopback no allowlist", base, "http://127.0.0.1:3000/", true},
+		{"localhost no allowlist", base, "http://localhost:3000/", true},
+
+		// With the allowlist, the exact provisioned loopback port is allowed.
+		{"allowed 127.0.0.1 port", allow, "http://127.0.0.1:3000/", false},
+		{"allowed localhost port", allow, "http://localhost:3000/", false},
+		{"allowed ipv6 loopback port", allow, "http://[::1]:3000/", false},
+
+		// A different loopback port is still blocked even with an allowlist.
+		{"other loopback port blocked", allow, "http://127.0.0.1:5000/", true},
+
+		// The dashboard's own port is NEVER allowed, even if the target port
+		// matches an (accidental) allowlist entry equal to the listener.
+		{"dashboard port never allowed", Config{BindAddr: "127.0.0.1", Port: dashboardPort, AllowLoopbackPorts: []int{dashboardPort}}, "http://127.0.0.1:9137/", true},
+
+		// A loopback target with no port is still self (no port to match).
+		{"loopback no port blocked", allow, "http://127.0.0.1/", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsLocalOrListener(tc.cfg, tc.target)
+			if got != tc.wantBlocked {
+				t.Fatalf("IsLocalOrListener(%q) = %v, want %v", tc.target, got, tc.wantBlocked)
+			}
+		})
+	}
+}

--- a/internal/scopeguard/scopeguard.go
+++ b/internal/scopeguard/scopeguard.go
@@ -48,6 +48,36 @@ import (
 type Config struct {
 	BindAddr string
 	Port     int
+
+	// AllowLoopbackPorts is a per-scan allowlist of loopback ports the
+	// caller has deliberately stood a target up on — used by "provision"
+	// code scans (Option 2), where the agent builds the target's source
+	// and runs it on 127.0.0.1:<port>, then pentests it. Only loopback
+	// hosts on exactly these ports are exempted from the "self" verdict;
+	// the dashboard's own listener port is NEVER exempted (even if it
+	// somehow appears here), and the operator's real interface addresses
+	// remain blocked. Empty (the default) preserves the strict behavior:
+	// all loopback is treated as self.
+	AllowLoopbackPorts []int
+}
+
+// loopbackPortAllowed reports whether hostPort (a decimal port string) is in
+// the per-scan loopback allowlist. The dashboard listener port is never
+// allowed, so a provisioned target can never be pointed at the dashboard.
+func (c Config) loopbackPortAllowed(hostPort string) bool {
+	if hostPort == "" || len(c.AllowLoopbackPorts) == 0 {
+		return false
+	}
+	pn, err := strconv.Atoi(hostPort)
+	if err != nil || pn == c.Port {
+		return false
+	}
+	for _, ap := range c.AllowLoopbackPorts {
+		if ap == pn {
+			return true
+		}
+	}
+	return false
 }
 
 // LookupHost is the package-level resolver indirection. Tests
@@ -99,9 +129,19 @@ func IsLocalOrListener(cfg Config, target string) bool {
 		}
 	}
 
+	// Per-scan provisioned-target exception: a "provision" code scan stood
+	// the target app up on a specific loopback port and explicitly opted it
+	// in. Loopback hosts on exactly that port are NOT self. The dashboard
+	// listener port is never in the allowlist (see loopbackPortAllowed), so
+	// this can never expose the operator's own dashboard.
+	allowLoopback := cfg.loopbackPortAllowed(hostPort)
+
 	// Explicit textual matches (fast path) — these always mean "self"
 	lower := strings.ToLower(host)
 	if lower == "localhost" || lower == "0.0.0.0" || lower == "[::1]" || lower == "::1" {
+		if allowLoopback && lower != "0.0.0.0" {
+			return false
+		}
 		return true
 	}
 
@@ -139,7 +179,13 @@ func IsLocalOrListener(cfg Config, target string) bool {
 	// cloud metadata (169.254.169.254), IPv6 ULA, etc. — these may
 	// be legitimate targets on the scanned host's network.
 	for _, ip := range resolvedIPs {
-		if ip.IsLoopback() || ip.IsUnspecified() {
+		if ip.IsLoopback() {
+			if allowLoopback {
+				return false // provisioned target on an opted-in loopback port
+			}
+			return true
+		}
+		if ip.IsUnspecified() {
 			return true
 		}
 	}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -629,8 +629,12 @@ func cliPickLoopbackPort() int {
 	if err != nil {
 		return 8137
 	}
-	defer l.Close()
-	return l.Addr().(*net.TCPAddr).Port
+	addr, ok := l.Addr().(*net.TCPAddr)
+	_ = l.Close()
+	if !ok {
+		return 8137
+	}
+	return addr.Port
 }
 
 // cliCodeLabel derives a short label from a repo URL/path for the synthesized

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -3,6 +3,8 @@ package tui
 
 import (
 	"fmt"
+	"net"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -563,9 +565,31 @@ func RunInteractive(cfg *config.Config, targets []string, instruction string) er
 }
 
 // RunCLI runs Xalgorix in non-interactive CLI mode.
-func RunCLI(cfg *config.Config, targets []string, instruction string) {
+func RunCLI(cfg *config.Config, targets []string, instruction string, codeScan string) {
 	fmt.Print(SplashText("0.1.0"))
-	fmt.Printf("  Targets: %s\n", strings.Join(targets, ", "))
+
+	// Code-first scans make the source the subject. "review" runs without a
+	// live target; "provision" builds & runs the source on a loopback port the
+	// scope guard allowlists for this run, then DASTs it.
+	guard := scopeguard.Config{BindAddr: "127.0.0.1", Port: 0}
+	codeMode := agent.CodeScanNone
+	switch strings.ToLower(strings.TrimSpace(codeScan)) {
+	case "review", "sast", "source":
+		codeMode = agent.CodeScanReview
+		if len(targets) == 0 {
+			targets = []string{"code://" + cliCodeLabel(cfg.SourceRepo)}
+		}
+		fmt.Printf("  Source review (no live target): %s\n", cfg.SourceRepo)
+	case "provision", "run", "dast":
+		codeMode = agent.CodeScanProvision
+		port := cliPickLoopbackPort()
+		guard.AllowLoopbackPorts = []int{port}
+		targets = []string{fmt.Sprintf("http://127.0.0.1:%d", port)}
+		fmt.Printf("  Provision + DAST from source: %s (target http://127.0.0.1:%d)\n", cfg.SourceRepo, port)
+	}
+	if codeMode == agent.CodeScanNone {
+		fmt.Printf("  Targets: %s\n", strings.Join(targets, ", "))
+	}
 	if instruction != "" {
 		fmt.Printf("  Instructions: %s\n", instruction)
 	}
@@ -575,7 +599,10 @@ func RunCLI(cfg *config.Config, targets []string, instruction string) {
 	// CLI mode has no dashboard listener; localGuard defaults keep the
 	// loopback / RFC1918 / link-local rejection active without firing
 	// the listener-port rule.
-	ag := agent.NewAgent(cfg, "XalgorixAgent", events, scopeguard.Config{BindAddr: "127.0.0.1", Port: 0})
+	ag := agent.NewAgent(cfg, "XalgorixAgent", events, guard)
+	if codeMode != agent.CodeScanNone {
+		ag.SetCodeScanMode(codeMode)
+	}
 
 	done := make(chan struct{})
 	go func() {
@@ -593,4 +620,27 @@ func RunCLI(cfg *config.Config, targets []string, instruction string) {
 	<-done
 
 	fmt.Print(FormatVulnSummary())
+}
+
+// cliPickLoopbackPort returns a free loopback TCP port for a provision scan.
+// Falls back to 8137 if the OS probe fails (the agent will still try to bind).
+func cliPickLoopbackPort() int {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 8137
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+// cliCodeLabel derives a short label from a repo URL/path for the synthesized
+// "code://<label>" review target.
+func cliCodeLabel(repo string) string {
+	r := strings.TrimSuffix(strings.TrimSpace(repo), "/")
+	r = strings.TrimSuffix(r, ".git")
+	base := filepath.Base(r)
+	if base == "" || base == "." || base == "/" {
+		return "source"
+	}
+	return base
 }

--- a/internal/web/codescan.go
+++ b/internal/web/codescan.go
@@ -1,0 +1,100 @@
+package web
+
+import (
+	"fmt"
+	"net"
+	"path/filepath"
+	"strings"
+
+	"github.com/xalgord/xalgorix/v4/internal/agent"
+	"github.com/xalgord/xalgorix/v4/internal/scopeguard"
+)
+
+// resolveCodeScan interprets a code-first scan request (req.CodeScan set). The
+// subject of a code scan is the source (req.SourceRepo), not a live target URL:
+//
+//   - "review"    → source review / SAST, NO running target (Option 1). The
+//     agent audits the code and reports source-verified findings.
+//   - "provision" → build & run the source locally on an allowlisted loopback
+//     port, then DAST the running instance (Option 2).
+//
+// On success it mutates req (Targets, codeScanMode, allowLoopbackPorts) and
+// returns isCodeScan=true. When req.CodeScan is empty it is a no-op returning
+// (false, ""). errMsg is a client-facing 400 message when the request is
+// malformed.
+func (s *Server) resolveCodeScan(req *ScanRequest) (isCodeScan bool, errMsg string) {
+	mode := strings.ToLower(strings.TrimSpace(req.CodeScan))
+	if mode == "" {
+		return false, ""
+	}
+	if strings.TrimSpace(req.SourceRepo) == "" {
+		return false, "code_scan requires source_repo (a git URL or local path to the codebase)"
+	}
+
+	switch mode {
+	case "review", "sast", "source":
+		req.codeScanMode = agent.CodeScanReview
+		// No live target — synthesize a stable, non-routable label so scan
+		// naming/records work. The agent is told (in-prompt) not to make
+		// network requests in review mode.
+		req.Targets = []string{"code://" + codeTargetLabel(req.SourceRepo)}
+		return true, ""
+
+	case "provision", "run", "dast":
+		port, err := pickLoopbackPort()
+		if err != nil {
+			return true, "could not allocate a local port for provisioning: " + err.Error()
+		}
+		req.codeScanMode = agent.CodeScanProvision
+		req.allowLoopbackPorts = []int{port}
+		// The agent builds the app from source and binds it here; the scope
+		// guard allowlists exactly this loopback port for this scan.
+		req.Targets = []string{fmt.Sprintf("http://127.0.0.1:%d", port)}
+		return true, ""
+
+	default:
+		return false, "code_scan must be 'review' or 'provision'"
+	}
+}
+
+// isBlockedTargetForScan is isBlockedTarget with a per-scan loopback allowlist.
+// When allowLoopbackPorts is empty it is byte-identical to isBlockedTarget;
+// with a port set, a loopback target on that exact port is permitted (used by
+// provision code scans). The dashboard's own listener port is never allowed.
+func (s *Server) isBlockedTargetForScan(target string, allowLoopbackPorts []int) bool {
+	return scopeguard.IsLocalOrListener(scopeguard.Config{
+		BindAddr:           s.cfg.BindAddr,
+		Port:               s.port,
+		AllowLoopbackPorts: allowLoopbackPorts,
+	}, target)
+}
+
+// pickLoopbackPort asks the OS for a free TCP port on 127.0.0.1 and returns it.
+// There is an inherent TOCTOU window between closing the probe listener and the
+// agent re-binding the port, but the provisioned app comes up moments later on
+// the same machine, so collisions are vanishingly rare in practice.
+func pickLoopbackPort() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
+// codeTargetLabel derives a short, human-readable label from a repo URL or
+// local path for use in the synthesized "code://<label>" review target.
+func codeTargetLabel(repo string) string {
+	r := strings.TrimSpace(repo)
+	r = strings.TrimSuffix(r, "/")
+	r = strings.TrimSuffix(r, ".git")
+	// Strip any credentials in a URL (user:pass@host) before taking the base.
+	if i := strings.LastIndex(r, "@"); i >= 0 && strings.Contains(r[:i], "://") {
+		r = r[i+1:]
+	}
+	base := filepath.Base(r)
+	if base == "" || base == "." || base == "/" {
+		return "source"
+	}
+	return base
+}

--- a/internal/web/codescan.go
+++ b/internal/web/codescan.go
@@ -78,8 +78,12 @@ func pickLoopbackPort() (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer l.Close()
-	return l.Addr().(*net.TCPAddr).Port, nil
+	addr, ok := l.Addr().(*net.TCPAddr)
+	_ = l.Close()
+	if !ok {
+		return 0, fmt.Errorf("unexpected listener address type %T", addr)
+	}
+	return addr.Port, nil
 }
 
 // codeTargetLabel derives a short, human-readable label from a repo URL or

--- a/internal/web/orchestrator.go
+++ b/internal/web/orchestrator.go
@@ -46,10 +46,15 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 		}
 	}
 
-	// Filter out local/internal targets to prevent self-scanning
+	// Filter out local/internal targets to prevent self-scanning. A
+	// "provision" code scan opts a specific loopback port into scope
+	// (req.allowLoopbackPorts); isBlockedTargetForScan honors that allowlist
+	// so the deliberately-provisioned 127.0.0.1:<port> target survives the
+	// filter. For all other scans allowLoopbackPorts is empty and this is
+	// identical to isBlockedTarget.
 	var safeTargets []string
 	for _, t := range cleanTargets {
-		if s.isBlockedTarget(t) {
+		if s.isBlockedTargetForScan(t, req.allowLoopbackPorts) {
 			log.Printf("[BLOCKLIST] Skipping blocked target: %s (local/internal IP or self-listener)", t)
 		} else {
 			safeTargets = append(safeTargets, t)
@@ -555,31 +560,33 @@ func (s *Server) runSingleTarget(_ context.Context, scanCfg *config.Config, req 
 	})
 
 	sess := &scanSession{
-		id:              filepath.Base(scanDir),
-		target:          target,
-		scanDir:         scanDir,
-		cfg:             scanCfg,
-		server:          s,
-		instruction:     buildAutonomousInstruction(target, instruction),
-		name:            req.Name,
-		userInstruction: req.Instruction,
-		severityFilter:  req.SeverityFilter,
-		discordWebhook:  req.DiscordWebhook,
-		discoveryMode:   false,
-		genReport:       true,
-		resetState:      !resumed,
-		instanceID:      req.InstanceID,
-		scanMode:        "single",
-		companyName:     req.CompanyName,
-		logoPath:        req.LogoPath,
-		phases:          req.Phases,
-		reconMode:       req.ReconMode,
-		scanIntensity:   req.ScanIntensity,
-		targetAuth:      req.TargetAuth,
-		targetAuthB:     req.TargetAuthSecondary,
-		sourceRepo:      req.SourceRepo,
-		scanContext:     req.ScanContext,
-		llmClient:       s.scanLLMClientForRequest(req, scanCfg),
+		id:                 filepath.Base(scanDir),
+		target:             target,
+		scanDir:            scanDir,
+		cfg:                scanCfg,
+		server:             s,
+		instruction:        buildAutonomousInstruction(target, instruction),
+		codeScanMode:       req.codeScanMode,
+		allowLoopbackPorts: req.allowLoopbackPorts,
+		name:               req.Name,
+		userInstruction:    req.Instruction,
+		severityFilter:     req.SeverityFilter,
+		discordWebhook:     req.DiscordWebhook,
+		discoveryMode:      false,
+		genReport:          true,
+		resetState:         !resumed,
+		instanceID:         req.InstanceID,
+		scanMode:           "single",
+		companyName:        req.CompanyName,
+		logoPath:           req.LogoPath,
+		phases:             req.Phases,
+		reconMode:          req.ReconMode,
+		scanIntensity:      req.ScanIntensity,
+		targetAuth:         req.TargetAuth,
+		targetAuthB:        req.TargetAuthSecondary,
+		sourceRepo:         req.SourceRepo,
+		scanContext:        req.ScanContext,
+		llmClient:          s.scanLLMClientForRequest(req, scanCfg),
 	}
 	s.executeScanSession(sess)
 	if s.instanceInterrupted(req.InstanceID) {
@@ -625,31 +632,33 @@ func (s *Server) runDASTTarget(_ context.Context, scanCfg *config.Config, req Sc
 	})
 
 	sess := &scanSession{
-		id:              filepath.Base(scanDir),
-		target:          target,
-		scanDir:         scanDir,
-		cfg:             scanCfg,
-		server:          s,
-		instruction:     dastInstruction,
-		name:            req.Name,
-		userInstruction: req.Instruction,
-		severityFilter:  req.SeverityFilter,
-		discordWebhook:  req.DiscordWebhook,
-		discoveryMode:   false,
-		genReport:       true,
-		resetState:      !resumed,
-		instanceID:      req.InstanceID,
-		scanMode:        "dast",
-		companyName:     req.CompanyName,
-		logoPath:        req.LogoPath,
-		phases:          req.Phases,
-		reconMode:       req.ReconMode,
-		scanIntensity:   req.ScanIntensity,
-		targetAuth:      req.TargetAuth,
-		targetAuthB:     req.TargetAuthSecondary,
-		sourceRepo:      req.SourceRepo,
-		scanContext:     req.ScanContext,
-		llmClient:       s.scanLLMClientForRequest(req, scanCfg),
+		id:                 filepath.Base(scanDir),
+		target:             target,
+		scanDir:            scanDir,
+		cfg:                scanCfg,
+		server:             s,
+		instruction:        dastInstruction,
+		codeScanMode:       req.codeScanMode,
+		allowLoopbackPorts: req.allowLoopbackPorts,
+		name:               req.Name,
+		userInstruction:    req.Instruction,
+		severityFilter:     req.SeverityFilter,
+		discordWebhook:     req.DiscordWebhook,
+		discoveryMode:      false,
+		genReport:          true,
+		resetState:         !resumed,
+		instanceID:         req.InstanceID,
+		scanMode:           "dast",
+		companyName:        req.CompanyName,
+		logoPath:           req.LogoPath,
+		phases:             req.Phases,
+		reconMode:          req.ReconMode,
+		scanIntensity:      req.ScanIntensity,
+		targetAuth:         req.TargetAuth,
+		targetAuthB:        req.TargetAuthSecondary,
+		sourceRepo:         req.SourceRepo,
+		scanContext:        req.ScanContext,
+		llmClient:          s.scanLLMClientForRequest(req, scanCfg),
 	}
 	s.executeScanSession(sess)
 	if s.instanceInterrupted(req.InstanceID) {
@@ -734,32 +743,34 @@ func (s *Server) runWildcardTarget(_ context.Context, scanCfg *config.Config, re
 		// skipNotesCleanup=true prevents cleanup() from deleting the notes store,
 		// keeping them available for collectSubdomains' Layer 3 (notes fallback).
 		discoverySess := &scanSession{
-			id:               filepath.Base(scanDir),
-			target:           target,
-			scanDir:          scanDir,
-			cfg:              scanCfg,
-			server:           s,
-			instruction:      discoveryInstruction,
-			name:             req.Name,
-			userInstruction:  req.Instruction,
-			severityFilter:   req.SeverityFilter,
-			discordWebhook:   req.DiscordWebhook,
-			discoveryMode:    true,
-			genReport:        false,
-			resetState:       true,
-			instanceID:       req.InstanceID,
-			scanMode:         "wildcard",
-			skipNotesCleanup: true, // preserve notes for subdomain collection
-			companyName:      req.CompanyName,
-			logoPath:         req.LogoPath,
-			phases:           req.Phases,
-			reconMode:        req.ReconMode,
-			scanIntensity:    req.ScanIntensity,
-			targetAuth:       req.TargetAuth,
-			targetAuthB:      req.TargetAuthSecondary,
-			sourceRepo:       req.SourceRepo,
-			scanContext:      req.ScanContext,
-			llmClient:        s.scanLLMClientForRequest(req, scanCfg),
+			id:                 filepath.Base(scanDir),
+			target:             target,
+			scanDir:            scanDir,
+			cfg:                scanCfg,
+			server:             s,
+			instruction:        discoveryInstruction,
+			codeScanMode:       req.codeScanMode,
+			allowLoopbackPorts: req.allowLoopbackPorts,
+			name:               req.Name,
+			userInstruction:    req.Instruction,
+			severityFilter:     req.SeverityFilter,
+			discordWebhook:     req.DiscordWebhook,
+			discoveryMode:      true,
+			genReport:          false,
+			resetState:         true,
+			instanceID:         req.InstanceID,
+			scanMode:           "wildcard",
+			skipNotesCleanup:   true, // preserve notes for subdomain collection
+			companyName:        req.CompanyName,
+			logoPath:           req.LogoPath,
+			phases:             req.Phases,
+			reconMode:          req.ReconMode,
+			scanIntensity:      req.ScanIntensity,
+			targetAuth:         req.TargetAuth,
+			targetAuthB:        req.TargetAuthSecondary,
+			sourceRepo:         req.SourceRepo,
+			scanContext:        req.ScanContext,
+			llmClient:          s.scanLLMClientForRequest(req, scanCfg),
 		}
 		s.executeScanSession(discoverySess)
 		if s.instanceInterrupted(req.InstanceID) {
@@ -985,6 +996,8 @@ func (s *Server) runWildcardTarget(_ context.Context, scanCfg *config.Config, re
 				cfg:                  scanCfg,
 				server:               s,
 				instruction:          scanInstruction,
+				codeScanMode:         req.codeScanMode,
+				allowLoopbackPorts:   req.allowLoopbackPorts,
 				name:                 req.Name,
 				userInstruction:      req.Instruction,
 				severityFilter:       req.SeverityFilter,

--- a/internal/web/scan_session.go
+++ b/internal/web/scan_session.go
@@ -92,8 +92,9 @@ func (s *Server) executeScanSession(sess *scanSession) {
 		agentOpts = append(agentOpts, agent.WithLLMClient(sess.llmClient))
 	}
 	agnt := agent.NewAgent(sess.cfg, "XalgorixAgent", events, scopeguard.Config{
-		BindAddr: s.cfg.BindAddr,
-		Port:     s.port,
+		BindAddr:           s.cfg.BindAddr,
+		Port:               s.port,
+		AllowLoopbackPorts: sess.allowLoopbackPorts,
 	}, agentOpts...)
 	agnt.SetPhaseRestrictions(sess.phases)
 	agnt.SetActivityPolicy(sess.reconMode, sess.scanIntensity, []string{sess.target, sess.parentTarget})
@@ -116,6 +117,9 @@ func (s *Server) executeScanSession(sess *scanSession) {
 	}
 	if sess.scanContext != "" {
 		agnt.SetScanContext(sess.scanContext)
+	}
+	if sess.codeScanMode != agent.CodeScanNone {
+		agnt.SetCodeScanMode(sess.codeScanMode)
 	}
 	sess.agent = agnt
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -293,6 +293,12 @@ type ScanRequest struct {
 	// git clone URL or a local path; the agent clones/opens it at scan
 	// start and exposes it via the code_search tool. Empty = blackbox.
 	SourceRepo string `json:"source_repo"`
+	// CodeScan selects a code-first scan (SourceRepo becomes the subject, no
+	// live target URL is required):
+	//   "review"    — source review / SAST, no running target (Option 1).
+	//   "provision" — build & run the source locally, then DAST it (Option 2).
+	// Empty = normal target-driven scan (SourceRepo, if set, augments it).
+	CodeScan string `json:"code_scan"`
 	// ScanContext is a path to operator-supplied context artifact(s) — an
 	// OpenAPI/Swagger spec, HAR capture, or Postman collection (file or dir).
 	// The engine parses them into a seeded attack surface (real endpoints +
@@ -325,6 +331,12 @@ type ScanRequest struct {
 	ResumeSubIndex       int      `json:"-"`
 	ResumeDiscoveryDone  bool     `json:"-"`
 	ResumeOriginalTarget int      `json:"-"`
+
+	// Code-scan internals, resolved server-side from CodeScan in handleScan.
+	// codeScanMode drives the agent's methodology; allowLoopbackPorts is the
+	// per-scan loopback allowlist the scope guard honors for provision scans.
+	codeScanMode       agent.CodeScanMode `json:"-"`
+	allowLoopbackPorts []int              `json:"-"`
 }
 
 // WSEvent is a WebSocket message sent to clients.
@@ -547,6 +559,7 @@ var dashboardRoutes = []string{
 	"/api/upload-instructions",
 	"/api/upload-logo",
 	"/api/upload-context",
+	"/api/upload-source",
 	"/uploads/logos/",
 	"/api/report/",
 	"/api/settings/rate-limit",
@@ -959,6 +972,7 @@ func (s *Server) Start() error {
 	mux.HandleFunc("/api/upload-instructions", s.handleUploadInstructions)
 	mux.HandleFunc("/api/upload-logo", s.handleUploadLogo)
 	mux.HandleFunc("/api/upload-context", s.handleUploadContext)
+	mux.HandleFunc("/api/upload-source", s.handleUploadSource)
 	// Serve uploaded logos
 	logosDir := filepath.Join(s.dataDir, "logos")
 	_ = os.MkdirAll(logosDir, 0700)
@@ -1418,8 +1432,18 @@ func (s *Server) handleScan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Code-first scans: the subject is source (SourceRepo), not a live URL.
+	// "review" needs no target; "provision" synthesizes a loopback target the
+	// agent stands the app up on. resolveCodeScan validates and, on success,
+	// sets req.Targets / req.codeScanMode / req.allowLoopbackPorts.
+	isCodeScan, codeErr := s.resolveCodeScan(&req)
+	if codeErr != "" {
+		http.Error(w, codeErr, http.StatusBadRequest)
+		return
+	}
+
 	if len(req.Targets) == 0 {
-		http.Error(w, "targets required", http.StatusBadRequest)
+		http.Error(w, "targets required (or provide source_repo with code_scan=review|provision)", http.StatusBadRequest)
 		return
 	}
 	normalizeScanRequestActivity(&req)
@@ -1430,7 +1454,9 @@ func (s *Server) handleScan(w http.ResponseWriter, r *http.Request) {
 	// instance with zero effective targets that the operator must then
 	// clean up. Surface a 400 instead. Mixed requests (at least one allowed
 	// target) proceed and the blocked entries are filtered downstream.
-	if !req.SaveOnly {
+	// Code scans are exempt: a "provision" target is a deliberate loopback
+	// address the scope guard allowlists for this scan only.
+	if !req.SaveOnly && !isCodeScan {
 		allBlocked := true
 		for _, t := range req.Targets {
 			if strings.TrimSpace(t) == "" {
@@ -2334,36 +2360,38 @@ func (s *Server) handleInstanceAction(w http.ResponseWriter, r *http.Request) {
 // scanSession isolates all per-scan state. Crashes in one session
 // cannot corrupt server-level state or leak into subsequent scans.
 type scanSession struct {
-	id                string
-	target            string
-	parentTarget      string // parent domain for subdomain scans (wildcard mode)
-	scanDir           string
-	cfg               *config.Config
-	agent             *agent.Agent
-	events            chan agent.Event
-	record            *ScanRecord
-	recordTokenOffset int
-	server            *Server
-	instruction       string
-	name              string
-	userInstruction   string
-	severityFilter    []string
-	discordWebhook    string
-	discoveryMode     bool
-	genReport         bool
-	resetState        bool
-	instanceID        string               // parent instance ID for multi-instance tracking
-	scanMode          string               // single, wildcard, dast — persisted so dashboard shows correct mode
-	sctx              *scanctx.ScanContext // per-session isolated state
-	companyName       string               // report branding: company name
-	logoPath          string               // report branding: logo path
-	phases            []int                // selected methodology phases
-	reconMode         string               // active or passive reconnaissance
-	scanIntensity     string               // active or passive testing/scanning
-	targetAuth        string               // per-scan authenticated-scanning material (see ScanRequest.TargetAuth)
-	targetAuthB       string               // per-scan second account for IDOR/BOLA (see ScanRequest.TargetAuthSecondary)
-	sourceRepo        string               // per-scan whitebox source repo/path (see ScanRequest.SourceRepo)
-	scanContext       string               // per-scan attack-surface context path (see ScanRequest.ScanContext)
+	id                 string
+	target             string
+	parentTarget       string // parent domain for subdomain scans (wildcard mode)
+	scanDir            string
+	cfg                *config.Config
+	agent              *agent.Agent
+	events             chan agent.Event
+	record             *ScanRecord
+	recordTokenOffset  int
+	server             *Server
+	instruction        string
+	name               string
+	userInstruction    string
+	severityFilter     []string
+	discordWebhook     string
+	discoveryMode      bool
+	genReport          bool
+	resetState         bool
+	instanceID         string               // parent instance ID for multi-instance tracking
+	scanMode           string               // single, wildcard, dast — persisted so dashboard shows correct mode
+	sctx               *scanctx.ScanContext // per-session isolated state
+	companyName        string               // report branding: company name
+	logoPath           string               // report branding: logo path
+	phases             []int                // selected methodology phases
+	reconMode          string               // active or passive reconnaissance
+	scanIntensity      string               // active or passive testing/scanning
+	targetAuth         string               // per-scan authenticated-scanning material (see ScanRequest.TargetAuth)
+	targetAuthB        string               // per-scan second account for IDOR/BOLA (see ScanRequest.TargetAuthSecondary)
+	sourceRepo         string               // per-scan whitebox source repo/path (see ScanRequest.SourceRepo)
+	scanContext        string               // per-scan attack-surface context path (see ScanRequest.ScanContext)
+	codeScanMode       agent.CodeScanMode   // code-first scan mode (see ScanRequest.CodeScan)
+	allowLoopbackPorts []int                // per-scan loopback allowlist for provision scans (scope-guard exemption)
 
 	// llmClient, when non-nil, is a pre-built llm.Client carrying
 	// a per-scan endpoint resolver derived from the originating

--- a/internal/web/uploads_source.go
+++ b/internal/web/uploads_source.go
@@ -1,0 +1,202 @@
+package web
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Source-upload limits. These bound both the compressed request body and the
+// decompressed output so a malicious archive (zip bomb / path traversal)
+// cannot exhaust disk or escape the sandbox directory.
+const (
+	maxSourceUpload       = 200 << 20 // 200MB compressed request body
+	maxSourceUncompressed = 800 << 20 // 800MB total decompressed
+	maxSourceFiles        = 20000     // max entries extracted
+)
+
+// handleUploadSource accepts a .zip archive of a codebase, extracts it safely
+// under <dataDir>/sources/<slug>/, and returns the ABSOLUTE path of the
+// extracted root. The caller passes that path back as ScanRequest.source_repo
+// (with code_scan=review|provision) so the engine can scan uploaded code with
+// no git URL and no live target — the frictionless "scan my code" entry point.
+func (s *Server) handleUploadSource(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "POST only", http.StatusMethodNotAllowed)
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxSourceUpload)
+	if err := r.ParseMultipartForm(32 << 20); err != nil {
+		http.Error(w, "failed to parse multipart form (max 200MB): "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		http.Error(w, "file required (a .zip of your codebase)", http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
+
+	originalName := filepath.Base(header.Filename)
+	if strings.ToLower(filepath.Ext(originalName)) != ".zip" {
+		http.Error(w, "unsupported format: upload a .zip archive of the codebase", http.StatusBadRequest)
+		return
+	}
+
+	// Spool the upload to a temp file so we can open it as a zip.ReaderAt.
+	tmp, err := os.CreateTemp("", "xalgorix-src-*.zip")
+	if err != nil {
+		log.Printf("[ERROR] source upload: temp create: %v", err)
+		http.Error(w, "server error", http.StatusInternalServerError)
+		return
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	size, err := io.Copy(tmp, file)
+	if err != nil {
+		tmp.Close()
+		log.Printf("[ERROR] source upload: spool: %v", err)
+		http.Error(w, "server error", http.StatusInternalServerError)
+		return
+	}
+	tmp.Close()
+
+	// Destination: <dataDir>/sources/<ts>_<safeName>/
+	nameOnly := strings.TrimSuffix(originalName, filepath.Ext(originalName))
+	safeName := regexp.MustCompile(`[^a-zA-Z0-9._-]+`).ReplaceAllString(nameOnly, "_")
+	safeName = strings.Trim(safeName, "._-")
+	if safeName == "" {
+		safeName = "source"
+	}
+	destRoot := filepath.Join(s.dataDir, "sources", fmt.Sprintf("%d_%s", time.Now().UnixMilli(), safeName))
+	if err := os.MkdirAll(destRoot, 0700); err != nil {
+		log.Printf("[ERROR] source upload: mkdir: %v", err)
+		http.Error(w, "server error", http.StatusInternalServerError)
+		return
+	}
+
+	fileCount, err := unzipInto(tmpPath, size, destRoot)
+	if err != nil {
+		_ = os.RemoveAll(destRoot)
+		http.Error(w, "could not extract archive: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// If the archive had a single top-level directory (the common
+	// "repo-main/…" GitHub shape), use it as the source root so code_search
+	// starts at the project root rather than a wrapper directory.
+	root := collapseSingleDir(destRoot)
+
+	log.Printf("Source uploaded: %s → %s (%d files)", header.Filename, root, fileCount)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"source_repo": root,
+		"files":       fileCount,
+		"name":        safeName,
+	})
+}
+
+// unzipInto extracts the zip at archivePath into destRoot with zip-slip,
+// file-count, and total-size protection. Symlinks are skipped. Returns the
+// number of regular files written.
+func unzipInto(archivePath string, archiveSize int64, destRoot string) (int, error) {
+	zr, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return 0, fmt.Errorf("not a valid zip: %w", err)
+	}
+	defer zr.Close()
+
+	// Resolve destRoot to an absolute, cleaned prefix for containment checks.
+	absDest, err := filepath.Abs(destRoot)
+	if err != nil {
+		return 0, err
+	}
+	prefix := absDest + string(os.PathSeparator)
+
+	var written int
+	var totalOut int64
+	for _, f := range zr.File {
+		if len(zr.File) > maxSourceFiles || written > maxSourceFiles {
+			return written, fmt.Errorf("archive has too many entries (max %d)", maxSourceFiles)
+		}
+		// Reject absolute paths and directory traversal outright (zip-slip).
+		name := f.Name
+		if strings.Contains(name, "\x00") {
+			return written, fmt.Errorf("archive entry has an invalid name")
+		}
+		rel := filepath.Clean(strings.ReplaceAll(name, "\\", "/"))
+		if filepath.IsAbs(rel) || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			return written, fmt.Errorf("archive entry escapes destination: %q", name)
+		}
+		target := filepath.Join(absDest, rel)
+		if target != absDest && !strings.HasPrefix(target, prefix) {
+			return written, fmt.Errorf("archive entry escapes destination: %q", name)
+		}
+
+		info := f.FileInfo()
+		if info.IsDir() {
+			if err := os.MkdirAll(target, 0700); err != nil {
+				return written, err
+			}
+			continue
+		}
+		// Skip symlinks and other non-regular files — never follow links out.
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0700); err != nil {
+			return written, err
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return written, err
+		}
+		out, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
+		if err != nil {
+			rc.Close()
+			return written, err
+		}
+		// Bound each copy against the remaining total-size budget to defuse
+		// zip bombs (a small archive that inflates to gigabytes).
+		remaining := maxSourceUncompressed - totalOut
+		if remaining <= 0 {
+			out.Close()
+			rc.Close()
+			return written, fmt.Errorf("archive exceeds max uncompressed size (%d bytes)", maxSourceUncompressed)
+		}
+		n, cErr := io.Copy(out, io.LimitReader(rc, remaining+1))
+		out.Close()
+		rc.Close()
+		if cErr != nil {
+			return written, cErr
+		}
+		if n > remaining {
+			return written, fmt.Errorf("archive exceeds max uncompressed size (%d bytes)", maxSourceUncompressed)
+		}
+		totalOut += n
+		written++
+	}
+	if written == 0 {
+		return 0, fmt.Errorf("archive contained no files")
+	}
+	return written, nil
+}
+
+// collapseSingleDir returns the child directory when destRoot contains exactly
+// one entry and that entry is a directory (the "repo-main/" wrapper GitHub zip
+// exports produce). Otherwise it returns destRoot unchanged.
+func collapseSingleDir(destRoot string) string {
+	entries, err := os.ReadDir(destRoot)
+	if err != nil || len(entries) != 1 || !entries[0].IsDir() {
+		return destRoot
+	}
+	return filepath.Join(destRoot, entries[0].Name())
+}

--- a/internal/web/uploads_source.go
+++ b/internal/web/uploads_source.go
@@ -59,7 +59,7 @@ func (s *Server) handleUploadSource(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	tmpPath := tmp.Name()
-	defer os.Remove(tmpPath)
+	defer func() { _ = os.Remove(tmpPath) }()
 	size, err := io.Copy(tmp, file)
 	if err != nil {
 		tmp.Close()
@@ -112,7 +112,7 @@ func unzipInto(archivePath string, archiveSize int64, destRoot string) (int, err
 	if err != nil {
 		return 0, fmt.Errorf("not a valid zip: %w", err)
 	}
-	defer zr.Close()
+	defer func() { _ = zr.Close() }()
 
 	// Resolve destRoot to an absolute, cleaned prefix for containment checks.
 	absDest, err := filepath.Abs(destRoot)

--- a/internal/web/uploads_source_test.go
+++ b/internal/web/uploads_source_test.go
@@ -1,0 +1,84 @@
+package web
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeZip(t *testing.T, entries map[string]string) (string, int64) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "src.zip")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zw := zip.NewWriter(f)
+	for name, body := range entries {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	info, _ := os.Stat(path)
+	return path, info.Size()
+}
+
+func TestUnzipInto_HappyPath(t *testing.T) {
+	arc, size := writeZip(t, map[string]string{
+		"app/main.py":     "print('hi')",
+		"app/routes/x.py": "x = 1",
+		"README.md":       "# app",
+	})
+	dest := t.TempDir()
+	n, err := unzipInto(arc, size, dest)
+	if err != nil {
+		t.Fatalf("unzipInto: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("files written = %d, want 3", n)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "app", "main.py")); err != nil {
+		t.Fatalf("expected extracted file: %v", err)
+	}
+}
+
+func TestUnzipInto_RejectsZipSlip(t *testing.T) {
+	arc, size := writeZip(t, map[string]string{
+		"../../etc/evil": "pwned",
+	})
+	dest := t.TempDir()
+	if _, err := unzipInto(arc, size, dest); err == nil {
+		t.Fatal("expected zip-slip entry to be rejected, got nil error")
+	}
+	// The traversal target must NOT exist outside dest.
+	if _, err := os.Stat(filepath.Join(filepath.Dir(filepath.Dir(dest)), "etc", "evil")); err == nil {
+		t.Fatal("zip-slip wrote a file outside the destination")
+	}
+}
+
+func TestCollapseSingleDir(t *testing.T) {
+	dest := t.TempDir()
+	inner := filepath.Join(dest, "repo-main")
+	if err := os.MkdirAll(inner, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if got := collapseSingleDir(dest); got != inner {
+		t.Fatalf("collapseSingleDir = %q, want %q", got, inner)
+	}
+	// Two entries → no collapse.
+	if err := os.WriteFile(filepath.Join(dest, "loose.txt"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if got := collapseSingleDir(dest); got != dest {
+		t.Fatalf("collapseSingleDir with 2 entries = %q, want %q", got, dest)
+	}
+}


### PR DESCRIPTION
Closes the deepest adoption gap vs tools like Strix: today Xalgorix requires a live target; this lets the **codebase itself be the subject** (git URL, local path, or uploaded zip), with no separate URL.

## Two modes (ScanRequest.code_scan)
- **review** (Option 1) — source review / SAST, **no running target**. The agent audits code (source→sink→reachability) and reports **source-verified** findings, explicitly labeled as not runtime-exploited.
- **provision** (Option 2) — the agent **builds & runs** the source on an allowlisted loopback port, then DASTs the running instance for **exploit-verified** findings. Falls back to review if the app can't be built/run.

## How it's wired
- **scopeguard**: new per-scan `AllowLoopbackPorts` exemption. A provisioned target on `127.0.0.1:<port>` becomes reachable, while the **dashboard listener and every other loopback address stay blocked**. Covered by `allowloopback_test.go` (includes a 'dashboard port is never allowed' case).
- **agent**: `CodeScanMode` (none/review/provision) with per-mode methodology injected into the prompt.
- **web**: `handleScan`/orchestrator accept code scans, synthesize the target, and thread the loopback allowlist; `isBlockedTargetForScan` keeps the default `isBlockedTarget` byte-identical (property tests untouched).
- **web**: `POST /api/upload-source` accepts a `.zip` codebase and extracts it safely — zip-slip rejection, zip-bomb size cap, file-count cap, symlinks skipped, non-root perms. Returns a path to use as `source_repo`.
- **CLI**: `--source <repo|path>` and `--code-scan review|provision`.

## Safety notes (please review)
- The only relaxation of the self-scan invariant is the **explicit, per-scan, single-loopback-port** allowlist for provision scans. It can never include the dashboard port. All other paths are unchanged.
- Provision mode is inherently best-effort (it depends on the agent building an arbitrary stack); it degrades to source review on failure.

## Verification
`go build ./...`, `go vet ./...`, `make lint`, and the scopeguard/web/agent/cmd test suites pass. Added tests: scopeguard allowlist matrix; zip extraction + zip-slip rejection.

Independent of PR #183 (install/docker/readme); no file overlap.