### PR TITLE
Docker: Kali batteries-included image (full toolset + runtime auto-install)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,8 @@
 # Build and publish the Xalgorix container image to GitHub Container Registry.
 #
 # Triggers on version tags (vX.Y.Z, pushed by release.sh) and can be run
-# manually. Publishes multi-arch (amd64 + arm64) images tagged with the
-# version and `latest`.
+# manually. Publishes the batteries-included amd64 image tagged with the
+# version and `latest`. (Release binaries remain multi-arch via the installer.)
 name: Docker
 
 on:
@@ -23,13 +23,20 @@ jobs:
   publish:
     name: Build and push image
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 240
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      # The Kali batteries-included image is many GB; the stock runner (~14GB
+      # free on /) can't hold it mid-build. Reclaim ~25-30GB by dropping
+      # preinstalled SDKs/toolchains we don't need.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" || true
+          sudo docker image prune --all --force || true
+          df -h /
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
@@ -55,7 +62,10 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          # amd64 only: the batteries-included toolset (Go/Rust/apt tools +
+          # nuclei templates) is impractical to build for arm64 under CI
+          # emulation. Release binaries stay multi-arch via the installer.
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,30 @@
-# Xalgorix — AI autonomous penetration testing platform.
+# Xalgorix — AI autonomous penetration testing platform (Kali, batteries-included).
+#
+# The runtime is based on Kali Linux and pulls in Kali's pentest metapackages,
+# so hundreds of offensive-security tools are preinstalled. On top of that every
+# package manager the agent uses (apt, go, cargo, pipx/pip, npm) is available at
+# runtime, so the LLM-driven terminal can still auto-install anything missing.
+#
+# It runs as ROOT on purpose: the engine only enables package auto-install for
+# uid 0 (internal/config: AllowAutoInstall defaults to os.Getuid()==0), and
+# apt/go/cargo installs need write access to system paths. The container is the
+# isolation boundary — treat it as a disposable, network-isolated scanning
+# sandbox and never expose the dashboard without auth.
+#
+# This is a large image (many GB — the full Kali toolset + wordlists + Go/Rust
+# toolchains). That is intentional; size is traded for a complete toolbox.
 #
 # Build:  docker build -t xalgorix .
 # Run:    docker run --rm -p 9137:9137 \
 #           -e XALGORIX_LLM=minimax/MiniMax-M2.7 \
 #           -e XALGORIX_API_KEY=your_provider_api_key \
-#           xalgorix
+#           -v xalgorix-data:/data \
+#           ghcr.io/xalgord/xalgorix:latest
 #
 # Then open http://127.0.0.1:9137
 #
-# The binary binds to 127.0.0.1 by default; inside the container we set
-# XALGORIX_BIND=0.0.0.0 so the published port is reachable. External access
-# without dashboard auth is refused, so set XALGORIX_USERNAME / XALGORIX_PASSWORD
-# when exposing this beyond localhost.
+# amd64 image. The release BINARIES remain multi-arch (Linux amd64/arm64) via
+# the one-line installer.
 
 # ── Stage 1: build the React web UI ──────────────────────────────────────────
 FROM node:20-bookworm-slim AS webui
@@ -22,35 +35,108 @@ COPY webui ./webui
 COPY internal/web ./internal/web
 RUN cd webui && npm run build
 
-# ── Stage 2: build the Go binary (embeds the UI from stage 1) ────────────────
-FROM golang:1.25-bookworm AS build
+# ── Stage 2: build the Go binary + the latest Go security toolset ────────────
+FROM golang:1.25-bookworm AS gobuild
+# libpcap-dev is needed to compile naabu (CGO); git for module fetches.
+RUN apt-get update && apt-get install -y --no-install-recommends libpcap-dev git \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-# Bring in the freshly built static assets so //go:embed picks them up.
 COPY --from=webui /src/internal/web/static ./internal/web/static
 ARG VERSION=docker
 RUN CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=${VERSION}" \
     -o /out/xalgorix ./cmd/xalgorix/
 
-# ── Stage 3: runtime ─────────────────────────────────────────────────────────
-FROM debian:bookworm-slim
-# chromium for browser-assisted DAST; ca-certificates for outbound TLS.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends chromium ca-certificates \
+# Latest versions of the Go tools the engine knows how to auto-install
+# (packageMap → goTools), into /go/bin. Best-effort per tool so one flaky
+# module never fails the image; anything missing stays runtime-installable.
+ENV GOBIN=/go/bin
+RUN set -eux; \
+    for pkg in \
+      github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest \
+      github.com/projectdiscovery/httpx/cmd/httpx@latest \
+      github.com/projectdiscovery/dnsx/cmd/dnsx@latest \
+      github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest \
+      github.com/projectdiscovery/katana/cmd/katana@latest \
+      github.com/jaeles-project/gospider@latest \
+      github.com/lc/gau/v2/cmd/gau@latest \
+      github.com/tomnomnom/waybackurls@latest \
+      github.com/tomnomnom/assetfinder@latest \
+      github.com/tomnomnom/qsreplace@latest \
+      github.com/tomnomnom/gf@latest \
+      github.com/tomnomnom/anew@latest \
+      github.com/hakluke/hakrawler@latest \
+      github.com/OJ/gobuster/v3@latest \
+      github.com/ffuf/ffuf/v2@latest \
+      github.com/hahwul/dalfox/v2@latest \
+      github.com/projectdiscovery/mapcidr/cmd/mapcidr@latest \
+      github.com/projectdiscovery/interactsh/cmd/interactsh-client@latest \
+      github.com/projectdiscovery/notify/cmd/notify@latest \
+    ; do go install -v "$pkg" || echo "WARN: go install $pkg failed (installable at runtime)"; done; \
+    CGO_ENABLED=1 go install -v github.com/projectdiscovery/naabu/v2/cmd/naabu@latest \
+      || echo "WARN: naabu build failed (installable at runtime)"
+
+# ── Stage 3: runtime — Kali Linux, full toolset, runs as root ────────────────
+FROM kalilinux/kali-rolling
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Kali metapackages = the extensive toolset. Recommends are left ON so the
+# metapackages pull their full tool set. Covers the web/app-pentest domains the
+# agent uses plus general coverage, and adds the package managers required for
+# runtime auto-install (go/cargo/pipx/npm) and Chromium for browser DAST.
+RUN apt-get update && apt-get install -y \
+      kali-linux-headless \
+      kali-tools-information-gathering \
+      kali-tools-web \
+      kali-tools-vulnerability \
+      kali-tools-fuzzing \
+      kali-tools-passwords \
+      kali-tools-exploitation \
+      kali-tools-post-exploitation \
+    && apt-get install -y --no-install-recommends \
+      ca-certificates curl wget git jq unzip zip p7zip-full file tree bc xxd \
+      seclists wordlists \
+      python3 python3-pip python3-venv pipx \
+      cargo \
+      nodejs npm \
+      build-essential pkg-config libpcap-dev \
+      chromium \
     && rm -rf /var/lib/apt/lists/*
+
+# Go toolchain at runtime so the agent can `go install` anything not baked in.
+COPY --from=gobuild /usr/local/go /usr/local/go
+# Prebuilt latest Go security tools → on PATH via /root/go/bin.
+COPY --from=gobuild /go/bin/ /root/go/bin/
+# The xalgorix binary itself.
+COPY --from=gobuild /out/xalgorix /usr/local/bin/xalgorix
+
+ENV PATH="/usr/local/go/bin:/root/go/bin:/root/.cargo/bin:/root/.local/bin:${PATH}" \
+    GOBIN=/root/go/bin \
+    HOME=/root
+
+# feroxbuster (Rust) — Kali packages it, but grab the latest release binary too
+# so it's current; cargo stays available at runtime as the engine's fallback.
+RUN curl -sSLo /tmp/ferox.zip https://github.com/epi052/feroxbuster/releases/latest/download/x86_64-linux-feroxbuster.zip \
+    && unzip -o /tmp/ferox.zip -d /usr/local/bin feroxbuster \
+    && chmod +x /usr/local/bin/feroxbuster \
+    && rm -f /tmp/ferox.zip \
+    || echo "WARN: feroxbuster prefetch failed (present via Kali/cargo)"
+
+# Python tools the engine auto-installs via pipx (best-effort at build).
+RUN pipx install scrapling || pip3 install --break-system-packages scrapling || echo "WARN: scrapling prefetch failed (installable at runtime)"
+
+# Bake nuclei templates so first-run scans don't stall on a template fetch.
+RUN /root/go/bin/nuclei -update-templates >/dev/null 2>&1 || echo "WARN: nuclei template prefetch skipped"
 
 ENV XALGORIX_BIND=0.0.0.0 \
     XALGORIX_BROWSER_PATH=/usr/bin/chromium \
-    XALGORIX_DATA_DIR=/data
+    XALGORIX_DATA_DIR=/data \
+    XALGORIX_ALLOW_AUTO_INSTALL=1
 
-COPY --from=build /out/xalgorix /usr/local/bin/xalgorix
-
-# Non-root runtime user; /data holds scan output and reports (mount a volume).
-RUN useradd --create-home --uid 10001 xalgorix \
-    && mkdir -p /data && chown xalgorix:xalgorix /data
-USER xalgorix
+RUN mkdir -p /data
 VOLUME ["/data"]
 EXPOSE 9137
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Launch the dashboard and open `http://127.0.0.1:9137`:
 xalgorix --web
 ```
 
-**Or run with Docker — no toolchain needed:**
+**Or run with Docker — batteries included, no toolchain needed:**
 
 ```bash
 docker run --rm -p 9137:9137 \
@@ -63,6 +63,8 @@ docker run --rm -p 9137:9137 \
   -v xalgorix-data:/data \
   ghcr.io/xalgord/xalgorix:latest
 ```
+
+The image ships an extensive offensive-security toolset preinstalled (nmap, nuclei, httpx, subfinder, katana, ffuf, gobuster, sqlmap, masscan, dalfox, feroxbuster, and more) **and** keeps every package manager (apt, go, cargo, pipx, npm) available so the agent can still auto-install anything missing at runtime. It runs as root inside the container by design — treat the container as a disposable, network-isolated scanning sandbox and never expose the dashboard without auth. (amd64 image; the installer above covers arm64.)
 
 **Or build from source** (needs Go 1.25+ and Node.js):
 
@@ -197,7 +199,9 @@ docker run --rm -p 9137:9137 \
   ghcr.io/xalgord/xalgorix:latest
 ```
 
-The image bundles Chromium for browser-assisted DAST and persists scan data to the `/data` volume. It binds to `0.0.0.0` inside the container; set `XALGORIX_USERNAME`/`XALGORIX_PASSWORD` before exposing it beyond localhost.
+The image is **batteries-included**: an extensive offensive-security toolset is preinstalled (nmap, nuclei, httpx, subfinder, dnsx, naabu, katana, ffuf, gobuster, dalfox, feroxbuster, sqlmap, masscan, nikto, whatweb, hydra, and more), plus Chromium for browser-assisted DAST. It also keeps the full package-manager set (apt, go, cargo, pipx, npm) available, so the agent auto-installs anything missing at runtime. Scan data persists to the `/data` volume, and the server binds `0.0.0.0` inside the container — set `XALGORIX_USERNAME`/`XALGORIX_PASSWORD` before exposing it beyond localhost.
+
+The container runs as root by design (the engine only enables runtime auto-install for uid 0, and apt/go/cargo installs need system write access). Treat it as a disposable, network-isolated scanning sandbox. It's published for `amd64`; use the one-line installer for arm64 hosts.
 
 ### Requirements (build from source)
 


### PR DESCRIPTION
Addresses the gap that the previous slim, non-root image couldn't install tools dynamically. This rebuilds the container so it ships an extensive toolset **and** keeps runtime auto-install working. Size is intentionally traded away for completeness (many GB).

## What changed
- **Runtime base → Kali Linux** (`kalilinux/kali-rolling`). Installs `kali-linux-headless` + the `information-gathering / web / vulnerability / fuzzing / passwords / exploitation / post-exploitation` metapackages, plus `seclists` and `wordlists`. That's hundreds of tools preinstalled.
- **Runtime auto-install still works**: apt (root), the **Go toolchain**, **cargo**, **pipx/pip**, and **npm** are all present in the runtime, plus `build-essential`/`pkg-config`/`libpcap-dev` so CGO/cargo builds compile. `XALGORIX_ALLOW_AUTO_INSTALL=1`. So anything not baked in, the agent installs on demand via `installPackage()`.
- **Prebuilt latest Go tools** (nuclei, httpx, subfinder, dnsx, katana, naabu, ffuf, gobuster, dalfox, gau, waybackurls, hakrawler, assetfinder, qsreplace, gf, anew, mapcidr, interactsh-client, notify) + feroxbuster + scrapling; nuclei templates baked.
- **Runs as root** — required because the engine only enables auto-install for uid 0 and apt/go/cargo need system write access. Chromium already launches with `--no-sandbox` in the engine, so browser DAST works as root. The container is the isolation boundary; docs say to keep it network-isolated and never expose the dashboard without auth.

## CI (`docker.yml`)
- **amd64 only** — the full Kali/Go/Rust toolset is impractical to build for arm64 under QEMU on hosted runners. Release binaries stay multi-arch via the installer.
- Frees ~25-30 GB of runner disk before building (the image is too big for the stock ~14 GB).
- Timeout raised to 240 min; GHA layer cache dropped (image exceeds the 10 GB cache limit).

## Caveats / for review
- **I could not build this locally** (no Docker in my environment) — CI will build and publish it on the next release tag. The Kali metapackage set is large; if any single metapackage name drifts, that step fails, so worth watching the first CI build.
- First post-merge **release tag** triggers the publish (like #183). Existing `ghcr.io/xalgord/xalgorix:latest` (slim) stays until then.