### PR TITLE
README: add Trendshift badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/xalgord/xalgorix)
 
+<a href="https://trendshift.io/repositories/35278?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-35278" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/35278/daily?language=Go" alt="xalgord/xalgorix | Trendshift" width="250" height="55"/></a>
+
 </div>
 
 <h1 align="center">Xalgorix — Open-source AI pentester that <em>proves</em> vulnerabilities</h1>


### PR DESCRIPTION
Adds the Trendshift trending-repo badge (repository #35278) to the README hero, next to the DeepWiki badge. Uses the exact embed snippet from Trendshift (daily/Go variant with attribution params). This is the last item from the growth-gap list.