### PR TITLE
docker: mirror image to Docker Hub (xalgord/xalgorix)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,15 @@
-# Build and publish the Xalgorix container image to GitHub Container Registry.
+# Build and publish the Xalgorix container image.
 #
 # Triggers on version tags (vX.Y.Z, pushed by release.sh) and can be run
 # manually. Publishes the batteries-included amd64 image tagged with the
-# version and `latest`. (Release binaries remain multi-arch via the installer.)
+# version and `latest` to:
+#   - GitHub Container Registry: ghcr.io/xalgord/xalgorix   (always)
+#   - Docker Hub:                docker.io/xalgord/xalgorix (when the
+#     DOCKERHUB_USERNAME + DOCKERHUB_TOKEN repo secrets are set)
+#
+# The Docker Hub target is OPTIONAL and self-gating: with no secrets, the run
+# still succeeds and publishes to GHCR only. (Release binaries remain
+# multi-arch via the installer.)
 name: Docker
 
 on:
@@ -24,6 +31,9 @@ jobs:
     name: Build and push image
     runs-on: ubuntu-latest
     timeout-minutes: 240
+    # Surfaced so steps can gate the Docker Hub path on the secret being set.
+    env:
+      DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USERNAME }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,11 +58,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Optional: only runs when the Docker Hub secrets are configured.
+      - name: Log in to Docker Hub
+        if: ${{ env.DOCKERHUB_USER != '' }}
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}
+          # GHCR always; Docker Hub (docker.io/xalgord/xalgorix) only when the
+          # secret is present — the empty line is ignored by the action.
+          images: |
+            ghcr.io/${{ github.repository }}
+            ${{ env.DOCKERHUB_USER != '' && 'docker.io/xalgord/xalgorix' || '' }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
Publishes the release image to **docker.io/xalgord/xalgorix** in addition to GHCR, so people searching Docker Hub find the official image instead of the unrelated squatted `mastomi/xalgorix`.

- Adds a Docker Hub login + `docker.io/xalgord/xalgorix` to the metadata images.
- **Optional and self-gating**: gated on `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` repo secrets. With no secrets, the run still succeeds and publishes to GHCR only (login skipped, docker.io line omitted). No release will break if the secrets aren't set.
- Same tags as GHCR (version, major.minor, latest), amd64.

## To activate (your side)
1. On Docker Hub as **xalgord**, create the repo `xalgorix` (reserves the name before more squatting).
2. Create an access token (Account Settings → Security → New Access Token, Read/Write).
3. Add repo secrets `DOCKERHUB_USERNAME=xalgord` and `DOCKERHUB_TOKEN=<token>`.
4. The next release tag then pushes to both registries.

README stays pointed at GHCR as canonical; I'll add the Docker Hub pull line once the first mirrored image is live.