### PR TITLE
docker: fix broken container startup (self-update loop + bind-without-auth)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -93,4 +93,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            VERSION=${{ github.ref_name }}
+            VERSION=${{ steps.meta.outputs.version || github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -134,11 +134,18 @@ RUN /root/go/bin/nuclei -update-templates >/dev/null 2>&1 || echo "WARN: nuclei 
 ENV XALGORIX_BIND=0.0.0.0 \
     XALGORIX_BROWSER_PATH=/usr/bin/chromium \
     XALGORIX_DATA_DIR=/data \
-    XALGORIX_ALLOW_AUTO_INSTALL=1
+    XALGORIX_ALLOW_AUTO_INSTALL=1 \
+    XALGORIX_NO_AUTO_UPDATE=1
+
+# Entrypoint generates dashboard credentials when none are supplied (the image
+# binds 0.0.0.0, which the engine won't do without auth) so a plain
+# `docker run` starts cleanly and securely.
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 RUN mkdir -p /data
 VOLUME ["/data"]
 EXPOSE 9137
 
-ENTRYPOINT ["xalgorix"]
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["--web"]

--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ The image is **batteries-included**: an extensive offensive-security toolset is 
 
 The container runs as root by design (the engine only enables runtime auto-install for uid 0, and apt/go/cargo installs need system write access). Treat it as a disposable, network-isolated scanning sandbox. It's published for `amd64`; use the one-line installer for arm64 hosts.
 
+On first run, if you don't set dashboard auth the container **generates a random admin password and prints it to the logs** (the image binds `0.0.0.0`, which the engine won't do without auth). Set `XALGORIX_USERNAME` + `XALGORIX_PASSWORD` (or `XALGORIX_PASSWORD_HASH`) to use your own. The binary never self-updates inside the container (`XALGORIX_NO_AUTO_UPDATE=1`) — pull a new image tag to upgrade.
+
 ### Requirements (build from source)
 
 | Requirement    | Notes                                                        |

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -811,6 +811,12 @@ func touchAutoUpdateMarker() {
 
 // autoUpdate checks GitHub for a newer release and self-updates if found.
 func autoUpdate() {
+	// Opt-out for immutable/managed deployments (containers, packaged installs).
+	// In a container the binary must NOT rewrite itself — updates come from
+	// pulling a new image tag — so the Docker image sets XALGORIX_NO_AUTO_UPDATE=1.
+	if v := strings.TrimSpace(os.Getenv("XALGORIX_NO_AUTO_UPDATE")); v == "1" || strings.EqualFold(v, "true") {
+		return
+	}
 	if autoUpdateThrottled() {
 		return
 	}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Container entrypoint for the Xalgorix image.
+#
+# The image binds 0.0.0.0 (so the published port works), but the engine refuses
+# to bind a non-loopback address without dashboard auth. Rather than fail a
+# plain `docker run`, we generate a random admin password when none is supplied,
+# print it once, and start. Operators can override by passing their own
+# XALGORIX_USERNAME + XALGORIX_PASSWORD (or XALGORIX_PASSWORD_HASH).
+set -euo pipefail
+
+bind="${XALGORIX_BIND:-0.0.0.0}"
+
+# Is the bind address loopback (no auth required by the engine)?
+is_loopback=false
+case "$bind" in
+  127.0.0.1 | localhost | ::1 | "") is_loopback=true ;;
+esac
+
+# Is dashboard auth already configured?
+has_auth=false
+if [ -n "${XALGORIX_USERNAME:-}" ] && { [ -n "${XALGORIX_PASSWORD:-}" ] || [ -n "${XALGORIX_PASSWORD_HASH:-}" ]; }; then
+  has_auth=true
+fi
+
+if [ "$is_loopback" = false ] && [ "$has_auth" = false ]; then
+  export XALGORIX_USERNAME="${XALGORIX_USERNAME:-admin}"
+  export XALGORIX_PASSWORD="$(openssl rand -base64 24 | tr -dc 'A-Za-z0-9' | head -c 20)"
+  echo "============================================================"
+  echo "  Xalgorix — no dashboard auth was provided."
+  echo "  Generated one-time credentials so the container can start:"
+  echo ""
+  echo "      username: ${XALGORIX_USERNAME}"
+  echo "      password: ${XALGORIX_PASSWORD}"
+  echo ""
+  echo "  Override by setting XALGORIX_USERNAME + XALGORIX_PASSWORD"
+  echo "  (or XALGORIX_PASSWORD_HASH). Rotate these before exposing"
+  echo "  the dashboard on an untrusted network."
+  echo "============================================================"
+fi
+
+exec xalgorix "$@"


### PR DESCRIPTION
Fixes the container failing to start (from user-reported logs) and the boot-time self-update.

## Symptoms (from container logs)
1. `Server error: refusing to bind to non-loopback address "0.0.0.0" without auth` — the image sets `XALGORIX_BIND=0.0.0.0` (needed so `-p 9137:9137` works), but the engine refuses a non-loopback bind without dashboard auth, and the quick-start `docker run` supplies none. **Every default run died.**
2. `🔄 New version available: vv4.5.50 → v4.5.50 … Updated … Restarting…` — the binary self-updated on every boot. The Docker build stamped `VERSION` from the raw tag `v4.5.50` (leading v), so it never equalled the release version and always looked 'newer'; the update marker lives outside `/data` so it isn't throttled across restarts.

## Fixes
- **Disable self-update in the image.** New `XALGORIX_NO_AUTO_UPDATE` opt-out (checked at the top of `autoUpdate()`), set to `1` in the Dockerfile. Containers upgrade by pulling a new tag, not by rewriting the binary.
- **Start securely by default.** New `docker-entrypoint.sh`: when binding non-loopback with no auth provided, it generates a random admin password, prints it once, and starts. Operators override with `XALGORIX_USERNAME` + `XALGORIX_PASSWORD`/`_HASH`.
- **Correct VERSION.** `docker.yml` now builds `VERSION` from `steps.meta.outputs.version` (`4.5.50`) instead of the raw tag, so the stamped version matches.
- README updated to document both behaviors.

Verified: `go build` + golangci-lint clean. Entrypoint `bash -n` clean. Needs a new release tag to rebuild/publish the fixed image.