### PR TITLE
docker: compose file + persist Settings-configured LLM on /data

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,18 @@ xalgorix --web
 
 ```bash
 docker run --rm -p 9137:9137 \
-  -e XALGORIX_LLM=minimax/MiniMax-M3 \
-  -e XALGORIX_API_KEY=your_provider_api_key \
   -v xalgorix-data:/data \
-  ghcr.io/xalgord/xalgorix:latest
+  xalgord/xalgorix:latest
+```
+
+Open `http://localhost:9137`. You **don't need an LLM key to start** — the dashboard launches without one; set the model + API key under **Settings → LLM** (it persists to the `/data` volume). If you don't pass `XALGORIX_USERNAME`/`XALGORIX_PASSWORD`, a random admin password is generated and printed to the container logs on first run.
+
+**Easiest — Docker Compose** (maps the port + a persistent volume for you):
+
+```bash
+curl -sSLO https://raw.githubusercontent.com/xalgord/xalgorix/main/docker-compose.yml
+docker compose up -d
+docker compose logs -f   # shows the generated admin password on first start
 ```
 
 The image ships an extensive offensive-security toolset preinstalled (nmap, nuclei, httpx, subfinder, katana, ffuf, gobuster, sqlmap, masscan, dalfox, feroxbuster, and more) **and** keeps every package manager (apt, go, cargo, pipx, npm) available so the agent can still auto-install anything missing at runtime. It runs as root inside the container by design — treat the container as a disposable, network-isolated scanning sandbox and never expose the dashboard without auth. (amd64 image; the installer above covers arm64.)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+# Xalgorix — one-command run. Publishes the dashboard on http://localhost:9137
+# and persists all data (scans, reports, and settings) to a named volume.
+#
+#   docker compose up -d
+#   docker compose logs -f      # shows the generated admin password on first run
+#
+# You do NOT need an LLM key to start — the dashboard launches without one and
+# you can configure the model + API key under Settings → LLM (it persists to the
+# volume). Set the env vars below only if you'd rather bake them in.
+services:
+  xalgorix:
+    image: xalgord/xalgorix:latest
+    # Or build locally instead of pulling:  build: .
+    ports:
+      - "9137:9137"
+    # Uncomment to bake in credentials / LLM (all optional). If you omit the
+    # login, a random admin password is generated and printed to the logs on
+    # first start. The LLM can be set here or under Settings → LLM.
+    # environment:
+    #   XALGORIX_USERNAME: admin
+    #   XALGORIX_PASSWORD: change-me-please
+    #   XALGORIX_LLM: minimax/MiniMax-M3
+    #   XALGORIX_API_KEY: your_provider_api_key
+    volumes:
+      - xalgorix-data:/data
+    restart: unless-stopped
+
+volumes:
+  xalgorix-data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,6 +8,20 @@
 # XALGORIX_USERNAME + XALGORIX_PASSWORD (or XALGORIX_PASSWORD_HASH).
 set -euo pipefail
 
+# Persist dashboard-configured settings on the /data volume. The engine writes
+# runtime settings (LLM model/key, integrations, etc.) to ~/.xalgorix.env
+# (=/root/.xalgorix.env). Symlinking it onto /data means anything you set under
+# Settings survives `docker run --rm` / container recreation, not just restarts.
+mkdir -p /data
+if [ ! -e /data/.xalgorix.env ]; then
+  if [ -f /root/.xalgorix.env ] && [ ! -L /root/.xalgorix.env ]; then
+    mv /root/.xalgorix.env /data/.xalgorix.env
+  else
+    : >/data/.xalgorix.env
+  fi
+fi
+ln -sf /data/.xalgorix.env /root/.xalgorix.env
+
 bind="${XALGORIX_BIND:-0.0.0.0}"
 
 # Is the bind address loopback (no auth required by the engine)?


### PR DESCRIPTION
Addresses 'container not reachable on localhost' and 'let it launch without LLM, configure in Settings.'

## Clarification
The dashboard **already launches without an LLM key** — the engine only needs an LLM for CLI scans, not the web UI (the user's own logs show a clean start). So the 'localhost refused to connect' was simply the container port not being published, not an LLM problem.

## Changes
- **docker-compose.yml** — `docker compose up -d` publishes 9137 and mounts a persistent `/data` volume, so no one has to remember `-p`. LLM env is optional/commented.
- **Entrypoint** — symlinks `~/.xalgorix.env` onto `/data`, so the LLM model/key (and other integrations) you set under **Settings → LLM** persist across `docker run --rm` / recreation, not just restarts. Migrates an existing in-image env file if present.
- **README** — Docker quick-start now leads with compose, states no LLM key is needed to start, and notes the auto-generated admin password.

## Notes
- The compose file + localhost fix work with the **current published image today** (they just add `-p` + volume).
- The env-persist symlink needs the image rebuilt — it ships on the next release tag.
- `bash -n` on the entrypoint and a compose structure check pass.