### PR TITLE
fix(notify): Telegram finding notifications show raw markdown

### DIFF
--- a/internal/web/notify.go
+++ b/internal/web/notify.go
@@ -10,11 +10,23 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/xalgord/xalgorix/v4/internal/safe"
 	"github.com/xalgord/xalgorix/v4/internal/scopeguard"
+)
+
+// The finding notification body is authored once in Discord Markdown
+// (**bold**, `code`, ```fenced```) and reused for Telegram. Telegram's HTML
+// parse_mode doesn't understand Markdown, so these convert the Discord markers
+// to Telegram HTML tags. Fenced blocks are matched before inline code so a
+// ``` block isn't chopped up by the single-backtick rule.
+var (
+	tgFencedCodeRe = regexp.MustCompile("(?s)```[a-zA-Z0-9_-]*\\n?(.*?)```")
+	tgInlineCodeRe = regexp.MustCompile("`([^`\n]+?)`")
+	tgBoldRe       = regexp.MustCompile(`\*\*([^*]+?)\*\*`)
 )
 
 // sendDiscord sends a rich embed message to the configured Discord webhook.
@@ -206,7 +218,22 @@ func telegramFormat(title, description string) string {
 	if description == "" {
 		return "<b>" + htmlEscape(title) + "</b>"
 	}
-	return "<b>" + htmlEscape(title) + "</b>\n" + htmlEscape(description)
+	return "<b>" + htmlEscape(title) + "</b>\n" + discordMarkdownToTelegramHTML(description)
+}
+
+// discordMarkdownToTelegramHTML converts the Discord-flavored Markdown used in
+// notification bodies (**bold**, `inline code`, ```fenced blocks```) into the
+// subset of HTML Telegram's HTML parse_mode supports (<b>, <code>, <pre>).
+// Text is HTML-escaped FIRST so finding content can't inject markup; the
+// Markdown markers (*, `) are not HTML-special, so escaping never disturbs
+// them. Without this, Telegram renders the raw "**", "`" characters literally.
+func discordMarkdownToTelegramHTML(s string) string {
+	s = htmlEscape(s)
+	// Fenced code first (so its contents aren't mangled by the inline rule).
+	s = tgFencedCodeRe.ReplaceAllString(s, "<pre>$1</pre>")
+	s = tgInlineCodeRe.ReplaceAllString(s, "<code>$1</code>")
+	s = tgBoldRe.ReplaceAllString(s, "<b>$1</b>")
+	return s
 }
 
 // htmlEscape escapes the four characters Telegram's HTML parse_mode

--- a/internal/web/notify_test.go
+++ b/internal/web/notify_test.go
@@ -1,0 +1,55 @@
+package web
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDiscordMarkdownToTelegramHTML(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bold", "**Host Header Injection**", "<b>Host Header Injection</b>"},
+		{"inline code", "endpoint `https://x/`", "endpoint <code>https://x/</code>"},
+		{
+			"label then value",
+			"📊 **CVSS:** `3.4` | **Severity:** `LOW`",
+			"📊 <b>CVSS:</b> <code>3.4</code> | <b>Severity:</b> <code>LOW</code>",
+		},
+		{
+			"fenced block",
+			"🧪 **PoC:**\n```\ncurl https://x\n```",
+			"🧪 <b>PoC:</b>\n<pre>curl https://x\n</pre>",
+		},
+		{"escapes html then converts", "**<script>**", "<b>&lt;script&gt;</b>"},
+		{"ampersand escaped", "a & b", "a &amp; b"},
+		{"plain text untouched", "just text", "just text"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := discordMarkdownToTelegramHTML(c.in)
+			if got != c.want {
+				t.Fatalf("discordMarkdownToTelegramHTML(%q)\n got: %q\nwant: %q", c.in, got, c.want)
+			}
+			// No raw Discord bold markers should survive.
+			if strings.Contains(got, "**") {
+				t.Fatalf("raw ** survived conversion: %q", got)
+			}
+		})
+	}
+}
+
+func TestTelegramFormatConvertsBody(t *testing.T) {
+	out := telegramFormat("🐛 LOW Vulnerability Found", "**Title**\n🔗 **Endpoint:** `https://x/`")
+	if strings.Contains(out, "**") {
+		t.Fatalf("telegramFormat left raw markdown: %q", out)
+	}
+	if !strings.HasPrefix(out, "<b>🐛 LOW Vulnerability Found</b>\n") {
+		t.Fatalf("title not bolded: %q", out)
+	}
+	if !strings.Contains(out, "<b>Title</b>") || !strings.Contains(out, "<code>https://x/</code>") {
+		t.Fatalf("body not converted: %q", out)
+	}
+}


### PR DESCRIPTION
## Problem
Telegram vulnerability notifications render **raw Markdown** — the message shows literal `**Description:**`, `**CVSS:**`, backticks, and ``` fences instead of formatted text (see the `xalgorix-test` channel screenshot).

## Cause
The finding notification body is authored once in **Discord Markdown** (`**bold**`, `\`code\``, ```fenced```) in `scan_session.go` and passed to **both** `sendDiscord` (which renders it) and `sendTelegram`. Telegram uses HTML parse_mode, and `telegramFormat` only HTML-escaped the body — it never translated the Markdown, so the `**`/backtick characters passed through literally.

## Fix
Add `discordMarkdownToTelegramHTML()` in `internal/web/notify.go` and use it for the Telegram body:
- HTML-escapes the text **first** (so finding content can't inject markup — the `*`/`\`` markers aren't HTML-special, so escaping leaves them intact).
- Converts ```fenced``` → `<pre>`, `\`inline\`` → `<code>`, `**bold**` → `<b>` (fenced handled before inline so blocks aren't chopped).

Centralized in the formatter, so every caller (per-finding alerts + report-ready messages) is fixed. Discord output is unchanged.

## Tests
New `internal/web/notify_test.go`: bold/inline/fenced conversion, the exact CVSS/Severity label line from the screenshot, HTML-escaping precedence (`**<script>**` → `<b>&lt;script&gt;</b>`), and that `telegramFormat` leaves no raw `**`.

`go build`, `go vet`, `golangci-lint` (repo config) all clean.