### PR TITLE
fix(reporting): reject host header injection without demonstrated impact

### DIFF
--- a/internal/tools/reporting/reporting.go
+++ b/internal/tools/reporting/reporting.go
@@ -955,6 +955,42 @@ func checkFalsePositive(title, description, severity, proof string) string {
 		}
 	}
 
+	// Pattern 11c: Host header injection / Host header poisoning. Reflecting the
+	// Host header (into a link, redirect, or absolute URL) is NOT a
+	// vulnerability on its own — it only matters with demonstrated impact:
+	// web-cache poisoning, password-reset-link poisoning, routing to an
+	// attacker-controlled host, or SSRF. Unlike the medium+ gates, this is
+	// enforced at low+ too (bare Host-header reflection is INFO, not even LOW).
+	isHostHeader := strings.Contains(lower, "host header injection") ||
+		strings.Contains(lower, "host header poison") ||
+		strings.Contains(lower, "host header attack") ||
+		(strings.Contains(lower, "host header") &&
+			(strings.Contains(lower, "inject") || strings.Contains(lower, "poison") ||
+				strings.Contains(lower, "spoof") || strings.Contains(lower, "override")))
+	if isHostHeader {
+		sev := strings.ToLower(strings.TrimSpace(severity))
+		if sev != "" && sev != "info" && sev != "informational" {
+			lowerProof := strings.ToLower(proof + " " + description)
+			impactKeywords := []string{
+				"cache poison", "web cache", "cache key", "poisoned response",
+				"password reset", "reset link", "reset token", "reset email",
+				"account takeover", "ato", "ssrf", "169.254", "metadata endpoint",
+				"internal host", "attacker-controlled host", "attacker controlled host",
+				"received the request", "oob", "interactsh", "collaborator", "out-of-band",
+			}
+			hasImpact := false
+			for _, kw := range impactKeywords {
+				if strings.Contains(lowerProof, kw) {
+					hasImpact = true
+					break
+				}
+			}
+			if !hasImpact {
+				return "❌ REJECTED: Host header injection with no demonstrated impact is INFORMATIONAL — reflecting/overriding the Host header is not a vulnerability by itself. To report as low+, prove concrete impact: web-cache poisoning, password-reset-link poisoning, routing to an attacker-controlled host (with an OOB callback), or SSRF — and include the evidence. Otherwise re-report as 'info'."
+			}
+		}
+	}
+
 	// Pattern 12: Analytics API writeKey "bypass" — these are public client-side tokens by design
 	analyticsKeywords := []string{"writekey", "write_key", "write key", "analytics key", "segment key", "analytics api"}
 	analyticsEndpoints := []string{"/v1/i", "/v1/t", "/v1/p", "/v1/batch", "/v1/identify", "/v1/track", "/v1/page", "/v1/screen", "/v1/group", "/v1/alias"}

--- a/internal/tools/reporting/reporting_test.go
+++ b/internal/tools/reporting/reporting_test.go
@@ -82,6 +82,57 @@ func TestCheckFalsePositive_UsernameEnumeration(t *testing.T) {
 	}
 }
 
+func TestCheckFalsePositive_HostHeaderInjection(t *testing.T) {
+	tests := []struct {
+		name       string
+		title      string
+		desc       string
+		severity   string
+		proof      string
+		wantReject bool
+	}{
+		{
+			"bare host header injection at low → rejected",
+			"Host Header Injection Nintendo Redirect Engine",
+			"The Host header is reflected in the response.",
+			"low", "changed Host header and it appeared in the redirect", true,
+		},
+		{
+			"host header injection at medium no impact → rejected",
+			"Host Header Injection on login",
+			"Host header reflected into an absolute URL.",
+			"medium", "sent evil.com as Host, saw it echoed", true,
+		},
+		{
+			"host header → password reset poisoning → allowed",
+			"Host Header Injection enabling password-reset poisoning",
+			"The reset email link is built from the Host header.",
+			"high", "set Host to attacker.com; the password reset link in the email pointed to attacker.com", false,
+		},
+		{
+			"host header → cache poisoning → allowed",
+			"Host Header Injection leads to web cache poisoning",
+			"Response is cached with attacker Host.",
+			"high", "poisoned the web cache so other users received the attacker host", false,
+		},
+		{
+			"host header reported as info → not rejected",
+			"Host Header Injection",
+			"Host header reflected.",
+			"info", "", false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := checkFalsePositive(tt.title, tt.desc, tt.severity, tt.proof)
+			gotReject := result != ""
+			if gotReject != tt.wantReject {
+				t.Errorf("wantReject=%v gotReject=%v (msg=%s)", tt.wantReject, gotReject, result)
+			}
+		})
+	}
+}
+
 func TestCheckFalsePositive_VersionDisclosure(t *testing.T) {
 	tests := []struct {
 		title      string


### PR DESCRIPTION
Follow-up to #206. The host-header-injection noise rule was pushed to that branch *after* it merged, so it never landed on main. This re-lands it via cherry-pick.

Rejects findings titled/described as host header injection/poisoning at **low+** unless the proof shows concrete impact (web-cache poisoning, password-reset-link poisoning, routing to an attacker-controlled host with an OOB callback, or SSRF). Bare Host-header reflection is informational, not even LOW — this is what produced the noisy `Host Header Injection … LOW / CVSS 3.4` alert.

Tests: `TestCheckFalsePositive_HostHeaderInjection` (bare reflection at low/medium → rejected; reset/cache poisoning → allowed; info → passes). build/vet/golangci-lint clean.