### PR TITLE
release: v4.5.56

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.55
+VERSION=4.5.56
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.55" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.56" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.55"
+var version = "4.5.56"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
### Changes

- 96f540a fix(reporting): reject host header injection without demonstrated impact (low+) (#209)
- afd2512 fix(notify): render Telegram finding notifications (convert Discord markdown to Telegram HTML) (#208)
- 234a3a3 release: v4.5.55 (#207)