### PR TITLE
chore: contributor onboarding (issue/PR templates, Code of Conduct, guide)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,74 @@
+name: 🐛 Bug report
+description: Something isn't working as expected.
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug! Please search existing issues first to avoid duplicates.
+
+        ⚠️ **Do not report security vulnerabilities here.** Follow the process in
+        [SECURITY.md](https://github.com/xalgord/xalgorix/security/policy).
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, including expected vs. actual behavior.
+      placeholder: When I run a scan with X, I expected Y but got Z.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Exact steps so we can reproduce it.
+      placeholder: |
+        1. Configure XALGORIX_LLM=...
+        2. Start with `xalgorix --web`
+        3. Launch a scan against ...
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs / output
+      description: Paste console/scan logs. Redact secrets, API keys, and target data.
+      render: shell
+  - type: input
+    id: version
+    attributes:
+      label: Xalgorix version
+      description: Output of `xalgorix --version` (or the Docker tag).
+      placeholder: v4.5.56
+    validations:
+      required: true
+  - type: dropdown
+    id: install
+    attributes:
+      label: How are you running it?
+      options:
+        - Prebuilt binary (installer)
+        - Docker
+        - Built from source
+        - Hosted (www.xalgorix.com)
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: OS / arch, and LLM provider if relevant.
+      placeholder: Ubuntu 24.04 amd64, MiniMax-M3
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-flight
+      options:
+        - label: I searched existing issues and this isn't a duplicate.
+          required: true
+        - label: This is NOT a security vulnerability (those go through SECURITY.md).
+          required: true
+        - label: I only tested targets I'm authorized to test.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📚 Documentation
+    url: https://docs.xalgorix.com
+    about: Setup, configuration, integrations, and the CLI/API reference.
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/xalgord/xalgorix/security/policy
+    about: Please do NOT open a public issue for security bugs — follow our responsible-disclosure process in SECURITY.md.
+  - name: ☁️ Hosted version (no install)
+    url: https://www.xalgorix.com
+    about: Prefer a managed, zero-setup version? Try the hosted cloud.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,48 @@
+name: 💡 Feature request
+description: Suggest an idea or enhancement.
+title: "[Feature]: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for the idea! Please check existing issues/discussions first.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: The use case or pain point. "As a <user>, I want <capability> so that <benefit>."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What you'd like to happen. Include env vars, CLI flags, or API shape if relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches or existing workarounds.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Agent / scanning methodology
+        - LLM providers / integrations
+        - Web UI / dashboard
+        - Reporting (PDF / findings)
+        - CLI / config
+        - Notifications (Discord / Telegram)
+        - Docs
+        - Other
+    validations:
+      required: true
+  - type: checkboxes
+    id: contribute
+    attributes:
+      label: Contribution
+      options:
+        - label: I'd be willing to help implement this.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+<!--
+Thanks for contributing to Xalgorix! Please fill this out so we can review quickly.
+`main` is branch-protected — PRs are the only way in. CI runs make lint,
+golangci-lint, go vet, and the test suite on every PR.
+-->
+
+## What & why
+
+<!-- What does this change and why? Link the issue it addresses. -->
+
+Closes #
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Docs
+- [ ] Refactor / internal
+- [ ] Other:
+
+## How was it tested?
+
+<!-- Commands you ran, new tests added, manual verification. -->
+
+- [ ] `make lint` passes
+- [ ] `golangci-lint run --config .golangci.yml ./...` passes
+- [ ] `go test ./...` passes
+- [ ] Added/updated tests for the change
+
+## Checklist
+
+- [ ] I read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md).
+- [ ] The tree is `gofmt`-clean.
+- [ ] I updated docs (`README`, `docs/`, help text) if behavior changed.
+- [ ] This does not weaken a security control (scope guard, verifier, false-positive gate) without explicit discussion.
+- [ ] For engine behavior changes: I noted any impact on scan findings/severity.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,61 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best for the overall community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Using this project or its tooling to attack systems you are not authorized to
+  test, or otherwise for illegal activity
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards
+and will take appropriate and fair corrective action in response to any behavior
+that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainers at **hello@xalgorix.com**. All complaints will be
+reviewed and investigated promptly and fairly. All maintainers are obligated to
+respect the privacy and security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ New here? These labels are the best entry points:
   — small, well-scoped tasks that don't require deep knowledge of the codebase.
 - [`help wanted`](https://github.com/xalgord/xalgorix/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
   — issues we'd love community help on.
-- [`docs`](https://github.com/xalgord/xalgorix/issues?q=is%3Aissue+is%3Aopen+label%3Adocs)
+- [`documentation`](https://github.com/xalgord/xalgorix/issues?q=is%3Aissue+is%3Aopen+label%3Adocumentation)
   — documentation improvements, great for a first PR.
 
 Comment on an issue to let us know you're picking it up so we don't double up.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,33 @@ autonomous AI pentesting engine: a single Go binary (`xalgorix`) that serves
 an embedded React dashboard (`webui`) and runs scans locally. This document
 covers the local development workflow.
 
+By participating you agree to our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Where to start
+
+New here? These labels are the best entry points:
+
+- [`good first issue`](https://github.com/xalgord/xalgorix/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+  — small, well-scoped tasks that don't require deep knowledge of the codebase.
+- [`help wanted`](https://github.com/xalgord/xalgorix/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+  — issues we'd love community help on.
+- [`docs`](https://github.com/xalgord/xalgorix/issues?q=is%3Aissue+is%3Aopen+label%3Adocs)
+  — documentation improvements, great for a first PR.
+
+Comment on an issue to let us know you're picking it up so we don't double up.
+Small fixes (typos, docs, obvious bugs) don't need an issue first — just open a PR.
+
+## Contribution workflow
+
+1. **Fork** the repo and create a topic branch off `main`
+   (`git checkout -b fix/short-description`).
+2. Make your change with tests. Keep the tree `gofmt`-clean and lint-clean.
+3. Run the gates locally (see below) before pushing.
+4. Open a PR against `main` using the PR template. CI runs `make lint`,
+   `golangci-lint`, `go vet`, and the test suite on every PR — all must pass.
+5. A maintainer reviews and merges. `main` is branch-protected; PRs are the
+   only way in.
+
 ## Prerequisites
 
 Install the following on your workstation:


### PR DESCRIPTION
Sets up proper open-source onboarding so forkers/contributors have a clear path in.

**Adds:**
- `.github/ISSUE_TEMPLATE/` — structured **bug report** and **feature request** forms, plus `config.yml` that disables blank issues and routes security reports to SECURITY.md, docs to docs.xalgorix.com, and the hosted option to the site.
- `.github/PULL_REQUEST_TEMPLATE.md` — checklist wired to the CI gates (make lint, golangci-lint, go vet, tests) and a note not to weaken security controls without discussion.
- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1 (contact: hello@xalgorix.com).
- `CONTRIBUTING.md` — new **Where to start** section (good first issue / help wanted / docs labels) and an explicit fork → branch → PR workflow.

Labels (`good first issue`, `help wanted`, `difficulty:*`, `area:*`) and a few seed good-first-issues are being set up directly via the GitHub API (they don't need this PR).