### PR TITLE
feat(skills): concept-based skill retrieval (search_skills)

### DIFF
--- a/internal/agent/agent_prompt.go
+++ b/internal/agent/agent_prompt.go
@@ -290,7 +290,7 @@ You have access to **expert-level vulnerability skills** via the read_skill and 
 - Chaining strategies to escalate low-severity findings into critical exploits
 
 ### MANDATORY Skill Loading Rules:
-1. **After Phase 1 recon** → call list_skills to see all available knowledge
+1. **After Phase 1 recon** → call list_skills to browse categories, or **search_skills query='<concept>'** to find the exact skill for what you observed (e.g. search_skills query='oauth token theft', query='graphql batching', query='price tampering'). search_skills ranks 800+ skills by relevance — use it whenever you don't already know the skill's name.
 2. **Before testing ANY vulnerability class** → call read_skill to load the deep methodology
    - Found a JSON API? → read_skill(name="nosql_injection") AND read_skill(name="mass_assignment")
    - Found Node.js? → read_skill(name="prototype_pollution") AND read_skill(category="frameworks", name="express")

--- a/internal/tools/skills/skills.go
+++ b/internal/tools/skills/skills.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/xalgord/xalgorix/v4/internal/tools"
 )
@@ -23,7 +24,7 @@ func Register(r *tools.Registry, _ string) {
 	}
 	r.Register(&tools.Tool{
 		Name:        "read_skill",
-		Description: "Load a structured cybersecurity skill to get deep testing/defense methodology, tooling commands, and verification steps. Use this BEFORE attempting work in a specific domain (e.g., read_skill name=analyzing-active-directory-acl-abuse). The skill catalog is sourced from the agentskills.io standard and covers offensive testing, threat hunting, DFIR, cloud, mobile, OT/ICS, AI security, and more. Run list_skills first to discover what's available.",
+		Description: "Load a structured cybersecurity skill to get deep testing/defense methodology, tooling commands, and verification steps. Use this BEFORE attempting work in a specific domain (e.g., read_skill name=analyzing-active-directory-acl-abuse). The skill catalog is sourced from the agentskills.io standard and covers offensive testing, threat hunting, DFIR, cloud, mobile, OT/ICS, AI security, and more. Don't know the exact name? Use search_skills query='<concept>' to find the right skill, or list_skills to browse categories.",
 		Parameters: []tools.Parameter{
 			{Name: "name", Description: "Kebab-case skill name without extension (e.g., performing-memory-forensics-with-volatility3, analyzing-active-directory-acl-abuse). Use list_skills to discover names.", Required: true},
 			{Name: "category", Description: "Optional category to disambiguate (e.g., web-application-security, threat-hunting, reconnaissance). If omitted, all categories are searched.", Required: false},
@@ -39,6 +40,197 @@ func Register(r *tools.Registry, _ string) {
 		},
 		Execute: makeListSkills(subFS),
 	})
+
+	r.Register(&tools.Tool{
+		Name:        "search_skills",
+		Description: "Search the skill catalog by keywords/concept and get the most relevant skills ranked, each with its category, name, and description. Use this when you don't know a skill's exact name — e.g. search_skills query='oauth token theft' or query='payment price tampering'. Then load the best match with read_skill. Far faster than scanning list_skills across 800+ skills.",
+		Parameters: []tools.Parameter{
+			{Name: "query", Description: "Keywords or a short phrase describing what you want (e.g. 'graphql batching', 'reset password poisoning', 'kubernetes pod escape').", Required: true},
+			{Name: "category", Description: "Optional category filter (e.g., web-application-security, cloud-security).", Required: false},
+			{Name: "max", Description: "Max results to return (default 10, hard cap 25).", Required: false},
+		},
+		Execute: makeSearchSkills(subFS),
+	})
+}
+
+// skillMeta is one indexed skill: its category, canonical name, a
+// human-readable description, and a lowercased haystack (name + description +
+// tags + category) used for keyword scoring.
+type skillMeta struct {
+	category    string
+	name        string
+	description string
+	haystack    string
+}
+
+var (
+	skillIndexOnce sync.Once
+	skillIndex     []skillMeta
+)
+
+// buildSkillIndex walks the embedded skill tree once and parses each
+// SKILL.md's YAML frontmatter (name/description/tags) into a searchable
+// record. Cached for the process lifetime; the embedded FS is immutable.
+func buildSkillIndex(fsys fs.FS) []skillMeta {
+	skillIndexOnce.Do(func() {
+		cats := listCategories(fsys)
+		for _, cat := range cats {
+			entries, err := fs.ReadDir(fsys, cat)
+			if err != nil {
+				continue
+			}
+			for _, e := range entries {
+				if !e.IsDir() {
+					continue
+				}
+				name := e.Name()
+				data, err := fs.ReadFile(fsys, cat+"/"+name+"/SKILL.md")
+				if err != nil {
+					continue
+				}
+				desc, fm := parseSkillFrontmatter(string(data))
+				hay := strings.ToLower(name + " " + cat + " " + fm)
+				skillIndex = append(skillIndex, skillMeta{
+					category:    cat,
+					name:        name,
+					description: desc,
+					haystack:    hay,
+				})
+			}
+		}
+	})
+	return skillIndex
+}
+
+// parseSkillFrontmatter extracts the description value and the raw frontmatter
+// block (name/description/tags/…) from a SKILL.md. The description may be a
+// YAML folded scalar spanning several indented lines; those are joined. Returns
+// (description, frontmatterText). Degrades gracefully when there is no
+// frontmatter.
+func parseSkillFrontmatter(content string) (string, string) {
+	lines := strings.Split(content, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return "", ""
+	}
+	var fm []string
+	var descParts []string
+	inDesc := false
+	for _, raw := range lines[1:] {
+		if strings.TrimSpace(raw) == "---" {
+			break
+		}
+		fm = append(fm, raw)
+		if inDesc {
+			// Continuation of a folded description: indented, not a new key.
+			if strings.HasPrefix(raw, " ") || strings.HasPrefix(raw, "\t") {
+				descParts = append(descParts, strings.TrimSpace(raw))
+				continue
+			}
+			inDesc = false
+		}
+		if strings.HasPrefix(raw, "description:") {
+			v := strings.TrimSpace(strings.TrimPrefix(raw, "description:"))
+			if v != "" {
+				descParts = append(descParts, v)
+			}
+			inDesc = true
+		}
+	}
+	desc := strings.Join(descParts, " ")
+	if len(desc) > 300 {
+		desc = desc[:297] + "..."
+	}
+	return desc, strings.Join(fm, "\n")
+}
+
+func makeSearchSkills(fsys fs.FS) func(args map[string]string) (tools.Result, error) {
+	return func(args map[string]string) (tools.Result, error) {
+		query := strings.ToLower(strings.TrimSpace(args["query"]))
+		if query == "" {
+			return tools.Result{Output: "❌ Provide a 'query' (keywords or a short phrase), e.g. query='oauth token theft'."}, nil
+		}
+		filterCat := strings.TrimSpace(args["category"])
+		max := 10
+		if s := strings.TrimSpace(args["max"]); s != "" {
+			if n, err := parseIntSafe(s); err == nil && n > 0 {
+				max = n
+			}
+		}
+		if max > 25 {
+			max = 25
+		}
+
+		// Tokenize on whitespace and commas; drop very short noise tokens.
+		tokens := strings.FieldsFunc(query, func(r rune) bool {
+			return r == ' ' || r == ',' || r == '\t' || r == '\n' || r == '/'
+		})
+		terms := make([]string, 0, len(tokens))
+		for _, t := range tokens {
+			if len(t) >= 2 {
+				terms = append(terms, t)
+			}
+		}
+		if len(terms) == 0 {
+			terms = []string{query}
+		}
+
+		type scored struct {
+			m     skillMeta
+			score int
+		}
+		var results []scored
+		for _, m := range buildSkillIndex(fsys) {
+			if filterCat != "" && m.category != filterCat {
+				continue
+			}
+			score := 0
+			for _, term := range terms {
+				// Name matches are the strongest signal, then frontmatter
+				// (tags/description), then the whole exact phrase.
+				if strings.Contains(strings.ToLower(m.name), term) {
+					score += 3
+				}
+				if strings.Contains(m.haystack, term) {
+					score += 1
+				}
+			}
+			if strings.Contains(m.haystack, query) {
+				score += 2 // exact full-phrase bonus
+			}
+			if score > 0 {
+				results = append(results, scored{m: m, score: score})
+			}
+		}
+		if len(results) == 0 {
+			return tools.Result{Output: fmt.Sprintf("No skills matched %q. Try broader keywords, or list_skills to browse categories.", query)}, nil
+		}
+		sort.SliceStable(results, func(i, j int) bool {
+			if results[i].score != results[j].score {
+				return results[i].score > results[j].score
+			}
+			return results[i].m.name < results[j].m.name
+		})
+		if len(results) > max {
+			results = results[:max]
+		}
+		var b strings.Builder
+		fmt.Fprintf(&b, "Top %d skill match(es) for %q — load one with read_skill name=<name>:\n\n", len(results), query)
+		for _, r := range results {
+			fmt.Fprintf(&b, "• %s  [%s]\n", r.m.name, r.m.category)
+			if r.m.description != "" {
+				fmt.Fprintf(&b, "  %s\n", r.m.description)
+			}
+		}
+		return tools.Result{Output: strings.TrimRight(b.String(), "\n")}, nil
+	}
+}
+
+// parseIntSafe parses a base-10 int, returning an error on any non-numeric
+// input. Small local helper so search_skills' `max` parsing has no deps.
+func parseIntSafe(s string) (int, error) {
+	n := 0
+	_, err := fmt.Sscanf(s, "%d", &n)
+	return n, err
 }
 
 // listCategories returns the set of category directories that exist on the

--- a/internal/tools/skills/skills_test.go
+++ b/internal/tools/skills/skills_test.go
@@ -1,6 +1,7 @@
 package skills
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -311,5 +312,52 @@ func TestReadSkill_Alias(t *testing.T) {
 	}
 	if !strings.Contains(result.Output, "SQL Injection") {
 		t.Errorf("underscore alias 'sql_injection' should resolve to full skill, got: %s", result.Output)
+	}
+}
+
+func TestSearchSkills_FindsByConcept(t *testing.T) {
+	subFS, err := fs.Sub(embeddedSkills, "data")
+	if err != nil {
+		t.Fatalf("fs.Sub: %v", err)
+	}
+	search := makeSearchSkills(subFS)
+
+	cases := []struct {
+		query     string
+		wantSkill string
+	}{
+		{"payment price tampering", "testing-ecommerce-and-payment-logic"},
+		{"reset password poisoning", "testing-password-reset-flaws"},
+		{"two factor otp bypass", "bypassing-two-factor-and-otp"},
+	}
+	for _, c := range cases {
+		t.Run(c.query, func(t *testing.T) {
+			res, err := search(map[string]string{"query": c.query})
+			if err != nil {
+				t.Fatalf("search error: %v", err)
+			}
+			if !strings.Contains(res.Output, c.wantSkill) {
+				t.Fatalf("query %q: expected %q in results, got:\n%s", c.query, c.wantSkill, res.Output)
+			}
+		})
+	}
+}
+
+func TestSearchSkills_EmptyQuery(t *testing.T) {
+	subFS, _ := fs.Sub(embeddedSkills, "data")
+	res, err := makeSearchSkills(subFS)(map[string]string{"query": "   "})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(res.Output, "Provide a 'query'") {
+		t.Fatalf("expected guidance for empty query, got: %s", res.Output)
+	}
+}
+
+func TestSearchSkills_NoMatch(t *testing.T) {
+	subFS, _ := fs.Sub(embeddedSkills, "data")
+	res, _ := makeSearchSkills(subFS)(map[string]string{"query": "zzqqxx-nonexistent-topic"})
+	if !strings.Contains(res.Output, "No skills matched") {
+		t.Fatalf("expected no-match message, got: %s", res.Output)
 	}
 }


### PR DESCRIPTION
## Why
Making the scanner find *more* real vulnerabilities isn't about adding skills — the engine already ships **862** across 40+ categories, with authenticated/two-account testing, OOB, the verifier, and the gap-analysis skills all in place. The bottleneck is **retrieval**: the agent could only `read_skill` by a known name/alias or `list_skills` by category. When it didn't know a skill's name, relevant deep methodology (exact payloads, bypasses) simply went unused.

## What
Add a **`search_skills`** tool: keyword/phrase search across every skill's YAML frontmatter (name, description, tags) + category, ranked by relevance, returning `name — [category] — description`. The agent can now find the right skill by *concept* (`search_skills query='oauth token theft'`) and then `read_skill` it.

- Lazy, process-cached index built once from the embedded skill tree (immutable).
- Scoring: name match (3) > frontmatter/tag match (1) + exact-phrase bonus (2).
- Wired into `read_skill`'s description and the methodology prompt's MANDATORY skill-loading rules so the agent reaches for it after recon.

## Tests
`search_skills_test.go`: concept queries resolve to the right skill (payment→ecommerce, reset poisoning→password-reset, otp→2fa), empty-query guidance, and no-match message. build/vet/golangci-lint clean.

## Impact
Higher chance the agent loads the *right* deep skill for what it observed → better payloads/bypasses → more true-positive findings, with zero precision cost (the verifier + FP gate are unchanged).