### PR TITLE
fix(tools): batch missing-required-param errors (stop report_vulnerability loop)

### DIFF
--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -203,13 +203,26 @@ func (r *Registry) Execute(name string, args map[string]string) (Result, error) 
 		delete(localArgs, "_raw")
 	}
 
-	// Validate required parameters
+	// Validate required parameters. Collect ALL missing ones and report them in
+	// a single error, rather than failing on the first — otherwise a tool with
+	// several required params (e.g. report_vulnerability) makes the agent
+	// resubmit once per missing field, burning iterations on a thrash loop.
+	var missing []string
 	for _, p := range tool.Parameters {
 		if p.Required {
 			if v, exists := localArgs[p.Name]; !exists || strings.TrimSpace(v) == "" {
-				return Result{}, fmt.Errorf("missing required parameter '%s' for tool '%s'", p.Name, name)
+				missing = append(missing, p.Name)
 			}
 		}
+	}
+	if len(missing) > 0 {
+		if len(missing) == 1 {
+			return Result{}, fmt.Errorf("missing required parameter '%s' for tool '%s'", missing[0], name)
+		}
+		return Result{}, fmt.Errorf(
+			"missing required parameters for tool '%s': %s — provide ALL of them in a single call (one <parameter=NAME>…</parameter> per field)",
+			name, strings.Join(missing, ", "),
+		)
 	}
 
 	result, err := tool.Execute(localArgs)

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -101,6 +101,42 @@ func TestExecute_MissingRequiredParam(t *testing.T) {
 	}
 }
 
+// TestExecute_BatchesMissingRequiredParams verifies that when SEVERAL required
+// params are missing, a single error lists ALL of them (so the agent fixes
+// them in one resubmit instead of thrashing one field per iteration — the
+// report_vulnerability loop).
+func TestExecute_BatchesMissingRequiredParams(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&Tool{
+		Name: "report",
+		Parameters: []Parameter{
+			{Name: "title", Required: true},
+			{Name: "severity", Required: true},
+			{Name: "description", Required: true},
+			{Name: "impact", Required: false},
+		},
+		Execute: func(_ map[string]string) (Result, error) {
+			t.Error("Execute should not run while required params are missing")
+			return Result{}, nil
+		},
+	})
+
+	// Provide only title → severity + description still missing.
+	_, err := r.Execute("report", map[string]string{"title": "SQLi"})
+	if err == nil {
+		t.Fatal("expected error when required params missing")
+	}
+	msg := err.Error()
+	for _, want := range []string{"severity", "description"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error should list missing %q; got: %s", want, msg)
+		}
+	}
+	if strings.Contains(msg, "title") {
+		t.Errorf("error should not list the provided 'title'; got: %s", msg)
+	}
+}
+
 // TestSchemaXML_EscapesUnsafeChars is the regression for the XML-injection
 // risk flagged in the review: a skill or tool with "<", ">", "&", or quote
 // characters in its name/description must produce well-formed XML.


### PR DESCRIPTION
## Problem
The event log shows the agent stuck on `report_vulnerability`, getting `missing required parameter` **one field at a time** across iterations (severity → exploitation_proof → verification_method → description), burning iterations 66–68 with stray tag fragments leaking as messages.

## Cause
`Registry.Execute` returned on the **first** missing required parameter. `report_vulnerability` has 6 required fields, so each resubmit surfaced only the next missing one → a multi-round-trip thrash loop.

## Fix
Collect **all** missing required params and return them in a single error (`missing required parameters for tool 'X': a, b, c — provide ALL of them in a single call`). The agent can now fix everything in one resubmit. Single-missing case keeps the original message (backward-compatible with existing tests).

## Test
`TestExecute_BatchesMissingRequiredParams`: only `title` provided → error lists `severity` + `description` (not the provided `title`). build/vet/golangci-lint clean.

## Note (follow-up, not in this PR)
The underlying trigger is likely the reasoning model **truncating** the large `report_vulnerability` call (it's the biggest tool call: description + proof + technical analysis + PoC + remediation) — the stray `</title>`/`</parameter>` fragments are a truncated tail. This PR makes recovery fast; a deeper fix would raise the per-scan output-token budget for the model and/or trim `report_vulnerability`'s required set (e.g. derive cvss from severity). Happy to do that next if you want.