### PR TITLE
feat(llm,reporting): configurable output-token budget + trim report_vulnerability required set

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,13 @@ type Config struct {
 	Temperature     *float64 // XALGORIX_TEMPERATURE — LLM temperature (0.0-2.0), default 0.2; pointer to distinguish unset from 0.0
 	LLMMaxRetries   int      // XALGORIX_LLM_MAX_RETRIES
 	MemCompTimeout  int      // XALGORIX_MEMORY_COMPRESSOR_TIMEOUT
+	// MaxOutputTokens caps the model's completion length per call (the
+	// OpenAI-compatible `max_tokens` / Anthropic `max_tokens`). Reasoning
+	// models (e.g. MiniMax-M3) spend part of this budget on hidden thinking
+	// BEFORE emitting a tool call, so a small provider default truncates large
+	// calls like report_vulnerability mid-stream. Set an explicit, generous
+	// budget so the full call fits. XALGORIX_MAX_OUTPUT_TOKENS, default 8192.
+	MaxOutputTokens int
 
 	// Runtime settings
 	RuntimeBackend string // XALGORIX_RUNTIME_BACKEND — always "native"
@@ -245,6 +252,7 @@ func load() *Config {
 		ReasoningEffort: envOr("XALGORIX_REASONING_EFFORT", "high"),
 		Temperature:     envOrFloatPtr("XALGORIX_TEMPERATURE", 0.2),
 		LLMMaxRetries:   envOrInt("XALGORIX_LLM_MAX_RETRIES", 5),
+		MaxOutputTokens: envOrInt("XALGORIX_MAX_OUTPUT_TOKENS", 8192),
 		MemCompTimeout:  envOrInt("XALGORIX_MEMORY_COMPRESSOR_TIMEOUT", 30),
 
 		// Runtime

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -534,6 +534,23 @@ func (c *Client) effectiveTemperature() *float64 {
 	return c.cfg.Temperature
 }
 
+// maxOutputTokens returns the per-call completion cap (max_tokens). Reasoning
+// models spend part of this budget on hidden thinking before emitting a tool
+// call, so we send an explicit, generous value rather than relying on the
+// provider's unset default (which some OpenAI-compatible backends set very
+// low, truncating large calls like report_vulnerability mid-stream). Clamped
+// to a sane floor so a misconfigured tiny value can't starve every call.
+func (c *Client) maxOutputTokens() int {
+	n := c.cfg.MaxOutputTokens
+	if n <= 0 {
+		n = 8192
+	}
+	if n < 1024 {
+		n = 1024
+	}
+	return n
+}
+
 func (c *Client) chatWithRetry(messages []Message) (string, error) {
 	maxRetries := c.cfg.LLMMaxRetries
 	if maxRetries < 3 {
@@ -688,7 +705,7 @@ func (c *Client) ChatStream(messages []Message) <-chan StreamChunk {
 					anthropicMsgs = append(anthropicMsgs, m)
 				}
 			}
-			maxTokens := 8192
+			maxTokens := c.maxOutputTokens()
 			anReq := anthropicRequest{
 				Model:     model,
 				Messages:  anthropicMsgs,
@@ -704,6 +721,7 @@ func (c *Client) ChatStream(messages []Message) <-chan StreamChunk {
 				Stream:        true,
 				StreamOptions: &streamOptions{IncludeUsage: true},
 				Temperature:   c.effectiveTemperature(),
+				MaxTokens:     c.maxOutputTokens(),
 			}
 			body, _ = json.Marshal(reqBody)
 		}
@@ -917,8 +935,8 @@ func (c *Client) doChat(messages []Message) (out string, err error) {
 				anthropicMsgs = append(anthropicMsgs, m)
 			}
 		}
-		// Default max_tokens; Anthropic requires this field
-		maxTokens := 8192
+		// Anthropic requires this field; use the configured budget.
+		maxTokens := c.maxOutputTokens()
 		anReq := anthropicRequest{
 			Model:     model,
 			Messages:  anthropicMsgs,
@@ -931,7 +949,7 @@ func (c *Client) doChat(messages []Message) (out string, err error) {
 			return "", fmt.Errorf("failed to marshal Anthropic request: %w", err)
 		}
 	} else {
-		reqBody := chatRequest{Model: model, Messages: messages, Stream: false, Temperature: c.effectiveTemperature()}
+		reqBody := chatRequest{Model: model, Messages: messages, Stream: false, Temperature: c.effectiveTemperature(), MaxTokens: c.maxOutputTokens()}
 		body, err = json.Marshal(reqBody)
 		if err != nil {
 			return "", fmt.Errorf("failed to marshal request: %w", err)

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -949,3 +949,29 @@ func TestClient_HeaderSwitch_Matrix(t *testing.T) {
 		})
 	}
 }
+
+// TestMaxOutputTokens verifies the per-call completion cap: the configured
+// value is used, an unset (0) value falls back to the 8192 default, and a
+// misconfigured tiny value is clamped up to the 1024 floor so no call is
+// starved.
+func TestMaxOutputTokens(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  int
+		want int
+	}{
+		{"explicit large value", 32000, 32000},
+		{"unset falls back to default", 0, 8192},
+		{"negative falls back to default", -5, 8192},
+		{"tiny value clamped to floor", 100, 1024},
+		{"floor boundary kept", 1024, 1024},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := NewClient(&config.Config{LLM: "openai/gpt-5.4", APIKey: "k", MaxOutputTokens: tc.cfg})
+			if got := c.maxOutputTokens(); got != tc.want {
+				t.Fatalf("maxOutputTokens() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/tools/reporting/reporting.go
+++ b/internal/tools/reporting/reporting.go
@@ -277,14 +277,14 @@ func Register(r *tools.Registry) {
 			{Name: "title", Description: "Vulnerability title", Required: true},
 			{Name: "severity", Description: "Severity per HackerOne CVSS ranges: critical (CVSS 9.0-10.0), high (7.0-8.9), medium (4.0-6.9), low (0.1-3.9), info (0.0). Must match your CVSS score.", Required: true},
 			{Name: "description", Description: "Detailed description of the vulnerability", Required: true},
-			{Name: "exploitation_proof", Description: "REQUIRED for medium+. Concrete evidence of exploitation: extracted data, reflected payload text, command output, timing measurement, callback confirmation. Paste actual output here.", Required: true},
-			{Name: "verification_method", Description: "How you verified: exploited, time_based, data_extracted, callback_received, error_based, blind_confirmed, reflected, authenticated, manual_verified", Required: true},
+			{Name: "exploitation_proof", Description: "REQUIRED for medium+. Concrete evidence of exploitation: extracted data, reflected payload text, command output, timing measurement, callback confirmation. Paste actual output here.", Required: false},
+			{Name: "verification_method", Description: "How you verified: exploited, time_based, data_extracted, callback_received, error_based, blind_confirmed, reflected, authenticated, manual_verified", Required: false},
 			{Name: "impact", Description: "Real-world impact assessment", Required: false},
 			{Name: "target", Description: "Target URL/host", Required: false},
 			{Name: "endpoint", Description: "Affected endpoint", Required: false},
 			{Name: "method", Description: "HTTP method", Required: false},
 			{Name: "cve", Description: "CVE identifier if known", Required: false},
-			{Name: "cvss", Description: "CVSS 3.1 base score (0.0-10.0). MUST match severity: critical=9.0-10.0, high=7.0-8.9, medium=4.0-6.9, low=0.1-3.9, info=0.0", Required: true},
+			{Name: "cvss", Description: "CVSS 3.1 base score (0.0-10.0). MUST match severity: critical=9.0-10.0, high=7.0-8.9, medium=4.0-6.9, low=0.1-3.9, info=0.0. If omitted, a default is derived from severity.", Required: false},
 			{Name: "cvss_vector", Description: "CVSS 3.1 vector string, e.g. CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H. Components: AV(Attack Vector):N/A/L/P, AC(Attack Complexity):L/H, PR(Privileges Required):N/L/H, UI(User Interaction):N/R, S(Scope):U/C, C(Confidentiality):N/L/H, I(Integrity):N/L/H, A(Availability):N/L/H", Required: false},
 			{Name: "technical_analysis", Description: "Technical details of the vulnerability", Required: false},
 			{Name: "poc_description", Description: "Step-by-step PoC description", Required: false},
@@ -331,7 +331,17 @@ func reportVulnWithContextID(contextID string, args map[string]string) (tools.Re
 	store.mu.RUnlock()
 
 	// ── Gate 1: Validate verification method ──
-	if method == "" || !validVerificationMethods[method] {
+	// verification_method is no longer a registry-required param (so the registry
+	// doesn't batch-reject before this richer, severity-aware gate runs). A real
+	// (non-info) finding must still declare HOW it was verified; info findings are
+	// advisory and may omit it. Any method that IS provided must be valid.
+	if severity != "info" && method == "" {
+		return tools.Result{
+			Output: fmt.Sprintf("❌ REJECTED: '%s' reported as %s but has NO verification_method. Exploit the vulnerability first, then report HOW you verified it (one of: %s). If it is not exploitable, downgrade severity to 'info'.",
+				title, strings.ToUpper(severity), formatValidMethods()),
+		}, nil
+	}
+	if method != "" && !validVerificationMethods[method] {
 		return tools.Result{
 			Output: fmt.Sprintf("❌ REJECTED: Invalid verification_method '%s'. Must be one of: %s\n\nYou must EXPLOIT the vulnerability first, then report with the correct verification method.",
 				method, formatValidMethods()),

--- a/internal/tools/reporting/reporting_test.go
+++ b/internal/tools/reporting/reporting_test.go
@@ -1763,3 +1763,86 @@ func TestHasConcreteImpact(t *testing.T) {
 		}
 	}
 }
+
+// TestReportVuln_OptionalParamsHandledByGates verifies that after demoting
+// exploitation_proof / verification_method / cvss from registry-required to
+// optional, the tool's own severity-aware gates take over:
+//   - an info finding with NO verification_method and NO cvss is accepted;
+//   - a non-info finding with NO verification_method is rejected by Gate 1;
+//   - any provided verification_method is still validated;
+//   - a finding with NO cvss gets a default derived from its severity.
+func TestReportVuln_OptionalParamsHandledByGates(t *testing.T) {
+	t.Run("info finding without method/cvss is accepted", func(t *testing.T) {
+		ctx := "opt-info-no-method"
+		CleanupContext(ctx)
+		defer CleanupContext(ctx)
+		info := map[string]string{
+			"title":       "Server version disclosed in response header",
+			"severity":    "info",
+			"description": "The server responds with a Server header revealing the exact software version.",
+			"target":      "https://example.com",
+			"endpoint":    "https://example.com/",
+			"method":      "GET",
+		}
+		res, err := reportVulnWithContextID(ctx, info)
+		if err != nil {
+			t.Fatalf("report error: %v", err)
+		}
+		if strings.Contains(res.Output, "REJECTED") {
+			t.Fatalf("info finding without verification_method must NOT be rejected, got: %s", res.Output)
+		}
+	})
+
+	t.Run("non-info finding without method is rejected by Gate 1", func(t *testing.T) {
+		ctx := "opt-high-no-method"
+		CleanupContext(ctx)
+		defer CleanupContext(ctx)
+		args := validReportArgs()
+		delete(args, "verification_method")
+		res, err := reportVulnWithContextID(ctx, args)
+		if err != nil {
+			t.Fatalf("report error: %v", err)
+		}
+		if !strings.Contains(res.Output, "REJECTED") || !strings.Contains(res.Output, "verification_method") {
+			t.Fatalf("high finding without verification_method must be rejected by Gate 1, got: %s", res.Output)
+		}
+	})
+
+	t.Run("invalid provided method is rejected", func(t *testing.T) {
+		ctx := "opt-invalid-method"
+		CleanupContext(ctx)
+		defer CleanupContext(ctx)
+		args := validReportArgs()
+		args["verification_method"] = "totally_made_up"
+		res, err := reportVulnWithContextID(ctx, args)
+		if err != nil {
+			t.Fatalf("report error: %v", err)
+		}
+		if !strings.Contains(res.Output, "REJECTED") || !strings.Contains(res.Output, "Invalid verification_method") {
+			t.Fatalf("invalid verification_method must be rejected, got: %s", res.Output)
+		}
+	})
+
+	t.Run("missing cvss gets a default derived from severity", func(t *testing.T) {
+		ctx := "opt-no-cvss"
+		CleanupContext(ctx)
+		defer CleanupContext(ctx)
+		args := validReportArgs()
+		delete(args, "cvss")
+		delete(args, "cvss_vector")
+		res, err := reportVulnWithContextID(ctx, args)
+		if err != nil {
+			t.Fatalf("report error: %v", err)
+		}
+		if strings.Contains(res.Output, "REJECTED") {
+			t.Fatalf("finding without cvss must not be rejected, got: %s", res.Output)
+		}
+		v := GetVulnerabilitiesForContext(ctx)
+		if len(v) != 1 {
+			t.Fatalf("expected 1 stored vuln, got %d", len(v))
+		}
+		if v[0].CVSS <= 0 {
+			t.Fatalf("expected a default CVSS derived from severity, got %v", v[0].CVSS)
+		}
+	})
+}

--- a/internal/web/settings_env.go
+++ b/internal/web/settings_env.go
@@ -123,6 +123,7 @@ func allEnvSettingDefinitions() []envSettingDefinition {
 		{Key: "XALGORIX_LLM_PROFILE", Label: "Active LLM profile", Category: "LLM", Description: "Active credential pointer (\"<provider>:<profileId>\"). Set by the LLM Settings tab; takes precedence over XALGORIX_API_KEY/XALGORIX_LLM when present.", Placeholder: "openai:default", InputType: "text"},
 		{Key: "XALGORIX_REASONING_EFFORT", Label: "Reasoning effort", Category: "LLM", Description: "Reasoning depth for providers that support it.", DefaultValue: "high", InputType: "select", Options: []string{"low", "medium", "high", "xhigh"}},
 		{Key: "XALGORIX_LLM_MAX_RETRIES", Label: "LLM max retries", Category: "LLM", Description: "Retry count for transient LLM provider failures.", DefaultValue: "5", InputType: "number"},
+		{Key: "XALGORIX_MAX_OUTPUT_TOKENS", Label: "Max output tokens", Category: "LLM", Description: "Per-call completion cap (max_tokens). Reasoning models spend part of this on hidden thinking before a tool call, so a small provider default can truncate large calls. Clamped to a 1024 floor.", DefaultValue: "8192", InputType: "number"},
 		{Key: "XALGORIX_MEMORY_COMPRESSOR_TIMEOUT", Label: "Memory compressor timeout", Category: "LLM", Description: "Timeout in seconds for context compression.", DefaultValue: "30", InputType: "number"},
 		{Key: "XALGORIX_MAX_ITERATIONS", Label: "Max iterations", Category: "Runtime", Description: "Maximum agent iterations per scan. 0 means unlimited.", DefaultValue: "0", InputType: "number"},
 		{Key: "XALGORIX_MAX_TOOL_CALLS", Label: "Max tool calls (budget)", Category: "Runtime", Description: "Per-scan tool-call cap; the scan stops cleanly when reached (findings preserved). 0 = unlimited.", DefaultValue: "0", InputType: "number", RequiresRestart: true},
@@ -675,6 +676,8 @@ func (s *Server) applyEnvironmentToRuntimeConfig(values map[string]string) {
 			s.cfg.ReasoningEffort = valueOrDefault(value, "high")
 		case "XALGORIX_LLM_MAX_RETRIES":
 			s.cfg.LLMMaxRetries = parseIntSetting(value, 5)
+		case "XALGORIX_MAX_OUTPUT_TOKENS":
+			s.cfg.MaxOutputTokens = parseIntSetting(value, 8192)
 		case "XALGORIX_MEMORY_COMPRESSOR_TIMEOUT":
 			s.cfg.MemCompTimeout = parseIntSetting(value, 30)
 		case "XALGORIX_MAX_ITERATIONS":
@@ -777,6 +780,8 @@ func (s *Server) envSettingValue(key string) string {
 		return valueOrDefault(s.cfg.ReasoningEffort, "high")
 	case "XALGORIX_LLM_MAX_RETRIES":
 		return strconv.Itoa(s.cfg.LLMMaxRetries)
+	case "XALGORIX_MAX_OUTPUT_TOKENS":
+		return strconv.Itoa(s.cfg.MaxOutputTokens)
 	case "XALGORIX_MEMORY_COMPRESSOR_TIMEOUT":
 		return strconv.Itoa(s.cfg.MemCompTimeout)
 	case "XALGORIX_MAX_ITERATIONS":
@@ -1010,6 +1015,8 @@ func normalizeEnvSettingValue(def envSettingDefinition, value string) (string, e
 		return strconv.Itoa(clampInt(parseIntSetting(value, 60), 10, 3600)), nil
 	case "XALGORIX_LLM_MAX_RETRIES":
 		return strconv.Itoa(clampInt(parseIntSetting(value, 5), 0, 20)), nil
+	case "XALGORIX_MAX_OUTPUT_TOKENS":
+		return strconv.Itoa(clampInt(parseIntSetting(value, 8192), 1024, 200000)), nil
 	case "XALGORIX_MEMORY_COMPRESSOR_TIMEOUT":
 		return strconv.Itoa(clampInt(parseIntSetting(value, 30), 5, 600)), nil
 	case "XALGORIX_MAX_ITERATIONS":


### PR DESCRIPTION
## Why

Follow-up to #217. Root cause of the `report_vulnerability` thrash loop: the reasoning model (MiniMax-M3) **truncates** the large tool call mid-stream because the request sent too small a `max_tokens`, then retries with missing params. #217 batched the missing-param errors; this addresses the two underlying causes.

## Changes

### 1. Configurable LLM output-token budget (`max_tokens`)
- `internal/config`: add `MaxOutputTokens` (`XALGORIX_MAX_OUTPUT_TOKENS`, default 8192).
- `internal/llm`: add `Client.maxOutputTokens()` (default 8192, floor 1024). Send it on **both** streaming and non-streaming Anthropic + OpenAI-compatible requests.
  - Before: Anthropic was hardcoded to 8192; the OpenAI-compatible path sent **no** `max_tokens`, so providers with a small default truncated large tool calls. Reasoning models spend part of the budget on hidden thinking *before* emitting the tool call, which makes truncation worse.
- `internal/web`: expose `XALGORIX_MAX_OUTPUT_TOKENS` in the settings catalog (clamped 1024–200000).

### 2. Trim `report_vulnerability` registry-required set
The tool's own gates already give richer, severity-aware errors than the generic registry batch-rejection.
- Demote `exploitation_proof`, `verification_method`, `cvss` to `Required: false` (`title`, `severity`, `description` stay required).
- **Gate 1 is now severity-aware**: `info` findings may omit `verification_method` (advisory / non-exploitable); non-info findings must still declare it; any *provided* method is still validated.
- `cvss` already defaults from `severity` inline, so omitting it is safe.

## Tests
- `TestMaxOutputTokens` — default/floor/explicit/clamp behavior.
- `TestReportVuln_OptionalParamsHandledByGates` — info-without-method accepted, non-info-without-method rejected, invalid method rejected, missing cvss defaults from severity.

## Verification
`go build ./...`, `go vet`, `golangci-lint run`, `gofmt -l`, and package tests (`llm`, `config`, `tools/reporting`, `web`) all clean.