### PR TITLE
release: v4.5.58

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.57
+VERSION=4.5.58
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.57" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.58" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.57"
+var version = "4.5.58"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
### Changes

- e7c8589 feat(llm,reporting): configurable output-token budget + trim report_vulnerability required set (#218)
- c41355e fix(tools): report ALL missing required params at once (stop report_vulnerability thrash) (#217)
- 4fa136f release: v4.5.57 (#216)