### PR TITLE
  Adds per-scan live guidance, provider-backed model selection, Novita AI support, and clearer Codex credential handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased] — Provider model selector
+
+### Added
+- **Provider model selection across authentication methods.** Settings now renders one reusable model field for API-key, OAuth, and credential-free providers. Saved values retain the canonical `provider/model` routing prefix.
+- **Live provider model discovery.** Providers with compatible OpenAI, Anthropic, Gemini, or Ollama model-list endpoints automatically load the models available to the selected credential. Discovery runs server-side and keeps credentials out of the browser. The built-in catalog no longer hardcodes model examples; providers without discovery support use explicit manual entry.
+- **Novita AI provider.** The built-in catalog now includes Novita's OpenAI-compatible API endpoint and API-key authentication, with models loaded dynamically from Novita's API.
+
+## [Unreleased] — Provider-specific CLI credential errors
+
+### Fixed
+- **Codex sign-in incorrectly reported missing Claude credentials.** Both CLI-reuse drivers previously returned the Claude-specific `auth.ErrNotFound` sentinel, so OAuth completion responded with `claude cli credentials not found` when the Codex credential was unavailable. Codex now returns a dedicated sentinel and the API responds with `codex cli credentials not found`. The sign-in modal also identifies the expected Codex credential path and read-only Docker mount.
+
 ## [Unreleased] — Per-scan live guidance
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased] — Per-scan live guidance
+
+### Added
+- **Operators can guide an agent while its scan is running.** The individual scan Events tab now includes a per-instance message composer with focused guidance suggestions, keyboard submission, delivery feedback, and responsive layout. Messages are routed to the exact running `instance_id`, queued for the agent's next iteration without interrupting its active work, and then surface in the same instance event stream. The WebUI client response type now also matches the existing `/api/chat` response contract.
+
 ## [Unreleased] — Markdown rendering in finding details
 
 ### Fixed

--- a/internal/auth/driver_codex.go
+++ b/internal/auth/driver_codex.go
@@ -114,7 +114,8 @@ type codexAuthFile struct {
 
 // Complete imports ~/.codex/auth.json into Profile_Store. Read-only on
 // the source file (O_RDONLY|O_NOFOLLOW); any open/read/parse failure that
-// means "no usable credential" surfaces as ErrNotFound → HTTP 404.
+// means "no usable credential" surfaces as ErrCodexCredentialsNotFound →
+// HTTP 404.
 func (d *codexReuseDriver) Complete(ctx context.Context, e providers.Entry, in CompleteInput) (Profile, error) {
 	if err := ctx.Err(); err != nil {
 		return Profile{}, err
@@ -122,18 +123,18 @@ func (d *codexReuseDriver) Complete(ctx context.Context, e providers.Entry, in C
 
 	path := codexCredentialPathFn()
 	if path == "" {
-		return Profile{}, ErrNotFound
+		return Profile{}, ErrCodexCredentialsNotFound
 	}
 
 	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
 	if err != nil {
-		return Profile{}, ErrNotFound
+		return Profile{}, ErrCodexCredentialsNotFound
 	}
 	defer func() { _ = f.Close() }()
 
 	body, err := io.ReadAll(f)
 	if err != nil {
-		return Profile{}, ErrNotFound
+		return Profile{}, ErrCodexCredentialsNotFound
 	}
 
 	var raw codexAuthFile
@@ -145,7 +146,7 @@ func (d *codexReuseDriver) Complete(ctx context.Context, e providers.Entry, in C
 	if access == "" {
 		// No access token (e.g. an api-key-mode CLI login) — nothing to
 		// import as an OAuth profile. Treat as "re-run codex login" → 404.
-		return Profile{}, ErrNotFound
+		return Profile{}, ErrCodexCredentialsNotFound
 	}
 	refresh := strings.TrimSpace(raw.Tokens.RefreshToken)
 

--- a/internal/auth/driver_codex_test.go
+++ b/internal/auth/driver_codex_test.go
@@ -124,7 +124,7 @@ func TestCodexReuse_AccountIDFromJWTFallback(t *testing.T) {
 }
 
 // TestCodexReuse_MissingFileIsNotFound maps a missing credential file to
-// ErrNotFound (HTTP 404).
+// ErrCodexCredentialsNotFound (HTTP 404).
 func TestCodexReuse_MissingFileIsNotFound(t *testing.T) {
 	d, entry, _ := newCodexReuseFixture(t)
 	prev := codexCredentialPathFn
@@ -132,8 +132,8 @@ func TestCodexReuse_MissingFileIsNotFound(t *testing.T) {
 	t.Cleanup(func() { codexCredentialPathFn = prev })
 
 	_, err := d.Complete(context.Background(), entry, CompleteInput{})
-	if !errors.Is(err, ErrNotFound) {
-		t.Fatalf("err = %v, want ErrNotFound", err)
+	if !errors.Is(err, ErrCodexCredentialsNotFound) {
+		t.Fatalf("err = %v, want ErrCodexCredentialsNotFound", err)
 	}
 }
 
@@ -149,7 +149,7 @@ func TestCodexReuse_NoAccessTokenIsNotFound(t *testing.T) {
 	t.Cleanup(func() { codexCredentialPathFn = prev })
 
 	_, err := d.Complete(context.Background(), entry, CompleteInput{})
-	if !errors.Is(err, ErrNotFound) {
-		t.Fatalf("err = %v, want ErrNotFound", err)
+	if !errors.Is(err, ErrCodexCredentialsNotFound) {
+		t.Fatalf("err = %v, want ErrCodexCredentialsNotFound", err)
 	}
 }

--- a/internal/auth/errors.go
+++ b/internal/auth/errors.go
@@ -71,6 +71,12 @@ var ErrReauthRequired = errors.New("oauth refresh required")
 // Validates: Requirement 9.2.
 var ErrNotFound = errors.New("claude cli credentials not found")
 
+// ErrCodexCredentialsNotFound is returned by the codex_cli_reuse driver when
+// ~/.codex/auth.json is missing, unreadable, or does not contain a usable
+// ChatGPT access token. It is distinct so the HTTP layer never reports a
+// Claude-specific error for a Codex sign-in.
+var ErrCodexCredentialsNotFound = errors.New("codex cli credentials not found")
+
 // ErrInvalidGrant is the sentinel each driver's exchange callback
 // returns from refreshWithSink when the upstream token endpoint
 // responded with the OAuth 2.0 invalid_grant error. The shared

--- a/internal/providers/builtin.go
+++ b/internal/providers/builtin.go
@@ -4,7 +4,7 @@
 // operator-editable catalog file, no openclaw importer, and no
 // startup catalog write.
 //
-// The 44 entries are sorted alphabetically by ID and end with the
+// The 45 entries are sorted alphabetically by ID and end with the
 // "custom" sentinel so the LLM tab dropdown ordering matches the
 // data ordering one-to-one ("custom" is alphabetically last by
 // design — it represents user-supplied endpoints rather than a
@@ -55,7 +55,6 @@ var builtinList = []Entry{
 		HeaderStyle: "anthropic",
 		AuthMethods: []string{"api_key", "oauth"},
 		Flow:        "claude_cli_reuse",
-		Models:      []string{"claude-sonnet-4-5-20250929", "claude-opus-4-1-20250805", "claude-haiku-4-5-20251022"},
 		Notes:       "OAuth path imports an existing Claude CLI credential file (~/.claude/.credentials.json).",
 	},
 	{
@@ -64,7 +63,6 @@ var builtinList = []Entry{
 		BaseURL:     "",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"arcee-spark"},
 		Notes:       "Set base URL via the Custom Provider option if the default is unknown.",
 	},
 	{
@@ -73,7 +71,6 @@ var builtinList = []Entry{
 		BaseURL:     "",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"skylark-pro"},
 		Notes:       "Set base URL via the Custom Provider option if the default is unknown.",
 	},
 	{
@@ -82,7 +79,6 @@ var builtinList = []Entry{
 		BaseURL:     "https://api.cerebras.ai/v1",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"llama3.1-70b"},
 	},
 	{
 		ID:          "chutes",
@@ -90,7 +86,6 @@ var builtinList = []Entry{
 		BaseURL:     "",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"meta-llama/Llama-3.1-70B-Instruct"},
 		Notes:       "Set base URL via the Custom Provider option if the default is unknown.",
 	},
 	{
@@ -99,7 +94,6 @@ var builtinList = []Entry{
 		BaseURL:     "",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"@cf/meta/llama-3.1-70b-instruct"},
 		Notes:       "Configure your account-specific gateway URL via Custom Provider (https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/openai).",
 	},
 	{
@@ -116,7 +110,6 @@ var builtinList = []Entry{
 		AuthorizationEndpoint: "https://auth.openai.com/oauth/authorize",
 		TokenEndpoint:         "https://auth.openai.com/oauth/token",
 		Scopes:                []string{"openid", "profile", "email", "offline_access"},
-		Models:                []string{"gpt-5.5", "gpt-5.5-codex", "gpt-5.2-codex", "gpt-5.1-codex-max", "gpt-5.1-codex", "gpt-5.2"},
 		Notes:                 "ChatGPT Plus/Pro subscription. Run `codex login` (official OpenAI Codex CLI) on this host, then click Import below. Talks the Responses API at chatgpt.com/backend-api/codex. Personal-use only per OpenAI's terms.",
 	},
 	{
@@ -133,7 +126,6 @@ var builtinList = []Entry{
 		TokenEndpoint:               "https://github.com/login/oauth/access_token",
 		DeviceAuthorizationEndpoint: "https://github.com/login/device/code",
 		Scopes:                      []string{"read:user"},
-		Models:                      []string{"gpt-4o"},
 		Notes:                       "GitHub Copilot CLI device-code flow. The matching API base URL depends on the proxy you point at — leave empty and use Custom Provider for self-hosted Copilot proxies.",
 	},
 	{
@@ -142,7 +134,6 @@ var builtinList = []Entry{
 		BaseURL:     "https://api.deepinfra.com/v1/openai",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"meta-llama/Meta-Llama-3.1-70B-Instruct"},
 	},
 	{
 		ID:          "deepseek",
@@ -150,7 +141,6 @@ var builtinList = []Entry{
 		BaseURL:     "https://api.deepseek.com/v1",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"deepseek-chat", "deepseek-reasoner"},
 	},
 	{
 		ID:          "fireworks",
@@ -158,7 +148,6 @@ var builtinList = []Entry{
 		BaseURL:     "https://api.fireworks.ai/inference/v1",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"accounts/fireworks/models/llama-v3p1-70b-instruct"},
 	},
 	{
 		ID:          "google",
@@ -173,7 +162,6 @@ var builtinList = []Entry{
 		AuthorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
 		TokenEndpoint:         "https://oauth2.googleapis.com/token",
 		Scopes:                []string{"https://www.googleapis.com/auth/cloud-platform"},
-		Models:                []string{"gemini-2.5-pro", "gemini-2.5-flash"},
 		Notes:                 "Set XALGORIX_GOOGLE_OAUTH_CLIENT_ID to your Google Cloud OAuth client.",
 	},
 	{
@@ -182,7 +170,6 @@ var builtinList = []Entry{
 		BaseURL:     "https://us-central1-aiplatform.googleapis.com",
 		HeaderStyle: "gemini",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"gemini-2.5-pro"},
 		Notes:       "Vertex auth normally uses gcloud-managed credentials picked up via env (GOOGLE_APPLICATION_CREDENTIALS).",
 	},
 	{
@@ -191,7 +178,6 @@ var builtinList = []Entry{
 		BaseURL:     "https://api.groq.com/openai/v1",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"llama-3.3-70b-versatile", "mixtral-8x7b-32768"},
 	},
 	{
 		ID:          "huggingface",
@@ -200,7 +186,6 @@ var builtinList = []Entry{
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key", "oauth"},
 		Flow:        "pkce",
-		Models:      []string{"meta-llama/Meta-Llama-3.1-70B-Instruct"},
 		Notes:       "OAuth flow is beta — Hugging Face's OAuth client metadata is not publicly stable yet; API key path is fully tested.",
 	},
 	{
@@ -209,7 +194,6 @@ var builtinList = []Entry{
 		BaseURL:     "",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"kilo/auto"},
 		Notes:       "Set base URL via the Custom Provider option if the default is unknown.",
 	},
 	{
@@ -218,7 +202,6 @@ var builtinList = []Entry{
 		BaseURL:     "http://localhost:4000/v1",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"gpt-4o"},
 		Notes:       "Default base URL points at the standard LiteLLM proxy (http://localhost:4000). Override via API Base if your proxy runs on a different host or port.",
 	},
 	{
@@ -227,7 +210,6 @@ var builtinList = []Entry{
 		BaseURL:     "http://localhost:1234/v1",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"none"},
-		Models:      []string{"local-model"},
 		Notes:       "Local runtime — no credential required.",
 	},
 	{
@@ -236,7 +218,6 @@ var builtinList = []Entry{
 		BaseURL:     "",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"gpt-4o"},
 		Notes:       "Configure your tenant-specific endpoint via Custom Provider.",
 	},
 	{
@@ -246,7 +227,6 @@ var builtinList = []Entry{
 		// Default recommended model.
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"MiniMax-M3", "MiniMax-M2.7"},
 	},
 	{
 		ID:          "mistral",
@@ -254,7 +234,6 @@ var builtinList = []Entry{
 		BaseURL:     "https://api.mistral.ai/v1",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"mistral-large-latest", "open-mistral-nemo"},
 	},
 	{
 		ID:          "moonshot",
@@ -262,7 +241,6 @@ var builtinList = []Entry{
 		BaseURL:     "https://api.moonshot.cn/v1",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"moonshot-v1-128k", "kimi-k2-0905-preview"},
 	},
 	{
 		ID:          "nvidia",
@@ -270,7 +248,14 @@ var builtinList = []Entry{
 		BaseURL:     "https://integrate.api.nvidia.com/v1",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"meta/llama-3.1-70b-instruct"},
+	},
+	{
+		ID:          "novita",
+		DisplayName: "Novita AI",
+		BaseURL:     "https://api.novita.ai/openai/v1",
+		HeaderStyle: "openai",
+		AuthMethods: []string{"api_key"},
+		Notes:       "OpenAI-compatible LLM API. Choose Custom model for any model returned by Novita's models endpoint.",
 	},
 	{
 		ID:          "ollama",
@@ -278,7 +263,6 @@ var builtinList = []Entry{
 		BaseURL:     "http://localhost:11434/v1",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"none"},
-		Models:      []string{"llama3.1"},
 		Notes:       "Local runtime — no credential required.",
 	},
 	{
@@ -287,7 +271,6 @@ var builtinList = []Entry{
 		BaseURL:     "https://api.openai.com/v1",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"gpt-5.5", "gpt-5.5-pro", "gpt-5.2", "gpt-5.1", "gpt-4o"},
 		Notes:       "OpenAI Platform API via API key (chat-completions). For ChatGPT Plus/Pro subscription access to Codex models, use the 'Codex (ChatGPT Subscription)' provider instead.",
 	},
 	{
@@ -297,7 +280,6 @@ var builtinList = []Entry{
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key", "oauth"},
 		Flow:        "pkce",
-		Models:      []string{"opencode-1"},
 		Notes:       "OAuth flow is beta — endpoints are not publicly documented yet; API key path is fully tested.",
 	},
 	{
@@ -306,7 +288,6 @@ var builtinList = []Entry{
 		BaseURL:     "https://openrouter.ai/api/v1",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"openrouter/auto", "anthropic/claude-3.5-sonnet"},
 	},
 	{
 		ID:          "qianfan",
@@ -314,7 +295,6 @@ var builtinList = []Entry{
 		BaseURL:     "",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"ernie-4.0-8k"},
 		Notes:       "Configure your Baidu Qianfan endpoint via Custom Provider.",
 	},
 	{
@@ -324,7 +304,6 @@ var builtinList = []Entry{
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key", "oauth"},
 		Flow:        "pkce",
-		Models:      []string{"qwen-max", "qwen-plus", "qwen-turbo"},
 		Notes:       "OAuth flow is beta — DashScope OAuth client metadata is not publicly stable yet; API key path is fully tested.",
 	},
 	{
@@ -333,7 +312,6 @@ var builtinList = []Entry{
 		BaseURL:     "http://localhost:30000/v1",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"none"},
-		Models:      []string{"local-model"},
 		Notes:       "Local runtime — no credential required.",
 	},
 	{
@@ -342,7 +320,6 @@ var builtinList = []Entry{
 		BaseURL:     "",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"step-1v-8k"},
 		Notes:       "Configure your StepFun endpoint via Custom Provider.",
 	},
 	{
@@ -351,7 +328,6 @@ var builtinList = []Entry{
 		BaseURL:     "",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"synthetic-1"},
 		Notes:       "Set base URL via the Custom Provider option if the default is unknown.",
 	},
 	{
@@ -360,7 +336,6 @@ var builtinList = []Entry{
 		BaseURL:     "",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"hunyuan-pro"},
 		Notes:       "Configure your Tencent Hunyuan endpoint via Custom Provider.",
 	},
 	{
@@ -369,7 +344,6 @@ var builtinList = []Entry{
 		BaseURL:     "https://api.together.xyz/v1",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"meta-llama/Llama-3.3-70B-Instruct-Turbo"},
 	},
 	{
 		ID:          "venice",
@@ -377,7 +351,6 @@ var builtinList = []Entry{
 		BaseURL:     "",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"venice-1"},
 		Notes:       "Set base URL via the Custom Provider option if the default is unknown.",
 	},
 	{
@@ -386,7 +359,6 @@ var builtinList = []Entry{
 		BaseURL:     "",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"openai/gpt-4o"},
 		Notes:       "Configure your Vercel AI Gateway endpoint via Custom Provider.",
 	},
 	{
@@ -395,7 +367,6 @@ var builtinList = []Entry{
 		BaseURL:     "http://localhost:8000/v1",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"none"},
-		Models:      []string{"local-model"},
 		Notes:       "Local runtime — no credential required.",
 	},
 	{
@@ -404,7 +375,6 @@ var builtinList = []Entry{
 		BaseURL:     "",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"doubao-pro-32k"},
 		Notes:       "Configure your Volcano Engine endpoint via Custom Provider.",
 	},
 	{
@@ -416,7 +386,6 @@ var builtinList = []Entry{
 		Flow:                  "pkce",
 		AuthorizationEndpoint: "https://x.ai/oauth/authorize",
 		TokenEndpoint:         "https://x.ai/oauth/token",
-		Models:                []string{"grok-4", "grok-3"},
 		Notes:                 "OAuth scopes vary by client — confirm via xAI developer console.",
 	},
 	{
@@ -425,7 +394,6 @@ var builtinList = []Entry{
 		BaseURL:     "",
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
-		Models:      []string{"mi-llm-1"},
 		Notes:       "Configure your Xiaomi endpoint via Custom Provider.",
 	},
 	{
@@ -435,7 +403,6 @@ var builtinList = []Entry{
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key", "oauth"},
 		Flow:        "pkce",
-		Models:      []string{"glm-4.5"},
 		Notes:       "OAuth flow is beta — Z.AI OAuth client metadata is not publicly stable yet; API key path is fully tested.",
 	},
 	// Custom is the explicit "operator-supplied endpoint" entry.

--- a/internal/providers/service_test.go
+++ b/internal/providers/service_test.go
@@ -106,6 +106,22 @@ func TestService_RoundTripsBuiltin(t *testing.T) {
 	}
 }
 
+func TestBuiltin_NovitaConfiguration(t *testing.T) {
+	entry, ok := LookupBuiltin("novita")
+	if !ok {
+		t.Fatal("Novita provider is missing from the built-in catalog")
+	}
+	if entry.BaseURL != "https://api.novita.ai/openai/v1" {
+		t.Errorf("Novita BaseURL = %q, want https://api.novita.ai/openai/v1", entry.BaseURL)
+	}
+	if entry.HeaderStyle != "openai" {
+		t.Errorf("Novita HeaderStyle = %q, want openai", entry.HeaderStyle)
+	}
+	if len(entry.AuthMethods) != 1 || entry.AuthMethods[0] != "api_key" {
+		t.Errorf("Novita AuthMethods = %v, want [api_key]", entry.AuthMethods)
+	}
+}
+
 // TestService_GetUnknown asserts an unknown id returns
 // (zero, false, nil) without an error so callers can branch
 // cleanly.

--- a/internal/providers/types.go
+++ b/internal/providers/types.go
@@ -34,9 +34,9 @@ package providers
 //     is shown when Flow is non-empty; "none" hides credential
 //     entry entirely (used by local-runtime providers like Ollama).
 //
-//   - Models is the best-effort suggestion list. The LLM tab
-//     prefills the Model input from Models[0] when picking the
-//     provider; operators always retain free-text override.
+//   - Models is retained for wire compatibility with older clients. Built-in
+//     entries leave it empty: the dashboard discovers models from provider
+//     APIs and falls back to manual entry when discovery is unavailable.
 //
 //   - Flow / ClientID / AuthorizationEndpoint / TokenEndpoint /
 //     DeviceAuthorizationEndpoint / Scopes mirror the v4.4.21

--- a/internal/web/handlers_profiles.go
+++ b/internal/web/handlers_profiles.go
@@ -35,7 +35,9 @@
 //
 //   - auth.ErrReauthRequired      → 401 ("oauth refresh required")
 //
-//   - auth.ErrNotFound            → 404 (claude cli credentials)
+//   - auth.ErrNotFound                    → 404 (Claude CLI credentials)
+//
+//   - auth.ErrCodexCredentialsNotFound    → 404 (Codex CLI credentials)
 //
 //   - providers.ErrUpstream{S,B}  → 502 with {statusCode, body}
 //
@@ -113,6 +115,8 @@ func profileErrorStatus(err error) int {
 		return http.StatusServiceUnavailable
 	case errors.Is(err, auth.ErrProfileNotFound):
 		return http.StatusNotFound
+	case errors.Is(err, auth.ErrCodexCredentialsNotFound):
+		return http.StatusNotFound
 	case errors.Is(err, auth.ErrNotFound):
 		return http.StatusNotFound
 	case errors.Is(err, auth.ErrFlowTimeout):
@@ -162,6 +166,12 @@ func writeProfileError(w http.ResponseWriter, err error) {
 	if errors.Is(err, auth.ErrNotFound) {
 		writeJSONStatus(w, http.StatusNotFound, map[string]string{
 			"error": "claude cli credentials not found",
+		})
+		return
+	}
+	if errors.Is(err, auth.ErrCodexCredentialsNotFound) {
+		writeJSONStatus(w, http.StatusNotFound, map[string]string{
+			"error": "codex cli credentials not found",
 		})
 		return
 	}
@@ -545,7 +555,8 @@ func (s *Server) handleOAuthStart(w http.ResponseWriter, r *http.Request) {
 //
 // Status mapping:
 //   - auth.ErrFlowTimeout                     → 408
-//   - auth.ErrNotFound (claude credentials)   → 404
+//   - auth.ErrNotFound (Claude credentials)                 → 404
+//   - auth.ErrCodexCredentialsNotFound (Codex credentials)  → 404
 //   - providers.ErrUpstream                   → 502 envelope
 //   - other errors                            → 500 / 400 per sentinel
 //

--- a/internal/web/handlers_profiles_error_test.go
+++ b/internal/web/handlers_profiles_error_test.go
@@ -1,0 +1,39 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/auth"
+)
+
+func TestWriteProfileErrorUsesProviderSpecificCredentialMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		message string
+	}{
+		{name: "codex", err: auth.ErrCodexCredentialsNotFound, message: "codex cli credentials not found"},
+		{name: "claude", err: auth.ErrNotFound, message: "claude cli credentials not found"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			writeProfileError(rr, tt.err)
+
+			if rr.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, want %d", rr.Code, http.StatusNotFound)
+			}
+			var body map[string]string
+			if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if body["error"] != tt.message {
+				t.Fatalf("error = %q, want %q", body["error"], tt.message)
+			}
+		})
+	}
+}

--- a/internal/web/handlers_provider_models.go
+++ b/internal/web/handlers_provider_models.go
@@ -1,0 +1,259 @@
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/xalgord/xalgorix/v4/internal/auth"
+	"github.com/xalgord/xalgorix/v4/internal/providers"
+)
+
+const providerModelsResponseLimit = 4 << 20
+const codexModelsClientVersion = "0.144.3"
+
+type discoveredModelsResponse struct {
+	Models []string `json:"models"`
+	Source string   `json:"source"`
+}
+
+// handleDiscoverProviderModels queries the selected provider's documented
+// model-list endpoint from the server. Credentials never cross the browser
+// boundary. Requests use either a compiled-in catalog URL or an endpoint the
+// operator already persisted as the active LLM base; arbitrary request URLs
+// are never accepted by this handler.
+func (s *Server) handleDiscoverProviderModels(w http.ResponseWriter, r *http.Request) {
+	providerID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/providers/"), "/models")
+	if providerID == "" || strings.Contains(providerID, "/") || providerID == "custom" {
+		writeJSONStatus(w, http.StatusBadRequest, map[string]string{"error": "provider does not support automatic model discovery"})
+		return
+	}
+	entry, ok, err := s.catalog.Get(r.Context(), providerID)
+	if err != nil || !ok {
+		writeJSONStatus(w, http.StatusNotFound, map[string]string{"error": "provider not found"})
+		return
+	}
+	if strings.TrimSpace(entry.BaseURL) == "" {
+		writeJSONStatus(w, http.StatusUnprocessableEntity, map[string]string{"error": "provider does not expose a compatible model-list endpoint"})
+		return
+	}
+
+	entry, credential, accountID, err := s.modelDiscoveryConfig(r, entry)
+	if err != nil {
+		writeJSONStatus(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	models, err := discoverProviderModels(r, entry, credential, accountID)
+	if err != nil {
+		writeJSONStatus(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSONStatus(w, http.StatusOK, discoveredModelsResponse{Models: models, Source: "remote"})
+}
+
+func (s *Server) modelDiscoveryConfig(r *http.Request, entry providers.Entry) (providers.Entry, string, string, error) {
+	for _, method := range entry.AuthMethods {
+		if method == "none" {
+			if s.cfg != nil && strings.HasPrefix(s.cfg.LLM, entry.ID+"/") && strings.TrimSpace(s.cfg.APIBase) != "" {
+				entry.BaseURL = strings.TrimSpace(s.cfg.APIBase)
+			}
+			return entry, "", "", nil
+		}
+	}
+	key := strings.TrimSpace(r.URL.Query().Get("profile"))
+	if key != "" {
+		if s.profiles == nil {
+			return entry, "", "", fmt.Errorf("credential profiles are unavailable")
+		}
+		profile, ok, err := s.profiles.Get(r.Context(), key)
+		if err != nil {
+			return entry, "", "", fmt.Errorf("load credential profile: %w", err)
+		}
+		if !ok || profile.Provider != entry.ID {
+			return entry, "", "", fmt.Errorf("credential profile does not belong to provider %q", entry.ID)
+		}
+		if strings.TrimSpace(profile.APIBaseOverride) != "" {
+			entry.BaseURL = strings.TrimSpace(profile.APIBaseOverride)
+		}
+		if profile.Type == auth.OAuth {
+			return entry, strings.TrimSpace(profile.AccessToken), strings.TrimSpace(profile.AccountID), nil
+		}
+		return entry, strings.TrimSpace(profile.APIKey), "", nil
+	}
+	if s.cfg != nil && strings.HasPrefix(s.cfg.LLM, entry.ID+"/") {
+		if strings.TrimSpace(s.cfg.APIBase) != "" {
+			entry.BaseURL = strings.TrimSpace(s.cfg.APIBase)
+		}
+		return entry, strings.TrimSpace(s.cfg.APIKey), "", nil
+	}
+	return entry, "", "", fmt.Errorf("save or select credentials before scanning models")
+}
+
+func discoverProviderModels(r *http.Request, entry providers.Entry, credential, accountID string) ([]string, error) {
+	endpoints, err := providerModelsURLs(entry)
+	if err != nil {
+		return nil, err
+	}
+	var lastErr error
+	for _, endpoint := range endpoints {
+		models, err := requestProviderModels(r, entry, credential, accountID, endpoint)
+		if err == nil {
+			return models, nil
+		}
+		lastErr = err
+	}
+	return nil, lastErr
+}
+
+func requestProviderModels(r *http.Request, entry providers.Entry, credential, accountID, endpoint string) ([]string, error) {
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build model discovery request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	switch entry.HeaderStyle {
+	case "anthropic":
+		if credential != "" {
+			req.Header.Set("x-api-key", credential)
+		}
+		req.Header.Set("anthropic-version", "2023-06-01")
+	case "gemini":
+		if credential != "" {
+			req.Header.Set("x-goog-api-key", credential)
+		}
+	case "openai", "openai_responses":
+		if credential != "" {
+			req.Header.Set("Authorization", "Bearer "+credential)
+		}
+		if accountID != "" {
+			req.Header.Set("chatgpt-account-id", accountID)
+		}
+		if entry.HeaderStyle == "openai_responses" {
+			req.Header.Set("version", codexModelsClientVersion)
+		}
+	default:
+		return nil, fmt.Errorf("provider does not expose a compatible model-list endpoint")
+	}
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("model discovery request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, providerModelsResponseLimit+1))
+	if err != nil {
+		return nil, fmt.Errorf("read model discovery response: %w", err)
+	}
+	if len(body) > providerModelsResponseLimit {
+		return nil, fmt.Errorf("model discovery response exceeded 4 MiB")
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("provider model discovery returned HTTP %d", resp.StatusCode)
+	}
+	return parseDiscoveredModels(entry.HeaderStyle, body)
+}
+
+func providerModelsURLs(entry providers.Entry) ([]string, error) {
+	base := strings.TrimRight(strings.TrimSpace(entry.BaseURL), "/")
+	for _, suffix := range []string{"/chat/completions", "/responses", "/messages", "/models"} {
+		base = strings.TrimSuffix(base, suffix)
+	}
+	u, err := url.Parse(base)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("provider has no valid model discovery URL")
+	}
+	if entry.HeaderStyle == "anthropic" && !strings.HasSuffix(u.Path, "/v1") {
+		u.Path = strings.TrimRight(u.Path, "/") + "/v1"
+	}
+	if entry.HeaderStyle == "openai" && !strings.HasSuffix(u.Path, "/v1") && !strings.Contains(u.Path, "/v1/") {
+		u.Path = strings.TrimRight(u.Path, "/") + "/v1"
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + "/models"
+	if entry.HeaderStyle == "openai_responses" {
+		query := u.Query()
+		query.Set("client_version", codexModelsClientVersion)
+		u.RawQuery = query.Encode()
+	}
+	endpoints := []string{u.String()}
+	if entry.ID == "ollama" {
+		native := *u
+		native.Path = strings.TrimSuffix(strings.TrimSuffix(native.Path, "/models"), "/v1") + "/api/tags"
+		endpoints = append(endpoints, native.String())
+	}
+	if u.Hostname() == "localhost" || u.Hostname() == "127.0.0.1" {
+		hostEndpoint := *u
+		hostEndpoint.Host = "host.docker.internal"
+		if port := u.Port(); port != "" {
+			hostEndpoint.Host += ":" + port
+		}
+		endpoints = append(endpoints, hostEndpoint.String())
+		if entry.ID == "ollama" {
+			native := hostEndpoint
+			native.Path = strings.TrimSuffix(strings.TrimSuffix(native.Path, "/models"), "/v1") + "/api/tags"
+			endpoints = append(endpoints, native.String())
+		}
+	}
+	return endpoints, nil
+}
+
+func parseDiscoveredModels(headerStyle string, body []byte) ([]string, error) {
+	var payload struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+		Models []struct {
+			Name                       string   `json:"name"`
+			Slug                       string   `json:"slug"`
+			SupportedGenerationMethods []string `json:"supportedGenerationMethods"`
+		} `json:"models"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("decode model discovery response: %w", err)
+	}
+	seen := make(map[string]struct{})
+	models := make([]string, 0, len(payload.Data)+len(payload.Models))
+	add := func(model string) {
+		model = strings.TrimSpace(strings.TrimPrefix(model, "models/"))
+		if model == "" {
+			return
+		}
+		if _, ok := seen[model]; ok {
+			return
+		}
+		seen[model] = struct{}{}
+		models = append(models, model)
+	}
+	for _, model := range payload.Data {
+		add(model.ID)
+	}
+	for _, model := range payload.Models {
+		if headerStyle == "gemini" && len(model.SupportedGenerationMethods) > 0 {
+			supported := false
+			for _, method := range model.SupportedGenerationMethods {
+				if method == "generateContent" {
+					supported = true
+					break
+				}
+			}
+			if !supported {
+				continue
+			}
+		}
+		if model.Slug != "" {
+			add(model.Slug)
+		} else {
+			add(model.Name)
+		}
+	}
+	if len(models) == 0 {
+		return nil, fmt.Errorf("provider returned no generative models")
+	}
+	sort.Strings(models)
+	return models, nil
+}

--- a/internal/web/handlers_provider_models_test.go
+++ b/internal/web/handlers_provider_models_test.go
@@ -1,0 +1,103 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/providers"
+)
+
+func TestDiscoverProviderModelsOpenAICompatible(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Fatalf("path = %q, want /v1/models", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer secret" {
+			t.Fatalf("Authorization header was not applied")
+		}
+		_, _ = w.Write([]byte(`{"data":[{"id":"model-b"},{"id":"model-a"}]}`))
+	}))
+	defer server.Close()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(context.Background())
+	models, err := discoverProviderModels(req, providers.Entry{
+		ID: "test", BaseURL: server.URL, HeaderStyle: "openai",
+	}, "secret", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"model-a", "model-b"}; !reflect.DeepEqual(models, want) {
+		t.Fatalf("models = %v, want %v", models, want)
+	}
+}
+
+func TestParseDiscoveredGeminiModelsFiltersNonGenerativeEntries(t *testing.T) {
+	body := []byte(`{"models":[{"name":"models/gemini-chat","supportedGenerationMethods":["generateContent"]},{"name":"models/text-embedding","supportedGenerationMethods":["embedContent"]}]}`)
+	models, err := parseDiscoveredModels("gemini", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"gemini-chat"}; !reflect.DeepEqual(models, want) {
+		t.Fatalf("models = %v, want %v", models, want)
+	}
+}
+
+func TestProviderModelsURLsIncludesOllamaNativeFallback(t *testing.T) {
+	urls, err := providerModelsURLs(providers.Entry{
+		ID: "ollama", BaseURL: "http://localhost:11434/v1", HeaderStyle: "openai",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"http://localhost:11434/v1/models",
+		"http://localhost:11434/api/tags",
+		"http://host.docker.internal:11434/v1/models",
+		"http://host.docker.internal:11434/api/tags",
+	}
+	if !reflect.DeepEqual(urls, want) {
+		t.Fatalf("URLs = %v, want %v", urls, want)
+	}
+}
+
+func TestModelDiscoveryConfigIgnoresProfilesForCredentialFreeProvider(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/providers/ollama/models?profile=codex:default", nil)
+	entry := providers.Entry{
+		ID: "ollama", BaseURL: "http://localhost:11434/v1", HeaderStyle: "openai", AuthMethods: []string{"none"},
+	}
+	got, credential, accountID, err := (&Server{}).modelDiscoveryConfig(req, entry)
+	if err != nil {
+		t.Fatalf("modelDiscoveryConfig returned error: %v", err)
+	}
+	if credential != "" || accountID != "" || got.BaseURL != entry.BaseURL {
+		t.Fatalf("config = (%q, %q), want (%q, empty credential)", got.BaseURL, credential, entry.BaseURL)
+	}
+}
+
+func TestParseDiscoveredCodexModelsUsesSlug(t *testing.T) {
+	body := []byte(`{"models":[{"slug":"gpt-5.5","display_name":"GPT-5.5"},{"slug":"gpt-5.4","display_name":"GPT-5.4"}]}`)
+	models, err := parseDiscoveredModels("openai_responses", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"gpt-5.4", "gpt-5.5"}
+	if !reflect.DeepEqual(models, want) {
+		t.Fatalf("models = %v, want %v", models, want)
+	}
+}
+
+func TestProviderModelsURLsUsesCodexCatalogProtocol(t *testing.T) {
+	urls, err := providerModelsURLs(providers.Entry{
+		ID: "codex", BaseURL: "https://chatgpt.com/backend-api/codex", HeaderStyle: "openai_responses",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "https://chatgpt.com/backend-api/codex/models?client_version=" + codexModelsClientVersion
+	if len(urls) != 1 || urls[0] != want {
+		t.Fatalf("URLs = %v, want [%s]", urls, want)
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1028,6 +1028,13 @@ func (s *Server) Start() error {
 		}
 		s.handleListProviders(w, r)
 	})
+	mux.HandleFunc("/api/providers/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/models") {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		s.handleDiscoverProviderModels(w, r)
+	})
 	mux.HandleFunc("/api/auth/profiles", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)

--- a/webui/src/api/client.ts
+++ b/webui/src/api/client.ts
@@ -377,6 +377,12 @@ export const api = {
   // ---------------------------------------------------------------
 
   listProviders: () => http<CatalogEntry[]>("/api/providers"),
+  discoverProviderModels: (provider: string, profile?: string) =>
+    http<{ models: string[]; source: "remote" }>(
+      `/api/providers/${encodeURIComponent(provider)}/models${
+        profile ? `?profile=${encodeURIComponent(profile)}` : ""
+      }`,
+    ),
 
   // ---------------------------------------------------------------
   // Multi-provider key store + model router (LiteLLM-style).

--- a/webui/src/api/client.ts
+++ b/webui/src/api/client.ts
@@ -343,7 +343,7 @@ export const api = {
     ),
 
   chat: (message: string, instanceId?: string) =>
-    http<{ reply?: string; error?: string }>("/api/chat", {
+    http<{ response: string }>("/api/chat", {
       method: "POST",
       json: { message, instance_id: instanceId },
     }),

--- a/webui/src/api/queries.ts
+++ b/webui/src/api/queries.ts
@@ -411,6 +411,13 @@ export function useProviders() {
   });
 }
 
+export function useDiscoverProviderModels() {
+  return useMutation({
+    mutationFn: ({ provider, profile }: { provider: string; profile?: string }) =>
+      api.discoverProviderModels(provider, profile),
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Auth profile mutation hooks. The catalog is read-only in v4.4.22, so
 // there is no provider-create / -update / -delete and no openclaw or

--- a/webui/src/pages/scan-detail.tsx
+++ b/webui/src/pages/scan-detail.tsx
@@ -9,6 +9,7 @@ import {
   CardDescription,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -65,6 +66,8 @@ import {
   Sparkles,
   ListChecks,
   ArrowRight,
+  Loader2,
+  Send,
 } from "lucide-react";
 import { LiveFeed, type FeedFilter } from "@/components/live-feed";
 import { Pagination, DEFAULT_PAGE_SIZE } from "@/components/Pagination";
@@ -342,6 +345,8 @@ export default function ScanDetailPage() {
           <EventsTab
             events={mergedEvents}
             scanId={scan.id}
+            instanceId={eventInstanceId}
+            status={status}
             target={scan.target}
           />
         </TabsContent>
@@ -1021,23 +1026,148 @@ function DetailSection({
 function EventsTab({
   events,
   scanId,
+  instanceId,
+  status,
   target,
 }: {
   events: FeedEvent[];
   scanId: string;
+  instanceId: string;
+  status: string;
   target: string;
 }) {
   const [filter, setFilter] = useState<FeedFilter>("all");
   return (
-    <LiveFeed
-      events={events}
-      filter={filter}
-      onFilterChange={setFilter}
-      exportFilePrefix={`xalgorix-${target || scanId}-events`}
-      exportScope={scanId}
-      emptyTitle="No events yet"
-      emptyDescription="Once the scan starts producing output it will stream here."
-    />
+    <div className="space-y-3">
+      <LiveFeed
+        events={events}
+        filter={filter}
+        onFilterChange={setFilter}
+        exportFilePrefix={`xalgorix-${target || scanId}-events`}
+        exportScope={scanId}
+        emptyTitle="No events yet"
+        emptyDescription="Once the scan starts producing output it will stream here."
+      />
+      {status === "running" && (
+        <ScanGuidanceComposer instanceId={instanceId} />
+      )}
+    </div>
+  );
+}
+
+const GUIDANCE_SUGGESTIONS = [
+  "Focus next on authentication and session handling.",
+  "Prioritize IDOR and broken access control checks.",
+  "Verify the strongest finding with reproducible evidence.",
+  "Summarize progress, then continue with the highest-risk gap.",
+];
+
+function ScanGuidanceComposer({ instanceId }: { instanceId: string }) {
+  const [message, setMessage] = useState("");
+  const [sending, setSending] = useState(false);
+  const [feedback, setFeedback] = useState<{
+    kind: "success" | "error";
+    text: string;
+  } | null>(null);
+
+  const trimmed = message.trim();
+
+  async function sendGuidance() {
+    if (!trimmed || sending) return;
+    setSending(true);
+    setFeedback(null);
+    try {
+      const result = await api.chat(trimmed, instanceId);
+      setMessage("");
+      setFeedback({
+        kind: "success",
+        text: result.response || "Guidance queued for the next agent iteration.",
+      });
+    } catch (err) {
+      setFeedback({
+        kind: "error",
+        text: err instanceof Error ? err.message : "Could not send guidance.",
+      });
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-sm">Guide this scan</CardTitle>
+        <CardDescription>
+          Send a priority or correction to this agent. It will pick it up on
+          its next iteration without interrupting the scan.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex flex-wrap gap-2" aria-label="Guidance suggestions">
+          {GUIDANCE_SUGGESTIONS.map((suggestion) => (
+            <Button
+              key={suggestion}
+              type="button"
+              size="sm"
+              variant="outline"
+              className="h-auto whitespace-normal py-1.5 text-left text-xs"
+              onClick={() => {
+                setMessage(suggestion);
+                setFeedback(null);
+              }}
+              disabled={sending}
+            >
+              {suggestion}
+            </Button>
+          ))}
+        </div>
+        <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-end">
+          <Textarea
+            value={message}
+            onChange={(event) => {
+              setMessage(event.target.value);
+              setFeedback(null);
+            }}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && !event.shiftKey) {
+                event.preventDefault();
+                void sendGuidance();
+              }
+            }}
+            placeholder="Example: Re-check the admin API with the second account before moving on."
+            aria-label="Message to the running scan agent"
+            rows={3}
+            maxLength={4000}
+            disabled={sending}
+          />
+          <Button
+            type="button"
+            onClick={() => void sendGuidance()}
+            disabled={!trimmed || sending}
+            className="shrink-0 sm:w-auto"
+          >
+            {sending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Send className="h-4 w-4" />
+            )}
+            Send
+          </Button>
+        </div>
+        <div className="flex items-center justify-between gap-3 text-[11px] text-muted-foreground">
+          <span
+            aria-live="polite"
+            className={cn(
+              feedback?.kind === "success" && "text-emerald-400",
+              feedback?.kind === "error" && "text-red-400",
+            )}
+          >
+            {feedback?.text || "Enter to send · Shift+Enter for a new line"}
+          </span>
+          <span className="mono shrink-0">{message.length}/4000</span>
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/webui/src/pages/settings.tsx
+++ b/webui/src/pages/settings.tsx
@@ -27,6 +27,7 @@ import {
   useAgentMail,
   useAuthProfiles,
   useDeleteAuthProfile,
+  useDiscoverProviderModels,
   useEnvironmentSettings,
   useLLMSettings,
   useProviders,
@@ -260,14 +261,18 @@ export default function SettingsPage() {
   function changeProvider(providerId: string) {
     const entry = sortedProviders.find((p) => p.id === providerId);
     const methods = entry?.authMethods ?? ["api_key"];
-    const firstModel = entry?.models?.[0] ?? "";
     setLLMForm((current) => ({
       ...current,
       provider: providerId,
       authMethod: (methods[0] as LLMFormState["authMethod"]) ?? "api_key",
-      // Prefill the model field with the catalog suggestion so the
-      // user sees a working default. They can still override it.
-      model: firstModel ? `${providerId}/${firstModel}` : current.model,
+      // Never carry a model across providers. The selected provider is
+      // discovered automatically when possible; otherwise the operator
+      // enters the model explicitly.
+      model: "",
+      activeProfileKey: "",
+      apiKey: "",
+      hasApiKey: false,
+      apiBaseOverride: "",
       // apiBase resets to the catalog default; "custom" leaves the
       // current free-text base intact.
       apiBase: entry?.id === "custom" ? current.apiBase : entry?.baseURL ?? "",
@@ -439,6 +444,33 @@ export default function SettingsPage() {
                   </div>
                 )}
 
+                {selectedProvider && (
+                  <CatalogModelField
+                    provider={selectedProvider}
+                    value={llmForm.model}
+                    profileKey={
+                      llmForm.authMethod === "none"
+                        ? ""
+                        : llmForm.activeProfileKey.startsWith(
+                              `${selectedProvider.id}:`,
+                            )
+                          ? llmForm.activeProfileKey
+                          : (providerProfiles[0]?.key ??
+                            (providerProfiles[0]
+                              ? `${providerProfiles[0].provider}:${providerProfiles[0].profileId}`
+                              : ""))
+                    }
+                    autoDiscover={
+                      llmForm.authMethod === "none" ||
+                      providerProfiles.length > 0 ||
+                      llm.data?.provider === selectedProvider.id
+                    }
+                    onChange={(model) =>
+                      setLLMForm({ ...llmForm, model })
+                    }
+                  />
+                )}
+
                 {/* Auth-method-specific form */}
                 {selectedProvider && llmForm.authMethod === "api_key" && (
                   <div className="grid gap-3 lg:grid-cols-2">
@@ -456,18 +488,6 @@ export default function SettingsPage() {
                       <p className="text-xs text-muted-foreground">
                         Keep the masked value to preserve the saved key.
                       </p>
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="llm-model">Model</Label>
-                      <Input
-                        id="llm-model"
-                        value={llmForm.model}
-                        onChange={(e) =>
-                          setLLMForm({ ...llmForm, model: e.target.value })
-                        }
-                        placeholder={selectedProvider.models?.[0] ?? "provider/model"}
-                        className="font-mono"
-                      />
                     </div>
                     {selectedProvider.id === "custom" ? (
                       <>
@@ -555,20 +575,8 @@ export default function SettingsPage() {
                   <div className="space-y-3 rounded-md border border-border bg-muted/30 p-4">
                     <p className="text-sm">
                       {selectedProvider.displayName} runs locally — no
-                      credential required. Just confirm the model below.
+                      credential required. Select or enter the model above.
                     </p>
-                    <div className="space-y-2">
-                      <Label htmlFor="llm-model-local">Model</Label>
-                      <Input
-                        id="llm-model-local"
-                        value={llmForm.model}
-                        onChange={(e) =>
-                          setLLMForm({ ...llmForm, model: e.target.value })
-                        }
-                        placeholder={selectedProvider.models?.[0] ?? "model"}
-                        className="font-mono"
-                      />
-                    </div>
                   </div>
                 )}
 
@@ -1229,6 +1237,154 @@ export default function SettingsPage() {
           </Card>
         </TabsContent>
       </Tabs>
+    </div>
+  );
+}
+
+function CatalogModelField({
+  provider,
+  value,
+  profileKey,
+  autoDiscover,
+  onChange,
+}: {
+  provider: CatalogEntry;
+  value: string;
+  profileKey: string;
+  autoDiscover: boolean;
+  onChange: (value: string) => void;
+}) {
+  const discovery = useDiscoverProviderModels();
+  const [discoveredModels, setDiscoveredModels] = useState<string[]>([]);
+  const [manualEntry, setManualEntry] = useState(false);
+  useEffect(() => {
+    setDiscoveredModels([]);
+    setManualEntry(false);
+    discovery.reset();
+    if (
+      autoDiscover &&
+      provider.id !== "custom" &&
+      provider.baseURL
+    ) {
+      discovery.mutate(
+        { provider: provider.id, profile: profileKey || undefined },
+        {
+          onSuccess: (result) => {
+            setDiscoveredModels(result.models);
+            if (result.models.length > 0) {
+              onChange(`${provider.id}/${result.models[0]}`);
+            }
+          },
+        },
+      );
+    }
+    // The provider/profile pair is the discovery identity. Mutation methods
+    // are intentionally excluded so query state updates do not rescan.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [provider.id, profileKey, autoDiscover]);
+  const models = discoveredModels;
+  const options = models.map((model) => ({
+    label: model,
+    value: `${provider.id}/${model}`,
+  }));
+  const selected = options.some((option) => option.value === value)
+    ? value
+    : options[0]?.value;
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor="llm-model">Model</Label>
+      {options.length > 0 && !manualEntry ? (
+        <Select
+          value={selected}
+          onValueChange={(next) => {
+            if (next === "__custom__") {
+              setManualEntry(true);
+              onChange("");
+            } else {
+              onChange(next);
+            }
+          }}
+        >
+          <SelectTrigger id="llm-model" className="font-mono">
+            <SelectValue placeholder="Select a model" />
+          </SelectTrigger>
+          <SelectContent>
+            {options.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+            <SelectItem value="__custom__">Custom model…</SelectItem>
+          </SelectContent>
+        </Select>
+      ) : null}
+      {(options.length === 0 || manualEntry) && (
+        <Input
+          id={options.length === 0 ? "llm-model" : undefined}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder={`${provider.id}/model-name`}
+          aria-label={`Custom model for ${provider.displayName}`}
+          className="font-mono"
+        />
+      )}
+      {manualEntry && options.length > 0 && (
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          onClick={() => {
+            setManualEntry(false);
+            onChange(options[0].value);
+          }}
+        >
+          Choose a discovered model
+        </Button>
+      )}
+      <p className="text-xs text-muted-foreground">
+        Models are loaded from the provider when its API supports discovery.
+        Otherwise, enter the exact model ID manually.
+      </p>
+      {provider.id !== "custom" && provider.baseURL && (
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={discovery.isPending}
+            onClick={() => {
+              discovery.mutate(
+                { provider: provider.id, profile: profileKey || undefined },
+                {
+                  onSuccess: (result) => {
+                    setDiscoveredModels(result.models);
+                    setManualEntry(false);
+                    if (result.models.length > 0) {
+                      onChange(`${provider.id}/${result.models[0]}`);
+                    }
+                  },
+                },
+              );
+            }}
+          >
+            <RefreshCw className={`mr-1.5 h-3.5 w-3.5 ${discovery.isPending ? "animate-spin" : ""}`} />
+            {discovery.isPending ? "Scanning models…" : "Scan available models"}
+          </Button>
+          {discovery.isSuccess && (
+            <span className="text-xs text-success">
+              {discoveredModels.length} models loaded
+            </span>
+          )}
+        </div>
+      )}
+      {discovery.isError && (
+        <p className="text-xs text-destructive">
+          {discovery.error instanceof Error
+            ? discovery.error.message
+            : "Model discovery failed"}
+        </p>
+      )}
     </div>
   );
 }

--- a/webui/src/pages/settings/oauth-modal.tsx
+++ b/webui/src/pages/settings/oauth-modal.tsx
@@ -282,8 +282,21 @@ export default function OAuthModal({
         )}
 
         {error && (
-          <div className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
-            {error}
+          <div className="space-y-1 rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+            <p>{error}</p>
+            {provider === "codex" &&
+              error === "codex cli credentials not found" && (
+                <p className="text-xs text-muted-foreground">
+                  Run <code className="font-mono">codex login</code> as the
+                  Xalgorix service user, or make the host file
+                  <code className="mx-1 font-mono">~/.codex/auth.json</code>
+                  available at
+                  <code className="ml-1 font-mono">
+                    /root/.codex/auth.json
+                  </code>
+                  .
+                </p>
+              )}
           </div>
         )}
 
@@ -385,6 +398,17 @@ export default function OAuthModal({
                 </code>
                 . The token never leaves this host.
               </p>
+              {provider === "codex" && (
+                <p className="text-xs text-muted-foreground">
+                  Expected file:
+                  <code className="mx-1 font-mono">~/.codex/auth.json</code>.
+                  In Docker, mount it read-only at
+                  <code className="ml-1 font-mono">
+                    /root/.codex/auth.json
+                  </code>
+                  .
+                </p>
+              )}
               <div className="flex justify-end">
                 <Button
                   size="sm"

--- a/webui/src/types/api.ts
+++ b/webui/src/types/api.ts
@@ -260,12 +260,12 @@ export interface CatalogEntry {
   displayName: string;
   baseURL: string;
   models?: string[];
-  headerStyle: "openai" | "anthropic" | "gemini";
+  headerStyle: "openai" | "openai_responses" | "anthropic" | "gemini";
   // v4.4.22 surfaces AuthMethods so the dashboard can render the
   // matching sub-form (api_key / oauth / none) without duplicating
   // the catalog's policy. Older servers omit this field entirely.
   authMethods?: Array<"api_key" | "oauth" | "none">;
-  flow?: "" | "pkce" | "device_code" | "setup_token" | "claude_cli_reuse";
+  flow?: "" | "pkce" | "device_code" | "setup_token" | "claude_cli_reuse" | "codex_cli_reuse";
   clientID?: string;
   authorizationEndpoint?: string;
   tokenEndpoint?: string;


### PR DESCRIPTION
 ## What & why
<img width="1620" height="397" alt="imagen" src="https://github.com/user-attachments/assets/a3efab0f-3873-426b-90e5-9cc482a82c9d" />

<img width="637" height="692" alt="Captura de pantalla 2026-07-14 080636" src="https://github.com/user-attachments/assets/5bf52f75-baf0-412a-899b-d27722508ec6" />


  Adds per-scan live guidance, dynamic provider model discovery, Novita AI support, and clearer Codex credential handling.

  Operators can send guidance while an individual scan is running directly from its Events view.

  The LLM Settings page now discovers available models from providers that expose compatible OpenAI, Anthropic, Gemini, or Ollama model-list endpoints.
  Discovery runs automatically when a provider and its credentials are selected, while a manual refresh action remains available.

  Model discovery is performed by the backend so API keys and OAuth access tokens are never exposed to the browser. Stored profile endpoint overrides and the
  active LLM endpoint are supported. Ollama uses its OpenAI-compatible `/v1/models` endpoint with `/api/tags` as a native fallback.

  The built-in provider catalog no longer contains hardcoded model examples. Providers without a compatible discovery endpoint use explicit manual model
  entry instead of potentially outdated suggestions.

  Novita AI is included as a built-in OpenAI-compatible provider.

  The Codex CLI credential reuse flow now reports a Codex-specific error instead of incorrectly displaying `claude cli credentials not found`. The UI also
  documents the expected credential path and Docker mount.


  Closes #

  ## Type of change

  - [x] Bug fix
  - [x] New feature
  - [ ] Docs
  - [ ] Refactor / internal
  - [ ] Other:

  ## How was it tested?

  - [x] `make lint` passes
  - [ ] `golangci-lint run --config .golangci.yml ./...` passes
  - [ ] `go test ./...` passes
  - [x] Added/updated tests for the change

  Additional verification:

  - Web UI TypeScript typecheck
  - Vite production build
  - OpenAI-compatible model discovery test
  - Gemini generative-model filtering test
  - Ollama `/v1/models` and `/api/tags` endpoint construction test
  - Authenticated Codex credential import smoke test
  - Provider catalog smoke test confirming no hardcoded models are returned
  - Served frontend bundle verification

  The complete test suite has an unrelated existing `internal/config` failure when executed inside the runtime image because image-level runtime
  configuration overrides the test fixture.

  ## Checklist

  - [ ] I read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md).
  - [x] The tree is `gofmt`-clean.
  - [x] I updated docs (`README`, `docs/`, help text) if behavior changed.
  - [x] This does not weaken a security control (scope guard, verifier, false-positive gate) without explicit discussion.
  - [x] For engine behavior changes: I noted any impact on scan findings/severity.

  This change does not alter scan findings, severity classification, security gates, or provider cybersecurity policy handling.
