### PR TITLE
fix(web): immediate force restart for /api/restart (force=true)

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log"
 	"net"
@@ -594,16 +595,20 @@ var dashboardRoutes = []string{
 
 // Server is the web UI server.
 type Server struct {
-	cfg                  *config.Config
-	port                 int
-	clients              map[*wsClient]bool
-	mu                   sync.RWMutex
-	currentAgents        map[string]*agent.Agent // scanID → agent (replaces singleton currentAgent)
-	cancelScan           context.CancelFunc      // cancels the current scan session context
-	running              atomic.Bool
-	stopReq              atomic.Bool
-	restartWhenIdle      atomic.Bool  // SIGUSR1 sets this; a watcher restarts once scans drain
-	httpServer           *http.Server // set in Start; used to trigger graceful restart from the API
+	cfg             *config.Config
+	port            int
+	clients         map[*wsClient]bool
+	mu              sync.RWMutex
+	currentAgents   map[string]*agent.Agent // scanID → agent (replaces singleton currentAgent)
+	cancelScan      context.CancelFunc      // cancels the current scan session context
+	running         atomic.Bool
+	stopReq         atomic.Bool
+	restartWhenIdle atomic.Bool  // SIGUSR1 sets this; a watcher restarts once scans drain
+	httpServer      *http.Server // set in Start; used to trigger graceful restart from the API
+	// forceRestartFn performs an immediate restart for POST /api/restart?force=true.
+	// nil in production (the handler re-execs via restartNow); tests set it to a
+	// stub so the force path can be exercised without exec'ing the process.
+	forceRestartFn       func()
 	dataDir              string
 	currentScanDir       string
 	currentScanID        string
@@ -1648,13 +1653,19 @@ func (s *Server) handleStop(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "stopped"})
 }
 
-// handleRestart schedules a graceful restart of the backend. The restart is
-// never immediate while work is in flight: it waits until no scan instance is
-// active and no tool process is leased, then restarts cleanly (in-flight scans
-// auto-resume afterwards). This is the HTTP equivalent of
-// `xalgorix --restart-when-idle` (SIGUSR1) and shares the same watcher.
+// handleRestart restarts the backend. By default the restart is graceful: it
+// waits until no scan instance is active and no tool process is leased, then
+// restarts cleanly (in-flight scans auto-resume afterwards). This is the HTTP
+// equivalent of `xalgorix --restart-when-idle` (SIGUSR1) and shares the watcher.
 //
-// POST /api/restart  → { "status": "scheduled"|"already_pending", "idle": bool }
+// With force=true (query param ?force=true or JSON body {"force":true}) the
+// restart is IMMEDIATE: it interrupts any in-flight scans/tools and restarts
+// right now. Interrupted scans are marked "stopped" (reason "server_restart")
+// when the process comes back and rebuilds instances from disk. Use force when
+// the scanner is wedged and would never reach idle on its own.
+//
+// POST /api/restart            → { "status": "scheduled"|"already_pending", "idle": bool }
+// POST /api/restart?force=true → { "status": "restarting", "idle": bool, "forced": true }
 func (s *Server) handleRestart(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method != http.MethodPost {
@@ -1663,6 +1674,40 @@ func (s *Server) handleRestart(w http.ResponseWriter, r *http.Request) {
 	}
 
 	idle := s.scannerIdle()
+
+	if restartForceRequested(r) {
+		log.Printf("[RESTART] /api/restart FORCE requested (idle=%v) — restarting immediately, interrupting any in-flight work", idle)
+		if s.discordWebhook != "" {
+			s.sendDiscord(0xff6b6b, "🔁 Xalgorix Force Restart",
+				"An immediate restart was requested. Xalgorix is restarting now; any in-flight scans are interrupted and marked stopped.")
+		}
+		if s.telegramConfigured() {
+			s.sendTelegram(0xff6b6b, "🔁 Xalgorix Force Restart",
+				"An immediate restart was requested. Xalgorix is restarting now; any in-flight scans are interrupted and marked stopped.")
+		}
+		// Prevent an already-scheduled idle watcher from also firing.
+		s.restartWhenIdle.Store(true)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "restarting",
+			"idle":   idle,
+			"forced": true,
+		})
+		// Flush the response so the caller sees 200 BEFORE the process re-execs
+		// (restartNow replaces/exits the process), then restart out-of-band.
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		if s.forceRestartFn != nil {
+			go s.forceRestartFn()
+			return
+		}
+		go func() {
+			time.Sleep(500 * time.Millisecond)
+			s.restartNow(s.httpServer)
+		}()
+		return
+	}
+
 	scheduled := s.scheduleGracefulRestart()
 
 	status := "scheduled"
@@ -1674,6 +1719,37 @@ func (s *Server) handleRestart(w http.ResponseWriter, r *http.Request) {
 		"status": status,
 		"idle":   idle,
 	})
+}
+
+// restartForceRequested reports whether the caller asked for an immediate
+// restart, via either the ?force=true query param or a JSON body {"force":true}.
+func restartForceRequested(r *http.Request) bool {
+	if isTrueish(r.URL.Query().Get("force")) {
+		return true
+	}
+	if r.Body == nil {
+		return false
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<16))
+	if err != nil || len(body) == 0 {
+		return false
+	}
+	var payload struct {
+		Force bool `json:"force"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return false
+	}
+	return payload.Force
+}
+
+func isTrueish(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -3133,3 +3133,91 @@ func TestAppendVulnSummaryUniqueIsFilterAgnostic(t *testing.T) {
 		t.Fatalf("expected 2 vulns (medium + critical), got %d: %#v", len(vulns), vulns)
 	}
 }
+
+// TestRestartForceRequested covers parsing of the force flag from either the
+// query string or a JSON body.
+func TestRestartForceRequested(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		body string
+		want bool
+	}{
+		{name: "no force", url: "/api/restart", want: false},
+		{name: "query true", url: "/api/restart?force=true", want: true},
+		{name: "query 1", url: "/api/restart?force=1", want: true},
+		{name: "query yes", url: "/api/restart?force=yes", want: true},
+		{name: "query false", url: "/api/restart?force=false", want: false},
+		{name: "body true", url: "/api/restart", body: `{"force":true}`, want: true},
+		{name: "body false", url: "/api/restart", body: `{"force":false}`, want: false},
+		{name: "empty body", url: "/api/restart", body: "", want: false},
+		{name: "garbage body", url: "/api/restart", body: "not json", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var r *http.Request
+			if tt.body != "" {
+				r = httptest.NewRequest(http.MethodPost, tt.url, strings.NewReader(tt.body))
+			} else {
+				r = httptest.NewRequest(http.MethodPost, tt.url, nil)
+			}
+			if got := restartForceRequested(r); got != tt.want {
+				t.Fatalf("restartForceRequested = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHandleRestart_ForceRestartsImmediately verifies that ?force=true triggers
+// the immediate-restart path (recorded via the injectable seam) rather than the
+// wait-for-idle scheduler — even when a scan is active.
+func TestHandleRestart_ForceRestartsImmediately(t *testing.T) {
+	s := newTestServer(t, nil)
+	// An active instance would normally block a graceful restart.
+	s.instancesMu.Lock()
+	s.instances = map[string]*ScanInstance{"inst-busy": {ID: "inst-busy", Status: "running"}}
+	s.instancesMu.Unlock()
+
+	done := make(chan struct{})
+	s.forceRestartFn = func() { close(done) }
+
+	rr := httptest.NewRecorder()
+	s.handleRestart(rr, httptest.NewRequest(http.MethodPost, "/api/restart?force=true", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"forced":true`) {
+		t.Fatalf("response missing forced marker: %s", rr.Body.String())
+	}
+	select {
+	case <-done:
+		// force restart fired
+	case <-time.After(2 * time.Second):
+		t.Fatal("force restart was not triggered")
+	}
+}
+
+// TestHandleRestart_DefaultSchedulesWhenBusy verifies the default (non-force)
+// path still only schedules a restart and does not fire immediately while a
+// scan is active.
+func TestHandleRestart_DefaultSchedulesWhenBusy(t *testing.T) {
+	s := newTestServer(t, nil)
+	s.instancesMu.Lock()
+	s.instances = map[string]*ScanInstance{"inst-busy": {ID: "inst-busy", Status: "running"}}
+	s.instancesMu.Unlock()
+	s.forceRestartFn = func() { t.Fatal("force restart must not fire on the default path") }
+
+	rr := httptest.NewRecorder()
+	s.handleRestart(rr, httptest.NewRequest(http.MethodPost, "/api/restart", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"status":"scheduled"`) {
+		t.Fatalf("expected scheduled status, got: %s", rr.Body.String())
+	}
+	if got := rr.Body.String(); strings.Contains(got, `"idle":true`) {
+		t.Fatalf("scanner should report busy (idle=false), got: %s", got)
+	}
+}


### PR DESCRIPTION
## Problem

The SaaS admin **Force restart** button doesn't restart a wedged scanner — the reported symptom ("force restart button is not working, scanner is not restarting").

Root cause: both the deferred and the force buttons call `POST /api/restart`, and that handler **only ever scheduled a restart-when-idle** (`scheduleGracefulRestart` → `restartWhenIdleWatcher`). If the scanner is busy or stuck and never reaches idle, it never restarts — yet the endpoint returns `{"status":"scheduled"}` `200`, so the UI looks like it worked. There was no immediate-restart path over HTTP at all.

## Fix

Add a force path to the existing endpoint:

- `POST /api/restart` → unchanged: graceful restart-when-idle.
- `POST /api/restart?force=true` (or JSON body `{"force":true}`) → **restarts immediately** via `restartNow`, interrupting any in-flight scans.

On restart, `rebuildInstancesFromDisk` already marks previously-running scans `stopped` (reason `server_restart`), and the SaaS reap cron reconciles them — so interrupting in-flight work is safe and accounted for.

Details:
- `restartForceRequested` parses the flag from the query string or a size-limited JSON body.
- The 200 response is flushed **before** the restart fires (500ms out-of-band) so the caller sees success before the process re-execs/exits.
- Sets `restartWhenIdle` so an already-scheduled idle watcher can't also fire.
- A `forceRestartFn` seam makes the force path unit-testable without exec'ing the process.

## Tests
- `TestRestartForceRequested` — query (`true/1/yes/false`) and body variants.
- `TestHandleRestart_ForceRestartsImmediately` — fires immediately even with an active instance.
- `TestHandleRestart_DefaultSchedulesWhenBusy` — default path still only schedules when busy.

## Verification
`go build ./...`, `go vet`, `golangci-lint run` (0 issues), `gofmt -l` clean, and `go test ./internal/web/...` all pass.

## Companion change
The SaaS `forceBackendRestart` is updated to call `/api/restart?force=true` (graceful path unchanged). Sending `?force=true` to an older engine is harmless — it's ignored and behaves as before — so there's no deploy-order coupling.