### PR TITLE
refactor(web): dedupe model-prefix helper + strip legacy prefix on no-auth path

### DIFF
--- a/internal/llm/resolver.go
+++ b/internal/llm/resolver.go
@@ -212,7 +212,7 @@ func (c *compositeResolver) Resolve(ctx context.Context) (Endpoint, error) {
 			if strings.TrimSpace(c.cfg.APIBase) != "" {
 				entry.BaseURL = strings.TrimSpace(c.cfg.APIBase)
 			}
-			return BuildCatalogEndpoint(entry, auth.Profile{}, strings.TrimSpace(c.cfg.LLM), c.cfg.APIBase)
+			return BuildCatalogEndpoint(entry, auth.Profile{}, modelForProvider(c.cfg.LLM, c.cfg.LLMProvider), c.cfg.APIBase)
 		}
 	}
 	// Branch 1 — explicit active credential pointer wins.

--- a/internal/web/scan_resolve.go
+++ b/internal/web/scan_resolve.go
@@ -269,7 +269,7 @@ func (s *Server) legacyOrCatalogDefaultEndpoint(ctx context.Context, cfg *config
 				if strings.TrimSpace(cfg.APIBase) != "" {
 					entry.BaseURL = strings.TrimSpace(cfg.APIBase)
 				}
-				if ep, berr := llm.BuildCatalogEndpoint(entry, auth.Profile{}, strings.TrimSpace(cfg.LLM), cfg.APIBase); berr == nil {
+				if ep, berr := llm.BuildCatalogEndpoint(entry, auth.Profile{}, modelForConfiguredProvider(cfg.LLM, cfg.LLMProvider), cfg.APIBase); berr == nil {
 					return ep
 				}
 			}

--- a/internal/web/scan_resolve_test.go
+++ b/internal/web/scan_resolve_test.go
@@ -69,3 +69,25 @@ func TestResolveScanCredentialsUsesCredentialFreeProviderAndBareModel(t *testing
 		t.Fatalf("credential-free endpoint contains credentials")
 	}
 }
+
+// TestResolveScanCredentialsStripsLegacyPrefixForCredentialFreeProvider verifies
+// the no-auth branch strips a matching "<provider>/" prefix from a legacy
+// XALGORIX_LLM value (while still preserving provider-native slashes, since only
+// the matching provider prefix is removed).
+func TestResolveScanCredentialsStripsLegacyPrefixForCredentialFreeProvider(t *testing.T) {
+	s := &Server{catalog: providers.NewService()}
+	cfg := &config.Config{
+		LLMProvider: "ollama",
+		// Legacy-shaped value that carries the provider prefix; only the matching
+		// "ollama/" prefix should be stripped, leaving the native model id intact.
+		LLM:     "ollama/deepseek-v4-pro:cloud",
+		APIBase: "http://host.docker.internal:11434/v1",
+	}
+	ep, err := s.resolveScanCredentials(context.Background(), ScanRequest{}, cfg)
+	if err != nil {
+		t.Fatalf("resolveScanCredentials: %v", err)
+	}
+	if ep.Model != "deepseek-v4-pro:cloud" {
+		t.Fatalf("Model = %q, want deepseek-v4-pro:cloud (legacy prefix should be stripped)", ep.Model)
+	}
+}

--- a/internal/web/settings_env.go
+++ b/internal/web/settings_env.go
@@ -419,7 +419,7 @@ func (s *Server) applyCatalogLLMSettings(ctx context.Context, req llmSettingsReq
 
 	// Legacy env-var sync. Always written when the operator
 	// supplied a model so the legacy path stays runnable.
-	if model := bareModelForProvider(strings.TrimSpace(req.Model), provider); model != "" {
+	if model := modelForConfiguredProvider(strings.TrimSpace(req.Model), provider); model != "" {
 		updates["XALGORIX_LLM"] = model
 	}
 
@@ -475,18 +475,6 @@ func (s *Server) applyCatalogLLMSettings(ctx context.Context, req llmSettingsReq
 		return err
 	}
 	return nil
-}
-
-func bareModelForProvider(model, provider string) string {
-	model = strings.TrimSpace(model)
-	provider = strings.ToLower(strings.TrimSpace(provider))
-	if provider != "" {
-		prefix := provider + "/"
-		if strings.HasPrefix(strings.ToLower(model), prefix) {
-			return strings.TrimSpace(model[len(prefix):])
-		}
-	}
-	return model
 }
 
 func containerReachableLocalBase(raw string) string {
@@ -560,7 +548,7 @@ func (s *Server) llmSettings(ctx context.Context) llmSettingsResponse {
 		}
 	}
 	resp.Provider = provider
-	resp.Model = bareModelForProvider(s.cfg.LLM, provider)
+	resp.Model = modelForConfiguredProvider(s.cfg.LLM, provider)
 
 	// AuthMethod derivation: dispatch precedence mirrors the
 	// resolver. cfg.LLMProfile present + Profile.Type drives the


### PR DESCRIPTION
Follow-up cleanup to #223, addressing the two review nits.

## 1. Dedupe the model-prefix helper
`internal/web` had two identical helpers: `modelForConfiguredProvider` (scan_resolve.go) and `bareModelForProvider` (settings_env.go). Removed `bareModelForProvider`; both call sites now use `modelForConfiguredProvider`. The `internal/llm` copy (`modelForProvider`) stays — it's across a package boundary.

## 2. Strip the legacy prefix on the no-auth path
The credential-free branches passed `XALGORIX_LLM` verbatim to `BuildCatalogEndpoint`. A legacy value carrying a matching `"<provider>/"` prefix (e.g. `ollama/deepseek-v4-pro:cloud`) would be sent unstripped. Both no-auth branches — `llm` resolver Branch 0 and web `legacyOrCatalogDefaultEndpoint` — now run the same prefix strip as every other path. Only a *matching* provider prefix is removed, so provider-native slashes (`zai-org/glm-4.5`) are preserved.

In practice the settings UI always writes a bare model when it sets the provider, so this is a robustness/consistency fix rather than a live bug — but it makes every routing path behave identically.

## Tests
Adds `TestResolveScanCredentialsStripsLegacyPrefixForCredentialFreeProvider`.

## Verification
`go build ./...`, `go vet`, `golangci-lint run` (0 issues), `gofmt -l` clean, and `go test ./internal/web/... ./internal/llm/...` all pass.