### PR TITLE
fix(agent): break loops on repeatedly guard-blocked tool calls (#158 follow-up)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -920,7 +920,7 @@ func (a *Agent) Run(targets []string, instruction string) {
 			}
 
 			if blocked, reason := a.shouldBlockForActivityPolicy(tc.Name, tc.Args); blocked {
-				blockMsg := "⛔ ACTIVITY POLICY BLOCKED TOOL — " + reason
+				blockMsg := "⛔ ACTIVITY POLICY BLOCKED TOOL — " + reason + noteBlockedToolCall(a.state, tc.Name, tc.Args)
 				a.emit(Event{Type: "tool_call", ToolName: tc.Name, ToolArgs: tc.Args})
 				a.emit(Event{Type: "tool_result", ToolName: tc.Name, ToolResult: tools.Result{Output: blockMsg}, TotalTokens: tokenCount()})
 				a.msgMu.Lock()
@@ -930,7 +930,7 @@ func (a *Agent) Run(targets []string, instruction string) {
 			}
 
 			if blocked, reason := a.shouldBlockForPhaseRestriction(tc.Name, tc.Args); blocked {
-				blockMsg := "⛔ PHASE RESTRICTION BLOCKED TOOL — " + reason
+				blockMsg := "⛔ PHASE RESTRICTION BLOCKED TOOL — " + reason + noteBlockedToolCall(a.state, tc.Name, tc.Args)
 				a.emit(Event{Type: "tool_call", ToolName: tc.Name, ToolArgs: tc.Args})
 				a.emit(Event{Type: "tool_result", ToolName: tc.Name, ToolResult: tools.Result{Output: blockMsg}, TotalTokens: tokenCount()})
 				a.msgMu.Lock()
@@ -946,7 +946,7 @@ func (a *Agent) Run(targets []string, instruction string) {
 			// pivoting to third-party hosts discovered via DNS, port
 			// scans, related infrastructure, etc.
 			if blocked, reason := a.shouldBlockForOutOfScope(tc.Name, tc.Args); blocked {
-				blockMsg := "⛔ OUT-OF-SCOPE TARGET BLOCKED — " + reason
+				blockMsg := "⛔ OUT-OF-SCOPE TARGET BLOCKED — " + reason + noteBlockedToolCall(a.state, tc.Name, tc.Args)
 				a.emit(Event{Type: "tool_call", ToolName: tc.Name, ToolArgs: tc.Args})
 				a.emit(Event{Type: "tool_result", ToolName: tc.Name, ToolResult: tools.Result{Output: blockMsg}, TotalTokens: tokenCount()})
 				a.msgMu.Lock()
@@ -954,6 +954,11 @@ func (a *Agent) Run(targets []string, instruction string) {
 				a.msgMu.Unlock()
 				continue
 			}
+
+			// This call passed every block guard — a real, allowed action.
+			// Clear the consecutive-blocked-call counter so only a SUSTAINED
+			// block loop (no allowed call in between) escalates.
+			a.state.ConsecutiveBlockedCalls = 0
 
 			a.hooks.Fire(OnToolCall, a.state, toolArgs)
 

--- a/internal/agent/blocked_loop_test.go
+++ b/internal/agent/blocked_loop_test.go
@@ -1,0 +1,79 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestNoteBlockedToolCall_EscalatesOnSustainedBlocks verifies the blocked-call
+// backstop: repeated guard-blocked calls escalate from silence → soft nudge →
+// hard "stop / pivot / finish" nudge, so a model fixating on a permanently
+// rejected action can't burn iterations without correction (issue #158
+// follow-up: the block branches short-circuit before the normal stuck tracker).
+func TestNoteBlockedToolCall_EscalatesOnSustainedBlocks(t *testing.T) {
+	st := NewScanState()
+	args := map[string]string{"command": "curl http://out-of-scope.example/"}
+
+	// Below the soft threshold: no nudge yet.
+	for i := 1; i < BlockedCallSoftNudge; i++ {
+		if msg := noteBlockedToolCall(st, "terminal_execute", args); msg != "" {
+			t.Fatalf("block #%d should not nudge yet, got %q", i, msg)
+		}
+	}
+
+	// At the soft threshold: a corrective nudge appears.
+	soft := noteBlockedToolCall(st, "terminal_execute", args)
+	if soft == "" {
+		t.Fatalf("expected a soft nudge at %d consecutive blocks", BlockedCallSoftNudge)
+	}
+	if strings.Contains(soft, "STOP") {
+		t.Fatalf("soft nudge should not be the hard escalation yet: %q", soft)
+	}
+
+	// Keep hitting blocks until the hard threshold → strong stop/pivot/finish.
+	var hard string
+	for st.ConsecutiveBlockedCalls < BlockedCallHardNudge {
+		hard = noteBlockedToolCall(st, "terminal_execute", args)
+	}
+	if !strings.Contains(hard, "STOP") || !strings.Contains(strings.ToLower(hard), "finish") {
+		t.Fatalf("expected hard escalation to tell the agent to stop and finish, got %q", hard)
+	}
+}
+
+// TestNoteBlockedToolCall_ResetClearsEscalation verifies that once an allowed
+// call clears the counter (as the dispatch loop does on a guard-pass), the
+// escalation starts over — so interleaved allowed work never trips the loop
+// backstop.
+func TestNoteBlockedToolCall_ResetClearsEscalation(t *testing.T) {
+	st := NewScanState()
+	args := map[string]string{"command": "curl http://out-of-scope.example/"}
+
+	for i := 0; i < BlockedCallSoftNudge; i++ {
+		noteBlockedToolCall(st, "terminal_execute", args)
+	}
+	if st.ConsecutiveBlockedCalls < BlockedCallSoftNudge {
+		t.Fatalf("counter did not accumulate: %d", st.ConsecutiveBlockedCalls)
+	}
+
+	// Simulate a call that passes the guards (dispatch loop does this).
+	st.ConsecutiveBlockedCalls = 0
+
+	// The next block is treated as fresh — no immediate nudge.
+	if msg := noteBlockedToolCall(st, "terminal_execute", args); msg != "" {
+		t.Fatalf("after a reset the first block should not nudge, got %q", msg)
+	}
+}
+
+// TestNoteBlockedToolCall_IdenticalRepeatMessaging verifies the soft nudge
+// calls out an exact-repeat loop distinctly from a varied-but-all-blocked loop.
+func TestNoteBlockedToolCall_IdenticalRepeatMessaging(t *testing.T) {
+	st := NewScanState()
+	same := map[string]string{"command": "curl http://oos.example/"}
+	for i := 0; i < BlockedCallSoftNudge-1; i++ {
+		noteBlockedToolCall(st, "terminal_execute", same)
+	}
+	msg := noteBlockedToolCall(st, "terminal_execute", same)
+	if !strings.Contains(msg, "exact blocked action") {
+		t.Fatalf("expected identical-repeat wording, got %q", msg)
+	}
+}

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -92,6 +92,18 @@ type ScanState struct {
 	LastResultFP          string
 	ConsecutiveSameResult int // same result-output fingerprint back-to-back
 
+	// Blocked-call loop detection. The three block guards (activity policy,
+	// phase restriction, out-of-scope) short-circuit the dispatch BEFORE the
+	// stuck tracker above ever runs, so a model that fixates on a
+	// permanently-rejected action — e.g. repeatedly probing an out-of-scope
+	// host, or active probes in passive mode — never trips a nudge and burns
+	// iterations to MaxIterations (default unlimited). These count consecutive
+	// blocked calls with no allowed tool call in between; reset the moment a
+	// call passes the guards. NOT reset by OnHealthyResponse — a "healthy"
+	// response that re-issues a blocked call is exactly the loop.
+	ConsecutiveBlockedCalls int
+	LastBlockedCallHash     string
+
 	// CumulativeRateLimitWait tracks the total time spent parked in the
 	// provider-rate-limit backoff loop across the whole scan. It bounds an
 	// otherwise-indefinite stall: a persistently 429'd provider would
@@ -203,7 +215,36 @@ const (
 	RepeatCallSoftNudge  = 3 // identical (tool,args) → soft pivot nudge + skip
 	RepeatCallHardSkip   = 5 // identical (tool,args) → strong force-skip nudge
 	RepeatResultHardSkip = 4 // identical result output across calls → force-skip
+
+	BlockedCallSoftNudge = 3 // consecutive guard-blocked calls → soft corrective nudge
+	BlockedCallHardNudge = 6 // consecutive guard-blocked calls → hard "stop / pivot / finish" nudge
 )
+
+// noteBlockedToolCall records that a Gated_Tool call was rejected by a block
+// guard (activity policy, phase restriction, or out-of-scope) and returns an
+// escalating corrective nudge (appended to the block message) once the agent
+// has been blocked repeatedly with no allowed call in between. Returns "" until
+// the soft threshold is reached. The dispatch loop resets
+// ConsecutiveBlockedCalls to 0 the moment a call passes the guards, so only a
+// sustained block loop escalates. This is the backstop for the block branches,
+// which short-circuit before the normal stuck tracker (issue #158 follow-up).
+func noteBlockedToolCall(state *ScanState, name string, args map[string]string) string {
+	state.ConsecutiveBlockedCalls++
+	hash := hashToolArgs(name, args)
+	identical := hash == state.LastBlockedCallHash
+	state.LastBlockedCallHash = hash
+
+	if state.ConsecutiveBlockedCalls < BlockedCallSoftNudge {
+		return ""
+	}
+	if state.ConsecutiveBlockedCalls >= BlockedCallHardNudge {
+		return fmt.Sprintf("\n\n⛔ STOP — %d of your last tool calls were rejected by scan guards with no allowed action in between. Repeating a blocked action cannot change the result. You MUST change course NOW: choose an IN-SCOPE target and a policy-allowed action, or — if in-scope testing is exhausted — call finish. Do not attempt this or any other blocked action again.", state.ConsecutiveBlockedCalls)
+	}
+	if identical {
+		return fmt.Sprintf("\n\n⚠️ You have attempted this exact blocked action %d times in a row — it will never be permitted. Stop repeating it and pick a different, in-scope and policy-allowed action.", state.ConsecutiveBlockedCalls)
+	}
+	return fmt.Sprintf("\n\n⚠️ %d of your last actions were blocked by scan guards. Change approach — only in-scope targets and policy-allowed actions will run.", state.ConsecutiveBlockedCalls)
+}
 
 // ── Per-Role Temperatures ────────────────────────────────────────────────────
 // Temperature controls the LLM's creativity vs determinism tradeoff.


### PR DESCRIPTION
## Problem

The v4.5.x loop-breaker (#158) catches repeated identical tool *calls*, but the changelog flagged a remaining gap — and it's still live. The three block guards in the dispatch loop —

- `shouldBlockForActivityPolicy` (active probe in passive mode)
- `shouldBlockForPhaseRestriction` (recon/report-only phase)
- `shouldBlockForOutOfScope` (agent tries a third-party/local host)

— emit a block message and `continue` **before** `OnToolCall`/`OnStuckCheck` run. So if the model fixates on a permanently-rejected action, nothing trips a nudge or skip, and the scan burns iterations to `MaxIterations` (default unlimited). It "looks running" but is stuck — the exact failure class #158 targeted.

## Fix

A dedicated consecutive-blocked-call backstop, kept **separate** from the normal stuck tracker so a blocked (non-executed) call is never miscounted as progress by `hookWorkTracker`:

- `ScanState.ConsecutiveBlockedCalls` / `LastBlockedCallHash` — **not** reset by `OnHealthyResponse` (a "healthy" response that re-issues a blocked call is exactly the loop).
- `noteBlockedToolCall()` increments the counter and appends an escalating corrective nudge to the block message:
  - `< 3`: silent
  - `3` (soft): pivot nudge, with distinct wording for an *exact-repeat* loop vs a *varied-but-all-blocked* loop
  - `6` (hard): "stop — pick an in-scope, policy-allowed action, or if in-scope testing is exhausted, call finish"
- The dispatch loop resets the counter to `0` the moment a call passes all guards, so only a **sustained** block loop escalates — interleaved allowed work never trips it.

No change to `MaxIterations`; no change to the existing stuck/repeat machinery.

## Tests
`TestNoteBlockedToolCall_EscalatesOnSustainedBlocks`, `_ResetClearsEscalation`, `_IdenticalRepeatMessaging`.

## Verification
`go build ./...`, `go vet`, `golangci-lint run` (0 issues), `gofmt -l` clean, and the full `./internal/agent/...` suite pass.