### PR TITLE
feat(webui): multi-line scan instructions (#229)

### DIFF
--- a/webui/src/components/new-scan-dialog.tsx
+++ b/webui/src/components/new-scan-dialog.tsx
@@ -160,11 +160,15 @@ export default function NewScanDialog({
           </div>
           <div className="space-y-2">
             <Label htmlFor="instruction">Instruction (optional)</Label>
-            <Input
+            <textarea
               id="instruction"
               value={instruction}
               onChange={(e) => setInstruction(e.target.value)}
-              placeholder="Focus on auth + injection. Skip noisy enumeration."
+              rows={4}
+              placeholder={
+                "Multiple lines are supported — e.g.\nFocus on auth + injection; skip noisy enumeration.\nCreds: admin@example.com / hunter2 (role: admin)\nSecond account: user@example.com / pass123 (role: member)"
+              }
+              className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm font-mono shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
             />
           </div>
           {error && (

--- a/webui/src/pages/schedules.tsx
+++ b/webui/src/pages/schedules.tsx
@@ -554,8 +554,9 @@ export default function SchedulesPage() {
               <Label htmlFor="sched-instruction">
                 Custom instruction (optional)
               </Label>
-              <Input
+              <Textarea
                 id="sched-instruction"
+                rows={4}
                 placeholder="e.g. Skip noisy subdomain enumeration, focus on api testing"
                 value={instruction}
                 onChange={(e) => setInstruction(e.target.value)}


### PR DESCRIPTION
Closes #229 (the multi-line instruction ask).

## Problem
The New Scan dialog and Schedules form used a single-line `<Input>` for the instruction field, so operators couldn't provide multi-line context — several directives, credentials for multiple roles/accounts, or scoping notes.

## Change
Both instruction fields are now multi-line `<textarea>` (rows=4), matching the existing Targets field styling. Placeholder shows the multi-line intent (directives + two role credential sets). No API change — the instruction string already flows through unchanged and renders whitespace-preserved on the scan detail page.

## Not included
The body of #229 also mentions attaching a context file to an *already-saved* scan. That's a separate, larger change (needs a backend endpoint to amend a saved scan's instructions/context) and is intentionally out of scope here.

## Verification
`tsc -b --noEmit` (webui) passes. The embedded `internal/web/static` bundle is regenerated at release time (per repo convention).