### PR TITLE
feat(scopeguard): opt-in local-target scanning for self-hosted installs (#228)

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,26 @@ Then open `http://<server-ip>:9137`.
 
 If the process is listening but the page still does not load remotely, allow TCP port `9137` in the server firewall or cloud security group.
 
+#### Scanning local/internal targets
+
+By default Xalgorix refuses to scan loopback, `localhost`, private-range, or
+its own interface addresses — they're the machine Xalgorix runs on, not a
+target. On a **self-hosted, single-tenant** box you can opt in to scan a
+locally-hosted demo/staging app:
+
+```bash
+echo 'XALGORIX_ALLOW_LOCAL_TARGETS=true' | sudo tee -a /root/.xalgorix.env
+sudo xalgorix --restart
+```
+
+The dashboard's own listener is **always** protected, even with this enabled.
+
+> **⚠️ Shared / multi-tenant / hosted deployments: keep this OFF.** Enabling it
+> would let a user's scan reach the operator's own machine and internal network.
+> It is off by default, so no action is needed to stay safe — do not set
+> `XALGORIX_ALLOW_LOCAL_TARGETS` (or pin `XALGORIX_ALLOW_LOCAL_TARGETS=false`),
+> and don't expose the engine's Settings page to untrusted users.
+
 ## Web UI Workflow
 
 1. Open the dashboard at `http://127.0.0.1:9137`.

--- a/README.md
+++ b/README.md
@@ -603,6 +603,7 @@ Some settings require a restart because they affect process startup or server bi
 | Variable                 | Default           | Description                        |
 | ------------------------ | ----------------- | ---------------------------------- |
 | `XALGORIX_BIND`          | `127.0.0.1`       | Web server listen address.         |
+| `XALGORIX_ALLOW_LOCAL_TARGETS` | `false`     | Allow scanning locally-hosted apps (localhost / 127.0.0.1 / private IPs) on a self-hosted install. The dashboard's own listener is always protected. Leave off on shared/hosted deployments. |
 | `XALGORIX_USERNAME`      | none              | Dashboard username.                |
 | `XALGORIX_PASSWORD`      | none              | Dashboard password.                |
 | `XALGORIX_PASSWORD_HASH` | none              | Preferred bcrypt password hash.    |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -152,6 +152,15 @@ type Config struct {
 	// the server will refuse to start.
 	BindAddr string // XALGORIX_BIND - listen address (default 127.0.0.1)
 
+	// AllowLocalTargets opts a self-hosted install into scanning locally-hosted
+	// apps — loopback, localhost, or one of this machine's own interface IPs
+	// (e.g. a demo/staging environment on the same box), which are blocked by
+	// default as "self". The dashboard's own listener is ALWAYS protected
+	// regardless of this flag. XALGORIX_ALLOW_LOCAL_TARGETS (default false).
+	// Leave OFF on any shared/hosted deployment — it would let a user reach
+	// the operator's own machine.
+	AllowLocalTargets bool
+
 	// Auto-install gating — the LLM-driven terminal tool can call apt/cargo/npm
 	// for missing binaries. Letting that happen under sudo on a multi-user box
 	// is a privilege-escalation surface, so it's now opt-in.
@@ -317,6 +326,10 @@ func load() *Config {
 
 		// Network binding — loopback-only by default.
 		BindAddr: envOr("XALGORIX_BIND", "127.0.0.1"),
+
+		// Self-hosted opt-in to scan locally-hosted apps (off by default; the
+		// dashboard's own listener stays protected regardless).
+		AllowLocalTargets: envOrBool("XALGORIX_ALLOW_LOCAL_TARGETS", false),
 
 		// Auto-install gates — default off for non-root; root sessions keep the
 		// historical behavior so existing systemd deployments keep working.

--- a/internal/scopeguard/allow_local_test.go
+++ b/internal/scopeguard/allow_local_test.go
@@ -1,0 +1,91 @@
+package scopeguard
+
+import (
+	"net"
+	"testing"
+)
+
+// firstLocalInterfaceIP returns a non-loopback IPv4 address bound to one of
+// this machine's interfaces, or "" if none is available.
+func firstLocalInterfaceIP() string {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return ""
+	}
+	for _, a := range addrs {
+		if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+			if v4 := ipnet.IP.To4(); v4 != nil {
+				return v4.String()
+			}
+		}
+	}
+	return ""
+}
+
+// TestAllowLocalTargets covers the self-hosted opt-in (issue #228): when
+// AllowLocalTargets is set, loopback/localhost targets become in-scope so a
+// locally-hosted demo app can be scanned — EXCEPT the dashboard's own listener,
+// which stays blocked on any local address, and the unspecified address, which
+// is always blocked.
+func TestAllowLocalTargets(t *testing.T) {
+	const dashboardPort = 9137
+	on := Config{BindAddr: "127.0.0.1", Port: dashboardPort, AllowLocalTargets: true}
+	off := Config{BindAddr: "127.0.0.1", Port: dashboardPort}
+
+	cases := []struct {
+		name        string
+		target      string
+		wantWhenOn  bool // blocked?
+		wantWhenOff bool // blocked?
+	}{
+		{"loopback app port", "http://127.0.0.1:3000/", false, true},
+		{"localhost app port", "http://localhost:3000/login", false, true},
+		{"ipv6 loopback app port", "http://[::1]:8080/", false, true},
+		{"loopback no port", "http://127.0.0.1/", false, true},
+		// The dashboard's own listener is never scannable, even with the opt-in.
+		{"loopback dashboard port", "http://127.0.0.1:9137/", true, true},
+		{"localhost dashboard port", "http://localhost:9137/", true, true},
+		// Unspecified is always self, opt-in or not.
+		{"unspecified", "http://0.0.0.0/", true, true},
+		// A real external target is unaffected either way.
+		{"external host", "http://example.com/", false, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsLocalOrListener(on, tc.target); got != tc.wantWhenOn {
+				t.Errorf("AllowLocalTargets=true: IsLocalOrListener(%q) = %v, want blocked=%v",
+					tc.target, got, tc.wantWhenOn)
+			}
+			if got := IsLocalOrListener(off, tc.target); got != tc.wantWhenOff {
+				t.Errorf("AllowLocalTargets=false (default): IsLocalOrListener(%q) = %v, want blocked=%v",
+					tc.target, got, tc.wantWhenOff)
+			}
+		})
+	}
+}
+
+// TestAllowLocalTargets_LocalInterfaceIP verifies that when the opt-in is on, a
+// target resolving to one of this machine's own interface IPs is allowed
+// (except on the dashboard port), while it stays blocked by default.
+func TestAllowLocalTargets_LocalInterfaceIP(t *testing.T) {
+	iface := firstLocalInterfaceIP()
+	if iface == "" {
+		t.Skip("no non-loopback local interface IP available")
+	}
+	withStubLookupHost(t, func(string) ([]string, error) { return []string{iface}, nil })
+
+	on := Config{BindAddr: "127.0.0.1", Port: 9137, AllowLocalTargets: true}
+	off := Config{BindAddr: "127.0.0.1", Port: 9137}
+
+	if IsLocalOrListener(on, "http://demo.local:3000/") {
+		t.Errorf("with opt-in, a local-interface target on a non-dashboard port should be allowed")
+	}
+	if !IsLocalOrListener(off, "http://demo.local:3000/") {
+		t.Errorf("by default, a local-interface target must be blocked")
+	}
+	// Even with the opt-in, the dashboard port on a local interface is blocked.
+	if !IsLocalOrListener(on, "http://demo.local:9137/") {
+		t.Errorf("dashboard port must stay blocked on a local-interface address even with the opt-in")
+	}
+}

--- a/internal/scopeguard/scopeguard.go
+++ b/internal/scopeguard/scopeguard.go
@@ -59,6 +59,33 @@ type Config struct {
 	// remain blocked. Empty (the default) preserves the strict behavior:
 	// all loopback is treated as self.
 	AllowLoopbackPorts []int
+
+	// AllowLocalTargets is a GLOBAL opt-in for self-hosted installs that want
+	// to scan a locally-hosted app (loopback, localhost, or one of the
+	// machine's own interface IPs) — e.g. a demo/staging environment on the
+	// same box. Default false. It NEVER exposes the dashboard's own listener:
+	// the self-listener fast-path still blocks the exact bind host:port, and
+	// any local target on the dashboard's Port is refused regardless, so this
+	// can't be turned into a self-scan loop. The unspecified address
+	// (0.0.0.0 / ::) is always blocked. Must remain off on multi-tenant /
+	// hosted deployments (it would let a user reach the operator's machine).
+	AllowLocalTargets bool
+}
+
+// localTargetsAllowed reports whether the global self-hosted local-scan opt-in
+// applies to a target on the given port. Gated so the dashboard's own listener
+// port is never in scope, even via a different local address.
+func (c Config) localTargetsAllowed(hostPort string) bool {
+	if !c.AllowLocalTargets {
+		return false
+	}
+	if hostPort == "" {
+		return true
+	}
+	if pn, err := strconv.Atoi(hostPort); err == nil && pn == c.Port {
+		return false // never scan the dashboard's own port, on any local address
+	}
+	return true
 }
 
 // loopbackPortAllowed reports whether hostPort (a decimal port string) is in
@@ -134,7 +161,11 @@ func IsLocalOrListener(cfg Config, target string) bool {
 	// in. Loopback hosts on exactly that port are NOT self. The dashboard
 	// listener port is never in the allowlist (see loopbackPortAllowed), so
 	// this can never expose the operator's own dashboard.
-	allowLoopback := cfg.loopbackPortAllowed(hostPort)
+	// The per-scan provisioned-port allowlist OR the global self-hosted
+	// local-scan opt-in can exempt loopback. Both are gated so the dashboard's
+	// own port is never in scope; the self-listener fast-path above already
+	// blocked the exact bind host:port.
+	allowLoopback := cfg.loopbackPortAllowed(hostPort) || cfg.localTargetsAllowed(hostPort)
 
 	// Explicit textual matches (fast path) — these always mean "self"
 	lower := strings.ToLower(host)
@@ -196,6 +227,12 @@ func IsLocalOrListener(cfg Config, target string) bool {
 	// operator's own public-facing services (SSH, Grafana, CUPS, etc.)
 	// even when the probed port differs from the dashboard listener.
 	if ipsMatchLocalInterface(resolvedIPs) {
+		// Self-hosted opt-in: the operator explicitly allows scanning apps on
+		// this machine's own interfaces (except the dashboard's port, which
+		// localTargetsAllowed excludes).
+		if cfg.localTargetsAllowed(hostPort) {
+			return false
+		}
 		return true
 	}
 

--- a/internal/web/autonomous.go
+++ b/internal/web/autonomous.go
@@ -3,8 +3,25 @@ package web
 
 import "fmt"
 
+// localScopeRule returns the scope paragraph about local/internal addresses.
+// By default it forbids scanning them (they're the operator's own machine). On
+// a self-hosted install that opted in via XALGORIX_ALLOW_LOCAL_TARGETS, the
+// configured target may itself be local, so we tell the agent to test it —
+// the dashboard's own listener is still protected by the scope guard.
+func localScopeRule(allowLocal bool) string {
+	if allowLocal {
+		return "**LOCAL TARGETS ARE IN SCOPE (self-hosted mode):** This installation is configured to test locally-hosted apps. If the target above is a loopback/localhost/private/link-local address, it IS your intended target — test it fully. The one thing you must never touch is the Xalgorix dashboard's own listener."
+	}
+	return "**⛔ STRICTLY FORBIDDEN — NEVER scan these (they are the local server, NOT the target):**\n" +
+		"- 127.0.0.1, localhost, 0.0.0.0, ::1 (loopback addresses)\n" +
+		"- 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 (private/internal IPs)\n" +
+		"- 169.254.0.0/16 (link-local addresses)\n" +
+		"- Any IP that resolves to the machine you are running on\n" +
+		"If a tool discovers a local/internal IP, SKIP IT and move to the next target. Do NOT run any scans, port scans, or vulnerability tests against local addresses."
+}
+
 // Build autonomous instruction that gives AI freedom to decide approach
-func buildAutonomousInstruction(target string, customInstruction string) string {
+func buildAutonomousInstruction(target string, customInstruction string, allowLocal bool) string {
 	baseInstruction := `## AUTONOMOUS PENTESTING MODE — EXPLOIT-FIRST METHODOLOGY
 
 You are an elite penetration tester. YOUR GOAL: Find REAL, EXPLOITABLE vulnerabilities with PROOF.
@@ -19,12 +36,7 @@ Your primary target is ` + "`" + `` + target + `` + "`" + `. However, the follow
 
 **Out of scope:** Completely different domains, third-party services (Google, AWS, CDNs), unless they are explicitly part of the target's infrastructure.
 
-**⛔ STRICTLY FORBIDDEN — NEVER scan these (they are the local server, NOT the target):**
-- 127.0.0.1, localhost, 0.0.0.0, ::1 (loopback addresses)
-- 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 (private/internal IPs)
-- 169.254.0.0/16 (link-local addresses)
-- Any IP that resolves to the machine you are running on
-If a tool discovers a local/internal IP, SKIP IT and move to the next target. Do NOT run any scans, port scans, or vulnerability tests against local addresses.
+` + localScopeRule(allowLocal) + `
 
 **Why:** Many applications split auth (login.example.com), API (api.example.com), and web (www.example.com) across subdomains. Testing only www would miss critical attack surface.
 
@@ -250,14 +262,14 @@ If you notice a possible vulnerability during recon, record it as an observation
 }
 
 // Build autonomous DAST instruction for URL scanning
-func buildDASTInstruction(target string) string {
+func buildDASTInstruction(target string, allowLocal bool) string {
 	return `## AUTONOMOUS DAST MODE — EXPLOIT-FIRST
 
 YOUR TARGET: ` + target + `
 
 **SCOPE:** Primary target + all sibling subdomains of the same root domain (e.g., www.example.com → login.example.com, api.example.com are in scope). Follow redirects to auth/SSO subdomains.
 
-**⛔ NEVER scan:** 127.0.0.1, localhost, 0.0.0.0, ::1, 10.x.x.x, 172.16-31.x.x, 192.168.x.x, 169.254.x.x — these are local/internal and NOT the target.
+` + localScopeRule(allowLocal) + `
 
 ## ORGANIZE YOUR WORK
 You are already inside the target's scan workspace. Save evidence and tool output in the current directory with clear filenames. Do not use cd to leave this workspace and do not write to /root, /tmp, or another home directory.

--- a/internal/web/codescan.go
+++ b/internal/web/codescan.go
@@ -66,6 +66,7 @@ func (s *Server) isBlockedTargetForScan(target string, allowLoopbackPorts []int)
 		BindAddr:           s.cfg.BindAddr,
 		Port:               s.port,
 		AllowLoopbackPorts: allowLoopbackPorts,
+		AllowLocalTargets:  s.cfg.AllowLocalTargets,
 	}, target)
 }
 

--- a/internal/web/notify.go
+++ b/internal/web/notify.go
@@ -160,8 +160,9 @@ func (s *Server) sendSimpleEmbed(color int, title, description string) {
 // (Requirement 3.8 / design.md → "DNS Lookup Semantics").
 func (s *Server) isBlockedTarget(target string) bool {
 	return scopeguard.IsLocalOrListener(scopeguard.Config{
-		BindAddr: s.cfg.BindAddr,
-		Port:     s.port,
+		BindAddr:          s.cfg.BindAddr,
+		Port:              s.port,
+		AllowLocalTargets: s.cfg.AllowLocalTargets,
 	}, target)
 }
 

--- a/internal/web/orchestrator.go
+++ b/internal/web/orchestrator.go
@@ -565,7 +565,7 @@ func (s *Server) runSingleTarget(_ context.Context, scanCfg *config.Config, req 
 		scanDir:            scanDir,
 		cfg:                scanCfg,
 		server:             s,
-		instruction:        buildAutonomousInstruction(target, instruction),
+		instruction:        buildAutonomousInstruction(target, instruction, scanCfg.AllowLocalTargets),
 		codeScanMode:       req.codeScanMode,
 		allowLoopbackPorts: req.allowLoopbackPorts,
 		name:               req.Name,
@@ -611,7 +611,7 @@ func (s *Server) runDASTTarget(_ context.Context, scanCfg *config.Config, req Sc
 		ActiveScanID:  filepath.Base(scanDir),
 	})
 
-	dastInstruction := buildDASTInstruction(target)
+	dastInstruction := buildDASTInstruction(target, scanCfg.AllowLocalTargets)
 	if req.Instruction != "" {
 		dastInstruction += "\n\n" + req.Instruction
 	}

--- a/internal/web/scan_session.go
+++ b/internal/web/scan_session.go
@@ -95,6 +95,7 @@ func (s *Server) executeScanSession(sess *scanSession) {
 		BindAddr:           s.cfg.BindAddr,
 		Port:               s.port,
 		AllowLoopbackPorts: sess.allowLoopbackPorts,
+		AllowLocalTargets:  s.cfg.AllowLocalTargets,
 	}, agentOpts...)
 	agnt.SetPhaseRestrictions(sess.phases)
 	agnt.SetActivityPolicy(sess.reconMode, sess.scanIntensity, []string{sess.target, sess.parentTarget})

--- a/internal/web/settings_env.go
+++ b/internal/web/settings_env.go
@@ -169,6 +169,7 @@ func allEnvSettingDefinitions() []envSettingDefinition {
 		{Key: "XALGORIX_PASSWORD", Label: "Dashboard password", Category: "Security", Description: "Plaintext dashboard password. Prefer XALGORIX_PASSWORD_HASH.", InputType: "secret", Sensitive: true, RequiresRestart: true},
 		{Key: "XALGORIX_PASSWORD_HASH", Label: "Dashboard password hash", Category: "Security", Description: "Bcrypt dashboard password hash.", InputType: "secret", Sensitive: true, RequiresRestart: true},
 		{Key: "XALGORIX_BIND", Label: "Bind address", Category: "Security", Description: "Web server listen address.", DefaultValue: "127.0.0.1", Placeholder: "127.0.0.1", InputType: "text", RequiresRestart: true},
+		{Key: "XALGORIX_ALLOW_LOCAL_TARGETS", Label: "Allow local targets", Category: "Security", Description: "Permit scanning locally-hosted apps (localhost / 127.0.0.1 / private IPs) — for self-hosted demo/staging on the same box. The dashboard's own listener is always protected. Leave OFF on shared/hosted deployments.", DefaultValue: "false", InputType: "boolean"},
 
 		{Key: "CAIDO_PORT", Label: "Caido port", Category: "Integrations", Description: "Caido proxy port. 0 means auto-detect.", DefaultValue: "0", InputType: "number"},
 		{Key: "CAIDO_API_TOKEN", Label: "Caido API token", Category: "Integrations", Description: "Caido API token for proxy integration.", InputType: "secret", Sensitive: true},
@@ -744,6 +745,8 @@ func (s *Server) applyEnvironmentToRuntimeConfig(values map[string]string) {
 			s.cfg.RateLimitBurst = parseIntSetting(value, 20)
 		case "XALGORIX_TLS_SKIP_VERIFY":
 			s.cfg.TLSSkipVerify = parseBoolSetting(value, false)
+		case "XALGORIX_ALLOW_LOCAL_TARGETS":
+			s.cfg.AllowLocalTargets = parseBoolSetting(value, false)
 		case "CAIDO_PORT":
 			s.cfg.CaidoPort = parseIntSetting(value, 0)
 		case "CAIDO_API_TOKEN":
@@ -844,6 +847,8 @@ func (s *Server) envSettingValue(key string) string {
 		return strconv.Itoa(s.cfg.RateLimitBurst)
 	case "XALGORIX_TLS_SKIP_VERIFY":
 		return strconv.FormatBool(s.cfg.TLSSkipVerify)
+	case "XALGORIX_ALLOW_LOCAL_TARGETS":
+		return strconv.FormatBool(s.cfg.AllowLocalTargets)
 	case "CAIDO_PORT":
 		return strconv.Itoa(s.cfg.CaidoPort)
 	case "CAIDO_API_TOKEN":


### PR DESCRIPTION
Closes #228.

## Problem
Self-hosted operators can't scan a locally-hosted app (demo/staging on the same box). The scope guard treats loopback/localhost/local-interface addresses as "self", so `handleScan` rejects them (*"all targets are local/internal addresses or the dashboard's own listener; refusing to self-scan"*) and the agent guard blocks the probes.

## Change
New opt-in **`XALGORIX_ALLOW_LOCAL_TARGETS`** (default `false` — behavior unchanged when off):

- `scopeguard.Config.AllowLocalTargets` + `localTargetsAllowed()`: when set, loopback and the machine's own interface IPs become in-scope — **except the dashboard's own listener**. The self-listener fast-path still blocks the exact bind `host:port`, and any local target on the dashboard's `Port` is refused on *any* local address, so this can never become a self-scan loop. `0.0.0.0` / `::` (unspecified) is always blocked.
- Wired into all three scope-guard sites: `isBlockedTarget` (the handleScan gate), `isBlockedTargetForScan` (the orchestrator target filter), and the per-scan **agent** guard (`scan_session`), so both the gate and the agent honor it.
- Agent prompt: the "NEVER scan local/internal" block in both instruction builders flips to "local targets are in scope" when enabled, so the agent tests the configured local target instead of skipping it.
- Dashboard: **Settings → Security → "Allow local targets"** toggle.
- README documents the flag.

## Security
Default **off**. Must stay off on any shared/hosted deployment — enabling it would let a user reach the operator's own machine. The dashboard's own listener is protected regardless of the flag.

## Tests
`TestAllowLocalTargets` (loopback/localhost allowed except the dashboard port; unspecified always blocked; external targets unaffected; default-off regression) and `TestAllowLocalTargets_LocalInterfaceIP`.

## Verification
`go build ./...`, `go vet`, `golangci-lint run` (0 issues), `gofmt -l` clean, and `./internal/scopeguard/... ./internal/config/... ./internal/web/...` tests pass.