### PR TITLE
feat(web): local-target rejection explains how to enable it (#228 follow-up)

### DIFF
--- a/internal/web/local_block_hint_test.go
+++ b/internal/web/local_block_hint_test.go
@@ -1,0 +1,56 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/config"
+)
+
+// TestHandleScan_LocalTargetBlockedHint verifies that an all-local scan request
+// is rejected with a helpful message: when local scanning is off, it tells a
+// self-hosted operator exactly how to enable it (#228 follow-up); when it's
+// already on, it explains the dashboard/unspecified addresses are never
+// scannable.
+func TestHandleScan_LocalTargetBlockedHint(t *testing.T) {
+	post := func(s *Server, body string) *httptest.ResponseRecorder {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/scan", strings.NewReader(body))
+		s.handleScan(rr, req)
+		return rr
+	}
+
+	t.Run("off → how-to-enable hint", func(t *testing.T) {
+		s := newTestServer(t, &config.Config{RateLimitRequests: 60, RateLimitWindow: 60})
+		rr := post(s, `{"targets":["http://127.0.0.1:3000/"],"scan_mode":"single"}`)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400; body=%s", rr.Code, rr.Body.String())
+		}
+		body := rr.Body.String()
+		if !strings.Contains(body, "XALGORIX_ALLOW_LOCAL_TARGETS") {
+			t.Fatalf("expected the enable hint, got: %s", body)
+		}
+	})
+
+	t.Run("on → still blocks dashboard/unspecified with explanation", func(t *testing.T) {
+		s := newTestServer(t, &config.Config{
+			RateLimitRequests: 60,
+			RateLimitWindow:   60,
+			AllowLocalTargets: true,
+		})
+		// Unspecified is always blocked, even with local targets enabled.
+		rr := post(s, `{"targets":["http://0.0.0.0/"],"scan_mode":"single"}`)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400; body=%s", rr.Code, rr.Body.String())
+		}
+		body := rr.Body.String()
+		if strings.Contains(body, "XALGORIX_ALLOW_LOCAL_TARGETS") {
+			t.Fatalf("should not suggest enabling when it's already on: %s", body)
+		}
+		if !strings.Contains(body, "even with local targets enabled") {
+			t.Fatalf("expected the already-enabled explanation, got: %s", body)
+		}
+	})
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1480,7 +1480,16 @@ func (s *Server) handleScan(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		if allBlocked {
-			http.Error(w, "all targets are local/internal addresses or the dashboard's own listener; refusing to self-scan", http.StatusBadRequest)
+			msg := "All targets are local/internal addresses or the dashboard's own listener, so the scan was refused (self-scan protection)."
+			if s.cfg.AllowLocalTargets {
+				// Local scanning is already on, so the only things still blocked
+				// are the dashboard itself and the unspecified address.
+				msg += " The dashboard's own listener and the unspecified address (0.0.0.0 / ::) are never scannable, even with local targets enabled — point the scan at the app's actual host:port instead."
+			} else {
+				// Self-hosted operators can opt in; tell them exactly how.
+				msg += " To scan a locally-hosted app on a self-hosted install, enable local targets: Settings → Security → \"Allow local targets\", or set XALGORIX_ALLOW_LOCAL_TARGETS=true in ~/.xalgorix.env and restart. (The dashboard's own listener stays protected either way. Leave this OFF on shared/hosted deployments.)"
+			}
+			http.Error(w, msg, http.StatusBadRequest)
 			return
 		}
 	}


### PR DESCRIPTION
Follow-up to #228/#231.

## Problem
When every target is local/internal, the scan was rejected with a dead-end 400: *"all targets are local/internal addresses or the dashboard's own listener; refusing to self-scan"* — with no hint that self-hosted installs can opt in.

## Change
The rejection message is now actionable, and adapts to the current setting:
- **Local scanning OFF:** tells the operator how to enable it — Settings → Security → "Allow local targets", or `XALGORIX_ALLOW_LOCAL_TARGETS=true` in `~/.xalgorix.env` + restart — notes the dashboard's own listener stays protected, and warns to keep it off on shared/hosted deployments.
- **Already ON:** explains the dashboard's own listener and the unspecified address (`0.0.0.0`/`::`) are never scannable regardless, and to point the scan at the app's real `host:port`.

The message flows through to the New Scan dialog (which renders the error text), so the fix shows inline.

## Note on SaaS
On hosted deployments the flag is off (and should stay off), so users there will see the "enable" hint text. It only names an operator-level env var they can't set — harmless, not a new capability. If you want the hint suppressed on hosted backends, that's part of the optional "hosted/locked-settings mode" I offered separately.

## Tests
`TestHandleScan_LocalTargetBlockedHint` — off → enable hint present; on → no enable hint + already-enabled explanation.

## Verification
`go build`, `go vet`, `golangci-lint` (0 issues), `gofmt -l` clean, full `./internal/web/...` suite pass.