### PR TITLE
fix(agent): record LLM-abort scans as failed, not completed

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -80,6 +80,16 @@ type Event struct {
 	AgentID     string
 	Timestamp   time.Time
 	TotalTokens int
+
+	// Aborted marks a "finished" event that is NOT a clean completion: the
+	// agent bailed out because of an LLM-side malfunction (refused to call
+	// tools, empty responses, repeated errors, provider rate-limit exhaustion).
+	// Consumers use this to record the scan as failed instead of completed — a
+	// forced abort produced no real result, so reporting it as "completed" is
+	// misleading (and, on hosted deployments, must trigger a refund).
+	// AbortReason is a short machine-readable tag (e.g. "llm_no_tool_calls").
+	Aborted     bool
+	AbortReason string
 }
 
 // toolExecResult holds the result of an async tool execution.
@@ -785,7 +795,7 @@ func (a *Agent) Run(targets []string, instruction string) {
 				// wait exceeds maxCumulativeRateLimitWait, fail the scan cleanly.
 				if maxCumulativeRateLimitWait > 0 && a.state.CumulativeRateLimitWait >= maxCumulativeRateLimitWait {
 					a.emit(Event{Type: "error", Content: fmt.Sprintf("⛔ Agent stopped: LLM provider rate limited for a cumulative %s without recovering.", a.state.CumulativeRateLimitWait), TotalTokens: tokenCount()})
-					a.emit(Event{Type: "finished", Content: fmt.Sprintf("Agent stopped: provider rate limited for a cumulative %s without recovering.", a.state.CumulativeRateLimitWait), TotalTokens: tokenCount()})
+					a.emit(Event{Type: "finished", Content: fmt.Sprintf("Agent stopped: provider rate limited for a cumulative %s without recovering.", a.state.CumulativeRateLimitWait), TotalTokens: tokenCount(), Aborted: true, AbortReason: "llm_rate_limited"})
 					return
 				}
 				a.emit(Event{Type: "error", Content: "⏳ Rate limited by LLM provider — waiting 30 minutes before retrying (will NOT skip this target)", TotalTokens: tokenCount()})
@@ -804,7 +814,7 @@ func (a *Agent) Run(targets []string, instruction string) {
 			a.emit(Event{Type: "error", Content: fmt.Sprintf("LLM error (attempt %d/25): %s", a.state.ConsecutiveErrors, errStr), TotalTokens: tokenCount()})
 			if a.state.ConsecutiveErrors >= 25 {
 				a.emit(Event{Type: "error", Content: fmt.Sprintf("⛔ Agent stopped: LLM failed %d consecutive times. Last error: %s", a.state.ConsecutiveErrors, errStr), TotalTokens: tokenCount()})
-				a.emit(Event{Type: "finished", Content: fmt.Sprintf("Agent stopped: LLM failed %d consecutive times. Last error: %s", a.state.ConsecutiveErrors, errStr), TotalTokens: tokenCount()})
+				a.emit(Event{Type: "finished", Content: fmt.Sprintf("Agent stopped: LLM failed %d consecutive times. Last error: %s", a.state.ConsecutiveErrors, errStr), TotalTokens: tokenCount(), Aborted: true, AbortReason: "llm_repeated_errors"})
 				return
 			}
 			// Exponential backoff: 10s, 20s, 30s... capped at 120s
@@ -824,7 +834,7 @@ func (a *Agent) Run(targets []string, instruction string) {
 			a.emit(Event{Type: "message", Content: fmt.Sprintf("⚠️ LLM returned empty response (%d/12)", a.state.EmptyResponseCount), TotalTokens: tokenCount()})
 			if emptyResult.ForceSkip {
 				a.emit(Event{Type: "error", Content: emptyResult.EmitMessage, TotalTokens: tokenCount()})
-				a.emit(Event{Type: "finished", Content: "Agent stopped: LLM returned too many empty responses", TotalTokens: tokenCount()})
+				a.emit(Event{Type: "finished", Content: "Agent stopped: LLM returned too many empty responses", TotalTokens: tokenCount(), Aborted: true, AbortReason: "llm_empty_responses"})
 				return
 			}
 			if emptyResult.Nudge != "" {
@@ -873,7 +883,7 @@ func (a *Agent) Run(targets []string, instruction string) {
 			noToolResult := a.hooks.Fire(OnNoToolResponse, a.state, map[string]string{"response": cleanText})
 			if noToolResult.ForceSkip {
 				a.emit(Event{Type: "error", Content: noToolResult.EmitMessage, TotalTokens: tokenCount()})
-				a.emit(Event{Type: "finished", Content: "Agent stopped: LLM refused to call tools after 15 attempts", TotalTokens: tokenCount()})
+				a.emit(Event{Type: "finished", Content: "Agent stopped: LLM refused to call tools after 15 attempts", TotalTokens: tokenCount(), Aborted: true, AbortReason: "llm_no_tool_calls"})
 				return
 			}
 			if noToolResult.Nudge != "" {

--- a/internal/web/scan_abort_test.go
+++ b/internal/web/scan_abort_test.go
@@ -1,0 +1,89 @@
+package web
+
+import (
+	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/agent"
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+)
+
+// A "finished" event flagged as an abnormal LLM-side abort must be captured on
+// the session so finalize records the scan as failed (not a clean completion).
+// Regression guard for scans that were force-stopped by the agent (LLM refused
+// to call tools, empty responses, repeated errors, rate-limit) yet showed up as
+// "completed" on the dashboard.
+func TestProcessEvent_AbortedFinishedCapturesReason(t *testing.T) {
+	s := newTestServer(t, nil)
+	sctx := scanctx.New("abort-capture", t.TempDir())
+	defer sctx.Close()
+
+	sess := &scanSession{
+		id:         "abort-capture",
+		target:     "https://example.com",
+		scanDir:    t.TempDir(),
+		record:     &ScanRecord{ID: "abort-capture", Target: "https://example.com", Status: "running"},
+		sctx:       sctx,
+		server:     s,
+		instanceID: "",
+	}
+
+	s.processEvent(agent.Event{
+		Type:        "finished",
+		Content:     "Agent stopped: LLM refused to call tools after 15 attempts",
+		Aborted:     true,
+		AbortReason: "llm_no_tool_calls",
+	}, sess)
+
+	if sess.abortReason != "llm_no_tool_calls" {
+		t.Fatalf("abortReason = %q, want %q", sess.abortReason, "llm_no_tool_calls")
+	}
+}
+
+// A clean finish (finish tool) must NOT set an abort reason — those scans are
+// genuine completions.
+func TestProcessEvent_CleanFinishHasNoAbortReason(t *testing.T) {
+	s := newTestServer(t, nil)
+	sctx := scanctx.New("clean-finish", t.TempDir())
+	defer sctx.Close()
+
+	sess := &scanSession{
+		id:      "clean-finish",
+		target:  "https://example.com",
+		scanDir: t.TempDir(),
+		record:  &ScanRecord{ID: "clean-finish", Target: "https://example.com", Status: "running"},
+		sctx:    sctx,
+		server:  s,
+	}
+
+	s.processEvent(agent.Event{
+		Type:    "finished",
+		Content: "Scan complete. Reported 3 findings.",
+	}, sess)
+
+	if sess.abortReason != "" {
+		t.Fatalf("abortReason = %q, want empty for a clean finish", sess.abortReason)
+	}
+}
+
+// An aborted event that omits an explicit reason still marks the session as
+// aborted (with a generic tag) so it is never treated as a clean completion.
+func TestProcessEvent_AbortedWithoutReasonUsesFallback(t *testing.T) {
+	s := newTestServer(t, nil)
+	sctx := scanctx.New("abort-fallback", t.TempDir())
+	defer sctx.Close()
+
+	sess := &scanSession{
+		id:      "abort-fallback",
+		target:  "https://example.com",
+		scanDir: t.TempDir(),
+		record:  &ScanRecord{ID: "abort-fallback", Target: "https://example.com", Status: "running"},
+		sctx:    sctx,
+		server:  s,
+	}
+
+	s.processEvent(agent.Event{Type: "finished", Content: "stopped", Aborted: true}, sess)
+
+	if sess.abortReason != "llm_aborted" {
+		t.Fatalf("abortReason = %q, want %q", sess.abortReason, "llm_aborted")
+	}
+}

--- a/internal/web/scan_session.go
+++ b/internal/web/scan_session.go
@@ -189,6 +189,43 @@ func (s *Server) executeScanSession(sess *scanSession) {
 		return
 	}
 
+	// 8b. Abnormal LLM-side abort (agent bailed: refused tools / empty responses
+	// / repeated errors / rate-limit). This is NOT a clean completion — the scan
+	// produced no real result — so record it as "failed" with a diagnostic stop
+	// reason instead of "finished". Downstream (dashboard / hosted refunds)
+	// keys off this so a force-stopped scan is never shown as completed.
+	//
+	// We update BOTH the persisted record AND the live instance: the scan-status
+	// API (applyInstanceSnapshot) overlays the in-memory instance status over the
+	// record, and runMultiScan's deferred finalize would otherwise flip a still-
+	// "running" instance to "finished". Marking the instance "failed" here makes
+	// every read path agree. This runs after the event processor has drained
+	// (<-done above), so there is no concurrent processEvent writer.
+	if sess.abortReason != "" {
+		finishedAt := time.Now().Format(time.RFC3339)
+		sess.record.Status = "failed"
+		sess.record.StopReason = sess.abortReason
+		sess.record.FinishedAt = finishedAt
+		if sess.instanceID != "" {
+			s.instancesMu.RLock()
+			inst, ok := s.instances[sess.instanceID]
+			s.instancesMu.RUnlock()
+			if ok {
+				inst.mu.Lock()
+				// Never clobber a user-initiated stop/pause; only downgrade a
+				// still-active instance to failed.
+				if inst.Status == "running" || inst.Status == "pending" || inst.Status == "" {
+					inst.Status = "failed"
+					inst.StopReason = sess.abortReason
+					inst.FinishedAt = finishedAt
+				}
+				inst.mu.Unlock()
+			}
+		}
+		s.saveScanRecordTo(sess.record, sess.scanDir)
+		return
+	}
+
 	// 9. Finalize record
 	sess.record.Status = "finished"
 	sess.record.FinishedAt = time.Now().Format(time.RFC3339)
@@ -380,6 +417,15 @@ func (s *Server) processEvent(evt agent.Event, sess *scanSession) {
 	}
 
 	if evt.Type == "finished" {
+		// An abnormal LLM-side abort (refused tools / empty responses / repeated
+		// errors / rate-limit) reuses the "finished" event type but is NOT a
+		// clean completion. Record the reason so finalize marks the scan failed.
+		if evt.Aborted {
+			sess.abortReason = evt.AbortReason
+			if sess.abortReason == "" {
+				sess.abortReason = "llm_aborted"
+			}
+		}
 		// Build set of vulns already broadcast in real-time to avoid duplicates
 		seen := make(map[string]bool)
 		for _, v := range sess.record.Vulns {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -2498,6 +2498,13 @@ type scanSession struct {
 	// Wildcard lifecycle flags
 	skipNotesCleanup     bool   // when true, don't delete notes store on cleanup (discovery phase)
 	parentReportingCtxID string // stable context ID for accumulating vulns across wildcard subdomain scans
+
+	// abortReason is set (via processEvent) when the agent emits a "finished"
+	// event flagged as an abnormal LLM-side abort — refused to call tools,
+	// empty responses, repeated errors, provider rate-limit exhaustion. When
+	// set, the session finalizes the record as "failed" (not "finished") so a
+	// force-stopped scan is never reported as a clean completion.
+	abortReason string
 }
 
 // cleanup tears down all per-session resources. Every sub-operation


### PR DESCRIPTION
## Problem

Reported by an operator: 5 scans showed **completed** on the dashboard, but their logs showed the agent was force-stopped due to an LLM issue (`⛔ LLM failed to call any tools for 15 consecutive responses. Force finishing.` → `Agent stopped: LLM refused to call tools after 15 attempts`).

## Root cause

When the agent force-stops because the LLM misbehaves, it emits an `Event{Type: "finished"}` — the **same event type** a genuine `finish`-tool completion uses. `executeScanSession` then finalizes the record as `"finished"`, which the dashboard/SaaS maps to **completed**. A force-stopped scan was therefore indistinguishable from a clean one.

The affected abort paths in `agent.go` (all previously → `finished`):
- LLM refused to call tools for 15 responses (`llm_no_tool_calls`)
- Too many empty responses (`llm_empty_responses`)
- 25 consecutive LLM errors (`llm_repeated_errors`)
- Cumulative provider rate-limit exhaustion (`llm_rate_limited`)

## Fix

- Add `Event.Aborted` + `Event.AbortReason` and set them on those four abort emits.
- `processEvent` captures the reason onto the session; finalize records the scan as **`failed`** with the diagnostic `stop_reason` instead of `finished`.
- Update **both** the persisted record and the live instance status — the scan-status API overlays the in-memory instance status over the record, and `runMultiScan`'s deferred finalize would otherwise flip a still-`running` instance to `finished`. A user-initiated stop/pause is never clobbered.

Genuine `finish`-tool completions and intentional caps (resource budget, max-iterations) are **unaffected** — only real LLM malfunctions are marked failed.

## Tests

New `scan_abort_test.go`: aborted finished → reason captured; clean finish → no reason; aborted-without-reason → `llm_aborted` fallback.

`go build`, `go vet`, `golangci-lint` (0 issues), and `internal/agent` + `internal/web` suites all pass.

## Companion

SaaS change maps the engine's new `failed` status → refund + user notification + operator alert (pushed separately).