### PR TITLE
fix(llm): use max_completion_tokens for OpenAI GPT-5 / o-series (#236)

### DIFF
--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -145,13 +145,18 @@ func (c *Client) loadCtx() context.Context {
 
 // chatRequest is the OpenAI-compatible chat completion request.
 type chatRequest struct {
-	Model           string         `json:"model"`
-	Messages        []Message      `json:"messages"`
-	Stream          bool           `json:"stream"`
-	StreamOptions   *streamOptions `json:"stream_options,omitempty"`
-	Temperature     *float64       `json:"temperature,omitempty"`
-	MaxTokens       int            `json:"max_tokens,omitempty"`
-	ReasoningEffort string         `json:"reasoning_effort,omitempty"`
+	Model         string         `json:"model"`
+	Messages      []Message      `json:"messages"`
+	Stream        bool           `json:"stream"`
+	StreamOptions *streamOptions `json:"stream_options,omitempty"`
+	Temperature   *float64       `json:"temperature,omitempty"`
+	MaxTokens     int            `json:"max_tokens,omitempty"`
+	// MaxCompletionTokens is the replacement for MaxTokens on OpenAI's newer
+	// models (GPT-5 family, o-series reasoning models), which reject the legacy
+	// `max_tokens` param with a 400. Exactly one of MaxTokens /
+	// MaxCompletionTokens is set per request (see buildChatRequest).
+	MaxCompletionTokens int    `json:"max_completion_tokens,omitempty"`
+	ReasoningEffort     string `json:"reasoning_effort,omitempty"`
 }
 
 // streamOptions opts into usage stats for OpenAI-compatible streaming
@@ -593,6 +598,52 @@ func (c *Client) maxOutputTokens() int {
 	return n
 }
 
+// usesMaxCompletionTokens reports whether an OpenAI model requires the
+// `max_completion_tokens` parameter and rejects the legacy `max_tokens` with a
+// 400 ("Unsupported parameter: 'max_tokens' is not supported with this model.
+// Use 'max_completion_tokens' instead."). This covers the GPT-5 family and the
+// o-series reasoning models (o1/o3/o4). These same models also only accept the
+// default temperature, so buildChatRequest omits temperature for them.
+//
+// Only OpenAI serves these model names, so matching on the bare model name is
+// safe even though the OpenAI-compatible request path is shared with providers
+// (MiniMax/DeepSeek/Groq/Ollama) that still use `max_tokens`.
+func usesMaxCompletionTokens(model string) bool {
+	m := strings.ToLower(strings.TrimSpace(model))
+	if i := strings.LastIndex(m, "/"); i >= 0 {
+		m = m[i+1:]
+	}
+	return strings.HasPrefix(m, "gpt-5") ||
+		strings.HasPrefix(m, "o1") ||
+		strings.HasPrefix(m, "o3") ||
+		strings.HasPrefix(m, "o4")
+}
+
+// buildChatRequest assembles the OpenAI-compatible chat completion request,
+// picking the correct completion-token parameter for the model. Newer OpenAI
+// models (GPT-5 / o-series) require `max_completion_tokens` and reject both
+// `max_tokens` and a non-default temperature; every other model keeps the
+// legacy `max_tokens` + configured temperature.
+func (c *Client) buildChatRequest(model string, messages []Message, endpoint string, stream bool) chatRequest {
+	req := chatRequest{
+		Model:           model,
+		Messages:        messages,
+		Stream:          stream,
+		ReasoningEffort: c.ollamaReasoningEffort(endpoint),
+	}
+	if stream {
+		req.StreamOptions = &streamOptions{IncludeUsage: true}
+	}
+	if usesMaxCompletionTokens(model) {
+		req.MaxCompletionTokens = c.maxOutputTokens()
+		// Leave Temperature nil — these models only accept the default.
+	} else {
+		req.MaxTokens = c.maxOutputTokens()
+		req.Temperature = c.effectiveTemperature()
+	}
+	return req
+}
+
 func (c *Client) chatWithRetry(messages []Message) (string, error) {
 	maxRetries := c.cfg.LLMMaxRetries
 	if maxRetries < 3 {
@@ -757,15 +808,7 @@ func (c *Client) ChatStream(messages []Message) <-chan StreamChunk {
 			}
 			body, _ = json.Marshal(anReq)
 		} else {
-			reqBody := chatRequest{
-				Model:           model,
-				Messages:        messages,
-				Stream:          true,
-				StreamOptions:   &streamOptions{IncludeUsage: true},
-				Temperature:     c.effectiveTemperature(),
-				MaxTokens:       c.maxOutputTokens(),
-				ReasoningEffort: c.ollamaReasoningEffort(endpoint),
-			}
+			reqBody := c.buildChatRequest(model, messages, endpoint, true)
 			body, _ = json.Marshal(reqBody)
 		}
 
@@ -992,14 +1035,7 @@ func (c *Client) doChat(messages []Message) (out string, err error) {
 			return "", fmt.Errorf("failed to marshal Anthropic request: %w", err)
 		}
 	} else {
-		reqBody := chatRequest{
-			Model:           model,
-			Messages:        messages,
-			Stream:          false,
-			Temperature:     c.effectiveTemperature(),
-			MaxTokens:       c.maxOutputTokens(),
-			ReasoningEffort: c.ollamaReasoningEffort(endpoint),
-		}
+		reqBody := c.buildChatRequest(model, messages, endpoint, false)
 		body, err = json.Marshal(reqBody)
 		if err != nil {
 			return "", fmt.Errorf("failed to marshal request: %w", err)

--- a/internal/llm/max_completion_tokens_test.go
+++ b/internal/llm/max_completion_tokens_test.go
@@ -1,0 +1,78 @@
+package llm
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/config"
+)
+
+// Newer OpenAI models (GPT-5 family, o-series reasoning models) reject the
+// legacy `max_tokens` param and require `max_completion_tokens`. Regression
+// guard for issue #236 ("Unsupported parameter: 'max_tokens' ... Use
+// 'max_completion_tokens' instead").
+func TestUsesMaxCompletionTokens(t *testing.T) {
+	cases := map[string]bool{
+		"gpt-5":          true,
+		"gpt-5.4":        true,
+		"gpt-5-mini":     true,
+		"openai/gpt-5.4": true,
+		"o1":             true,
+		"o1-mini":        true,
+		"o3":             true,
+		"o3-mini":        true,
+		"o4-mini":        true,
+
+		"gpt-4o":          false,
+		"gpt-4.1":         false,
+		"gpt-4-turbo":     false,
+		"deepseek-v4-pro": false,
+		"claude-sonnet-4": false,
+		"minimax-01":      false,
+		"llama3.1":        false,
+	}
+	for model, want := range cases {
+		if got := usesMaxCompletionTokens(model); got != want {
+			t.Errorf("usesMaxCompletionTokens(%q) = %v, want %v", model, got, want)
+		}
+	}
+}
+
+func TestBuildChatRequest_GPT5UsesMaxCompletionTokens(t *testing.T) {
+	c := NewClient(&config.Config{LLM: "openai/gpt-5.4", APIKey: "k", MaxOutputTokens: 4096})
+	req := c.buildChatRequest("gpt-5.4", []Message{{Role: "user", Content: "hi"}},
+		"https://api.openai.com/v1/chat/completions", false)
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(body)
+	if !strings.Contains(s, `"max_completion_tokens":4096`) {
+		t.Errorf("expected max_completion_tokens:4096, got %s", s)
+	}
+	if strings.Contains(s, `"max_tokens"`) {
+		t.Errorf("gpt-5 request must NOT contain max_tokens, got %s", s)
+	}
+	// GPT-5 / o-series only accept the default temperature — it must be omitted.
+	if strings.Contains(s, `"temperature"`) {
+		t.Errorf("gpt-5 request must NOT contain temperature, got %s", s)
+	}
+}
+
+func TestBuildChatRequest_LegacyModelUsesMaxTokens(t *testing.T) {
+	c := NewClient(&config.Config{LLM: "openai/gpt-4o", APIKey: "k", MaxOutputTokens: 4096})
+	req := c.buildChatRequest("gpt-4o", []Message{{Role: "user", Content: "hi"}},
+		"https://api.openai.com/v1/chat/completions", false)
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(body)
+	if !strings.Contains(s, `"max_tokens":4096`) {
+		t.Errorf("expected max_tokens:4096, got %s", s)
+	}
+	if strings.Contains(s, `"max_completion_tokens"`) {
+		t.Errorf("legacy model request must NOT contain max_completion_tokens, got %s", s)
+	}
+}


### PR DESCRIPTION
## Problem (fixes #236)

Running a scan with a newer OpenAI model (e.g. `XALGORIX_LLM=openai/gpt-5.4`) fails on every LLM call:

```
API returned 400: Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.
```

The agent retries, every attempt 400s, and the scan dies at "Agent reached maximum iterations" having done nothing.

## Cause

The OpenAI-compatible request builder always sent `max_tokens`. OpenAI's GPT-5 family and o-series reasoning models (o1/o3/o4) reject `max_tokens` (require `max_completion_tokens`) and also only accept the default `temperature`.

## Fix

- Add `max_completion_tokens` to `chatRequest`.
- New `buildChatRequest` helper (shared by the streaming + non-streaming paths) picks the right param: GPT-5 / o-series → `max_completion_tokens` and **no** `temperature`; every other model keeps `max_tokens` + configured temperature.
- `usesMaxCompletionTokens(model)` matches `gpt-5*`, `o1*`, `o3*`, `o4*`. Only OpenAI serves these names, so the match is safe even though the OpenAI-compatible path is shared with MiniMax/DeepSeek/Groq/Ollama (which keep `max_tokens`).

## Tests

New `max_completion_tokens_test.go`: predicate table + outbound-body assertions (gpt-5.4 → `max_completion_tokens`, no `max_tokens`/`temperature`; gpt-4o → `max_tokens`, no `max_completion_tokens`).

`go build`, `go vet`, `gofmt`, `golangci-lint` (0 issues), and the full `internal/llm` suite pass.