### PR TITLE
fix(llm): recover tool calls with malformed opening tags (root cause of llm_no_tool_calls aborts)

### DIFF
--- a/internal/llm/parser.go
+++ b/internal/llm/parser.go
@@ -30,6 +30,20 @@ var (
 	invokeOpen   = regexp.MustCompile(`<invoke\s+name=["']([^"']+)["']>`)
 	funcCallsTag = regexp.MustCompile(`</?function_calls>`)
 
+	// Recover malformed tool-call OPEN tags. Some models intermittently drop
+	// the leading "<" — or the whole "<function" — from the opening tag while
+	// still emitting a well-formed body and "</function>", e.g.
+	//     function=terminal_execute><parameter=command>id</parameter></function>
+	//     =send_request><parameter=method>GET</parameter></function>
+	// The strict fnRegex never matched these, so the call was counted as a
+	// "no tool call" response; 15 of those in a row force-stops the whole scan
+	// (observed in production). Requiring a "<parameter" or "</function>"
+	// immediately after the ">" makes this a specific, low-false-positive
+	// signal — ordinary prose does not contain "=word><parameter". Correct
+	// "<function=name>" tags also match this pattern and are rewritten to the
+	// identical canonical form, so the repair is idempotent.
+	repairFnOpenRe = regexp.MustCompile(`(?s)<?(?:function)?\s*=\s*([A-Za-z_][A-Za-z0-9_-]*)\s*>(\s*(?:<parameter|</function>))`)
+
 	// Normalize quotes around = in tags: <function = "name"> → <function=name>
 	stripQuotesRe = regexp.MustCompile(`<(function|parameter)\s*=\s*["']?([^>"']+?)["']?\s*>`)
 
@@ -155,6 +169,9 @@ func normalizeFormat(content string) string {
 		content = invokeOpen.ReplaceAllString(content, "<function=$1>")
 		content = strings.ReplaceAll(content, "</invoke>", "</function>")
 	}
+
+	// Repair malformed function-open tags (missing leading "<" / "<function").
+	content = repairFnOpenRe.ReplaceAllString(content, "<function=${1}>${2}")
 
 	// Normalize quotes/spaces around = signs: <function = "name"> → <function=name>
 	content = stripQuotesRe.ReplaceAllStringFunc(content, func(s string) string {

--- a/internal/llm/parser_repair_test.go
+++ b/internal/llm/parser_repair_test.go
@@ -1,0 +1,93 @@
+package llm
+
+import "testing"
+
+// Regression for the production incident where the model emitted tool calls
+// with a corrupted opening tag (missing the leading "<" or the whole
+// "<function"). The strict parser skipped them, they counted as "no tool call"
+// responses, and 15 in a row force-stopped the scan. These are the exact
+// shapes observed in the bidatabox.com scan log.
+func TestParseToolCalls_RepairsMalformedOpenTag(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		wantName string
+		wantKey  string
+		wantVal  string
+	}{
+		{
+			name:     "missing leading angle bracket",
+			input:    `function=terminal_execute><parameter=command>curl -sk https://x</parameter></function>`,
+			wantName: "terminal_execute",
+			wantKey:  "command",
+			wantVal:  "curl -sk https://x",
+		},
+		{
+			name:     "missing whole <function, bare equals",
+			input:    `=terminal_execute><parameter=command>echo "test"</parameter></function>`,
+			wantName: "terminal_execute",
+			wantKey:  "command",
+			wantVal:  `echo "test"`,
+		},
+		{
+			name:     "bare equals send_request",
+			input:    `=send_request><parameter=method>GET</parameter><parameter=url>https://bidatabox.com/Login.aspx</parameter></function>`,
+			wantName: "send_request",
+			wantKey:  "method",
+			wantVal:  "GET",
+		},
+		{
+			name:     "malformed with leading prose",
+			input:    "Let me run this:\nfunction=http_request><parameter=url>https://x</parameter></function>",
+			wantName: "http_request",
+			wantKey:  "url",
+			wantVal:  "https://x",
+		},
+		{
+			name:     "correct tag still parses (idempotent)",
+			input:    "<function=finish>\n<parameter=summary>done</parameter>\n</function>",
+			wantName: "finish",
+			wantKey:  "summary",
+			wantVal:  "done",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := ParseToolCalls(tc.input)
+			if len(calls) != 1 {
+				t.Fatalf("got %d tool calls, want 1 (input=%q)", len(calls), tc.input)
+			}
+			if calls[0].Name != tc.wantName {
+				t.Errorf("name = %q, want %q", calls[0].Name, tc.wantName)
+			}
+			if got := calls[0].Args[tc.wantKey]; got != tc.wantVal {
+				t.Errorf("args[%q] = %q, want %q", tc.wantKey, got, tc.wantVal)
+			}
+		})
+	}
+}
+
+// Ordinary prose containing "=word>" but NOT a tool-call body must never be
+// mistaken for a tool call.
+func TestParseToolCalls_DoesNotMisparseProse(t *testing.T) {
+	inputs := []string{
+		"The comparison a=b> shows the config value.",
+		"Set timeout=30> in the file and restart.",
+		"No tools here, just explaining the plan for the next step.",
+	}
+	for _, in := range inputs {
+		if calls := ParseToolCalls(in); len(calls) != 0 {
+			t.Errorf("ParseToolCalls(%q) = %d calls, want 0", in, len(calls))
+		}
+	}
+}
+
+// The repaired malformed call must also be stripped from displayed text so the
+// UI doesn't show raw "function=terminal_execute>..." noise as a message.
+func TestCleanContent_StripsRepairedMalformedCall(t *testing.T) {
+	in := "Running fingerprint:\nfunction=terminal_execute><parameter=command>id</parameter></function>"
+	got := CleanContent(in)
+	if got != "Running fingerprint:" {
+		t.Errorf("CleanContent = %q, want %q", got, "Running fingerprint:")
+	}
+}


### PR DESCRIPTION
## The smoking gun

The bidatabox.com scan log shows the model **was** calling tools, but with a corrupted opening tag, so every call was skipped:

```
message: function=terminal_execute><parameter=command>curl -sk ...</parameter></function>
message: =send_request><parameter=method>GET</parameter>...</function>
message: =terminal_execute><parameter=command>echo "test"</parameter></function>
...15 in a row...
error: LLM failed to call any tools for 15 consecutive responses. Force finishing.
```

The opening tag lost its leading `<` (`function=name>`) or the whole `<function` (`=name>`), while the body (`<parameter=…>`) and `</function>` stayed well-formed. `fnRegex` requires a literal `<function=`, so these parsed as **zero** tool calls → counted as "no tool call" → 15 consecutive → force-stop. This is the actual root cause behind the wave of `llm_no_tool_calls` scan aborts (not model rambling).

## Fix

`normalizeFormat` now repairs malformed function-open tags back to canonical `<function=name>`. Guard rails:
- Requires a `<parameter` or `</function>` **immediately after** the `>`, so ordinary prose (`a=b>`) is never misparsed.
- Idempotent: correct `<function=name>` tags rewrite to themselves.
- Fixes both parsing (`ParseToolCalls`) and display (`CleanContent`, so the UI stops showing raw `function=…>` noise).

## Tests

`parser_repair_test.go` uses the exact malformed shapes from the log, plus negative prose cases and a CleanContent strip test. Full `internal/llm` suite + build/vet/gofmt/golangci-lint (0 issues) pass.

## Note

This is the real cure for the earlier "all scans failing" incident. Recommend releasing alongside #242 (max_completion_tokens).