### PR TITLE
release: v4.5.65

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.64
+VERSION=4.5.65
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.64" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.65" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.64"
+var version = "4.5.65"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
### Changes

- 47ba7e5 fix(llm): recover tool calls with malformed opening tags (#243)
- 0418af7 fix(llm): use max_completion_tokens for OpenAI GPT-5 / o-series models (#242)
- b5b79f8 release: v4.5.64 (#241)