### PR TITLE
fix(web): stopping/deleting a scan halts its queue + clears resume state (#239)

### DIFF
--- a/internal/web/queue_state.go
+++ b/internal/web/queue_state.go
@@ -391,7 +391,24 @@ func (s *Server) instanceRunStatus(instanceID string) (string, string) {
 }
 
 func (s *Server) instanceInterrupted(instanceID string) bool {
-	status, _ := s.instanceRunStatus(instanceID)
+	if instanceID == "" {
+		return false
+	}
+	s.instancesMu.RLock()
+	inst := s.instances[instanceID]
+	s.instancesMu.RUnlock()
+	// A missing instance means it was DELETED mid-run (DELETE /api/scans/{id}).
+	// runMultiScan registers the instance in the map before any target is
+	// scanned and never removes it on normal completion, so "not in the map"
+	// reliably means "deleted". The running queue / subdomain loops must treat
+	// deletion as a hard stop — otherwise they keep scanning the rest of the
+	// queue and burning tokens after the user removed the scan (issue #239).
+	if inst == nil {
+		return true
+	}
+	inst.mu.RLock()
+	status := inst.Status
+	inst.mu.RUnlock()
 	return isInterruptedInstanceStatus(status)
 }
 

--- a/internal/web/scan_lifecycle_test.go
+++ b/internal/web/scan_lifecycle_test.go
@@ -1,0 +1,115 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+// A deleted instance (removed from the map mid-run) must be treated as
+// interrupted so the queue / subdomain loops stop scanning. Regression for
+// issue #239 where deleting a scan left the pipeline running in the background.
+func TestInstanceInterrupted_MissingInstanceIsInterrupted(t *testing.T) {
+	s := newTestServer(t, nil)
+
+	s.instancesMu.Lock()
+	s.instances["run-1"] = &ScanInstance{ID: "run-1", Status: "running"}
+	s.instances["stopped-1"] = &ScanInstance{ID: "stopped-1", Status: "stopped"}
+	s.instancesMu.Unlock()
+
+	if s.instanceInterrupted("run-1") {
+		t.Error("running instance should NOT be interrupted")
+	}
+	if !s.instanceInterrupted("stopped-1") {
+		t.Error("stopped instance should be interrupted")
+	}
+	if !s.instanceInterrupted("never-existed") {
+		t.Error("missing/deleted instance MUST be treated as interrupted")
+	}
+	if s.instanceInterrupted("") {
+		t.Error("empty instance id should not be interrupted")
+	}
+}
+
+// Deleting a running scan must halt it: cancel the in-flight context, mark the
+// instance stopped, remove it from the map, AND delete the persisted queue
+// resume file so the startup auto-resume never replays it (issue #239).
+func TestHandleDeleteScan_StopsInstanceAndClearsQueueState(t *testing.T) {
+	s := newTestServer(t, nil)
+
+	canceled := false
+	inst := &ScanInstance{ID: "del-1", Targets: "a.com, b.com", Status: "running"}
+	inst.cancel = func() { canceled = true }
+	s.instancesMu.Lock()
+	s.instances["del-1"] = inst
+	s.instancesMu.Unlock()
+
+	// Persist a resume file for this queue (2 targets, still at index 0).
+	s.saveQueueState(0, ScanRequest{
+		InstanceID: "del-1",
+		Targets:    []string{"a.com", "b.com"},
+		ScanMode:   "wildcard",
+	})
+	queuePath := s.queueStatePathForInstance("del-1")
+	if _, err := os.Stat(queuePath); err != nil {
+		t.Fatalf("precondition: queue state file should exist: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	s.handleGetScan(rr, httptest.NewRequest(http.MethodDelete, "/api/scans/del-1", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("delete code = %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	if !canceled {
+		t.Error("delete must cancel the running instance's context")
+	}
+	s.instancesMu.RLock()
+	_, stillThere := s.instances["del-1"]
+	s.instancesMu.RUnlock()
+	if stillThere {
+		t.Error("instance should be removed from the map after delete")
+	}
+	if _, err := os.Stat(queuePath); !os.IsNotExist(err) {
+		t.Errorf("queue state file must be removed after delete (err=%v)", err)
+	}
+}
+
+// Stopping a single instance clears its persisted resume file so the dashboard
+// queue counter clears immediately and nothing is auto-resumed.
+func TestHandleInstanceStop_ClearsQueueState(t *testing.T) {
+	s := newTestServer(t, nil)
+
+	inst := &ScanInstance{ID: "stop-1", Targets: "a.com", Status: "running"}
+	inst.cancel = func() {}
+	s.instancesMu.Lock()
+	s.instances["stop-1"] = inst
+	s.instancesMu.Unlock()
+
+	s.saveQueueState(0, ScanRequest{
+		InstanceID: "stop-1",
+		Targets:    []string{"a.com", "b.com"},
+		ScanMode:   "wildcard",
+	})
+	queuePath := s.queueStatePathForInstance("stop-1")
+	if _, err := os.Stat(queuePath); err != nil {
+		t.Fatalf("precondition: queue state file should exist: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	s.handleInstanceAction(rr, httptest.NewRequest(http.MethodPost, "/api/instances/stop-1/stop", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("stop code = %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	s.instancesMu.RLock()
+	got := s.instances["stop-1"]
+	s.instancesMu.RUnlock()
+	if got == nil || got.Status != "stopped" {
+		t.Fatalf("instance should be marked stopped, got %#v", got)
+	}
+	if _, err := os.Stat(queuePath); !os.IsNotExist(err) {
+		t.Errorf("queue state file must be removed after stop (err=%v)", err)
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1657,6 +1657,11 @@ func (s *Server) handleStop(w http.ResponseWriter, r *http.Request) {
 	// Kill all spawned processes as a safety net
 	terminal.KillAllProcesses()
 
+	// A global user stop is terminal for every queue — clear all persisted
+	// resume files so the dashboard queue counter clears and nothing is
+	// auto-resumed on the next start (issue #239).
+	s.clearQueueState()
+
 	s.broadcast(WSEvent{Type: "stopped", Content: "All instances stopped by user"})
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "stopped"})
@@ -2236,6 +2241,12 @@ func (s *Server) handleInstanceAction(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		inst.mu.Unlock()
+
+		// Drop the persisted resume file now so the dashboard's queue counter
+		// clears immediately and the startup auto-resume never replays it. A
+		// user stop is terminal (non-resumable); the runMultiScan defer also
+		// clears it on exit, so this is just the prompt path (issue #239).
+		s.clearQueueState(instanceID)
 
 		// Broadcast stop to clients watching this instance
 		s.broadcastToInstance(instanceID, WSEvent{Type: "stopped", Content: "Instance stopped by user"})
@@ -3063,9 +3074,31 @@ func (s *Server) handleGetScan(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			seenInstanceIDs[id] = true
-			if inst := s.instances[id]; inst != nil && inst.cancel != nil {
-				inst.cancel()
+			// Deleting a scan must HALT it, not just drop the map entry. Mark
+			// the instance stopped (so runMultiScan's queue loop breaks on its
+			// captured pointer), cancel the in-flight target's context, and
+			// stop the agent so the current LLM/tool loop aborts immediately.
+			// Without this the queue kept scanning in the background and
+			// consuming tokens after deletion (issue #239).
+			if inst := s.instances[id]; inst != nil {
+				inst.mu.Lock()
+				if inst.Status == "running" || inst.Status == "pending" || inst.Status == "paused" {
+					inst.Status = "stopped"
+					inst.StopReason = "user_deleted"
+					inst.FinishedAt = time.Now().Format(time.RFC3339Nano)
+				}
+				if inst.cancel != nil {
+					inst.cancel()
+				}
+				if inst.agent != nil {
+					inst.agent.Stop()
+				}
+				inst.mu.Unlock()
 			}
+			// Remove the persisted resume file so the startup auto-resume
+			// goroutine never replays this queue (previously the only fix was
+			// wiping the whole .xalgorix data dir).
+			s.clearQueueState(id)
 			delete(s.instances, id)
 		}
 		s.instancesMu.Unlock()


### PR DESCRIPTION
## Problem (fixes #239)

Stopping — and especially **deleting** — a running scan didn't stop the pipeline: queued domains kept scanning in the background and consuming tokens, the dashboard still showed a resumable queue, and the only workaround was wiping the entire `.xalgorix` data dir.

## Root cause

`DELETE /api/scans/{id}` (`handleGetScan` delete branch) only:
- called `inst.cancel()` (aborts just the *current* target's context), and
- `delete(s.instances, id)` (drops the map entry).

It never:
1. set `inst.Status = "stopped"` — so `runMultiScan`'s queue loop, which holds a **captured** `*ScanInstance` pointer, still saw `"running"` and advanced to the next queued target with a fresh context; and
2. cleared `queue_state_<id>.json` — so the startup **auto-resume** goroutine replayed the whole queue.

On top of that, `instanceInterrupted(id)` returned **false** for a deleted instance (missing from the map → status `""`), so the wildcard **subdomain** loop kept scanning the remaining subdomains too.

## Fix

- **DELETE** now marks the instance `stopped` (`StopReason=user_deleted`), cancels its context, stops its agent, and clears its persisted queue state — then removes it from the map. Setting status on the captured pointer breaks the outer queue loop even after the map entry is gone.
- **`instanceInterrupted`** treats a missing (deleted) instance as interrupted. `runMultiScan` always registers the instance before scanning and never removes it on normal completion, so "missing" reliably means "deleted" — this stops the wildcard subdomain loop and the post-session early-returns.
- **Stop handlers** (global + per-instance) clear the persisted queue state immediately, so the dashboard queue counter clears and nothing auto-resumes (a user stop is terminal; the `runMultiScan` defer already cleared it on exit — this just makes it prompt). Per-instance stop is correctly scoped (no `KillAllProcesses`, which would have hit other concurrent scans).

## Tests

`scan_lifecycle_test.go`: deleted/missing instance is interrupted; DELETE cancels the instance + removes it + deletes the queue file; per-instance stop marks stopped + clears the queue file. Full `internal/web` suite + build/vet/gofmt/golangci-lint (0 issues) pass.

Reported against v4.5.60; root cause confirmed still present on current main.