### PR TITLE
fix(llm): force temperature=1 for Kimi K2.6 / K3 models (#237)

### DIFF
--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -572,9 +572,29 @@ func (c *Client) SetTemperature(temp *float64) {
 	}
 }
 
-// effectiveTemperature returns the per-call override if set, otherwise
-// falls back to the config default.
+// modelRequiresFixedTemperature reports whether a model rejects any
+// temperature other than the default 1 (returns 400 "only 1 is allowed for
+// this model"). Moonshot's Kimi K2.6 and K3 models enforce this. For these the
+// agent's per-role SetTemperature overrides (validator/reporter/scanner, which
+// use values like 0.0) MUST be ignored — otherwise every call errors. Matching
+// on the bare model name is safe: only Moonshot serves these names.
+func modelRequiresFixedTemperature(model string) bool {
+	m := strings.ToLower(strings.TrimSpace(model))
+	if i := strings.LastIndex(m, "/"); i >= 0 {
+		m = m[i+1:]
+	}
+	return strings.Contains(m, "kimi-k2.6") || strings.Contains(m, "kimi-k3")
+}
+
+// effectiveTemperature returns the temperature to send. Models that only accept
+// the default (Kimi K2.6 / K3) always get 1 regardless of config or per-call
+// overrides. Otherwise the per-call override wins, falling back to the config
+// default.
 func (c *Client) effectiveTemperature() *float64 {
+	if modelRequiresFixedTemperature(c.apiModel) {
+		one := 1.0
+		return &one
+	}
 	if v, ok := c.tempOverride.Load().(*float64); ok && v != nil {
 		return v
 	}

--- a/internal/llm/fixed_temperature_test.go
+++ b/internal/llm/fixed_temperature_test.go
@@ -1,0 +1,66 @@
+package llm
+
+import (
+	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/config"
+)
+
+// Kimi K2.6 / K3 reject any temperature other than 1 ("only 1 is allowed for
+// this model"). Regression for issue #237.
+func TestModelRequiresFixedTemperature(t *testing.T) {
+	cases := map[string]bool{
+		"kimi-k2.6":        true,
+		"kimi-k3":          true,
+		"kimi-k3.0":        true,
+		"kimi-k3-max":      true,
+		"openai/kimi-k2.6": true,
+		"moonshot/kimi-k3": true,
+
+		"kimi-k2.5":       false,
+		"kimi-k2":         false,
+		"gpt-4o":          false,
+		"gpt-5.4":         false,
+		"deepseek-v4-pro": false,
+		"claude-sonnet-4": false,
+	}
+	for model, want := range cases {
+		if got := modelRequiresFixedTemperature(model); got != want {
+			t.Errorf("modelRequiresFixedTemperature(%q) = %v, want %v", model, got, want)
+		}
+	}
+}
+
+// For a fixed-temperature model, effectiveTemperature must always return 1 —
+// even after the agent's per-role SetTemperature override (e.g. validator 0.0)
+// and regardless of the configured XALGORIX_TEMPERATURE.
+func TestEffectiveTemperature_FixedModelIgnoresOverrideAndConfig(t *testing.T) {
+	half := 0.5
+	c := NewClient(&config.Config{LLM: "openai/kimi-k2.6", APIKey: "k", Temperature: &half})
+
+	if got := c.effectiveTemperature(); got == nil || *got != 1.0 {
+		t.Fatalf("kimi effectiveTemperature (config 0.5) = %v, want 1.0", got)
+	}
+
+	zero := 0.0
+	c.SetTemperature(&zero) // agent validator override
+	if got := c.effectiveTemperature(); got == nil || *got != 1.0 {
+		t.Fatalf("kimi effectiveTemperature after SetTemperature(0.0) = %v, want 1.0", got)
+	}
+}
+
+// Non-fixed models keep the existing behavior: per-call override wins, else
+// the config default.
+func TestEffectiveTemperature_NormalModelHonorsOverride(t *testing.T) {
+	def := 0.2
+	c := NewClient(&config.Config{LLM: "openai/gpt-4o", APIKey: "k", Temperature: &def})
+
+	if got := c.effectiveTemperature(); got == nil || *got != 0.2 {
+		t.Fatalf("gpt-4o default temperature = %v, want 0.2", got)
+	}
+	override := 0.7
+	c.SetTemperature(&override)
+	if got := c.effectiveTemperature(); got == nil || *got != 0.7 {
+		t.Fatalf("gpt-4o overridden temperature = %v, want 0.7", got)
+	}
+}


### PR DESCRIPTION
## Problem (fixes #237)

Scanning with a Kimi K2.6 / K3 model fails on every LLM call:

```
API returned 400: {"error":{"message":"invalid temperature: only 1 is allowed for this model"...}}
```

Even with `XALGORIX_TEMPERATURE=1`, because the agent switches temperature **per role** via `SetTemperature` (validator `0.0`, reporter, reasoner, scanner) — and `effectiveTemperature` returns that override ahead of the config, so a non-1 value is sent.

## Fix

`effectiveTemperature` now returns a fixed `1` for models that only accept the default (Kimi K2.6 / K3), **before** consulting the per-call override or config. This neutralizes the agent's `SetTemperature` calls for those models. Every other model keeps the existing override→config behavior.

`modelRequiresFixedTemperature` matches the bare model name (`kimi-k2.6`, `kimi-k3*`); only Moonshot serves those names, so it's safe on the shared path. This is the approach suggested in the issue.

Note: GPT-5 / o-series (also default-temperature-only) are already handled separately in `buildChatRequest` (#242) by omitting temperature, so there's no overlap.

## Tests

`fixed_temperature_test.go`: the predicate table; a Kimi client returns 1 despite config `0.5` and a `SetTemperature(0.0)` override; a normal model still honors override→config. build/vet/gofmt/golangci-lint (0 issues) + full `internal/llm` suite pass.