### PR TITLE
release: v4.5.66

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.65
+VERSION=4.5.66
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.65" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.66" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.65"
+var version = "4.5.66"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
### Changes

- 18b87f8 fix(llm): force temperature=1 for Kimi K2.6 / K3 models (#246)
- 85409d0 fix(web): stopping/deleting a scan halts its queue and clears resume state (#245)
- 5bd121c release: v4.5.65 (#244)