### PR TITLE
fix(llm): recover tool-call tags with a stray quote before '>' (follow-up to #243)

### DIFF
--- a/internal/llm/parser.go
+++ b/internal/llm/parser.go
@@ -30,19 +30,22 @@ var (
 	invokeOpen   = regexp.MustCompile(`<invoke\s+name=["']([^"']+)["']>`)
 	funcCallsTag = regexp.MustCompile(`</?function_calls>`)
 
-	// Recover malformed tool-call OPEN tags. Some models intermittently drop
-	// the leading "<" — or the whole "<function" — from the opening tag while
-	// still emitting a well-formed body and "</function>", e.g.
-	//     function=terminal_execute><parameter=command>id</parameter></function>
-	//     =send_request><parameter=method>GET</parameter></function>
-	// The strict fnRegex never matched these, so the call was counted as a
-	// "no tool call" response; 15 of those in a row force-stops the whole scan
-	// (observed in production). Requiring a "<parameter" or "</function>"
-	// immediately after the ">" makes this a specific, low-false-positive
-	// signal — ordinary prose does not contain "=word><parameter". Correct
-	// "<function=name>" tags also match this pattern and are rewritten to the
-	// identical canonical form, so the repair is idempotent.
-	repairFnOpenRe = regexp.MustCompile(`(?s)<?(?:function)?\s*=\s*([A-Za-z_][A-Za-z0-9_-]*)\s*>(\s*(?:<parameter|</function>))`)
+	// Recover malformed tool-call OPEN tags. Some models intermittently mangle
+	// the opening tag while still emitting a well-formed body and "</function>".
+	// Observed variants (all counted as "no tool call" by the strict fnRegex):
+	//     function=terminal_execute><parameter=command>id</parameter></function>   (no leading "<")
+	//     =send_request><parameter=method>GET</parameter></function>               (no "<function")
+	//     function=terminal_execute"><parameter=command>id</parameter></function>  (stray quote before ">")
+	//     <function="terminal_execute"><parameter=...>                             (quoted name)
+	// 15 such responses in a row force-stops the whole scan (observed in
+	// production against bitbank.cc). This repair rebuilds the canonical
+	// "<function=name>" form, tolerating an optional leading "<"/"<function",
+	// optional surrounding quotes, and stray quotes/whitespace before the ">".
+	// Requiring a "<parameter" or "</function>" immediately after makes it a
+	// specific, low-false-positive signal (ordinary prose has no
+	// "=word><parameter"), and correct "<function=name>" tags rewrite to the
+	// identical form, so it is idempotent.
+	repairFnOpenRe = regexp.MustCompile(`(?s)<?(?:function)?\s*=\s*["']?([A-Za-z_][A-Za-z0-9_-]*)["'\s]*>(\s*(?:<parameter|</function>))`)
 
 	// Normalize quotes around = in tags: <function = "name"> → <function=name>
 	stripQuotesRe = regexp.MustCompile(`<(function|parameter)\s*=\s*["']?([^>"']+?)["']?\s*>`)

--- a/internal/llm/parser_repair_test.go
+++ b/internal/llm/parser_repair_test.go
@@ -44,6 +44,27 @@ func TestParseToolCalls_RepairsMalformedOpenTag(t *testing.T) {
 			wantVal:  "https://x",
 		},
 		{
+			name:     "stray quote before angle bracket (missing leading <)",
+			input:    "function=terminal_execute\">\n<parameter=command>id</parameter>\n</function>",
+			wantName: "terminal_execute",
+			wantKey:  "command",
+			wantVal:  "id",
+		},
+		{
+			name:     "stray quote before angle bracket, bare equals",
+			input:    "=terminal_execute\">\n<parameter=command>whoami</parameter></function>",
+			wantName: "terminal_execute",
+			wantKey:  "command",
+			wantVal:  "whoami",
+		},
+		{
+			name:     "quoted name",
+			input:    "<function=\"send_request\"><parameter=method>GET</parameter></function>",
+			wantName: "send_request",
+			wantKey:  "method",
+			wantVal:  "GET",
+		},
+		{
 			name:     "correct tag still parses (idempotent)",
 			input:    "<function=finish>\n<parameter=summary>done</parameter>\n</function>",
 			wantName: "finish",


### PR DESCRIPTION
## Another malformed-tag variant

A bitbank.cc scan reached **phase 22** then force-stopped with `llm_no_tool_calls`. The event log shows the model emitting tool calls like:

```
message: function=terminal_execute">
         <parameter=command># Test the api.bitbank.cc endpoint ...</parameter>
         </function>
message: =terminal_execute">
         <parameter=command>...</parameter></function>
```

Missing the leading `<` **and** with a stray `"` between the tool name and `>` (`terminal_execute">`). The #243 repair only allowed whitespace before `>`, so the quote broke the match — the call parsed as **zero** tool calls, counted as a no-tool response, and 15 in a row force-stopped the scan. The model was doing real work (SQLi/WAF-bypass probing), so this is an unnecessary failure.

## Fix

Harden `repairFnOpenRe` to also tolerate:
- an optional quote right after `=` (quoted names: `<function="name">`), and
- stray quotes/whitespace before `>` (`name">`, `name '>`, etc.).

Still gated on a following `<parameter`/`</function>` (no prose false positives) and idempotent for correct `<function=name>` tags.

## Tests

Added the exact `name">` shapes (with and without leading `<`/`function`) and a quoted-name case to `parser_repair_test.go`; existing idempotency + prose-safety tests still pass. build/vet/gofmt/golangci-lint (0 issues) + full `internal/llm` suite pass.

## Note

The same log also shows some `<think>`-only responses (model reasoning without emitting a tool call) — those are handled by the existing no-tool nudge. This parser fix is the high-value part: it keeps the model fed with real tool results instead of silently dropping its actions, which is what drives the no-tool streaks.