### PR TITLE
fix(web): don't fail a wildcard scan when Phase 1 discovery LLM-aborts

### DIFF
--- a/internal/web/abort_instance_gate_test.go
+++ b/internal/web/abort_instance_gate_test.go
@@ -1,0 +1,36 @@
+package web
+
+import "testing"
+
+// Only a top-level single/DAST session may fail the whole instance on an
+// LLM-abort. Wildcard discovery + subdomain sub-sessions share the parent
+// instance ID, so failing the instance from them marks a still-running scan
+// as failed (issue: "scan is running but marked as failed" on att.com, where
+// Phase 1 discovery aborted after finding 3026 subdomains and Phase 2 kept
+// scanning).
+func TestShouldFailInstanceOnAbort(t *testing.T) {
+	cases := []struct {
+		name         string
+		scanMode     string
+		parentTarget string
+		discovery    bool
+		want         bool
+	}{
+		{name: "single scan", scanMode: "single", want: true},
+		{name: "dast scan", scanMode: "dast", want: true},
+		{name: "empty mode top-level", scanMode: "", want: true},
+		{name: "wildcard discovery session", scanMode: "wildcard", discovery: true, want: false},
+		{name: "wildcard subdomain session", scanMode: "wildcard", parentTarget: "att.com", want: false},
+		{name: "wildcard mixed case", scanMode: "Wildcard", want: false},
+		{name: "subdomain session without explicit mode", scanMode: "", parentTarget: "att.com", want: false},
+		{name: "discovery flag without wildcard mode", scanMode: "", discovery: true, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldFailInstanceOnAbort(tc.scanMode, tc.parentTarget, tc.discovery); got != tc.want {
+				t.Errorf("shouldFailInstanceOnAbort(%q,%q,%v) = %v, want %v",
+					tc.scanMode, tc.parentTarget, tc.discovery, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/web/scan_session.go
+++ b/internal/web/scan_session.go
@@ -15,6 +15,31 @@ import (
 	"github.com/xalgord/xalgorix/v4/internal/tools/reporting"
 )
 
+// shouldFailInstanceOnAbort reports whether an LLM-abort (no-tool / empty /
+// repeated-error / rate-limit) in THIS session may mark the whole scan
+// instance failed.
+//
+// Only a top-level single/DAST scan qualifies. A wildcard scan runs a discovery
+// session plus one session per subdomain, and every one of them shares the
+// parent instance ID: Phase 1 discovery normally ends with a no-tool abort
+// after it has already enumerated the subdomains, and a single subdomain
+// session can abort while hundreds more are still queued. Failing the instance
+// from any wildcard sub-session marks a scan that is still actively running as
+// "failed" (and wrongly refunds it). Wildcard parent status is decided by the
+// orchestrator, so those sessions must fall through to the normal finalize.
+func shouldFailInstanceOnAbort(scanMode, parentTarget string, discoveryMode bool) bool {
+	if strings.EqualFold(strings.TrimSpace(scanMode), "wildcard") {
+		return false
+	}
+	if discoveryMode {
+		return false
+	}
+	if strings.TrimSpace(parentTarget) != "" {
+		return false
+	}
+	return true
+}
+
 // executeScanSession runs a single scan in complete isolation.
 // It NEVER panics upward — all panics are caught and logged.
 func (s *Server) executeScanSession(sess *scanSession) {
@@ -213,7 +238,18 @@ func (s *Server) executeScanSession(sess *scanSession) {
 	// otherwise flip a still-"running" instance to "finished". This runs after
 	// the event processor has drained (<-done above), so there is no concurrent
 	// processEvent writer.
-	if sess.abortReason != "" {
+	//
+	// CRITICAL: only a TOP-LEVEL single/DAST session may fail the instance on
+	// abort. A wildcard scan runs one discovery session + one session per
+	// subdomain, and they ALL share the parent instance ID. Phase 1 discovery
+	// routinely ends with a no-tool abort AFTER it has already enumerated the
+	// subdomains, and individual subdomain sessions can abort while hundreds
+	// more are still queued. Failing the instance from any of those clobbers a
+	// scan that is genuinely still running (the reported "running but marked
+	// failed" bug) and wrongly refunds it. Wildcard parent status is owned by
+	// the orchestrator (runWildcardTarget / runMultiScan), so wildcard
+	// sub-sessions fall through to the normal "finished" finalize below.
+	if sess.abortReason != "" && shouldFailInstanceOnAbort(sess.scanMode, sess.parentTarget, sess.discoveryMode) {
 		reportedVulns := 0
 		if sess.sctx != nil {
 			reportedVulns = len(reporting.GetVulnerabilitiesForContext(sess.sctx.ID))


### PR DESCRIPTION
## Problem

Reported: an att.com scan showed **failed** on the dashboard while it was **still actively running** (Phase 2, live probes) and was wrongly refunded.

## Root cause

From the event log: Phase 1 subdomain discovery ended with `llm_no_tool_calls` ("force finishing") **after it had already found 3026 subdomains**, and Phase 2 proceeded to scan them.

The abort-to-failed handling I added for single scans (#240) fires inside `executeScanSession`, which a wildcard scan calls **once per discovery + once per subdomain — all sharing the parent instance ID**. Discovery reports no vulns, so `producedResults` was false and the code set the **parent instance** `Status = "failed"`. But `isInterruptedInstanceStatus` does not treat `"failed"` as interrupted, so `runWildcardTarget` did **not** stop — Phase 2 kept scanning while the instance was marked failed. The SaaS then mapped `failed` → failed + refund + operator alert, all while the engine ran on.

## Fix

New `shouldFailInstanceOnAbort(scanMode, parentTarget, discoveryMode)` gate: only a **top-level single/DAST** session may fail the instance on an LLM-abort. Wildcard discovery and per-subdomain sub-sessions fall through to the normal `finished` finalize; the wildcard parent's final status stays owned by the orchestrator (`runWildcardTarget`/`runMultiScan`). Single/DAST behavior (fail+refund on a genuine no-result abort) is unchanged.

## Tests

`abort_instance_gate_test.go` covers single/dast/empty (may fail) vs wildcard discovery/subdomain/mixed-case (must not). Existing `processEvent` abort tests still pass. build/vet/gofmt/golangci-lint (0 issues) + full `internal/web` suite pass.

## Note

This only prevents FUTURE mislabeling. The already-failed att.com scan is a historical record (and may have been refunded) — I did not touch it.