### PR TITLE
reporting: reject control-less bypass-class false positives (smuggling, OAuth state, host-header)

### DIFF
--- a/internal/tools/reporting/host_bypass_fp_test.go
+++ b/internal/tools/reporting/host_bypass_fp_test.go
@@ -1,0 +1,59 @@
+package reporting
+
+import "testing"
+
+// A Host-header / deployment-protection "bypass" that only reaches public
+// production content is a false positive. It must carry a production-direct
+// control showing the direct response DIFFERS (staging-only content). Without
+// that differential it is rejected at medium+.
+func TestCheckFalsePositive_HostHeaderDeploymentBypass(t *testing.T) {
+	tests := []struct {
+		name       string
+		title      string
+		desc       string
+		severity   string
+		proof      string
+		wantReject bool
+	}{
+		{
+			name:       "vercel staging host-header bypass, no control (the reported FP)",
+			title:      "Vercel Deployment Protection bypass via Host header",
+			desc:       "staging.store returns 401 but adding Host: store.nintendo.fr returns 200 with JSON + cookies, bypassing the password protection",
+			severity:   "high",
+			proof:      "curl staging with Host override -> 200, EUID cookie adb831..., /api/customer JSON returned. 401 -> 200 via Host header.",
+			wantReject: true,
+		},
+		{
+			name:       "generic host-header password-protection bypass, no baseline",
+			title:      "Password protection bypass via Host header",
+			desc:       "401 changes to 200 when Host is overridden",
+			severity:   "medium",
+			proof:      "Sent Host: prod-alias, got 200 and the app loaded.",
+			wantReject: true,
+		},
+		{
+			name:       "real bypass with production-direct control showing difference → accepted",
+			title:      "Deployment protection bypass exposes staging-only debug endpoint",
+			desc:       "Host override reaches a staging-only /debug/env route",
+			severity:   "high",
+			proof:      "Via Host trick: GET /debug/env -> 200 with staging env vars. Control: production directly returns 404 for /debug/env — this route is not available on production, staging-only.",
+			wantReject: false,
+		},
+		{
+			name:       "info severity exempt",
+			title:      "Host header behavior on staging",
+			desc:       "401 to 200 via host",
+			severity:   "info",
+			proof:      "",
+			wantReject: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := checkFalsePositive(tt.title, tt.desc, tt.severity, tt.proof)
+			if gotReject := result != ""; gotReject != tt.wantReject {
+				t.Errorf("reject=%v want %v (msg=%q)", gotReject, tt.wantReject, result)
+			}
+		})
+	}
+}

--- a/internal/tools/reporting/oauth_fp_test.go
+++ b/internal/tools/reporting/oauth_fp_test.go
@@ -1,0 +1,113 @@
+package reporting
+
+import "testing"
+
+// OAuth `state` is validated by the client app, not the authorization server.
+// A "CSRF" finding whose only proof is the authorize endpoint accepting/echoing
+// state=test must be rejected at medium+; a full-callback proof passes.
+func TestCheckFalsePositive_OAuthStateCSRF(t *testing.T) {
+	tests := []struct {
+		name       string
+		title      string
+		desc       string
+		severity   string
+		proof      string
+		wantReject bool
+	}{
+		{
+			name:       "state=test accepted by authorize endpoint (the reported FP)",
+			title:      "OAuth CSRF — missing state validation",
+			desc:       "The authorize endpoint accepts state=test with no rejection, proving CSRF protection is nonexistent",
+			severity:   "high",
+			proof:      "Sent state=test to /oauth2/authorize -> HTTP 200, no AADSTS error. Also XALGORIX-GARBAGE and empty state both returned 200.",
+			wantReject: true,
+		},
+		{
+			name:       "state parameter echoed, medium",
+			title:      "Missing state validation in OAuth flow",
+			desc:       "state parameter is reflected back unchanged",
+			severity:   "medium",
+			proof:      "authorize endpoint echoed the arbitrary state value in the response",
+			wantReject: true,
+		},
+		{
+			name:       "genuine state CSRF with callback completion → accepted",
+			title:      "OAuth CSRF via missing state validation",
+			desc:       "Client app accepts an unissued state at the callback",
+			severity:   "high",
+			proof:      "Completed the flow: the callback at app.example.com/callback accepted ?code=...&state=test that it never issued and logged me into the victim's account (usable session).",
+			wantReject: false,
+		},
+		{
+			name:       "info severity exempt",
+			title:      "OAuth state parameter observation",
+			desc:       "state accepted at authorize",
+			severity:   "info",
+			proof:      "",
+			wantReject: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := checkFalsePositive(tt.title, tt.desc, tt.severity, tt.proof)
+			if gotReject := result != ""; gotReject != tt.wantReject {
+				t.Errorf("reject=%v want %v (msg=%q)", gotReject, tt.wantReject, result)
+			}
+		})
+	}
+}
+
+// Public OAuth/OIDC identifiers (tenant ID, client_id, openid-configuration,
+// branding) are not secrets; reporting them as disclosure is rejected unless a
+// real credential is included.
+func TestCheckFalsePositive_OAuthPublicIdentifiers(t *testing.T) {
+	tests := []struct {
+		name       string
+		title      string
+		desc       string
+		severity   string
+		proof      string
+		wantReject bool
+	}{
+		{
+			name:       "azure tenant id disclosure",
+			title:      "Sensitive information disclosure: Azure AD tenant ID",
+			desc:       "The Azure AD tenant UUID is exposed via openid-configuration",
+			severity:   "medium",
+			proof:      "GET /.well-known/openid-configuration returns tenant id 12345678-...",
+			wantReject: true,
+		},
+		{
+			name:       "client_id leak",
+			title:      "OAuth client_id disclosure",
+			desc:       "client_id leaked in authorization URL",
+			severity:   "high",
+			proof:      "client_id=abcd visible in the authorize request",
+			wantReject: true,
+		},
+		{
+			name:       "tenant branding exposed",
+			title:      "Information disclosure of tenant branding",
+			desc:       "Tenant branding 'Nintendo of Europe' exposed on login page",
+			severity:   "low",
+			proof:      "login page shows the org display name",
+			wantReject: true,
+		},
+		{
+			name:       "real client_secret leak → not rejected by the OAuth-public-id gate",
+			title:      "OAuth client_id and client_secret exposed via config endpoint",
+			desc:       "client_secret leaked from an unauthenticated /config API",
+			severity:   "critical",
+			proof:      "GET /api/config returned client_secret=SUPER-SECRET-VALUE; exchanged it at /oauth/token for a valid access token",
+			wantReject: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := checkFalsePositive(tt.title, tt.desc, tt.severity, tt.proof)
+			if gotReject := result != ""; gotReject != tt.wantReject {
+				t.Errorf("reject=%v want %v (msg=%q)", gotReject, tt.wantReject, result)
+			}
+		})
+	}
+}

--- a/internal/tools/reporting/reporting.go
+++ b/internal/tools/reporting/reporting.go
@@ -265,6 +265,7 @@ func Register(r *tools.Registry) {
 1. You MUST have already EXPLOITED this vulnerability before calling this tool.
 2. You MUST provide exploitation_proof showing concrete evidence (extracted data, reflected payload, command output, callback, timing proof).
 3. Reports without exploitation proof for severity >= medium will be REJECTED — exploit first, then report.
+3b. MANDATORY CONTROL/BASELINE TEST for any "bypass", "desync", or "differential" claim: before reporting, prove the behavior does NOT already happen WITHOUT your exploit. Run the baseline and put BOTH results in exploitation_proof. Examples: a Host-header/deployment "bypass" → hit production directly with no Host trick; if the response is identical it is PUBLIC, not a bypass. Request smuggling → resend the two requests with NO CL/TE headers; two responses then = pipelining, not desync. OAuth "state CSRF" → the authorize endpoint echoing state=test is by design (state is client-validated); complete the callback. If baseline == exploit-result, it is a FALSE POSITIVE — do not report.
 4. Do NOT report missing headers, version disclosure, or scanner-only findings as vulnerabilities — those are INFO at best.
 5. Duplicate checks are scoped to the current scan run only. If the same issue was found in a previous scan and is still exploitable now, report it again for this scan.
 6. SEVERITY MUST MATCH CVSS SCORE per HackerOne standards:
@@ -891,6 +892,183 @@ func checkFalsePositive(title, description, severity, proof string) string {
 	for _, kw := range traceKeywords {
 		if strings.Contains(lower, kw) {
 			return "❌ REJECTED: TRACE/OPTIONS methods enabled is INFORMATIONAL. Modern browsers block cross-site TRACE (XST), making this unexploitable. Do not report."
+		}
+	}
+
+	// Pattern 11a: HTTP request smuggling / desync claimed without a genuine
+	// desync proof. The canonical automated false positive: HTTP/1.1
+	// PIPELINING (two responses on one connection) plus a redirect engine
+	// ECHOING the request path into the Location header, misread as a
+	// CL.TE/TE.CL desync + cache poisoning. Real proof is a DIFFERENTIAL — a
+	// timing hang vs. an instant baseline, OR a paired follow-up/victim request
+	// on a SEPARATE connection that gets corrupted/redirected/delayed or
+	// receives the smuggled prefix. "Two responses", a canary reflected in
+	// Location, and `x-cache: HIT` on a redirect are NOT proof. Fires only at
+	// medium+ and only when the proof shows none of the differential signals,
+	// so a genuine desync (which cites timing/victim evidence) passes through.
+	smugglingKeywords := []string{
+		"request smuggling", "http smuggling", "smuggl", "desync", "desynchron",
+		"cl.te", "te.cl", "cl-te", "te-cl", "te.te", "http/1.1 desync", "http desync",
+		"request queue poison", "request tunnel", "h2.cl", "h2.te",
+	}
+	isSmuggling := false
+	for _, kw := range smugglingKeywords {
+		if strings.Contains(lower, kw) {
+			isSmuggling = true
+			break
+		}
+	}
+	if isSmuggling && isHighSev {
+		lowerProof := strings.ToLower(proof)
+		// Specific phrases only — avoid generic tokens like "baseline" or
+		// "socket" that appear in canaries/prose and would wave a FP through.
+		desyncSignals := []string{
+			// (a) timing differential — a hang vs. an instant baseline
+			"time-based", "time based", "timing differential", "hang", "hung",
+			"delayed", "timed out", "time out", "sleep(", "pg_sleep", "waitfor delay",
+			"returned instantly", "instant baseline", "vs baseline", "vs instant",
+			"response time delta", "second delay", "seconds delay",
+			// (b) cross-connection / victim contamination
+			"victim", "another connection", "different connection", "separate connection",
+			"second connection", "cross-connection", "socket reuse", "socket-reuse",
+			"another socket", "victim socket", "unrelated request", "another user",
+			// (c) the follow-up request itself being corrupted by the prefix
+			"poisoned the next", "poisoned the following", "next request received",
+			"next request returned", "follow-up request", "corrupted the next",
+			"405 on the follow", "400 on the follow", "queue poison", "prefix landed on",
+		}
+		hasDesyncProof := false
+		for _, kw := range desyncSignals {
+			if strings.Contains(lowerProof, kw) {
+				hasDesyncProof = true
+				break
+			}
+		}
+		if !hasDesyncProof {
+			return "❌ REJECTED: HTTP request smuggling / desync needs a DIFFERENTIAL proof, not a single response. Two responses on one connection is HTTP/1.1 PIPELINING, and a canary reflected in the Location header is just the redirect engine echoing the path — neither proves a desync, and `x-cache: HIT` on a redirect is normal. Prove it with EITHER (a) a time-delay probe (incomplete chunk / bad length) that hangs ~5-10s versus an instant baseline — run the baseline too — OR (b) a paired follow-up/victim request on a SEPARATE connection that gets corrupted, redirected, delayed, or receives your smuggled prefix. First run the two mandatory controls: (1) pipelining control — send the same two requests with NO Content-Length/Transfer-Encoding smuggling headers; if you STILL get two responses it is pipelining, not smuggling; (2) redirect-echo control — send a single benign GET /<canary>; if the canary appears in Location, reflection proves nothing. If neither differential holds, this is a false positive — do not report it (downgrade to 'info' only if there is a real, distinct issue)."
+		}
+	}
+
+	// Pattern 11a-2: OAuth "state" CSRF claimed from the AUTHORIZATION endpoint
+	// alone. The OAuth `state` parameter is generated and validated by the
+	// CLIENT application (relying party), NOT by the authorization server
+	// (RFC 6749 §10.12). Every authorize endpoint — Microsoft, Google, Okta —
+	// accepts and echoes ANY state (state=test, garbage, empty) by design and
+	// returns 200; that proves nothing. A real state-CSRF requires completing
+	// the full redirect callback and showing the CLIENT app accepts a state it
+	// never issued (forced login / account linking with a usable session). Fire
+	// at medium+ only when there is no callback/session evidence.
+	isStateCSRF := (strings.Contains(lower, "csrf") || strings.Contains(lower, "cross-site request forgery")) &&
+		strings.Contains(lower, "state")
+	isStateCSRF = isStateCSRF ||
+		strings.Contains(lower, "state parameter") ||
+		strings.Contains(lower, "missing state validation") ||
+		strings.Contains(lower, "state validation") ||
+		(strings.Contains(lower, "oauth") && strings.Contains(lower, "state"))
+	if isStateCSRF && isHighSev {
+		lowerProof := strings.ToLower(proof + " " + description)
+		// Evidence that the CLIENT app (not just the authorize endpoint)
+		// actually accepted an unissued state / that a session was forced.
+		callbackProof := []string{
+			"callback", "?code=", "&code=", "code= ", "authorization code",
+			"obtained a token", "usable token", "access token returned", "id_token returned",
+			"logged into", "logged in as", "authenticated session", "session fixated",
+			"account link", "account takeover", "forced login", "victim's account",
+			"my listener", "my server received", "exchanged the code",
+			"relying party accepted", "app accepted", "unissued state",
+		}
+		hasCallbackProof := false
+		for _, kw := range callbackProof {
+			if strings.Contains(lowerProof, kw) {
+				hasCallbackProof = true
+				break
+			}
+		}
+		if !hasCallbackProof {
+			return "❌ REJECTED: OAuth `state` is validated by the CLIENT application, NOT the authorization server (RFC 6749 §10.12). The authorize endpoint accepting/echoing `state=test` (or any value) and returning 200 is BY DESIGN and proves nothing — every Microsoft/Google/Okta authorize endpoint does this. To report a real state-CSRF you must complete the full redirect callback and show the CLIENT app at the redirect_uri accepts a state it never issued, yielding a forced login / account-linking with a usable session. Without that end-to-end proof this is a false positive — do not report (downgrade to 'info' only if there is a distinct, real issue)."
+		}
+	}
+
+	// Pattern 11a-3: Public OAuth/OIDC identifiers reported as "secret" /
+	// "disclosure". The Azure AD tenant ID/UUID, the OAuth `client_id`, the
+	// `/.well-known/openid-configuration` document, and tenant branding
+	// (display name/logo) are PUBLIC BY DESIGN — they are sent in the clear in
+	// every authorization URL and discovery document and are required for
+	// federated login. They are not secrets. Only a real credential
+	// (client_secret, private/signing key, refresh/access token, password)
+	// makes this reportable.
+	oauthPublicIDKeywords := []string{
+		"client_id", "client id", "tenant id", "tenant uuid", "tenant identifier",
+		"azure ad tenant", "azure tenant", "openid-configuration", "openid configuration",
+		".well-known/openid", "tenant branding", "oauth metadata", "oidc metadata",
+		"issuer disclosure", "authorization server metadata",
+	}
+	isOAuthPublicID := false
+	for _, kw := range oauthPublicIDKeywords {
+		if strings.Contains(lower, kw) {
+			isOAuthPublicID = true
+			break
+		}
+	}
+	if isOAuthPublicID &&
+		(strings.Contains(lower, "disclos") || strings.Contains(lower, "expos") ||
+			strings.Contains(lower, "leak") || strings.Contains(lower, "secret") ||
+			strings.Contains(lower, "sensitive") || strings.Contains(lower, "information disclosure")) {
+		lowerProof := strings.ToLower(proof + " " + description)
+		realSecret := []string{
+			"client_secret", "client secret", "private key", "signing key",
+			"refresh_token", "refresh token", "access_token", "bearer ey",
+			"password", "api_key", "api key", "-----begin",
+		}
+		hasRealSecret := false
+		for _, kw := range realSecret {
+			if strings.Contains(lowerProof, kw) {
+				hasRealSecret = true
+				break
+			}
+		}
+		if !hasRealSecret {
+			return "❌ REJECTED: OAuth/OIDC public identifiers — the Azure AD tenant ID/UUID, the `client_id`, the `/.well-known/openid-configuration` document, tenant branding (display name/logo) — are PUBLIC BY DESIGN (RFC 6749 §2.2; the tenant ID is in every discovery document). They are sent in the clear in every authorization URL and are not secrets. This is not a vulnerability. Only a genuine credential leak — client_secret, private/signing key, a live refresh/access token, or a password — is reportable; include the actual secret value as proof. Otherwise do not report."
+		}
+	}
+
+	// Pattern 11a-4: Host-header / deployment-protection "bypass" that only
+	// reaches PUBLIC content. Sending `Host: prod.example.com` to a staging
+	// alias (Vercel/Netlify/etc.) commonly returns 200 — but that is because
+	// the platform routes the request to the PRODUCTION alias, which is
+	// intentionally public. You did not bypass anything; you asked for the
+	// public site and got it. A real bypass must reach content that is NOT
+	// available by hitting production directly (staging-only code/config/data,
+	// a debug endpoint, an internal backend). The mandatory control is: repeat
+	// the request directly against production with NO Host trick — if the
+	// response is identical, it is a false positive by construction. Fire at
+	// medium+ only when the proof shows no such differential/control.
+	isHostBypass := (strings.Contains(lower, "host header") && strings.Contains(lower, "bypass")) ||
+		strings.Contains(lower, "deployment protection") ||
+		(strings.Contains(lower, "vercel") && (strings.Contains(lower, "bypass") || strings.Contains(lower, "protection"))) ||
+		((strings.Contains(lower, "staging") || strings.Contains(lower, "password protection") || strings.Contains(lower, "password-protected")) && strings.Contains(lower, "bypass")) ||
+		(strings.Contains(lower, "401") && strings.Contains(lower, "200") && strings.Contains(lower, "host"))
+	if isHostBypass && isHighSev {
+		lowerProof := strings.ToLower(proof + " " + description)
+		// Evidence that the bypass reaches something NOT public on production.
+		differentialSignals := []string{
+			"production directly", "prod directly", "direct to production", "directly against production",
+			"without the host", "without the bypass", "without host override", "no host override",
+			"control request", "baseline request", "differs from production", "differs from prod",
+			"not available on production", "not public on production", "staging-only", "staging only",
+			"only reachable via", "only accessible via the host", "prod returns 401", "prod returns 403",
+			"prod returns 404", "production returns 401", "production returns 403", "production returns 404",
+			"different content", "differs staging", "staging-specific", "debug endpoint not on prod",
+		}
+		hasDifferential := false
+		for _, kw := range differentialSignals {
+			if strings.Contains(lowerProof, kw) {
+				hasDifferential = true
+				break
+			}
+		}
+		if !hasDifferential {
+			return "❌ REJECTED: A Host-header / deployment-protection 'bypass' that returns 200 usually just reached PUBLIC production. Staging and production are commonly two aliases of the SAME deployment (Vercel/Netlify): sending `Host: prod-domain` routes you to the production alias, which is intentionally public — that is not a bypass. MANDATORY control: repeat the exact request DIRECTLY against production with NO Host trick. If the direct-to-production response is identical (same status/body/cookies), this is a false positive by construction — do not report. To be a real finding you must reach content that is NOT available on production directly: a staging-only endpoint/config/env, a debug route, or an internal backend the public site does not expose — show the production-direct control returning 401/403/404 alongside the bypass returning 200 with distinct content. Note: a constant anonymous guest token (e.g. a Salesforce Commerce guest EUID) and public OAuth client_id/redirect_uri are normal public-store behavior, not credentials."
 		}
 	}
 

--- a/internal/tools/reporting/smuggling_fp_test.go
+++ b/internal/tools/reporting/smuggling_fp_test.go
@@ -1,0 +1,78 @@
+package reporting
+
+import "testing"
+
+// HTTP request smuggling / desync findings must carry a differential proof
+// (timing hang vs. baseline, or cross-connection victim contamination). The
+// canonical automated FP — HTTP/1.1 pipelining + a redirect engine echoing the
+// path into Location, misread as a CL.TE desync + cache poisoning — must be
+// rejected at medium+.
+func TestCheckFalsePositive_RequestSmuggling(t *testing.T) {
+	tests := []struct {
+		name       string
+		title      string
+		desc       string
+		severity   string
+		proof      string
+		wantReject bool
+	}{
+		{
+			name:       "pipelining + redirect echo misread as desync (the reported FP)",
+			title:      "CL.TE HTTP Request Smuggling",
+			desc:       "CL.TE desync enabling cache poisoning and request hijacking",
+			severity:   "high",
+			proof:      "Sent smuggling request, got 2 responses in 0.20s. Canary reflected in Location: https://host/ECHO-BASELINE. x-cache: HIT on the redirect.",
+			wantReject: true,
+		},
+		{
+			name:       "two responses only, no headers ruled out",
+			title:      "HTTP Desync (TE.CL)",
+			desc:       "Two responses returned from one connection",
+			severity:   "critical",
+			proof:      "The smuggled request produced two HTTP responses on the same socket.",
+			wantReject: true,
+		},
+		{
+			name:       "front-end simply rejected the malformed request",
+			title:      "Request smuggling via conflicting CL and TE",
+			desc:       "ALB desync",
+			severity:   "high",
+			proof:      "Sent conflicting Content-Length and Transfer-Encoding; got 405 Method Not Allowed.",
+			wantReject: true,
+		},
+		{
+			name:       "genuine timing differential → accepted",
+			title:      "CL.TE HTTP Request Smuggling",
+			desc:       "Back-end desyncs on incomplete chunk",
+			severity:   "high",
+			proof:      "Time-based probe: the CL.TE request hung for 9.8s while an identical baseline request returned instantly (0.2s). Reproduced 3x.",
+			wantReject: false,
+		},
+		{
+			name:       "genuine cross-connection victim contamination → accepted",
+			title:      "HTTP Request Smuggling (TE.CL)",
+			desc:       "Smuggled prefix poisons the next request",
+			severity:   "critical",
+			proof:      "A victim request on a separate connection received a 302 redirect to /admin that it never requested — the smuggled prefix landed on the victim socket.",
+			wantReject: false,
+		},
+		{
+			name:       "info severity is exempt",
+			title:      "Possible HTTP desync",
+			desc:       "two responses observed",
+			severity:   "info",
+			proof:      "",
+			wantReject: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := checkFalsePositive(tt.title, tt.desc, tt.severity, tt.proof)
+			gotReject := result != ""
+			if gotReject != tt.wantReject {
+				t.Errorf("checkFalsePositive(%q) reject=%v, want %v (msg=%q)",
+					tt.title, gotReject, tt.wantReject, result)
+			}
+		})
+	}
+}

--- a/internal/tools/skills/data/web-application-security/exploiting-http-request-smuggling/SKILL.md
+++ b/internal/tools/skills/data/web-application-security/exploiting-http-request-smuggling/SKILL.md
@@ -43,6 +43,24 @@ nist_csf:
   - Retry with a different HTTP method, a cache-busting path, and connection keep-alive forced — front-ends sometimes only desync on specific routes.
 - WAF/proxy normalization can hide a real desync on `/` but not on a deeper path; test multiple endpoints before calling it clean.
 
+### MANDATORY controls BEFORE you report (avoid false positives)
+Request smuggling is the #1 source of automated false positives. Before you call it CONFIRMED, you MUST run these two controls and paste their results into `exploitation_proof`. If you cannot, it is NOT a confirmed finding.
+
+- **These are NOT proof of smuggling — never report on them alone:**
+  - **Two responses on one connection.** This is ordinary **HTTP/1.1 pipelining**, which needs no smuggling headers at all. It does not prove a desync.
+  - **A canary/path reflected in the `Location` header.** Redirect engines echo whatever path you send into `Location` (e.g. `GET /ECHO-123` → `Location: https://host/ECHO-123`). This is trivial reflection, not a smuggled prefix.
+  - **`x-cache: HIT` on a redirect.** Redirects are cacheable; a cache hit on one proves nothing about poisoning.
+  - **A single request that hangs ~10s.** That is usually the keep-alive **idle timeout**, not a desync. Only a timing *differential* (attack hangs, baseline is instant) counts.
+
+- **Control 1 — pipelining rule-out (REQUIRED):** resend the exact same two requests with **NO** `Content-Length`/`Transfer-Encoding` smuggling headers (two plain pipelined GETs). If you STILL get two responses, the "two responses" signal was pipelining → **NOT smuggling**.
+- **Control 2 — redirect-echo rule-out (REQUIRED):** send a single benign `GET /<unique-canary>` with no smuggling. If the canary comes back in `Location`/body, then a reflected canary is just echo → the canary is **NOT** smuggling proof.
+- **Confirm with a real differential (REQUIRED — at least one):**
+  - **Timing:** an incomplete-chunk / mismatched-length probe that hangs ~5-10s **while an identical baseline returns instantly** (report both timings), or
+  - **Cross-connection victim:** a follow-up/normal request on a **separate** connection is corrupted, redirected to an endpoint you did not request, returns 400/405, delayed, or receives your smuggled prefix.
+- If the malformed request is simply rejected (e.g. `405 Method Not Allowed`, `400 Bad Request`) by the front-end/ALB, the desync did **not** propagate → do NOT report.
+
+The reporting gate enforces this: a medium+ smuggling finding whose proof shows none of the differential signals above is auto-rejected as a false positive.
+
 ## Prerequisites
 
 - **Authorization**: Written penetration testing agreement explicitly covering request smuggling (high-risk test)

--- a/internal/tools/skills/data/web-application-security/exploiting-oauth-misconfiguration/SKILL.md
+++ b/internal/tools/skills/data/web-application-security/exploiting-oauth-misconfiguration/SKILL.md
@@ -156,8 +156,18 @@ curl -s -X POST "https://auth.target.example.com/oauth/token" \
 # Test state parameter absence/predictability
 # Remove state parameter entirely
 curl -s "https://auth.target.example.com/oauth/authorize?response_type=code&client_id=APP_ID&redirect_uri=https://app.example.com/callback&scope=openid"
-# If no error, CSRF on OAuth flow is possible
+# NOTE: the authorize endpoint returning 200 (or echoing state=test / a missing
+# state) is NOT proof of anything — `state` is generated and validated by the
+# CLIENT app (relying party), never by the authorization server (RFC 6749
+# §10.12). Microsoft/Google/Okta accept ANY state by design. See the
+# false-positive controls below before concluding "CSRF possible".
 ```
+
+### CONFIRM correctly — do NOT report these as vulnerabilities (false-positive controls)
+- **`state=test` accepted at /authorize → 200.** Not a finding. `state` is client-validated, not server-validated (RFC 6749 §10.12); every authorize endpoint echoes any state. To prove a real state-CSRF you must complete the full redirect **callback** and show the CLIENT app at `redirect_uri` accepts a state it never issued, yielding a forced login / account link with a **usable session**.
+- **Public identifiers are not secrets.** The `client_id` (RFC 6749 §2.2), the Azure AD **tenant ID/UUID**, the `/.well-known/openid-configuration` document, and tenant **branding** (org display name/logo) are public by design — they ship in every authorization URL and discovery document. Do not report their "disclosure". Only a real credential (client_secret, private/signing key, live refresh/access token, password) is reportable — include the actual value.
+- **Reachability control.** Before writing "an unauthenticated user visits …", confirm the host is publicly resolvable and reachable. A host that CNAMEs to an `internal-*.elb.amazonaws.com` / resolves to RFC1918 is VPC-internal and not publicly exploitable.
+- **Public guest tokens are not credentials.** A constant anonymous token that every unauthenticated visitor receives (e.g. a Salesforce Commerce guest `EUID`) is normal storefront behavior, not session fixation or a shared credential.
 
 ### Step 4: Test Scope Escalation and Privilege Manipulation
 


### PR DESCRIPTION
## Context

Three findings were hands-on verified as false positives. All shared ONE root cause: the agent confirmed on a signal that is actually normal behavior, and never ran the control/baseline test ("is this already true WITHOUT my exploit?").

## Deterministic gates added (backstops to the independent verifier)

1. **HTTP request smuggling / desync** — reject a medium+ finding whose proof shows no DIFFERENTIAL: a timing hang vs. an instant baseline, or a cross-connection victim contamination. Two responses on one connection is HTTP/1.1 **pipelining**; a canary echoed in `Location` is the redirect engine; `x-cache: HIT` on a redirect is normal.
2. **OAuth `state` CSRF** — reject when the "proof" is only the **authorization** endpoint accepting/echoing `state=test`. `state` is validated by the **client app**, not the auth server (RFC 6749 §10.12); every authorize endpoint accepts any state. Requires full-callback proof (client accepts an unissued state → usable session).
3. **Public OAuth/OIDC identifiers as "disclosure"** — tenant ID/UUID, `client_id`, `/.well-known/openid-configuration`, tenant branding are public by design. Only a real credential (client_secret, private/signing key, live token, password) qualifies.
4. **Host-header / deployment-protection "bypass" that only reaches PUBLIC production** — Vercel/Netlify staging + prod are commonly aliases of the same deployment; sending `Host: prod` routes to the public production alias. Require a production-direct control showing the direct response DIFFERS (staging-only content). If prod-direct == bypass-response, it's a FP by construction.

Plus a general **MANDATORY CONTROL/BASELINE** rule in the `report_vulnerability` tool description, and hardened smuggling + OAuth skill docs (incl. fixing a misleading "if no error, CSRF is possible" line and noting reachability / public-guest-token pitfalls).

## Tests

Table-driven tests per gate: each reported FP rejects; a genuine finding with proper differential/callback/secret/control proof passes. Existing reporting + skills suites unchanged. build/vet/gofmt/golangci-lint (0 issues) pass.

These gates are high-precision (fire only at medium+ and only when the differential/control proof is absent), so real findings that include the right evidence are unaffected.