### PR TITLE
release: v4.5.68

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.67
+VERSION=4.5.68
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.67" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.68" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.67"
+var version = "4.5.68"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
### Changes

- 38498c1 reporting: reject control-less bypass-class false positives + require baseline (#251)
- 0fbd572 fix(web): don't fail a wildcard scan when Phase 1 discovery LLM-aborts (#250)
- 96cf61c release: v4.5.67 (#249)