### PR TITLE
fix(web): stop/start/delete work from the scan-detail page

### DIFF
--- a/internal/web/instance_action_resolve_test.go
+++ b/internal/web/instance_action_resolve_test.go
@@ -1,0 +1,52 @@
+package web
+
+import "testing"
+
+// The per-instance action endpoints (stop/pause/restart/start) must resolve not
+// just the live instance id but also a scan RECORD id / short alias, because the
+// scan-detail page routes by those. Previously a record id 404'd, so Stop/Delete
+// did nothing on the scan-detail page while working on the Instances page.
+func TestResolveInstanceForAction(t *testing.T) {
+	s := newTestServer(t, nil)
+
+	// Live instance keyed by its instance id.
+	s.instancesMu.Lock()
+	s.instances["inst-xyz"] = &ScanInstance{ID: "inst-xyz", Targets: "att.com", Status: "running"}
+	s.instancesMu.Unlock()
+
+	// A persisted scan record whose directory-slug ID differs from the instance
+	// id but points back to it via InstanceID (the wildcard-parent shape).
+	writeScanRecord(t, s.dataDir, "att.com/2026-07-20/att.com_slug", ScanRecord{
+		ID:         "att.com_slug",
+		InstanceID: "inst-xyz",
+		Target:     "att.com",
+		StartedAt:  "2026-07-20T10:00:00Z",
+		Status:     "running",
+	})
+
+	t.Run("exact instance id", func(t *testing.T) {
+		inst, ok := s.resolveInstanceForAction("inst-xyz")
+		if !ok || inst == nil || inst.ID != "inst-xyz" {
+			t.Fatalf("exact id did not resolve: ok=%v inst=%#v", ok, inst)
+		}
+	})
+
+	t.Run("scan record id resolves to instance", func(t *testing.T) {
+		inst, ok := s.resolveInstanceForAction("att.com_slug")
+		if !ok || inst == nil || inst.ID != "inst-xyz" {
+			t.Fatalf("record id did not resolve to instance: ok=%v inst=%#v", ok, inst)
+		}
+	})
+
+	t.Run("unknown id", func(t *testing.T) {
+		if _, ok := s.resolveInstanceForAction("does-not-exist"); ok {
+			t.Fatal("unknown id should not resolve")
+		}
+	})
+
+	t.Run("empty id", func(t *testing.T) {
+		if _, ok := s.resolveInstanceForAction(""); ok {
+			t.Fatal("empty id should not resolve")
+		}
+	})
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -2199,6 +2199,39 @@ func (s *Server) handleInstances(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleInstanceAction handles per-instance operations (stop, etc)
+// resolveInstanceForAction maps a URL id to a live ScanInstance for the
+// per-instance action endpoints (stop/pause/resume/restart/start/events).
+//
+// The exact in-memory instance id always wins. But the scan-detail page routes
+// by the scan RECORD id (and sometimes a short hex alias), which for wildcard
+// scans differs from the instance id — so a plain map lookup 404'd and the
+// Stop/Delete buttons silently did nothing there, while the Instances page
+// (which passes the real instance id) worked. Fall back to resolving the id as
+// a record id / short alias and mapping that record to its instance.
+func (s *Server) resolveInstanceForAction(id string) (*ScanInstance, bool) {
+	if id == "" {
+		return nil, false
+	}
+	s.instancesMu.RLock()
+	inst, ok := s.instances[id]
+	s.instancesMu.RUnlock()
+	if ok {
+		return inst, true
+	}
+	// Not a live instance id — try to resolve it as a scan record id, then as a
+	// recent short alias, and map the resolved record back to its instance.
+	_, rec := s.findScanByID(id)
+	if rec == nil {
+		_, rec = s.findRecentScanForShortAlias(id)
+	}
+	if rec != nil {
+		if inst := s.instanceForRecord(rec); inst != nil {
+			return inst, true
+		}
+	}
+	return nil, false
+}
+
 func (s *Server) handleInstanceAction(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	// Path: /api/instances/{id}/stop or /api/instances/{id}
@@ -2209,9 +2242,7 @@ func (s *Server) handleInstanceAction(w http.ResponseWriter, r *http.Request) {
 	}
 	instanceID := parts[0]
 
-	s.instancesMu.RLock()
-	inst, ok := s.instances[instanceID]
-	s.instancesMu.RUnlock()
+	inst, ok := s.resolveInstanceForAction(instanceID)
 	if !ok {
 		http.Error(w, "instance not found", http.StatusNotFound)
 		return

--- a/webui/src/pages/scan-detail.tsx
+++ b/webui/src/pages/scan-detail.tsx
@@ -190,7 +190,9 @@ export default function ScanDetailPage() {
               variant="outline"
               size="sm"
               onClick={() =>
-                start.mutate(scan.id, {
+                // Instance-action endpoints key off the instance id, which for
+                // wildcard scans differs from the scan record id (scan.id).
+                start.mutate(scan.instance_id || scan.id, {
                   onSuccess: (res) => {
                     if (res.instance_id) {
                       navigate(`/scans/${res.instance_id}`);
@@ -209,7 +211,7 @@ export default function ScanDetailPage() {
             <Button
               variant="outline"
               size="sm"
-              onClick={() => stop.mutate(scan.id)}
+              onClick={() => stop.mutate(scan.instance_id || scan.id)}
               disabled={stop.isPending}
             >
               <X className="mr-1 h-4 w-4" /> Stop


### PR DESCRIPTION
## Problem

Reported: on the scan-detail page (`/scans/{id}`), the **Stop / Start / Delete** buttons did nothing; the same actions worked from the **Instances** page.

## Root cause

The per-instance action endpoints (`/api/instances/{id}/stop|start|restart|pause`) required an **exact in-memory instance-id map key** and returned 404 "instance not found" otherwise. The scan-detail page routes by the scan **record** id (and sometimes a short hex alias like `96ad252e`), which for **wildcard** scans differs from the instance id. So the buttons POSTed an id the endpoint couldn't match → silent no-op. The Instances page passes the real `instance.id`, so it worked.

## Fix

- **Engine:** `handleInstanceAction` now resolves the id via `resolveInstanceForAction` — exact instance id first, else resolve it as a scan record id / recent short alias and map that record back to its instance (`findScanByID` / `findRecentScanForShortAlias` → `instanceForRecord`).
- **WebUI:** scan-detail Stop/Start now use `scan.instance_id` (fallback `scan.id`), matching the websocket subscription id and the Instances page.
- Delete already resolved robustly via `/api/scans/{id}` + `findScanByID`; the engine resolver makes stop/start consistent with it.

## Tests

`instance_action_resolve_test.go`: exact instance id resolves; a record id whose `InstanceID` points to a live instance resolves; unknown/empty do not. build/vet/gofmt/golangci-lint (0 issues) + full `internal/web` suite pass.