### PR TITLE
fix(recon): exempt subdomain-discovery & liveness tools from the rate policy

### DIFF
--- a/internal/agent/agent_ratepolicy.go
+++ b/internal/agent/agent_ratepolicy.go
@@ -61,8 +61,9 @@ func buildRequestRatePolicySection(policy scanctx.RequestRatePolicy) string {
 	threads := policy.CommandRPS()
 	return fmt.Sprintf(`### Request Rate Policy
 - Effective outbound target-touching request budget: **max %s requests/second** (%s).
-- This overrides every methodology example and every tool default. Never choose a higher rate, timing template, thread count, or crawler concurrency.
-- For nuclei/httpx/dnsx/subfinder/katana/naabu/feroxbuster, use rate flags at or below %d and keep concurrency at or below %d.
+- This overrides every methodology example and every tool default for TARGET-HAMMERING tools. Never choose a higher rate, timing template, thread count, or crawler concurrency for them.
+- EXEMPT — subdomain discovery & liveness tools run at FULL speed: subfinder, assetfinder, findomain, amass, dnsx, httpx, puredns, massdns, shuffledns, alterx. They hit third-party sources or fan out ONE request across many distinct hosts, so the per-target cap does not apply. Use high concurrency/rate for these so enumeration of large targets actually completes.
+- For nuclei/katana/naabu/feroxbuster (they focus load on one host/app), use rate flags at or below %d and keep concurrency at or below %d.
 - For nmap, do not use -T4/-T5 or --min-rate. Use -T2, --max-rate %d, and --scan-delay %s or slower.
 - For ffuf, use -rate %d and -t %d or lower. For gobuster, use --delay %s and a single worker because it has no reliable global RPS limiter.
 - For custom loops, xargs, parallel, or scripts, add sleeps/delays so aggregate traffic stays under %s requests/second.`, rate, policy.Source, threads, threads, threads, delay, threads, threads, delay, rate)

--- a/internal/tools/terminal/terminal.go
+++ b/internal/tools/terminal/terminal.go
@@ -200,10 +200,35 @@ func rewriteShellSegments(command string, rewrite func(string) string) string {
 	return b.String()
 }
 
+// rateExemptDiscoveryTools are subdomain-discovery / liveness-probing tools that
+// are EXEMPT from the request-rate rewrite. They either hit third-party sources
+// (passive subdomain enumeration) or fan out a single request across thousands
+// of DISTINCT hosts (DNS resolution, HTTP liveness probing), so a global low-RPS
+// cap cripples enumeration without protecting any single target. The rate policy
+// exists to keep AGGRESSIVE testing of ONE host/app polite (nuclei, ffuf, nmap,
+// masscan, naabu port scans, sqlmap) — not to throttle recon. Throttling httpx
+// to ~10 rps is what made a wildcard scan of a huge target (e.g. att.com) find
+// only a fraction of its live subdomains before the 30-min per-command kill.
+var rateExemptDiscoveryTools = []string{
+	"httpx", "dnsx", "subfinder", "assetfinder", "findomain", "amass",
+	"puredns", "massdns", "shuffledns", "alterx", "chaos", "gau", "gauplus",
+	"waybackurls", "github-subdomains", "dnsgen", "cero",
+}
+
 func rewriteCommandSegmentForRequestRatePolicy(segment string, policy scanctx.RequestRatePolicy) string {
 	rps := policy.CommandRPS()
 	if rps <= 0 {
 		return segment
+	}
+	// Discovery / liveness tools run at full speed — the per-target rate cap
+	// does not apply to recon that fans out across many hosts or third-party
+	// sources. A command segment is a single piped stage (rewriteShellSegments
+	// splits on ; | && ||), so this exempts e.g. the `httpx` stage of
+	// `subfinder -d x | dnsx | httpx` while a later `nuclei` stage stays capped.
+	for _, tool := range rateExemptDiscoveryTools {
+		if hasToolCommand(segment, tool) {
+			return segment
+		}
 	}
 	rate := strconv.Itoa(rps)
 	delay := formatPolicyDelay(policy)
@@ -227,16 +252,8 @@ func rewriteCommandSegmentForRequestRatePolicy(segment string, policy scanctx.Re
 		rewritten = setFlagValue(rewritten, []string{"-rate"}, rate)
 		rewritten = capFlagValue(rewritten, []string{"-c"}, rate)
 	}
-	for _, tool := range []string{"httpx", "dnsx"} {
-		if hasToolCommand(rewritten, tool) {
-			rewritten = setFlagValue(rewritten, []string{"-rl", "-rate-limit"}, rate)
-			rewritten = capFlagValue(rewritten, []string{"-threads", "-t"}, rate)
-		}
-	}
-	if hasToolCommand(rewritten, "subfinder") {
-		rewritten = setFlagValue(rewritten, []string{"-rl", "-rate-limit"}, rate)
-		rewritten = capFlagValue(rewritten, []string{"-t"}, rate)
-	}
+	// NOTE: httpx, dnsx, and subfinder are intentionally NOT throttled here —
+	// they are handled by the rateExemptDiscoveryTools early-return above.
 	if hasToolCommand(rewritten, "katana") {
 		rewritten = setFlagValue(rewritten, []string{"-rl", "-rate-limit"}, rate)
 		rewritten = capFlagValue(rewritten, []string{"-c"}, rate)

--- a/internal/tools/terminal/terminal_test.go
+++ b/internal/tools/terminal/terminal_test.go
@@ -119,10 +119,10 @@ func TestNormalizeCommandForRequestRatePolicy_RewritesScannerFlags(t *testing.T)
 			bad:  []string{"-T4", "--min-rate"},
 		},
 		{
-			name: "httpx pipeline",
-			cmd:  "cat urls.txt | httpx -silent -threads 50 -rl 20 | tee live.txt",
-			want: []string{"httpx -silent -threads 3 -rl 3"},
-			bad:  []string{"-threads 50", "-rl 20"},
+			name: "naabu still throttled",
+			cmd:  "naabu -host example.test -rate 1000 -c 50",
+			want: []string{"-rate 3", "-c 3"},
+			bad:  []string{"-rate 1000", "-c 50"},
 		},
 		{
 			name: "gobuster delay",
@@ -161,6 +161,52 @@ func TestNormalizeCommandForRequestRatePolicy_RewritesScannerFlags(t *testing.T)
 				}
 			}
 		})
+	}
+}
+
+// Subdomain-discovery / liveness tools are EXEMPT from the rate rewrite so
+// enumeration of large targets can actually complete (issue: att.com wildcard
+// scan found only a fraction of its live subdomains because httpx/dnsx were
+// throttled to ~10 rps). Their commands must pass through UNCHANGED with no
+// rate-policy note.
+func TestNormalizeCommandForRequestRatePolicy_ExemptsDiscoveryTools(t *testing.T) {
+	sc := scanctx.New("term-rate-exempt", t.TempDir())
+	sc.SetRequestRatePolicy(scanctx.RequestRatePolicy{MaxRPS: 3, Source: "custom instructions"})
+	scanctx.Activate(sc)
+	defer func() {
+		CleanupContext(sc.ID)
+		scanctx.Deactivate(sc.ID)
+	}()
+
+	exempt := []string{
+		"cat urls.txt | httpx -silent -threads 50 -rl 200 | tee live.txt",
+		"cat all_subs.txt | dnsx -silent -a -resp -threads 100",
+		"subfinder -d att.com -all -recursive -silent -t 50 -rl 100 -o subs.txt",
+		"assetfinder --subs-only att.com",
+		"puredns resolve subs.txt -r resolvers.txt",
+	}
+	for _, cmd := range exempt {
+		got, note := NormalizeCommandForRequestRatePolicy(sc.ID, cmd)
+		if note != "" {
+			t.Errorf("discovery command should NOT be rate-rewritten: %q -> note %q", cmd, note)
+		}
+		if got != cmd {
+			t.Errorf("discovery command should be unchanged:\n  in:  %q\n  out: %q", cmd, got)
+		}
+	}
+
+	// A discovery stage piped into an aggressive stage: the discovery stage is
+	// exempt, the aggressive stage is still throttled.
+	mixed := "subfinder -d att.com -silent | httpx -silent -threads 50 | nuclei -rl 100 -c 50"
+	got, note := NormalizeCommandForRequestRatePolicy(sc.ID, mixed)
+	if note == "" {
+		t.Fatal("mixed pipeline with nuclei should still produce a rate note")
+	}
+	if !strings.Contains(got, "-threads 50") {
+		t.Errorf("httpx stage in mixed pipeline should stay unthrottled: %q", got)
+	}
+	if strings.Contains(got, "-rl 100") || strings.Contains(got, "-c 50") {
+		t.Errorf("nuclei stage in mixed pipeline should be throttled: %q", got)
 	}
 }
 


### PR DESCRIPTION
## Problem

A wildcard scan of a large target (att.com) found only ~219 live subdomains despite thousands existing. Root cause: the outbound rate policy (default `XALGORIX_RATE_RPS=10`) rewrites `httpx`/`dnsx`/`subfinder` flags down to ~10 concurrency/rate, and the 30-minute per-command watchdog kill then truncates the throttled live-probe before it finishes the candidate set.

## Fix

The rate cap exists to keep **aggressive testing of one host/app** polite — it should not throttle **recon** that hits third-party sources (passive enumeration) or fans out a single request across thousands of **distinct** hosts (DNS resolution, HTTP liveness). 

- Exempt these from the command rewrite (early return in `rewriteCommandSegmentForRequestRatePolicy`): `httpx, dnsx, subfinder, assetfinder, findomain, amass, puredns, massdns, shuffledns, alterx, chaos, gau, gauplus, waybackurls, github-subdomains, dnsgen, cero`.
- Aggressive tools stay throttled: `nuclei, ffuf, gobuster, feroxbuster, nmap, masscan, naabu, katana`. In a mixed pipeline (`subfinder | httpx | nuclei`) the discovery stages are exempt while the `nuclei` stage stays capped (segments split on `; | && ||`).
- Update the rate-policy prompt so the agent knows discovery tools run at full speed.

## Tests

Existing rate test keeps nuclei/nmap/gobuster/naabu throttled; new `TestNormalizeCommandForRequestRatePolicy_ExemptsDiscoveryTools` asserts httpx/dnsx/subfinder/assetfinder/puredns pass through unchanged (no note) and the mixed-pipeline case. build/vet/gofmt/golangci-lint (0 issues) pass.

## Note

This addresses the throttle half of the low-subdomain-count issue. The 30-min per-command kill is still hardcoded, and discovery remains LLM-driven (non-deterministic) — separate follow-ups if you want them.