### PR TITLE
fix(agent): cap tool output into context + report the real no-tool abort reason

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -882,8 +882,9 @@ func (a *Agent) Run(targets []string, instruction string) {
 		if len(toolCalls) == 0 {
 			noToolResult := a.hooks.Fire(OnNoToolResponse, a.state, map[string]string{"response": cleanText})
 			if noToolResult.ForceSkip {
+				reason, detail := classifyNoToolAbort(a.state)
 				a.emit(Event{Type: "error", Content: noToolResult.EmitMessage, TotalTokens: tokenCount()})
-				a.emit(Event{Type: "finished", Content: "Agent stopped: LLM refused to call tools after 15 attempts", TotalTokens: tokenCount(), Aborted: true, AbortReason: "llm_no_tool_calls"})
+				a.emit(Event{Type: "finished", Content: detail, TotalTokens: tokenCount(), Aborted: true, AbortReason: reason})
 				return
 			}
 			if noToolResult.Nudge != "" {

--- a/internal/agent/agent_messages.go
+++ b/internal/agent/agent_messages.go
@@ -10,9 +10,33 @@ import (
 	"github.com/xalgord/xalgorix/v4/internal/tools/notes"
 )
 
+// maxToolResultBytes caps how much of a single tool result is fed into the LLM
+// context. A raw `cat`/`strings`/`curl` of a large asset (a 500 KB minified JS
+// bundle, a big HTML page, a huge JSON) would otherwise flood the context in
+// one shot — the model then degrades into empty/reasoning-only responses with
+// no tool calls and the scan force-stops. We keep the head and tail (the useful
+// parts of most outputs) and drop the middle, telling the model to re-extract
+// what it needs with grep/head/jq. On-disk files written by the tool are
+// untouched, so subdomain collection etc. still see the full data.
+const maxToolResultBytes = 16000
+
+func capToolOutputForLLM(output string) string {
+	if len(output) <= maxToolResultBytes {
+		return output
+	}
+	const headBytes = 12000
+	const tailBytes = 3000
+	head := output[:headBytes]
+	tail := output[len(output)-tailBytes:]
+	return fmt.Sprintf(
+		"%s\n\n… [TOOL OUTPUT TRUNCATED — showed %d of %d bytes to fit the context window. Do NOT dump whole files/pages again; re-run with grep/head/jq/rg to extract only the specific lines, endpoints, or fields you need.] …\n\n%s",
+		head, headBytes+tailBytes, len(output), tail,
+	)
+}
+
 // formatToolResult formats tool execution results with helpful suggestions
 func formatToolResult(toolName string, result tools.Result) string {
-	output := result.Output
+	output := capToolOutputForLLM(result.Output)
 	errorMsg := result.Error
 
 	var msg string

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -1187,9 +1187,13 @@ func hookNoToolHandler(state *ScanState, args map[string]string) HookResult {
 	}
 
 	if state.NoToolCount >= 15 {
+		msg := "⛔ Model returned 15 consecutive responses with no tool call — it stopped taking actions (likely context flooded by a large tool output, or a reasoning loop). Force finishing."
+		if state.RefusalCount >= 3 {
+			msg = "⛔ Model declined to act for 15 consecutive responses (safety refusal). Force finishing — try a model that permits authorized security testing."
+		}
 		return HookResult{
 			ForceSkip:   true,
-			EmitMessage: "⛔ LLM failed to call any tools for 15 consecutive responses. Force finishing.",
+			EmitMessage: msg,
 		}
 	}
 
@@ -1230,6 +1234,19 @@ Call a tool NOW in your next response.`,
 	return HookResult{
 		Nudge: "Please use the available tools by calling them with the XML format shown in the system prompt. Do not just describe what you would do — actually call the tools.",
 	}
+}
+
+// classifyNoToolAbort turns a no-tool force-stop into a machine reason tag plus
+// a human explanation of the ACTUAL cause, instead of the old catch-all
+// "LLM refused to call tools". It distinguishes a genuine safety refusal from a
+// "stopped taking actions" stall — the latter is almost always context
+// exhaustion (a huge tool output dumped into the window) or a reasoning loop,
+// not a target problem.
+func classifyNoToolAbort(state *ScanState) (reason, detail string) {
+	if state != nil && state.RefusalCount >= 3 {
+		return "llm_safety_refusal", "Agent stopped: the model repeatedly declined to run the assessment (safety refusal) across 15 responses. This is a model-side refusal, not a target or scanner issue — switch to a model that permits authorized security testing."
+	}
+	return "llm_no_tool_calls", "Agent stopped: the model returned 15 consecutive responses with NO tool call — it stopped taking actions. This is typically caused by a very large tool output flooding the context (e.g. dumping a whole JS bundle or page instead of grepping it) or a reasoning loop — not by the target being unscannable."
 }
 
 // isRefusal reports whether the model's text looks like a safety/ethics refusal

--- a/internal/agent/tool_output_cap_test.go
+++ b/internal/agent/tool_output_cap_test.go
@@ -1,0 +1,63 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+// A huge tool output (e.g. cat/strings of a 500 KB minified JS bundle) must be
+// capped before it enters the LLM context — otherwise it floods the window and
+// the model stalls into no-tool responses until the scan force-stops
+// (observed on app.joinhomebase.com).
+func TestCapToolOutputForLLM(t *testing.T) {
+	small := "endpoints:\n/graphql\n/api/v5/users"
+	if got := capToolOutputForLLM(small); got != small {
+		t.Errorf("small output should pass through unchanged, got %q", got)
+	}
+
+	big := strings.Repeat("A", 40000) + "TAIL_MARKER"
+	got := capToolOutputForLLM(big)
+	if len(got) >= len(big) {
+		t.Fatalf("large output was not capped: in=%d out=%d", len(big), len(got))
+	}
+	if len(got) > maxToolResultBytes+500 {
+		t.Errorf("capped output too large: %d bytes", len(got))
+	}
+	if !strings.Contains(got, "TOOL OUTPUT TRUNCATED") {
+		t.Error("capped output missing truncation notice")
+	}
+	if !strings.HasPrefix(got, "AAAA") {
+		t.Error("capped output should keep the head")
+	}
+	if !strings.HasSuffix(got, "TAIL_MARKER") {
+		t.Error("capped output should keep the tail")
+	}
+}
+
+// The no-tool force-stop must report the ACTUAL cause, not the old catch-all
+// "refused to call tools".
+func TestClassifyNoToolAbort(t *testing.T) {
+	// Stall (no refusals) → generic no-tool with context-flood explanation.
+	reason, detail := classifyNoToolAbort(&ScanState{NoToolCount: 15, RefusalCount: 0})
+	if reason != "llm_no_tool_calls" {
+		t.Errorf("reason = %q, want llm_no_tool_calls", reason)
+	}
+	ld := strings.ToLower(detail)
+	if !strings.Contains(ld, "no tool call") || strings.Contains(ld, "refused to call tools after 15 attempts") {
+		t.Errorf("stall detail should describe the stall, got %q", detail)
+	}
+
+	// Repeated refusals → safety-refusal reason.
+	reason, detail = classifyNoToolAbort(&ScanState{NoToolCount: 15, RefusalCount: 5})
+	if reason != "llm_safety_refusal" {
+		t.Errorf("reason = %q, want llm_safety_refusal", reason)
+	}
+	if !strings.Contains(strings.ToLower(detail), "refusal") {
+		t.Errorf("refusal detail should mention refusal, got %q", detail)
+	}
+
+	// Nil state must not panic.
+	if r, _ := classifyNoToolAbort(nil); r != "llm_no_tool_calls" {
+		t.Errorf("nil state reason = %q, want llm_no_tool_calls", r)
+	}
+}


### PR DESCRIPTION
## Problem

A single scan of app.joinhomebase.com force-stopped with `llm_no_tool_calls` (the "error still not resolved" the reporter saw). From the event log: around iteration 70 the agent ran `strings/cat/grep` over a ~500KB minified JS bundle (`loot/app-init.js`), the tool result dumped that whole blob into the model's context, and iterations 71-86 then went **thinking-only (no tool calls)** until the 15-response force-stop.

Two problems: (1) nothing capped the tool output before it entered context, and (2) the failure reason was a misleading catch-all ("LLM refused to call tools after 15 attempts") that told the operator nothing.

## Fix

- **Cap tool output fed to the LLM** (`formatToolResult` → `capToolOutputForLLM`): a single tool result is capped at 16KB (12KB head + 3KB tail) with a notice telling the model to `grep/head/jq` instead of re-dumping. This prevents one `cat`/`curl` of a big asset from flooding the window. On-disk files the tool writes are untouched, so subdomain collection and friends still see the full data.
- **Report the real reason** (`classifyNoToolAbort`): the no-tool force-stop now says either "the model stopped taking actions (usually a large tool output flooding the context or a reasoning loop)" or, when the model was actually refusing, a distinct `llm_safety_refusal` reason ("try a model that permits authorized security testing"). Applied to the error line, the `finished` content, and the `AbortReason` tag.

## Tests

`tool_output_cap_test.go`: small output passes unchanged; a 40KB output is capped with head+tail + notice; `classifyNoToolAbort` returns the stall reason with no refusals and `llm_safety_refusal` with repeated refusals (nil-safe). build/vet/gofmt/golangci-lint (0 issues) + full `internal/agent` suite pass.

## Companion (SaaS, pushed separately)

`describeEngineFailure` updated: clearer `llm_no_tool_calls` text + the new `llm_safety_refusal` mapping, so the dashboard error_message / user notification / operator alert show the proper reason.