### PR TITLE
Fix flaky wsbridge port bind race in Start/Stop

### DIFF
--- a/internal/tools/browser/wsbridge.go
+++ b/internal/tools/browser/wsbridge.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -39,6 +40,7 @@ type WSBridge struct {
 	mu       sync.Mutex
 	conn     *websocket.Conn
 	server   *http.Server
+	listener net.Listener
 	addr     string
 	pending  map[string]chan json.RawMessage
 	reqIDSeq atomic.Int64
@@ -87,23 +89,48 @@ func (b *WSBridge) Start() error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ext", b.handleExtWS)
 
-	b.server = &http.Server{
-		Addr:    b.addr,
+	// Bind the listener synchronously so that (a) bind errors surface here
+	// instead of being swallowed inside a goroutine, and (b) the socket is
+	// guaranteed to be closable via b.listener on Stop(). Binding inside the
+	// serve goroutine races with Stop()->Close(): if Close() runs before
+	// Serve() tracks the listener, the bound socket leaks and the port stays
+	// occupied ("address already in use" on the next Start).
+	ln, err := net.Listen("tcp", b.addr)
+	if err != nil {
+		return fmt.Errorf("wsbridge listen on %s: %w", b.addr, err)
+	}
+	// Resolve the actual bound address (important when addr uses port 0).
+	b.addr = ln.Addr().String()
+	b.listener = ln
+
+	srv := &http.Server{
 		Handler: mux,
 		// Bound header-read time to avoid a Slowloris-style hang on this
 		// loopback control channel.
 		ReadHeaderTimeout: 15 * time.Second,
 	}
+	b.server = srv
+	addr := b.addr
 
+	// Capture srv in a local so a concurrent Stop() (which nils b.server)
+	// can't turn this into a nil-pointer dereference.
 	go func() {
-		log.Printf("[wsbridge] Starting WebSocket server on %s", b.addr)
-		if err := b.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Printf("[wsbridge] Starting WebSocket server on %s", addr)
+		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
 			log.Printf("[wsbridge] Server error: %v", err)
 		}
 	}()
 
 	b.running = true
 	return nil
+}
+
+// Addr returns the address the bridge server is bound to. When the bridge was
+// started with a port of 0, this reflects the OS-assigned ephemeral port.
+func (b *WSBridge) Addr() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.addr
 }
 
 // Stop shuts down the WebSocket server and closes connections.
@@ -122,6 +149,14 @@ func (b *WSBridge) Stop() {
 
 	if b.server != nil {
 		_ = b.server.Close()
+		b.server = nil
+	}
+
+	// Close the listener explicitly in case the serve goroutine hasn't yet
+	// started tracking it (server.Close only closes tracked listeners).
+	if b.listener != nil {
+		_ = b.listener.Close()
+		b.listener = nil
 	}
 
 	// Cancel all pending requests

--- a/internal/tools/browser/wsbridge_test.go
+++ b/internal/tools/browser/wsbridge_test.go
@@ -114,13 +114,13 @@ func TestBridge_SendCommand_Roundtrip(t *testing.T) {
 	resetBridge()
 	b := GetBridge()
 	b.mu.Lock()
-	b.addr = "127.0.0.1:38402"
+	b.addr = "127.0.0.1:0"
 	b.mu.Unlock()
 	b.Start()
 	defer func() { b.Stop(); resetBridge() }()
 
 	// Connect mock extension
-	conn := connectMockExtension(t, "127.0.0.1:38402")
+	conn := connectMockExtension(t, b.Addr())
 	defer conn.Close()
 
 	// Wait for connection to register
@@ -164,12 +164,12 @@ func TestBridge_SendCommand_Timeout(t *testing.T) {
 	resetBridge()
 	b := GetBridge()
 	b.mu.Lock()
-	b.addr = "127.0.0.1:38403"
+	b.addr = "127.0.0.1:0"
 	b.mu.Unlock()
 	b.Start()
 	defer func() { b.Stop(); resetBridge() }()
 
-	conn := connectMockExtension(t, "127.0.0.1:38403")
+	conn := connectMockExtension(t, b.Addr())
 	defer conn.Close()
 	time.Sleep(100 * time.Millisecond)
 
@@ -187,12 +187,12 @@ func TestBridge_ExtHello(t *testing.T) {
 	resetBridge()
 	b := GetBridge()
 	b.mu.Lock()
-	b.addr = "127.0.0.1:38404"
+	b.addr = "127.0.0.1:0"
 	b.mu.Unlock()
 	b.Start()
 	defer func() { b.Stop(); resetBridge() }()
 
-	conn := connectMockExtension(t, "127.0.0.1:38404")
+	conn := connectMockExtension(t, b.Addr())
 	defer conn.Close()
 
 	// Send ext_hello
@@ -219,12 +219,12 @@ func TestBridge_Keepalive(t *testing.T) {
 	resetBridge()
 	b := GetBridge()
 	b.mu.Lock()
-	b.addr = "127.0.0.1:38405"
+	b.addr = "127.0.0.1:0"
 	b.mu.Unlock()
 	b.Start()
 	defer func() { b.Stop(); resetBridge() }()
 
-	conn := connectMockExtension(t, "127.0.0.1:38405")
+	conn := connectMockExtension(t, b.Addr())
 	defer conn.Close()
 
 	// Send keepalive — should not crash


### PR DESCRIPTION
## Summary

Fixes the intermittent `Unit tests` CI failure on `TestBridge_ExtHello`:

```
[wsbridge] Server error: listen tcp 127.0.0.1:38404: bind: address already in use
--- FAIL: TestBridge_ExtHello: failed to connect mock extension: dial tcp 127.0.0.1:38404: connect: connection refused
```

## Root cause

Two issues combined:

1. **Bind race in `Start()`.** The port was bound inside a goroutine via `server.ListenAndServe()`, so binding happened after `Start()` returned. `Stop()`'s `server.Close()` only closes listeners already tracked by `Serve()`. When `Close()` ran in the window after `net.Listen` bound the socket but before `Serve()` tracked it, the socket leaked and kept the port occupied, so the next bind failed with "address already in use".
2. **Hardcoded ports.** Tests pinned ports 38402–38405, turning the leaked socket into a guaranteed collision.

## Changes

- `Start()` binds the listener **synchronously** via `net.Listen`, returning bind errors directly and always storing a closable listener. The goroutine only runs `srv.Serve(ln)`.
- Serve goroutine captures `srv`/`addr` in locals to avoid a nil-deref race with `Stop()` (which now nils `server`/`listener`).
- `b.addr` is resolved from the bound address; added `Addr()` accessor to support ephemeral port `0`.
- `Stop()` closes the listener explicitly.
- Tests bind `127.0.0.1:0` and dial `b.Addr()`, removing hardcoded-port collisions.

## Verification

- `go build ./...` — clean
- `go vet ./internal/tools/browser/` — clean
- `go test ./internal/tools/browser/ -run TestBridge -count=30` — pass
- `go test ... -race -count=5` — pass, no data races
