### PR TITLE
fix(web): use /v1beta path for Google (Gemini) model discovery

### DIFF
--- a/internal/web/handlers_provider_models.go
+++ b/internal/web/handlers_provider_models.go
@@ -174,6 +174,9 @@ func providerModelsURLs(entry providers.Entry) ([]string, error) {
 	if entry.HeaderStyle == "openai" && !strings.HasSuffix(u.Path, "/v1") && !strings.Contains(u.Path, "/v1/") {
 		u.Path = strings.TrimRight(u.Path, "/") + "/v1"
 	}
+	if entry.HeaderStyle == "gemini" && !strings.HasSuffix(u.Path, "/v1beta") && !strings.Contains(u.Path, "/v1beta/") {
+		u.Path = strings.TrimRight(u.Path, "/") + "/v1beta"
+	}
 	u.Path = strings.TrimRight(u.Path, "/") + "/models"
 	if entry.HeaderStyle == "openai_responses" {
 		query := u.Query()


### PR DESCRIPTION
Fixes #261.

## Problem
"Scan available models" (provider model discovery) returns `HTTP 502 Bad Gateway: provider model discovery returned HTTP 404` for the **Google (Gemini)** provider — for any model.

## Cause
`providerModelsURLs()` adds a version path prefix for the `anthropic` and `openai` header styles before appending `/models`, but adds nothing for the `gemini` header style. For Google (`base = https://generativelanguage.googleapis.com`, `HeaderStyle = "gemini"`) discovery therefore requests `{base}/models` → **404**. Gemini lists models at `/v1beta/models`.

## Fix
Add a `gemini` branch mirroring the `openai` one:
```go
if entry.HeaderStyle == "gemini" && !strings.HasSuffix(u.Path, "/v1beta") && !strings.Contains(u.Path, "/v1beta/") {
    u.Path = strings.TrimRight(u.Path, "/") + "/v1beta"
}
```
The rest of the discovery path was already Gemini-aware — `requestProviderModels` sets `x-goog-api-key` for the gemini header style, and `parseDiscoveredModels` already reads the `models[]` array, filters by `supportedGenerationMethods` containing `generateContent`, and strips the `models/` prefix. Generation was never affected (`internal/llm/{client,router,resolver}.go` already build `/v1beta/models/{model}:generateContent`).

## Verification
Built and hot-swapped into a running `v4.5.71` container: `GET /api/providers/google/models` now returns **HTTP 200** with the full Gemini model list (`gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3-pro-preview`, …) instead of 404. `gofmt` clean; one-line-per-header-style change, no other behavior touched.