### PR TITLE
fix(web): recognize XALGORIX_LLM_PROVIDER in "Scan available models" discovery

### DIFF
--- a/internal/web/handlers_provider_models.go
+++ b/internal/web/handlers_provider_models.go
@@ -56,10 +56,28 @@ func (s *Server) handleDiscoverProviderModels(w http.ResponseWriter, r *http.Req
 	writeJSONStatus(w, http.StatusOK, discoveredModelsResponse{Models: models, Source: "remote"})
 }
 
+// activeConfigTargetsProvider reports whether the operator's persisted active
+// LLM config (XALGORIX_LLM*) targets providerID. It matches either the legacy
+// "<provider>/<model>" prefix carried on XALGORIX_LLM or the explicit
+// XALGORIX_LLM_PROVIDER routing field, which deliberately keeps the provider
+// separate from a bare, provider-native model name (for example
+// LLMProvider="deepseek" with LLM="deepseek-v4-pro"). Without the LLMProvider
+// branch, discovery for such providers falls through to "save or select
+// credentials" even though the active credentials are already persisted.
+func (s *Server) activeConfigTargetsProvider(providerID string) bool {
+	if s.cfg == nil {
+		return false
+	}
+	if strings.HasPrefix(s.cfg.LLM, providerID+"/") {
+		return true
+	}
+	return strings.TrimSpace(s.cfg.LLMProvider) == providerID
+}
+
 func (s *Server) modelDiscoveryConfig(r *http.Request, entry providers.Entry) (providers.Entry, string, string, error) {
 	for _, method := range entry.AuthMethods {
 		if method == "none" {
-			if s.cfg != nil && strings.HasPrefix(s.cfg.LLM, entry.ID+"/") && strings.TrimSpace(s.cfg.APIBase) != "" {
+			if s.activeConfigTargetsProvider(entry.ID) && strings.TrimSpace(s.cfg.APIBase) != "" {
 				entry.BaseURL = strings.TrimSpace(s.cfg.APIBase)
 			}
 			return entry, "", "", nil
@@ -85,7 +103,7 @@ func (s *Server) modelDiscoveryConfig(r *http.Request, entry providers.Entry) (p
 		}
 		return entry, strings.TrimSpace(profile.APIKey), "", nil
 	}
-	if s.cfg != nil && strings.HasPrefix(s.cfg.LLM, entry.ID+"/") {
+	if s.activeConfigTargetsProvider(entry.ID) {
 		if strings.TrimSpace(s.cfg.APIBase) != "" {
 			entry.BaseURL = strings.TrimSpace(s.cfg.APIBase)
 		}

--- a/internal/web/handlers_provider_models_test.go
+++ b/internal/web/handlers_provider_models_test.go
@@ -106,7 +106,7 @@ func TestProviderModelsURLsUsesCodexCatalogProtocol(t *testing.T) {
 func TestModelDiscoveryConfigMatchesActiveProviderByLLMProvider(t *testing.T) {
 	// Providers routed via XALGORIX_LLM_PROVIDER (for example DeepSeek) persist a
 	// bare, provider-native model name with no "<provider>/" prefix on XALGORIX_LLM
-	// (LLMProvider="deepseek", LLM="deepseek-v4-pro"). Discovery must recognise the
+	// (LLMProvider="deepseek", LLM="deepseek-v4-pro"). Discovery must recognize the
 	// active provider from LLMProvider and reuse the saved credentials instead of
 	// failing with "save or select credentials before scanning models".
 	req := httptest.NewRequest(http.MethodGet, "/api/providers/deepseek/models", nil)

--- a/internal/web/handlers_provider_models_test.go
+++ b/internal/web/handlers_provider_models_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/xalgord/xalgorix/v4/internal/config"
 	"github.com/xalgord/xalgorix/v4/internal/providers"
 )
 
@@ -99,5 +100,36 @@ func TestProviderModelsURLsUsesCodexCatalogProtocol(t *testing.T) {
 	want := "https://chatgpt.com/backend-api/codex/models?client_version=" + codexModelsClientVersion
 	if len(urls) != 1 || urls[0] != want {
 		t.Fatalf("URLs = %v, want [%s]", urls, want)
+	}
+}
+
+func TestModelDiscoveryConfigMatchesActiveProviderByLLMProvider(t *testing.T) {
+	// Providers routed via XALGORIX_LLM_PROVIDER (for example DeepSeek) persist a
+	// bare, provider-native model name with no "<provider>/" prefix on XALGORIX_LLM
+	// (LLMProvider="deepseek", LLM="deepseek-v4-pro"). Discovery must recognise the
+	// active provider from LLMProvider and reuse the saved credentials instead of
+	// failing with "save or select credentials before scanning models".
+	req := httptest.NewRequest(http.MethodGet, "/api/providers/deepseek/models", nil)
+	entry := providers.Entry{
+		ID: "deepseek", BaseURL: "https://api.deepseek.com/v1", HeaderStyle: "openai", AuthMethods: []string{"api_key"},
+	}
+	srv := &Server{cfg: &config.Config{
+		LLM:         "deepseek-v4-pro",
+		LLMProvider: "deepseek",
+		APIKey:      "secret",
+		APIBase:     "https://api.deepseek.com/v1",
+	}}
+	got, credential, accountID, err := srv.modelDiscoveryConfig(req, entry)
+	if err != nil {
+		t.Fatalf("modelDiscoveryConfig returned error: %v", err)
+	}
+	if credential != "secret" {
+		t.Fatalf("credential = %q, want %q", credential, "secret")
+	}
+	if accountID != "" {
+		t.Fatalf("accountID = %q, want empty", accountID)
+	}
+	if got.BaseURL != "https://api.deepseek.com/v1" {
+		t.Fatalf("BaseURL = %q, want %q", got.BaseURL, "https://api.deepseek.com/v1")
 	}
 }


### PR DESCRIPTION
## Summary

Settings → LLM **"Scan available models"** returns:

> HTTP 400 Bad Request: save or select credentials before scanning models

for **DeepSeek** — and for any provider selected through the explicit `XALGORIX_LLM_PROVIDER` routing field — **even when a valid API key is already saved and active**. The discovery button is effectively unusable for these providers; operators have to type the model ID by hand.

## Root cause

`modelDiscoveryConfig` (`internal/web/handlers_provider_models.go`) resolves the credential used for discovery. When no `?profile=` is supplied, it falls back to the operator's **active** LLM config — but it only recognizes that config as belonging to the requested provider when `XALGORIX_LLM` carries a `"<provider>/<model>"` prefix:

```go
if s.cfg != nil && strings.HasPrefix(s.cfg.LLM, entry.ID+"/") {
```

Providers configured via `XALGORIX_LLM_PROVIDER` intentionally persist a **bare, provider-native** model name (per the field's own description: *"explicit provider ID used to route the selected model without adding a provider prefix to its model name"*). For DeepSeek the saved config is:

```
XALGORIX_LLM_PROVIDER=deepseek
XALGORIX_LLM=deepseek-v4-pro
```

`strings.HasPrefix("deepseek-v4-pro", "deepseek/")` is `false`, so the fallback misses and the function returns `save or select credentials before scanning models` — despite the key being saved.

## Fix

Add `activeConfigTargetsProvider(providerID)`, which matches **either** the legacy `"<provider>/"` prefix on `XALGORIX_LLM` **or** the explicit `XALGORIX_LLM_PROVIDER`, and use it in both the no-auth and credential fallback branches. No behavior change for providers that use the prefixed form (Gemini, OpenAI, …).

## Reproduction

1. Settings → LLM → Provider **DeepSeek**, paste a valid API key, **Save**.
2. Click **Scan available models** → `HTTP 400 … save or select credentials before scanning models`.

The persisted config is `LLMProvider=deepseek`, `LLM=deepseek-v4-pro` (no `deepseek/` prefix), which is the intended shape for `XALGORIX_LLM_PROVIDER` routing.

## Verification

- `go build ./internal/web/` — OK
- `go test ./internal/web/` — passing, including the new `TestModelDiscoveryConfigMatchesActiveProviderByLLMProvider`
- `gofmt` clean
- End-to-end: with the fix, discovery reaches `GET https://api.deepseek.com/v1/models`, which returns HTTP 200 with the models (`deepseek-v4-flash`, `deepseek-v4-pro`).

## Scope

Fixes discovery for every provider routed through `XALGORIX_LLM_PROVIDER` (DeepSeek and the documented Ollama example among them). Independent of the generation request path, which already routes correctly via `XALGORIX_LLM_PROVIDER`.