### PR TITLE
fix(webui): preserve saved LLM model in settings dropdown after discovery

### DIFF
--- a/webui/src/pages/settings.tsx
+++ b/webui/src/pages/settings.tsx
@@ -1339,7 +1339,7 @@ function CatalogModelField({
         {
           onSuccess: (result) => {
             setDiscoveredModels(result.models);
-            if (result.models.length > 0) {
+            if (result.models.length > 0 && !result.models.includes(value)) {
               onChange(result.models[0]);
             }
           },
@@ -1428,7 +1428,7 @@ function CatalogModelField({
                   onSuccess: (result) => {
                     setDiscoveredModels(result.models);
                     setManualEntry(false);
-                    if (result.models.length > 0) {
+                    if (result.models.length > 0 && !result.models.includes(value)) {
                       onChange(result.models[0]);
                     }
                   },


### PR DESCRIPTION
## Problem

`CatalogModelField` (Settings → LLM) always overwrote the selected model with the first discovered one. On successful provider model discovery it called:

```ts
onChange(result.models[0]);
```

unconditionally. So when the page loaded the saved settings (`value` = the persisted `XALGORIX_LLM`), the auto-discovery effect immediately clobbered it with `result.models[0]`, and the dropdown showed the first model the provider returned instead of the configured one.

Two consequences:

- The **Settings → LLM** model dropdown never reflected the saved model — it looked like the configured model hadn't been applied (e.g. a project configured for `gemini-2.5-pro` showed the first item of the discovered list instead).
- Because a web-launched scan sends the dropdown's model and `req.Model` overrides the configured default (`internal/web/server.go`: `if req.Model != "" { scanCfg.LLM = req.Model }`), a scan started from the UI could silently run a **different** model than the one saved in `~/.xalgorix.env`.

## Fix

Guard both `onSuccess` handlers (the initial auto-discovery `useEffect` and the **Scan available models** button) so the fallback to `result.models[0]` only happens when the current `value` is empty or **not** among the discovered models:

```ts
if (result.models.length > 0 && !result.models.includes(value)) {
  onChange(result.models[0]);
}
```

The saved selection is preserved whenever it is still a valid discovered model. Behavior is unchanged when the value is empty or stale (it still defaults to the first discovered model).

## Notes

- UI-only change, single file (`webui/src/pages/settings.tsx`).
- No backend/API behavior change.