### PR TITLE
feat(web): configurable day and time of day for scan schedules

### DIFF
--- a/internal/web/scheduler.go
+++ b/internal/web/scheduler.go
@@ -6,16 +6,34 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
+
+	// Embed the IANA timezone database so schedules anchored to a Timezone
+	// resolve even on minimal container images that ship without tzdata.
+	_ "time/tzdata"
 
 	"github.com/xalgord/xalgorix/v4/internal/safe"
 )
 
 type ScanSchedule struct {
-	ID             string    `json:"id"`
-	Name           string    `json:"name"`
-	Interval       string    `json:"interval"` // "hourly", "daily", "weekly", "monthly"
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Interval string `json:"interval"` // "hourly", "daily", "weekly", "monthly"
+	// RunAt anchors the schedule to a wall-clock time of day, "HH:MM" in 24h
+	// form. Empty keeps the legacy behavior of firing one interval after the
+	// schedule was created or last ran. For "hourly" only the minutes apply.
+	RunAt string `json:"run_at,omitempty"`
+	// RunDay picks the day within the interval: weekday for "weekly"
+	// (0=Sunday … 6=Saturday) and day of month for "monthly" (1-31, clamped to
+	// the last day of shorter months). Ignored for the other intervals. No
+	// omitempty: 0 is a meaningful weekly value (Sunday).
+	RunDay int `json:"run_day"`
+	// Timezone is the IANA name RunAt/RunDay are interpreted in, e.g.
+	// "America/Argentina/Buenos_Aires". Empty means server local time.
+	Timezone       string    `json:"timezone,omitempty"`
 	NextRun        time.Time `json:"next_run"`
 	LastRun        time.Time `json:"last_run,omitempty"`
 	Enabled        bool      `json:"enabled"`
@@ -32,8 +50,137 @@ type ScanSchedule struct {
 	Model          string    `json:"model,omitempty"`
 }
 
-func calculateNextRun(interval string, from time.Time) time.Time {
-	switch strings.ToLower(interval) {
+// runAtPattern validates ScanSchedule.RunAt as a 24h "HH:MM" time of day.
+var runAtPattern = regexp.MustCompile(`^([01][0-9]|2[0-3]):([0-5][0-9])$`)
+
+// scheduleTiming is the comparable subset of a schedule that determines when it
+// fires. On update, a change here means NextRun has to be recomputed.
+type scheduleTiming struct {
+	Interval string
+	RunAt    string
+	RunDay   int
+	Timezone string
+}
+
+// timing returns the comparable subset of the schedule that decides when it
+// fires, so an update can tell whether NextRun has to be recomputed.
+func (sch *ScanSchedule) timing() scheduleTiming {
+	return scheduleTiming{
+		Interval: sch.Interval,
+		RunAt:    sch.RunAt,
+		RunDay:   sch.RunDay,
+		Timezone: sch.Timezone,
+	}
+}
+
+// normalizeScheduleTiming validates and canonicalizes the day/time-of-day
+// fields. It returns an error for values the scheduler could not honor so the
+// API answers 400 instead of silently running at the wrong moment.
+func normalizeScheduleTiming(sch *ScanSchedule) error {
+	if sch == nil {
+		return nil
+	}
+	sch.RunAt = strings.TrimSpace(sch.RunAt)
+	sch.Timezone = strings.TrimSpace(sch.Timezone)
+
+	if sch.RunAt != "" && !runAtPattern.MatchString(sch.RunAt) {
+		return fmt.Errorf("run_at must be a 24h time of day such as 09:30, got %q", sch.RunAt)
+	}
+	if sch.Timezone != "" {
+		if _, err := time.LoadLocation(sch.Timezone); err != nil {
+			return fmt.Errorf("unknown timezone %q", sch.Timezone)
+		}
+	}
+
+	switch strings.ToLower(sch.Interval) {
+	case "weekly":
+		if sch.RunDay < 0 || sch.RunDay > 6 {
+			return fmt.Errorf("run_day must be 0 (Sunday) through 6 (Saturday) for weekly schedules, got %d", sch.RunDay)
+		}
+	case "monthly":
+		if sch.RunDay == 0 {
+			sch.RunDay = 1
+		}
+		if sch.RunDay < 1 || sch.RunDay > 31 {
+			return fmt.Errorf("run_day must be 1 through 31 for monthly schedules, got %d", sch.RunDay)
+		}
+	default:
+		// Hourly and daily have no day component.
+		sch.RunDay = 0
+	}
+	return nil
+}
+
+// scheduleLocation resolves the schedule timezone, falling back to server local
+// time for empty or unknown names.
+func scheduleLocation(name string) *time.Location {
+	if name == "" {
+		return time.Local
+	}
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		log.Printf("[SCHEDULER] Unknown timezone %q, falling back to server local time", name)
+		return time.Local
+	}
+	return loc
+}
+
+// calculateNextRun returns the next execution instant, always strictly after
+// from. With RunAt set the schedule is anchored to that wall-clock time (and to
+// RunDay for weekly/monthly); otherwise it simply adds one interval to from.
+func calculateNextRun(sch *ScanSchedule, from time.Time) time.Time {
+	interval := strings.ToLower(sch.Interval)
+	parts := runAtPattern.FindStringSubmatch(sch.RunAt)
+	if parts == nil {
+		return addInterval(interval, from)
+	}
+	hour, _ := strconv.Atoi(parts[1])
+	minute, _ := strconv.Atoi(parts[2])
+	loc := scheduleLocation(sch.Timezone)
+	base := from.In(loc)
+
+	switch interval {
+	case "hourly":
+		// Only the minutes matter: the next :MM of any hour.
+		next := time.Date(base.Year(), base.Month(), base.Day(), base.Hour(), minute, 0, 0, loc)
+		for !next.After(from) {
+			next = next.Add(time.Hour)
+		}
+		return next
+	case "weekly":
+		// Wrap rather than trust RunDay: schedules loaded from disk are not
+		// re-validated, and an out-of-range weekday must not derail the tick.
+		weekday := time.Weekday(((sch.RunDay % 7) + 7) % 7)
+		next := time.Date(base.Year(), base.Month(), base.Day(), hour, minute, 0, 0, loc)
+		next = next.AddDate(0, 0, (int(weekday)-int(next.Weekday())+7)%7)
+		if !next.After(from) {
+			next = next.AddDate(0, 0, 7)
+		}
+		return next
+	case "monthly":
+		// This month first, then the two following ones — enough to clear any
+		// slot that already passed.
+		for i := 0; i < 3; i++ {
+			month := time.Date(base.Year(), base.Month()+time.Month(i), 1, 0, 0, 0, 0, loc)
+			next := monthlyRun(month, sch.RunDay, hour, minute, loc)
+			if next.After(from) {
+				return next
+			}
+		}
+		return from.AddDate(0, 1, 0)
+	default:
+		// "daily" and any unknown interval.
+		next := time.Date(base.Year(), base.Month(), base.Day(), hour, minute, 0, 0, loc)
+		if !next.After(from) {
+			next = next.AddDate(0, 0, 1)
+		}
+		return next
+	}
+}
+
+// addInterval is the unanchored fallback: one interval after from.
+func addInterval(interval string, from time.Time) time.Time {
+	switch interval {
 	case "hourly":
 		return from.Add(time.Hour)
 	case "daily":
@@ -46,6 +193,19 @@ func calculateNextRun(interval string, from time.Time) time.Time {
 		// Default fallback to 1 day
 		return from.AddDate(0, 0, 1)
 	}
+}
+
+// monthlyRun builds the run instant for day within month, clamping to the last
+// day when the month is shorter (31 -> 28 in February).
+func monthlyRun(month time.Time, day, hour, minute int, loc *time.Location) time.Time {
+	if day < 1 {
+		day = 1
+	}
+	// Day 0 of the following month is the last day of this one.
+	if last := time.Date(month.Year(), month.Month()+1, 0, 0, 0, 0, 0, loc).Day(); day > last {
+		day = last
+	}
+	return time.Date(month.Year(), month.Month(), day, hour, minute, 0, 0, loc)
 }
 
 // loadSchedulesFromDisk reads schedules directory and loads them into memory.
@@ -78,6 +238,11 @@ func (s *Server) loadSchedulesFromDisk() {
 			continue
 		}
 		normalizeScheduleActivity(&sch)
+		if err := normalizeScheduleTiming(&sch); err != nil {
+			// Keep the schedule: calculateNextRun tolerates the bad value, so
+			// losing the whole entry over it would be worse.
+			log.Printf("[SCHEDULER] Schedule %s has invalid timing (%v), scheduling defensively", sch.ID, err)
+		}
 		s.schedules[sch.ID] = &sch
 	}
 	log.Printf("[SCHEDULER] Loaded %d schedules from disk", len(s.schedules))
@@ -174,7 +339,7 @@ func (s *Server) checkAndRunSchedules() {
 				go s.runMultiScan(req, &scanCfg, instanceID)
 
 				sch.LastRun = now
-				sch.NextRun = calculateNextRun(sch.Interval, now)
+				sch.NextRun = calculateNextRun(sch, now)
 
 				if err := s.saveScheduleToDisk(sch); err != nil {
 					log.Printf("[SCHEDULER] Error saving triggered schedule %s: %v", sch.ID, err)

--- a/internal/web/scheduler_test.go
+++ b/internal/web/scheduler_test.go
@@ -3,6 +3,7 @@ package web
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -22,9 +23,176 @@ func TestCalculateNextRun(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.interval, func(t *testing.T) {
-			got := calculateNextRun(tc.interval, now)
+			got := calculateNextRun(&ScanSchedule{Interval: tc.interval}, now)
 			if !got.Equal(tc.want) {
 				t.Errorf("calculateNextRun(%q) = %v, want %v", tc.interval, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCalculateNextRunAnchored(t *testing.T) {
+	utc := time.UTC
+	// Buenos Aires is UTC-3 year round, so 09:00 local == 12:00 UTC.
+	buenosAires, err := time.LoadLocation("America/Argentina/Buenos_Aires")
+	if err != nil {
+		t.Fatalf("LoadLocation: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		sch  ScanSchedule
+		from time.Time
+		want time.Time
+	}{
+		{
+			name: "daily later today",
+			sch:  ScanSchedule{Interval: "daily", RunAt: "23:30", Timezone: "UTC"},
+			from: time.Date(2026, 5, 22, 12, 0, 0, 0, utc),
+			want: time.Date(2026, 5, 22, 23, 30, 0, 0, utc),
+		},
+		{
+			name: "daily rolls to tomorrow once passed",
+			sch:  ScanSchedule{Interval: "daily", RunAt: "09:00", Timezone: "UTC"},
+			from: time.Date(2026, 5, 22, 12, 0, 0, 0, utc),
+			want: time.Date(2026, 5, 23, 9, 0, 0, 0, utc),
+		},
+		{
+			name: "daily exactly at the slot rolls forward",
+			sch:  ScanSchedule{Interval: "daily", RunAt: "12:00", Timezone: "UTC"},
+			from: time.Date(2026, 5, 22, 12, 0, 0, 0, utc),
+			want: time.Date(2026, 5, 23, 12, 0, 0, 0, utc),
+		},
+		{
+			name: "hourly uses only the minutes",
+			sch:  ScanSchedule{Interval: "hourly", RunAt: "07:15", Timezone: "UTC"},
+			from: time.Date(2026, 5, 22, 12, 0, 0, 0, utc),
+			want: time.Date(2026, 5, 22, 12, 15, 0, 0, utc),
+		},
+		{
+			name: "hourly rolls to the next hour",
+			sch:  ScanSchedule{Interval: "hourly", RunAt: "07:15", Timezone: "UTC"},
+			from: time.Date(2026, 5, 22, 12, 30, 0, 0, utc),
+			want: time.Date(2026, 5, 22, 13, 15, 0, 0, utc),
+		},
+		{
+			// 2026-05-22 is a Friday; RunDay 1 = Monday.
+			name: "weekly picks the configured weekday",
+			sch:  ScanSchedule{Interval: "weekly", RunAt: "03:00", RunDay: 1, Timezone: "UTC"},
+			from: time.Date(2026, 5, 22, 12, 0, 0, 0, utc),
+			want: time.Date(2026, 5, 25, 3, 0, 0, 0, utc),
+		},
+		{
+			name: "weekly on today rolls a full week when the slot passed",
+			sch:  ScanSchedule{Interval: "weekly", RunAt: "03:00", RunDay: int(time.Friday), Timezone: "UTC"},
+			from: time.Date(2026, 5, 22, 12, 0, 0, 0, utc),
+			want: time.Date(2026, 5, 29, 3, 0, 0, 0, utc),
+		},
+		{
+			name: "weekly sunday is run_day zero",
+			sch:  ScanSchedule{Interval: "weekly", RunAt: "03:00", RunDay: int(time.Sunday), Timezone: "UTC"},
+			from: time.Date(2026, 5, 22, 12, 0, 0, 0, utc),
+			want: time.Date(2026, 5, 24, 3, 0, 0, 0, utc),
+		},
+		{
+			// Persisted schedules are not re-validated on load, so an
+			// out-of-range weekday has to wrap instead of hanging the tick.
+			name: "weekly wraps an out of range run_day",
+			sch:  ScanSchedule{Interval: "weekly", RunAt: "03:00", RunDay: 8, Timezone: "UTC"},
+			from: time.Date(2026, 5, 22, 12, 0, 0, 0, utc),
+			want: time.Date(2026, 5, 25, 3, 0, 0, 0, utc), // 8 % 7 == Monday
+		},
+		{
+			name: "monthly later this month",
+			sch:  ScanSchedule{Interval: "monthly", RunAt: "02:00", RunDay: 28, Timezone: "UTC"},
+			from: time.Date(2026, 5, 22, 12, 0, 0, 0, utc),
+			want: time.Date(2026, 5, 28, 2, 0, 0, 0, utc),
+		},
+		{
+			name: "monthly rolls to next month once passed",
+			sch:  ScanSchedule{Interval: "monthly", RunAt: "02:00", RunDay: 10, Timezone: "UTC"},
+			from: time.Date(2026, 5, 22, 12, 0, 0, 0, utc),
+			want: time.Date(2026, 6, 10, 2, 0, 0, 0, utc),
+		},
+		{
+			// 2026 is not a leap year: day 31 clamps to February 28.
+			name: "monthly clamps to the last day of a short month",
+			sch:  ScanSchedule{Interval: "monthly", RunAt: "02:00", RunDay: 31, Timezone: "UTC"},
+			from: time.Date(2026, 2, 1, 12, 0, 0, 0, utc),
+			want: time.Date(2026, 2, 28, 2, 0, 0, 0, utc),
+		},
+		{
+			name: "timezone is honored",
+			sch:  ScanSchedule{Interval: "daily", RunAt: "09:00", Timezone: "America/Argentina/Buenos_Aires"},
+			from: time.Date(2026, 5, 22, 6, 0, 0, 0, utc),
+			want: time.Date(2026, 5, 22, 9, 0, 0, 0, buenosAires),
+		},
+		{
+			name: "unknown timezone falls back instead of failing",
+			sch:  ScanSchedule{Interval: "daily", RunAt: "23:30", Timezone: "Mars/Olympus_Mons"},
+			from: time.Date(2026, 5, 22, 12, 0, 0, 0, time.Local),
+			want: time.Date(2026, 5, 22, 23, 30, 0, 0, time.Local),
+		},
+		{
+			name: "malformed run_at falls back to the relative interval",
+			sch:  ScanSchedule{Interval: "daily", RunAt: "9am", Timezone: "UTC"},
+			from: time.Date(2026, 5, 22, 12, 0, 0, 0, utc),
+			want: time.Date(2026, 5, 23, 12, 0, 0, 0, utc),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := calculateNextRun(&tc.sch, tc.from)
+			if !got.Equal(tc.want) {
+				t.Errorf("calculateNextRun(%+v, %v) = %v, want %v", tc.sch, tc.from, got, tc.want)
+			}
+			if !got.After(tc.from) {
+				t.Errorf("next run %v is not strictly after %v", got, tc.from)
+			}
+		})
+	}
+}
+
+func TestNormalizeScheduleTiming(t *testing.T) {
+	cases := []struct {
+		name       string
+		sch        ScanSchedule
+		wantErr    bool
+		wantRunDay int
+	}{
+		{name: "empty is valid", sch: ScanSchedule{Interval: "daily"}},
+		{name: "valid time", sch: ScanSchedule{Interval: "daily", RunAt: "09:30"}},
+		{name: "trims whitespace", sch: ScanSchedule{Interval: "daily", RunAt: "  09:30  "}},
+		{name: "rejects 24h", sch: ScanSchedule{Interval: "daily", RunAt: "24:00"}, wantErr: true},
+		{name: "rejects bad minutes", sch: ScanSchedule{Interval: "daily", RunAt: "09:60"}, wantErr: true},
+		{name: "rejects free text", sch: ScanSchedule{Interval: "daily", RunAt: "9am"}, wantErr: true},
+		{name: "rejects unknown timezone", sch: ScanSchedule{Interval: "daily", Timezone: "Mars/Olympus_Mons"}, wantErr: true},
+		{name: "accepts known timezone", sch: ScanSchedule{Interval: "daily", Timezone: "America/Argentina/Buenos_Aires"}},
+		{name: "weekly sunday", sch: ScanSchedule{Interval: "weekly", RunDay: 0}},
+		{name: "weekly rejects out of range", sch: ScanSchedule{Interval: "weekly", RunDay: 7}, wantErr: true},
+		{name: "monthly defaults to the first", sch: ScanSchedule{Interval: "monthly", RunDay: 0}, wantRunDay: 1},
+		{name: "monthly rejects day 32", sch: ScanSchedule{Interval: "monthly", RunDay: 32}, wantErr: true},
+		{name: "daily drops the day component", sch: ScanSchedule{Interval: "daily", RunDay: 4}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := normalizeScheduleTiming(&tc.sch)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got nil (schedule: %+v)", tc.sch)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.sch.RunDay != tc.wantRunDay {
+				t.Errorf("RunDay = %d, want %d", tc.sch.RunDay, tc.wantRunDay)
+			}
+			if strings.TrimSpace(tc.sch.RunAt) != tc.sch.RunAt {
+				t.Errorf("RunAt was not trimmed: %q", tc.sch.RunAt)
 			}
 		})
 	}

--- a/internal/web/schedules.go
+++ b/internal/web/schedules.go
@@ -47,9 +47,13 @@ func (s *Server) handleSchedules(w http.ResponseWriter, r *http.Request) {
 			req.Interval = "daily"
 		}
 		normalizeScheduleActivity(&req)
+		if err := normalizeScheduleTiming(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 		req.ID = randomSlug()
 		req.Enabled = true
-		req.NextRun = calculateNextRun(req.Interval, time.Now())
+		req.NextRun = calculateNextRun(&req, time.Now())
 
 		s.schedulesMu.Lock()
 		s.schedules[req.ID] = &req
@@ -150,13 +154,20 @@ func (s *Server) handleScheduleDetail(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		normalizeScheduleActivity(&req)
+		if err := normalizeScheduleTiming(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 
 		s.schedulesMu.Lock()
 		oldEnabled := sch.Enabled
-		oldInterval := sch.Interval
+		oldTiming := sch.timing()
 
 		sch.Name = req.Name
 		sch.Interval = req.Interval
+		sch.RunAt = req.RunAt
+		sch.RunDay = req.RunDay
+		sch.Timezone = req.Timezone
 		sch.Enabled = req.Enabled
 		sch.Targets = req.Targets
 		sch.Instruction = req.Instruction
@@ -170,9 +181,9 @@ func (s *Server) handleScheduleDetail(w http.ResponseWriter, r *http.Request) {
 		sch.DiscordWebhook = req.DiscordWebhook
 		sch.Model = req.Model
 
-		// If interval changed, or enabled transitioned false -> true, recalculate NextRun
-		if sch.Interval != oldInterval || (sch.Enabled && !oldEnabled) {
-			sch.NextRun = calculateNextRun(sch.Interval, time.Now())
+		// If any timing field changed, or enabled transitioned false -> true, recalculate NextRun
+		if sch.timing() != oldTiming || (sch.Enabled && !oldEnabled) {
+			sch.NextRun = calculateNextRun(sch, time.Now())
 		}
 
 		diskCopy := *sch // snapshot under lock for race-free disk write

--- a/webui/src/pages/schedules.tsx
+++ b/webui/src/pages/schedules.tsx
@@ -54,6 +54,66 @@ import { api } from "@/api/client";
 const SEVERITIES = ["info", "low", "medium", "high", "critical"];
 type ActivityMode = "active" | "passive";
 
+// Mirrors Go's time.Weekday: index 0 is Sunday.
+const WEEKDAYS = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
+const MONTH_DAYS = Array.from({ length: 31 }, (_, i) => i + 1);
+
+// Intervals that carry a day component; the others only take a time of day.
+function hasDayPicker(interval: string): boolean {
+  return interval === "weekly" || interval === "monthly";
+}
+
+// Keep the selected day inside the range the interval's picker offers.
+function clampRunDay(day: number, interval: string): number {
+  if (interval === "weekly") return Math.min(Math.max(day, 0), 6);
+  if (interval === "monthly") return Math.min(Math.max(day, 1), 31);
+  return day;
+}
+
+function detectTimeZone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
+}
+
+// Full IANA list when the browser exposes it (Chrome 99+/FF 93+/Safari 15.4+),
+// otherwise just the detected zone so the picker is never empty.
+function listTimeZones(detected: string): string[] {
+  let all: string[] = [];
+  try {
+    all = Intl.supportedValuesOf?.("timeZone") ?? [];
+  } catch {
+    all = [];
+  }
+  return Array.from(new Set(["UTC", detected, ...all])).sort();
+}
+
+// One-line summary of when a schedule fires, for the list view.
+function formatScheduleWindow(s: ScanSchedule): string {
+  if (!s.run_at) return "";
+  const tz = s.timezone ? ` · ${s.timezone}` : "";
+  switch (s.interval) {
+    case "hourly":
+      return `:${s.run_at.slice(3)} every hour${tz}`;
+    case "weekly":
+      return `${WEEKDAYS[s.run_day ?? 0] ?? WEEKDAYS[0]} ${s.run_at}${tz}`;
+    case "monthly":
+      return `Day ${s.run_day ?? 1} · ${s.run_at}${tz}`;
+    default:
+      return `${s.run_at}${tz}`;
+  }
+}
+
 export default function SchedulesPage() {
   const { data, isLoading, error, refetch } = useSchedulesList();
   const createMutation = useCreateSchedule();
@@ -71,6 +131,12 @@ export default function SchedulesPage() {
   // Form State
   const [name, setName] = useState("");
   const [interval, setInterval] = useState("daily");
+  // Day/time-of-day anchor. `runAt` empty means "run one interval after
+  // creation or the last run" — the behavior schedules had before this was
+  // configurable — so existing schedules keep working untouched.
+  const [runAt, setRunAt] = useState("");
+  const [runDay, setRunDay] = useState(1);
+  const [timezone, setTimezone] = useState(detectTimeZone);
   const [targetsText, setTargetsText] = useState("");
   const [scanMode, setScanMode] = useState("single");
   const [reconMode, setReconMode] = useState<ActivityMode>("active");
@@ -107,6 +173,11 @@ export default function SchedulesPage() {
   // each profile's catalog entry to render `displayName · profileId`.
   // When neither query has loaded yet the picker collapses to the
   // single "Server default" option.
+  const timeZoneOptions = useMemo(
+    () => listTimeZones(detectTimeZone()),
+    [],
+  );
+
   const profilesQuery = useAuthProfiles();
   const catalogQuery = useProviders();
   const profileOptions = useMemo(() => {
@@ -128,6 +199,9 @@ export default function SchedulesPage() {
     setEditingSchedule(null);
     setName("");
     setInterval("daily");
+    setRunAt("");
+    setRunDay(1);
+    setTimezone(detectTimeZone());
     setTargetsText("");
     setScanMode("single");
     setReconMode("active");
@@ -149,6 +223,9 @@ export default function SchedulesPage() {
     setEditingSchedule(sch);
     setName(sch.name);
     setInterval(sch.interval);
+    setRunAt(sch.run_at || "");
+    setRunDay(clampRunDay(sch.run_day ?? 1, sch.interval));
+    setTimezone(sch.timezone || detectTimeZone());
     setTargetsText(sch.targets.join("\n"));
     setScanMode(sch.scan_mode || "single");
     const nextScanIntensity = sch.scan_intensity || "active";
@@ -246,6 +323,11 @@ export default function SchedulesPage() {
     const payload = {
       name: name.trim() || undefined,
       interval,
+      run_at: runAt || undefined,
+      run_day: hasDayPicker(interval) ? runDay : undefined,
+      // Only meaningful alongside a time of day; omit it otherwise so the
+      // schedule stays on the legacy relative behavior.
+      timezone: runAt ? timezone : undefined,
       targets,
       scan_mode: scanMode,
       recon_mode: reconMode,
@@ -374,6 +456,11 @@ export default function SchedulesPage() {
                         <Badge variant="outline" className="capitalize">
                           {s.interval}
                         </Badge>
+                        {s.run_at && (
+                          <div className="mt-1 text-[11px] text-muted-foreground">
+                            {formatScheduleWindow(s)}
+                          </div>
+                        )}
                       </td>
                       <td className="px-4 py-3 align-middle max-w-xs truncate mono text-xs text-muted-foreground">
                         {s.targets.join(", ")}
@@ -440,7 +527,15 @@ export default function SchedulesPage() {
               </div>
               <div className="space-y-2">
                 <Label htmlFor="sched-interval">Frequency Interval *</Label>
-                <Select value={interval} onValueChange={setInterval}>
+                <Select
+                  value={interval}
+                  onValueChange={(v) => {
+                    setInterval(v);
+                    // Weekdays are 0-6 and days of month 1-31, so carry the
+                    // selection into the range the new picker can display.
+                    setRunDay((cur) => clampRunDay(cur, v));
+                  }}
+                >
                   <SelectTrigger id="sched-interval">
                     <SelectValue />
                   </SelectTrigger>
@@ -452,6 +547,85 @@ export default function SchedulesPage() {
                   </SelectContent>
                 </Select>
               </div>
+            </div>
+
+            <div className="space-y-2">
+              <div
+                className={cn(
+                  "grid gap-4",
+                  hasDayPicker(interval) ? "sm:grid-cols-3" : "sm:grid-cols-2",
+                )}
+              >
+                {hasDayPicker(interval) && (
+                  <div className="space-y-2">
+                    <Label htmlFor="sched-run-day">
+                      {interval === "weekly" ? "Day of week" : "Day of month"}
+                    </Label>
+                    <Select
+                      value={String(runDay)}
+                      onValueChange={(v) => setRunDay(Number(v))}
+                    >
+                      <SelectTrigger id="sched-run-day">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {interval === "weekly"
+                          ? WEEKDAYS.map((day, i) => (
+                              <SelectItem key={day} value={String(i)}>
+                                {day}
+                              </SelectItem>
+                            ))
+                          : MONTH_DAYS.map((day) => (
+                              <SelectItem key={day} value={String(day)}>
+                                {day}
+                              </SelectItem>
+                            ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
+                <div className="space-y-2">
+                  <Label htmlFor="sched-run-at">Run at</Label>
+                  <Input
+                    id="sched-run-at"
+                    type="time"
+                    value={runAt}
+                    onChange={(e) => setRunAt(e.target.value)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="sched-timezone">Timezone</Label>
+                  <Select
+                    value={timezone}
+                    onValueChange={setTimezone}
+                    disabled={!runAt}
+                  >
+                    <SelectTrigger id="sched-timezone">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent className="max-h-72">
+                      {timeZoneOptions.map((tz) => (
+                        <SelectItem key={tz} value={tz}>
+                          {tz}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              <p className="text-[11px] text-muted-foreground">
+                {interval === "hourly"
+                  ? "Only the minutes are used: the scan runs at that minute of every hour."
+                  : `Wall-clock time the scan is launched${
+                      hasDayPicker(interval)
+                        ? interval === "weekly"
+                          ? ", on the selected weekday"
+                          : ", on the selected day of the month (clamped to the last day of shorter months)"
+                        : ""
+                    }.`}{" "}
+                Leave blank to keep running one interval after the schedule was
+                created or last ran.
+              </p>
             </div>
 
             <div className="space-y-2">

--- a/webui/src/types/api.ts
+++ b/webui/src/types/api.ts
@@ -479,6 +479,18 @@ export interface ScanSchedule {
   id: string;
   name: string;
   interval: string;
+  // Wall-clock time of day the schedule fires, "HH:MM" in 24h form and
+  // interpreted in `timezone`. Empty/absent keeps the legacy behavior of
+  // running one interval after creation or the last run. For the "hourly"
+  // interval only the minutes apply.
+  run_at?: string;
+  // Day within the interval: weekday for "weekly" (0=Sunday … 6=Saturday) and
+  // day of month for "monthly" (1-31, clamped to the last day of shorter
+  // months). Ignored for "hourly" and "daily".
+  run_day?: number;
+  // IANA timezone name `run_at`/`run_day` are read in, e.g.
+  // "America/Argentina/Buenos_Aires". Empty means the server's local time.
+  timezone?: string;
   next_run: string;
   last_run?: string;
   enabled: boolean;


### PR DESCRIPTION
## Problem

A scan schedule only stores a frequency interval (`hourly` / `daily` / `weekly` /
`monthly`). `calculateNextRun` just adds that interval to `time.Now()`, so the
moment a schedule actually launches is whatever time it happened to be created
or last run.

That makes it impossible to express the thing operators normally want from a
recurring scan: *"every Monday at 03:00"*. A weekly schedule saved at 14:20 on a
Thursday will keep firing Thursdays at 14:20 forever, and any restart-driven
catch-up shifts it again.

## What this adds

Three new fields on `ScanSchedule`, all optional and all surfaced in the
Schedules dialog:

| Field | Meaning |
|---|---|
| `run_at` | Wall-clock time of day, `"HH:MM"` 24h. For `hourly`, only the minutes apply (`:15` of every hour). |
| `run_day` | Weekday for `weekly` (`0`=Sunday … `6`=Saturday); day of month for `monthly` (`1`-`31`). Ignored otherwise. |
| `timezone` | IANA name the two above are read in, e.g. `America/Argentina/Buenos_Aires`. Empty = server local time. |

`calculateNextRun` now takes the schedule rather than just the interval string
and anchors `NextRun` to that window. It always returns an instant **strictly
after** `from`, so a schedule that just fired cannot re-trigger on the same
30s tick.

**Leaving `run_at` blank keeps the exact previous behavior**, so schedules
created before this change are unaffected and no migration is needed — a
persisted schedule simply decodes with an empty `run_at`.

## Behavior details

- A monthly `run_day` clamps to the last day of shorter months (`31` → Feb 28 in
  a non-leap year) instead of skipping the month.
- `POST`/`PUT /api/schedules` reject a malformed `run_at`, an unknown timezone,
  or an out-of-range `run_day` with `400` rather than silently scanning at the
  wrong moment. `PUT` recomputes `NextRun` whenever any timing field changes,
  not just the interval.
- `run_day` is serialized **without** `omitempty`, because `0` is a meaningful
  weekly value (Sunday).
- Schedules loaded from disk are not re-validated, so the weekly path wraps
  `run_day` modulo 7 defensively — an out-of-range value in a hand-edited JSON
  must not be able to stall the scheduler goroutine, which holds
  `schedulesMu` while it ticks.
- `time/tzdata` is embedded (blank import) so `time.LoadLocation` resolves on
  container images that ship without the system timezone database. Without it,
  a perfectly valid timezone would be rejected with `400` at runtime.

## Web UI

- Day / time / timezone row in the schedule dialog, with the day picker shown
  only for `weekly` and `monthly`, and the timezone select disabled until a time
  is set.
- The timezone defaults to the browser's zone and lists the full IANA set via
  `Intl.supportedValuesOf("timeZone")`, falling back to just the detected zone
  on browsers that lack it.
- The schedules table shows the configured window under the interval badge
  (e.g. `Monday 03:00 · America/Argentina/Buenos_Aires`).

## Verification

- `gofmt -l internal/web/` clean, `go vet ./internal/web/` clean.
- `go test ./internal/web/` passes, including the pre-existing
  `TestCalculateNextRun` (updated for the new signature) plus new table tests:
  `TestCalculateNextRunAnchored` (14 cases: same-day vs rolled-over slots, the
  hourly minutes-only rule, weekday selection incl. Sunday and the out-of-range
  wrap, month-end clamping, timezone handling, and the fallbacks for an unknown
  timezone / malformed `run_at`) and `TestNormalizeScheduleTiming` (13 cases).
  Every anchored case also asserts the result is strictly after `from`.
- `tsc -b` and `vite build` clean for the webui.
- Deployed end to end: image rebuilt from this tree and the container recreated;
  schedules created through the API land on the expected `next_run`.
