### PR TITLE
fix(agent): recover reasoning loops via context compaction instead of aborting

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -887,6 +887,20 @@ func (a *Agent) Run(targets []string, instruction string) {
 				a.emit(Event{Type: "finished", Content: detail, TotalTokens: tokenCount(), Aborted: true, AbortReason: reason})
 				return
 			}
+			// Reasoning-loop recovery: the hook asked for an aggressive
+			// context compaction to break a think-only loop. Collapse the
+			// message history into a digest BEFORE injecting the nudge so
+			// the focused "call a tool now" prompt lands in a clean window
+			// rather than on top of the noisy output that caused the loop.
+			// We intentionally do NOT reset NoToolCount here — the hook
+			// already incremented ReasoningLoopCompactions / DensityCompactions,
+			// and the count climbing toward NoToolAbortAt is what gives a
+			// model that ignores the compaction a bounded number of turns
+			// before the scan gives up.
+			if noToolResult.ForceCompact {
+				a.emit(Event{Type: "message", Content: "🧹 Reasoning loop detected — compacting context to refocus. The model stopped calling tools; collapsing old output into a digest and prompting a concrete next action.", TotalTokens: tokenCount()})
+				a.forcePruneMessages()
+			}
 			if noToolResult.Nudge != "" {
 				a.msgMu.Lock()
 				a.messages = append(a.messages, llm.Message{Role: "user", Content: noToolResult.Nudge})

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -112,6 +112,27 @@ type ScanState struct {
 	// the scan cleanly once the ceiling is reached.
 	CumulativeRateLimitWait time.Duration
 
+	// Reasoning-loop recovery tracking. A "reasoning loop" is the model
+	// emitting think-only responses (or prose) with no tool calls. The
+	// consecutive counter (NoToolCount) is reset to 0 by OnHealthyResponse
+	// the instant the model makes one tool call — so a model that reasons
+	// for 10 turns then calls a tool once, repeatedly, never reaches the 15
+	// abort threshold and the scan runs for hours. The density counters
+	// below are NEVER reset, so they catch the non-consecutive pattern:
+	//
+	//   - ReasoningLoopCompactions: how many times we've force-compacted the
+	//     context to break a reasoning loop. Caps recovery attempts so a
+	//     model that simply won't act eventually aborts instead of looping
+	//     forever between compact + reset.
+	//   - TotalNoToolResponses: every no-tool response since scan start.
+	//     Compared against TotalIterations to compute the reasoning ratio.
+	//   - DensityCompactions: compactions triggered by the density check
+	//     (distinct from the consecutive-count compactions) so the two
+	//     recovery paths don't double-compact on the same stall.
+	ReasoningLoopCompactions int
+	TotalNoToolResponses     int
+	DensityCompactions       int
+
 	// New enrichment hooks
 	WAFDetected          bool
 	DetectedTechs        map[string]bool // e.g. "php", "nodejs", "java"
@@ -143,6 +164,14 @@ type HookResult struct {
 	ForceSkip      bool   // skip current tool call
 	EmitMessage    string // emit to UI without injecting into conversation
 	CleanupBrowser bool   // signal to force-close browser
+	// ForceCompact signals the loop to aggressively compact the message
+	// history (forcePruneMessages) before injecting Nudge. Used by the
+	// reasoning-loop recovery path: a model stuck emitting think-only
+	// responses is far more likely to resume acting once the noisy
+	// context (raw tool output, loaded skill docs) is collapsed into a
+	// compact digest. The Nudge returned alongside it must be a focused
+	// "resume from here and call a tool" prompt, not a generic nudge.
+	ForceCompact bool
 }
 
 // ── Hook Registry ────────────────────────────────────────────────────────────
@@ -196,6 +225,9 @@ func (r *HookRegistry) Fire(event string, state *ScanState, args map[string]stri
 		if result.CleanupBrowser {
 			merged.CleanupBrowser = true
 		}
+		if result.ForceCompact {
+			merged.ForceCompact = true
+		}
 	}
 	return merged
 }
@@ -218,6 +250,34 @@ const (
 
 	BlockedCallSoftNudge = 3 // consecutive guard-blocked calls → soft corrective nudge
 	BlockedCallHardNudge = 6 // consecutive guard-blocked calls → hard "stop / pivot / finish" nudge
+
+	// ReasoningLoopCompactAt and the related thresholds govern reasoning-loop
+	// recovery. A reasoning loop is the model emitting think-only / prose
+	// responses with NO tool calls. The two recovery paths are:
+	//
+	//   1. Consecutive: NoToolCount climbs to ReasoningLoopCompactAt, we
+	//      force-compact the context (collapsing noisy raw output + loaded
+	//      skill docs into a digest) and inject a focused "resume from here"
+	//      prompt. A second compact fires at ReasoningLoopCompactAt2. The
+	//      scan only aborts at NoToolAbortAt (15) if both compaction
+	//      attempts failed to break the loop.
+	//
+	//   2. Density (non-consecutive): if the model makes an occasional
+	//      tool call — just often enough to reset NoToolCount — the
+	//      consecutive path never trips. ReasoningDensityMinResponses +
+	//      ReasoningDensityRatio catch this: once enough iterations have
+	//      elapsed, a high no-tool ratio (>60%) means the scan is burning
+	//      most of its turns reasoning; we compact once, and if the ratio
+	//      stays high we abort rather than running for hours.
+	ReasoningLoopCompactAt  = 6  // consecutive no-tool → 1st context compaction
+	ReasoningLoopCompactAt2 = 10 // consecutive no-tool → 2nd context compaction
+	NoToolAbortAt           = 15 // consecutive no-tool → force-stop scan
+
+	ReasoningDensityMinResponses  = 20   // need ≥ this many no-tool responses before the density check applies
+	ReasoningDensityCompactRatio  = 0.6  // >60% no-tool responses → compact
+	ReasoningDensityAbortRatio    = 0.75 // >75% no-tool responses after a compact → abort
+	ReasoningDensityAbortMinIters = 40   // ...only once ≥40 iterations elapsed
+	MaxReasoningCompactions       = 2    // cap total recovery compactions (consecutive + density combined)
 )
 
 // noteBlockedToolCall records that a Gated_Tool call was rejected by a block
@@ -1170,15 +1230,35 @@ func hookEmptyResponseHandler(state *ScanState, args map[string]string) HookResu
 }
 
 // ── hookNoToolHandler ────────────────────────────────────────────────────────
-// Handles LLM responding without any tool calls. Nudges after 3, force-stops after 15.
+// Handles LLM responding without any tool calls. This is the single biggest
+// cause of failed scans: the model degrades into a "reasoning loop" — emitting
+// think-only or prose responses with no tool calls — and the scan force-stops.
 //
-// Special-cases model-side safety refusals (e.g. Gemini replying "Sorry, I cannot
-// fulfill your request to perform a security assessment..."). A refusal is not a
-// formatting problem, so the generic "use the XML format" nudge does nothing —
-// instead we re-assert the authorized-engagement context, which reliably gets
-// safety-tuned models back on task.
+// Two recovery paths, both backed by CONTEXT COMPACTION (not just nudges):
+//
+//  1. Consecutive — the model emits ReasoningLoopCompactAt (6) no-tool
+//     responses in a row. We force-compact the context (collapsing the
+//     raw tool output / loaded skill docs that likely triggered the loop
+//     into a structured digest) and inject a focused resume prompt. A
+//     second compaction fires at ReasoningLoopCompactAt2 (10). The scan
+//     only aborts at NoToolAbortAt (15) if both compactions failed.
+//
+//  2. Density (non-consecutive) — the model makes an occasional tool
+//     call, just often enough to reset the consecutive counter, so the
+//     consecutive path never trips and the scan runs for hours. Once
+//     enough no-tool responses have accumulated (ReasoningDensityMinResponses),
+//     a no-tool ratio above ReasoningDensityCompactRatio triggers a
+//     compaction; if the ratio stays above ReasoningDensityAbortRatio
+//     past ReasoningDensityAbortMinIters iterations, the scan aborts.
+//
+// Special-cases model-side safety refusals (e.g. Gemini replying "Sorry, I
+// cannot fulfill your request to perform a security assessment..."). A
+// refusal is not a formatting problem, so the generic "use the XML format"
+// nudge does nothing — instead we re-assert the authorized-engagement
+// context, which reliably gets safety-tuned models back on task.
 func hookNoToolHandler(state *ScanState, args map[string]string) HookResult {
 	state.NoToolCount++
+	state.TotalNoToolResponses++
 
 	if isRefusal(args["response"]) {
 		state.RefusalCount++
@@ -1186,7 +1266,7 @@ func hookNoToolHandler(state *ScanState, args map[string]string) HookResult {
 		state.RefusalCount = 0
 	}
 
-	if state.NoToolCount >= 15 {
+	if state.NoToolCount >= NoToolAbortAt {
 		msg := "⛔ Model returned 15 consecutive responses with no tool call — it stopped taking actions (likely context flooded by a large tool output, or a reasoning loop). Force finishing."
 		if state.RefusalCount >= 3 {
 			msg = "⛔ Model declined to act for 15 consecutive responses (safety refusal). Force finishing — try a model that permits authorized security testing."
@@ -1213,6 +1293,68 @@ Resume the assessment NOW by calling a tool. For example, to run a command:
 		}
 	}
 
+	// ── Density-based recovery (non-consecutive reasoning loops) ──
+	// Catches a model that makes occasional tool calls — enough to reset
+	// NoToolCount but not enough to make real progress — and would
+	// otherwise run for hours. The consecutive path only fires at
+	// NoToolCount >= 6, so a model that calls a tool every ~5 turns keeps
+	// NoToolCount ≤ 4 and the consecutive path NEVER trips. This path uses
+	// the cumulative (never-reset) counters so it sees the real picture.
+	totalCompactions := state.ReasoningLoopCompactions + state.DensityCompactions
+	if iters := state.Iteration + 1; iters > 0 &&
+		state.TotalNoToolResponses >= ReasoningDensityMinResponses {
+		ratio := float64(state.TotalNoToolResponses) / float64(iters)
+		// Abort once the density is sustained past the min-iteration gate,
+		// AFTER at least one recovery compaction has been attempted (so a
+		// genuinely slow-but-progressing scan gets a chance to recover first).
+		// We deliberately do NOT require totalCompactions >= MaxReasoningCompactions
+		// here — for the pure non-consecutive pattern the consecutive path can
+		// never supply a second compaction, so gating on it would make this
+		// abort unreachable (the exact 48-hour bug this path exists to catch).
+		if ratio > ReasoningDensityAbortRatio && iters >= ReasoningDensityAbortMinIters &&
+			totalCompactions >= 1 {
+			return HookResult{
+				ForceSkip: true,
+				EmitMessage: fmt.Sprintf(
+					"⛔ Scan aborted: reasoning loop — %d of %d iterations (%.0f%%) produced no tool call after %d context compaction(s). The model is not making progress; switch model or lower reasoning effort.",
+					state.TotalNoToolResponses, iters, ratio*100, totalCompactions),
+			}
+		}
+		// Recovery: compact while we still have budget. Bound by the
+		// COMBINED total (consecutive + density) so the two paths share the
+		// MaxReasoningCompactions cap instead of each getting its own.
+		if ratio > ReasoningDensityCompactRatio &&
+			totalCompactions < MaxReasoningCompactions {
+			state.DensityCompactions++
+			return HookResult{
+				ForceCompact: true,
+				Nudge:        reasoningLoopResumePrompt(state, "density"),
+			}
+		}
+	}
+
+	// ── Consecutive recovery: compact the context to break the loop ──
+	// Guard by the COMBINED compaction total so a density compaction counts
+	// against the consecutive budget (and vice versa). Without this, a
+	// density compact (1) + two consecutive compacts (2) = 3 compactions,
+	// violating MaxReasoningCompactions.
+	if state.NoToolCount >= ReasoningLoopCompactAt2 &&
+		totalCompactions < MaxReasoningCompactions {
+		state.ReasoningLoopCompactions++
+		return HookResult{
+			ForceCompact: true,
+			Nudge:        reasoningLoopResumePrompt(state, "consecutive"),
+		}
+	}
+	if state.NoToolCount >= ReasoningLoopCompactAt &&
+		totalCompactions < MaxReasoningCompactions {
+		state.ReasoningLoopCompactions++
+		return HookResult{
+			ForceCompact: true,
+			Nudge:        reasoningLoopResumePrompt(state, "consecutive"),
+		}
+	}
+
 	if state.NoToolCount >= 3 {
 		return HookResult{
 			Nudge: `You MUST use tools to interact with the target. Do not just explain — take action NOW.
@@ -1236,15 +1378,62 @@ Call a tool NOW in your next response.`,
 	}
 }
 
+// reasoningLoopResumePrompt builds the focused "break out of the reasoning
+// loop" nudge injected alongside a context compaction. It is deliberately
+// short and action-oriented: the compaction already preserved a digest of
+// prior work + saved notes, so the prompt only needs to point the model at
+// the single most-likely next action and forbid more prose-only turns.
+//
+// `trigger` is "consecutive" or "density" and only affects the framing line
+// so the operator-facing log / emitted message can distinguish the two paths.
+func reasoningLoopResumePrompt(state *ScanState, trigger string) string {
+	prefix := "⚠️ REASONING LOOP DETECTED — you have produced several responses with no tool call."
+	if trigger == "density" {
+		prefix = "⚠️ REASONING LOOP DETECTED — most of your recent responses produced no tool call."
+	}
+	// Surface a concrete next action when we have endpoint coverage data;
+	// otherwise keep it generic so the prompt never lies about state.
+	next := "Pick ONE untested endpoint or vuln class and test it NOW."
+	if n := len(state.EndpointsTested); n > 0 {
+		next = fmt.Sprintf("You have mapped %d endpoint(s). Pick one you have NOT tested for injection / IDOR / XSS and test it NOW.", n)
+	}
+	return prefix + ` The conversation context has just been COMPACTED — old tool output was collapsed into the digest above so you can focus.
+
+STOP planning. STOP reasoning aloud. Your NEXT response MUST contain exactly one tool call. ` + next + `
+
+Do NOT:
+- produce another thinking-only or prose-only response
+- re-summarize what you already know
+- ask whether you should proceed (you are authorized — proceed)
+
+Call a tool in your very next message. For example:
+<function=terminal_execute>
+<parameter=command>curl -sk "https://TARGET/api/UNTESTED" -w "\n[%{http_code}]\n"</parameter>
+</function>`
+}
+
 // classifyNoToolAbort turns a no-tool force-stop into a machine reason tag plus
 // a human explanation of the ACTUAL cause, instead of the old catch-all
-// "LLM refused to call tools". It distinguishes a genuine safety refusal from a
-// "stopped taking actions" stall — the latter is almost always context
-// exhaustion (a huge tool output dumped into the window) or a reasoning loop,
-// not a target problem.
+// "LLM refused to call tools". It distinguishes three cases:
+//   - a genuine safety refusal,
+//   - a non-consecutive reasoning loop (density abort — the scan ran a long
+//     time making little progress), and
+//   - the classic consecutive "stopped taking actions" stall (almost always
+//     context exhaustion / reasoning loop, not a target problem).
 func classifyNoToolAbort(state *ScanState) (reason, detail string) {
 	if state != nil && state.RefusalCount >= 3 {
 		return "llm_safety_refusal", "Agent stopped: the model repeatedly declined to run the assessment (safety refusal) across 15 responses. This is a model-side refusal, not a target or scanner issue — switch to a model that permits authorized security testing."
+	}
+	if state != nil && state.TotalNoToolResponses >= ReasoningDensityMinResponses {
+		iters := state.Iteration + 1
+		if iters >= ReasoningDensityAbortMinIters {
+			ratio := float64(state.TotalNoToolResponses) / float64(iters)
+			if ratio > ReasoningDensityAbortRatio {
+				return "llm_reasoning_loop", fmt.Sprintf(
+					"Agent stopped: reasoning loop — %d of %d iterations (%.0f%%) produced no tool call after %d context compactions. The model spent most of its turns reasoning without acting. Lower the reasoning effort (XALGORIX_REASONING_EFFORT), switch to a less reasoning-heavy model, or reduce the amount of raw output fed back (grep/head instead of cat).",
+					state.TotalNoToolResponses, iters, ratio*100, state.ReasoningLoopCompactions+state.DensityCompactions)
+			}
+		}
 	}
 	return "llm_no_tool_calls", "Agent stopped: the model returned 15 consecutive responses with NO tool call — it stopped taking actions. This is typically caused by a very large tool output flooding the context (e.g. dumping a whole JS bundle or page instead of grepping it) or a reasoning loop — not by the target being unscannable."
 }

--- a/internal/agent/reasoning_loop_test.go
+++ b/internal/agent/reasoning_loop_test.go
@@ -1,0 +1,154 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+// hookNoToolHandler must trigger a context compaction (ForceCompact) at the
+// first consecutive threshold (6), not wait until the abort at 15. This is the
+// reasoning-loop recovery path — without it the scan force-stops on the exact
+// "llm_no_tool_calls" failure the reaper-search.biz scan hit.
+func TestNoToolHandlerCompactsBeforeAbort(t *testing.T) {
+	state := NewScanState()
+
+	// Iterations 1-5: plain nudges, no compaction yet.
+	for i := 0; i < ReasoningLoopCompactAt-1; i++ {
+		res := hookNoToolHandler(state, map[string]string{"response": "let me think"})
+		if res.ForceSkip {
+			t.Fatalf("iter %d: ForceSkip before the abort threshold", i)
+		}
+		if res.ForceCompact {
+			t.Fatalf("iter %d: ForceCompact fired before ReasoningLoopCompactAt (%d)", i, ReasoningLoopCompactAt)
+		}
+		if state.ReasoningLoopCompactions != 0 {
+			t.Fatalf("iter %d: compaction counter incremented too early", i)
+		}
+	}
+
+	// Iteration 6 (NoToolCount == ReasoningLoopCompactAt): first compaction.
+	res := hookNoToolHandler(state, map[string]string{"response": "let me think"})
+	if !res.ForceCompact {
+		t.Fatalf("NoToolCount=%d: expected ForceCompact, got %+v", state.NoToolCount, res)
+	}
+	if state.ReasoningLoopCompactions != 1 {
+		t.Fatalf("after first compact: ReasoningLoopCompactions=%d, want 1", state.ReasoningLoopCompactions)
+	}
+	if res.Nudge == "" {
+		t.Fatal("ForceCompact result must carry a focused resume nudge")
+	}
+	if !strings.Contains(res.Nudge, "tool call") && !strings.Contains(res.Nudge, "terminal_execute") {
+		t.Errorf("resume nudge should demand a tool call, got %q", res.Nudge)
+	}
+	if res.ForceSkip {
+		t.Fatal("first compaction must NOT abort the scan")
+	}
+
+	// The abort at 15 only fires after the compaction cap is exhausted. Walk
+	// the count up past the second compaction (at 10) and toward the abort.
+	// NoToolCount is NOT reset by the compaction, so it keeps climbing.
+	for i := state.NoToolCount; i < ReasoningLoopCompactAt2; i++ {
+		hookNoToolHandler(state, map[string]string{"response": "thinking"})
+	}
+	res = hookNoToolHandler(state, map[string]string{"response": "thinking"})
+	if state.ReasoningLoopCompactions > MaxReasoningCompactions {
+		t.Fatalf("ReasoningLoopCompactions=%d exceeds MaxReasoningCompactions=%d", state.ReasoningLoopCompactions, MaxReasoningCompactions)
+	}
+
+	// Drive to the abort. After MaxReasoningCompactions, ForceCompact stops
+	// firing and the count climbs to NoToolAbortAt, which ForceSkips.
+	for state.NoToolCount < NoToolAbortAt {
+		res = hookNoToolHandler(state, map[string]string{"response": "thinking"})
+	}
+	if !res.ForceSkip {
+		t.Fatalf("NoToolCount=%d: expected ForceSkip (abort), got %+v", state.NoToolCount, res)
+	}
+}
+
+// The density path must catch a model that makes occasional tool calls —
+// enough to reset the consecutive counter but not enough to make progress —
+// which would otherwise run for hours. This is the exact 48-hour pattern:
+// NoToolCount never reaches the consecutive threshold (6) so the consecutive
+// recovery never fires, and without the density abort the scan runs forever.
+func TestNoToolHandlerDensityRecovery(t *testing.T) {
+	state := NewScanState()
+
+	// Simulate the non-consecutive pattern: a tool call every 5 turns resets
+	// NoToolCount to ≤4, so the consecutive compact (needs ≥6) never fires.
+	// 4 of 5 turns are no-tool → ratio 0.8, which clears both the compact
+	// (>0.6) and abort (>0.75) thresholds. Drive enough iterations that the
+	// cumulative density crosses compact, then (after a compaction) abort.
+	var sawCompact, sawAbort bool
+	for i := 0; i < 200; i++ {
+		// Reset the consecutive counter on a tool call (mimics OnHealthyResponse).
+		if i%5 == 0 {
+			state.NoToolCount = 0
+			state.Iteration++
+			continue
+		}
+		state.Iteration++
+		res := hookNoToolHandler(state, map[string]string{"response": "thinking"})
+
+		if res.ForceCompact {
+			sawCompact = true
+		}
+		if res.ForceSkip {
+			sawAbort = true
+			break
+		}
+	}
+	if !sawCompact {
+		t.Fatalf("density path never compacted — TotalNoToolResponses=%d Iteration=%d (recovery should fire at ratio > %.2f)",
+			state.TotalNoToolResponses, state.Iteration, ReasoningDensityCompactRatio)
+	}
+	if !sawAbort {
+		t.Fatalf("density abort never fired for a non-consecutive reasoning loop — NoToolCount stayed ≤%d so the consecutive path never tripped, and the density abort was expected to catch it. TotalNoToolResponses=%d Iteration=%d",
+			state.NoToolCount, state.TotalNoToolResponses, state.Iteration)
+	}
+	// The abort reason must classify as the reasoning loop, not the generic stall.
+	reason, _ := classifyNoToolAbort(state)
+	if reason != "llm_reasoning_loop" {
+		t.Errorf("classifyNoToolAbort reason = %q, want llm_reasoning_loop", reason)
+	}
+}
+
+// classifyNoToolAbort must report the density-based reasoning loop as a
+// distinct reason from the consecutive stall, so operators can tell a
+// "ran for hours making no progress" scan from a "flooded context" scan.
+func TestClassifyNoToolAbortDensityReason(t *testing.T) {
+	state := &ScanState{
+		NoToolCount:          NoToolAbortAt,
+		RefusalCount:         0,
+		TotalNoToolResponses: 60,
+		Iteration:            49, // 50 iters
+	}
+	reason, detail := classifyNoToolAbort(state)
+	if reason != "llm_reasoning_loop" {
+		t.Errorf("reason = %q, want llm_reasoning_loop", reason)
+	}
+	if !strings.Contains(strings.ToLower(detail), "reasoning loop") {
+		t.Errorf("density detail should mention reasoning loop, got %q", detail)
+	}
+}
+
+// A safety refusal must still take priority over both recovery paths.
+func TestNoToolHandlerRefusalPriority(t *testing.T) {
+	state := NewScanState()
+	// Three refusals → RefusalCount climbs; the authorization nudge must fire,
+	// not a compaction or abort.
+	for i := 0; i < 3; i++ {
+		res := hookNoToolHandler(state, map[string]string{"response": "I cannot fulfill this request"})
+		if res.ForceSkip {
+			t.Fatal("refusal should nudge, not abort, before the 15 threshold")
+		}
+		if res.ForceCompact {
+			t.Fatal("refusal should not trigger compaction")
+		}
+		if !strings.Contains(res.Nudge, "AUTHORIZED") {
+			t.Errorf("refusal nudge should re-assert authorization, got %q", res.Nudge)
+		}
+	}
+	if state.RefusalCount != 3 {
+		t.Errorf("RefusalCount=%d, want 3", state.RefusalCount)
+	}
+}


### PR DESCRIPTION
## Problem

`llm_no_tool_calls` was the single biggest cause of failed scans (~50%): the model degrades into a think-only reasoning loop and the scan force-stops at 15 consecutive no-tool responses, losing all work.

Observed on `reaper-search.biz` — iterations 19-38 emitted only `thinking` events with zero tool calls (pure `<think>` blocks), then force-aborted at iteration 39.

## Root cause

1. **Nudges never reset the noisy context.** The no-tool handler nudged at count 3/8, but nudges just add text to the already-noisy context (loaded skill docs + capped-but-still-noisy tool output). They never compacted the context that caused the loop.

2. **Proactive pruning never fired.** `shouldPruneBeforeLLM()` only triggers at 500 KB. The failing scan's context was ~200 KB — under the threshold, so no compaction ever ran and the model stayed stuck reasoning in the same noisy window.

3. **The 48-hour failure pattern.** `OnHealthyResponse` resets `NoToolCount` to 0 on any single tool call. A model that reasons ~10 turns then calls a tool once, repeatedly, never reaches 15 consecutive — so the abort never fires and the scan runs forever (no duration ceiling: `MaxDurationSec` defaults to 0, watchdog `scanMaxDuration` hardcoded to 0).

## Fix — two recovery paths, both backed by context compaction

### 1. Consecutive recovery
At **6/10** consecutive no-tool responses (not 15), force-compact the conversation (`forcePruneMessages` collapses raw output + loaded skill docs into a digest) and inject a focused `STOP reasoning, call a tool NOW` resume prompt. The scan only aborts at 15 if both compactions fail.

### 2. Density recovery (non-consecutive)
New cumulative counters (`TotalNoToolResponses`, never reset) catch the 48-hour pattern. Once 20+ no-tool responses accumulate:
- ratio >0.6 → compact once
- ratio >0.75 past 40 iterations → abort cleanly with a distinct `llm_reasoning_loop` reason

### New `ForceCompact` hook signal
The loop calls `forcePruneMessages()` before injecting the resume nudge, so the focused prompt lands in a clean window instead of on top of the noise.

### Better abort reasons
`classifyNoToolAbort` now distinguishes `llm_safety_refusal`, `llm_reasoning_loop`, and `llm_no_tool_calls` so the dashboard surfaces the real cause + actionable fix (lower reasoning effort / switch model).

## Review-driven fixes

A local review caught three bugs in the initial implementation, all fixed in this PR:
- **CRITICAL:** density abort was unreachable for the exact non-consecutive pattern it was built to catch (the 48h bug) — gated on `totalCompactions >= 2` which only the consecutive path could supply. Fixed: abort on density ratio alone once ≥1 compaction attempted.
- **WARNING:** consecutive guards didn't check the combined compaction cap, allowing 3 compactions (1 density + 2 consecutive) > `MaxReasoningCompactions=2`. Fixed: both guards use `totalCompactions`.
- **WARNING:** density test passed without exercising the abort path. Fixed: test now fails on buggy code, passes on fixed code.

## What changes for operators

- Scans that previously force-aborted with `llm_no_tool_calls` will now **compact and recover** at iteration ~6 — the same target becomes scannable.
- Scans that ran 48h (occasional tool call resetting the counter) now get density-detected and either recover or abort cleanly with a clear message instead of hanging.
- For MiniMax-M3 + xhigh reasoning: the density path catches the reasoning-heavy pattern and tells the operator to drop to `high`/`medium` — the real lever for this model class.

## Verification

```
go build ./...          # clean
go vet ./internal/agent/ # clean
gofmt -l ...            # clean
go test ./internal/agent/ -count=1   # all pass
go test ./internal/web/ -count=1     # all pass
```

New tests in `reasoning_loop_test.go`:
- `TestNoToolHandlerCompactsBeforeAbort` — consecutive compaction at 6/10 before abort at 15
- `TestNoToolHandlerDensityRecovery` — non-consecutive pattern (fails on buggy code, passes on fix)
- `TestClassifyNoToolAbortDensityReason` — distinct `llm_reasoning_loop` reason
- `TestNoToolHandlerRefusalPriority` — safety refusal still takes priority

> [!IMPORTANT]
> Use Xalgorix only on systems you own or have explicit permission to test.