### PR TITLE
Fix/pr264 misspell lint

### DIFF
--- a/internal/web/handlers_provider_models.go
+++ b/internal/web/handlers_provider_models.go
@@ -56,10 +56,28 @@ func (s *Server) handleDiscoverProviderModels(w http.ResponseWriter, r *http.Req
 	writeJSONStatus(w, http.StatusOK, discoveredModelsResponse{Models: models, Source: "remote"})
 }
 
+// activeConfigTargetsProvider reports whether the operator's persisted active
+// LLM config (XALGORIX_LLM*) targets providerID. It matches either the legacy
+// "<provider>/<model>" prefix carried on XALGORIX_LLM or the explicit
+// XALGORIX_LLM_PROVIDER routing field, which deliberately keeps the provider
+// separate from a bare, provider-native model name (for example
+// LLMProvider="deepseek" with LLM="deepseek-v4-pro"). Without the LLMProvider
+// branch, discovery for such providers falls through to "save or select
+// credentials" even though the active credentials are already persisted.
+func (s *Server) activeConfigTargetsProvider(providerID string) bool {
+	if s.cfg == nil {
+		return false
+	}
+	if strings.HasPrefix(s.cfg.LLM, providerID+"/") {
+		return true
+	}
+	return strings.TrimSpace(s.cfg.LLMProvider) == providerID
+}
+
 func (s *Server) modelDiscoveryConfig(r *http.Request, entry providers.Entry) (providers.Entry, string, string, error) {
 	for _, method := range entry.AuthMethods {
 		if method == "none" {
-			if s.cfg != nil && strings.HasPrefix(s.cfg.LLM, entry.ID+"/") && strings.TrimSpace(s.cfg.APIBase) != "" {
+			if s.activeConfigTargetsProvider(entry.ID) && strings.TrimSpace(s.cfg.APIBase) != "" {
 				entry.BaseURL = strings.TrimSpace(s.cfg.APIBase)
 			}
 			return entry, "", "", nil
@@ -85,7 +103,7 @@ func (s *Server) modelDiscoveryConfig(r *http.Request, entry providers.Entry) (p
 		}
 		return entry, strings.TrimSpace(profile.APIKey), "", nil
 	}
-	if s.cfg != nil && strings.HasPrefix(s.cfg.LLM, entry.ID+"/") {
+	if s.activeConfigTargetsProvider(entry.ID) {
 		if strings.TrimSpace(s.cfg.APIBase) != "" {
 			entry.BaseURL = strings.TrimSpace(s.cfg.APIBase)
 		}

--- a/internal/web/handlers_provider_models_test.go
+++ b/internal/web/handlers_provider_models_test.go
@@ -106,7 +106,7 @@ func TestProviderModelsURLsUsesCodexCatalogProtocol(t *testing.T) {
 func TestModelDiscoveryConfigMatchesActiveProviderByLLMProvider(t *testing.T) {
 	// Providers routed via XALGORIX_LLM_PROVIDER (for example DeepSeek) persist a
 	// bare, provider-native model name with no "<provider>/" prefix on XALGORIX_LLM
-	// (LLMProvider="deepseek", LLM="deepseek-v4-pro"). Discovery must recognise the
+	// (LLMProvider="deepseek", LLM="deepseek-v4-pro"). Discovery must recognize the
 	// active provider from LLMProvider and reuse the saved credentials instead of
 	// failing with "save or select credentials before scanning models".
 	req := httptest.NewRequest(http.MethodGet, "/api/providers/deepseek/models", nil)

--- a/internal/web/handlers_provider_models_test.go
+++ b/internal/web/handlers_provider_models_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/xalgord/xalgorix/v4/internal/config"
 	"github.com/xalgord/xalgorix/v4/internal/providers"
 )
 
@@ -99,5 +100,36 @@ func TestProviderModelsURLsUsesCodexCatalogProtocol(t *testing.T) {
 	want := "https://chatgpt.com/backend-api/codex/models?client_version=" + codexModelsClientVersion
 	if len(urls) != 1 || urls[0] != want {
 		t.Fatalf("URLs = %v, want [%s]", urls, want)
+	}
+}
+
+func TestModelDiscoveryConfigMatchesActiveProviderByLLMProvider(t *testing.T) {
+	// Providers routed via XALGORIX_LLM_PROVIDER (for example DeepSeek) persist a
+	// bare, provider-native model name with no "<provider>/" prefix on XALGORIX_LLM
+	// (LLMProvider="deepseek", LLM="deepseek-v4-pro"). Discovery must recognise the
+	// active provider from LLMProvider and reuse the saved credentials instead of
+	// failing with "save or select credentials before scanning models".
+	req := httptest.NewRequest(http.MethodGet, "/api/providers/deepseek/models", nil)
+	entry := providers.Entry{
+		ID: "deepseek", BaseURL: "https://api.deepseek.com/v1", HeaderStyle: "openai", AuthMethods: []string{"api_key"},
+	}
+	srv := &Server{cfg: &config.Config{
+		LLM:         "deepseek-v4-pro",
+		LLMProvider: "deepseek",
+		APIKey:      "secret",
+		APIBase:     "https://api.deepseek.com/v1",
+	}}
+	got, credential, accountID, err := srv.modelDiscoveryConfig(req, entry)
+	if err != nil {
+		t.Fatalf("modelDiscoveryConfig returned error: %v", err)
+	}
+	if credential != "secret" {
+		t.Fatalf("credential = %q, want %q", credential, "secret")
+	}
+	if accountID != "" {
+		t.Fatalf("accountID = %q, want empty", accountID)
+	}
+	if got.BaseURL != "https://api.deepseek.com/v1" {
+		t.Fatalf("BaseURL = %q, want %q", got.BaseURL, "https://api.deepseek.com/v1")
 	}
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Xalgorix! Please fill this out so we can review quickly.
`main` is branch-protected — PRs are the only way in. CI runs make lint,
golangci-lint, go vet, and the test suite on every PR.
-->

## What & why

<!-- What does this change and why? Link the issue it addresses. -->

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Refactor / internal
- [ ] Other:

## How was it tested?

<!-- Commands you ran, new tests added, manual verification. -->

- [ ] `make lint` passes
- [ ] `golangci-lint run --config .golangci.yml ./...` passes
- [ ] `go test ./...` passes
- [ ] Added/updated tests for the change

## Checklist

- [ ] I read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md).
- [ ] The tree is `gofmt`-clean.
- [ ] I updated docs (`README`, `docs/`, help text) if behavior changed.
- [ ] This does not weaken a security control (scope guard, verifier, false-positive gate) without explicit discussion.
- [ ] For engine behavior changes: I noted any impact on scan findings/severity.
