### PR TITLE
fix(webui): serve missing dev-mock endpoints so the dashboard renders offline

### DIFF
--- a/webui/mock-backend.mjs
+++ b/webui/mock-backend.mjs
@@ -124,8 +124,66 @@ let state = {
   },
   rateLimit: { requests: 60, window: 60 },
   agentMail: { pod: "ops-pod-1", apiKey: "", hasApiKey: true },
+  schedules: [],
+  authProfiles: [],
   reqCounter: 0,
 };
+
+const providerCatalog = [
+  { id: "openai", displayName: "OpenAI", baseURL: "https://api.openai.com/v1", headerStyle: "openai", authMethods: ["api_key"], models: ["gpt-5", "gpt-5-mini"] },
+  { id: "google", displayName: "Google Gemini", baseURL: "https://generativelanguage.googleapis.com/v1beta", headerStyle: "gemini", authMethods: ["api_key"], models: ["gemini-2.5-pro", "gemini-2.5-flash"] },
+];
+
+const llmSettings = {
+  model: "",
+  apiBase: "",
+  apiKey: "",
+  hasApiKey: false,
+  reasoningEffort: "high",
+  ollamaCompatible: false,
+  llmMaxRetries: 3,
+  memoryCompressorTimeout: 120,
+  maxIterations: 40,
+  geminiApiKey: "",
+  hasGeminiApiKey: false,
+  envFile: "~/.xalgorix.env",
+  provider: "",
+  authMethod: "api_key",
+  profiles: [],
+};
+
+// Flatten every seeded instance vuln into the FlatFinding shape the
+// /findings page and Overview totals consume, so the list, the summary
+// widget and the per-scan counts all agree.
+function allFindings() {
+  const out = [];
+  for (const inst of state.instances) {
+    for (const v of inst.vulns || []) {
+      out.push({
+        ...v,
+        scan_id: inst.id,
+        scan_target: inst.parent_target || inst.targets,
+        scan_started_at: inst.started_at,
+        verified: v.severity === "critical" || v.severity === "high",
+        tags: [],
+      });
+    }
+  }
+  return out;
+}
+
+function findingsSummary() {
+  const totals = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+  for (const f of allFindings()) {
+    const sev = (f.severity || "").toLowerCase();
+    if (sev in totals) totals[sev] += 1;
+  }
+  return {
+    totals,
+    as_of: nowIso(),
+    etag: `mock-${totals.critical}${totals.high}${totals.medium}${totals.low}${totals.info}`,
+  };
+}
 
 function runningInstance() {
   return state.instances.find((i) => i.status === "running");
@@ -410,7 +468,50 @@ const server = http.createServer(async (req, res) => {
     });
   }
 
-  // Default
+  // -------- Findings list + on-disk summary --------------------------------
+  if (method === "GET" && url === "/api/findings") {
+    return send(res, allFindings());
+  }
+  if (method === "GET" && url === "/api/findings/summary") {
+    return send(res, findingsSummary());
+  }
+
+  // -------- Per-instance persisted event history ---------------------------
+  // The live feed streams over the WebSocket below; there is no synthetic
+  // backlog, so return an empty (but valid) WSEvent[] history.
+  if (method === "GET" && /^\/api\/instances\/[^/]+\/events$/.test(url)) {
+    return send(res, []);
+  }
+
+  // -------- Schedules ------------------------------------------------------
+  if (method === "GET" && url === "/api/schedules") {
+    return send(res, state.schedules);
+  }
+
+  // -------- Provider catalog + stored auth profiles ------------------------
+  if (method === "GET" && url === "/api/providers") {
+    return send(res, providerCatalog);
+  }
+  if (method === "GET" && url === "/api/auth/profiles") {
+    return send(res, state.authProfiles);
+  }
+
+  // -------- LLM / environment / legacy-import settings ---------------------
+  if (method === "GET" && url === "/api/settings/llm") {
+    return send(res, llmSettings);
+  }
+  if (method === "GET" && url === "/api/settings/environment") {
+    return send(res, { envFile: "~/.xalgorix.env", variables: [], restartRequired: false });
+  }
+  if (method === "GET" && url === "/api/legacy-import/status") {
+    return send(res, { count: 0, dismissed: true });
+  }
+
+  // Default. For an unhandled GET /api/* route fall back to an empty array
+  // so a forgotten endpoint degrades to an empty collection instead of an
+  // object that crashes array consumers with "(...).map is not a function".
+  // Non-GET keeps the neutral ok envelope.
+  if (method === "GET" && url.startsWith("/api/")) return send(res, []);
   send(res, { ok: true });
 });
 


### PR DESCRIPTION
## What

The dev mock backend (`webui/mock-backend.mjs`) only implemented a subset of the API. Every other `/api/*` route fell through to the default handler, which returns `{ ok: true }` — an **object**. Pages that `.map()`/`.find()` over the response then threw `X.map is not a function`, and React Router replaced the whole page with its default error boundary. So running the SPA against the mock (`npm run dev`, no real backend) crashed on load:

| Page | Endpoint that returned `{ ok: true }` | Crash |
|---|---|---|
| Overview | `/api/instances/:id/events` | `(q.data ?? []).map is not a function` |
| New scan | `/api/auth/profiles` | `profiles.map is not a function` |
| Settings | `/api/settings/environment` | `Cannot read properties of undefined (reading 'find')` |
| Findings / Schedules | `/api/findings`, `/api/schedules`, `/api/providers` | `.map is not a function` |

## Fix

Implement the missing GET endpoints with the shapes their consumers expect (mirroring `internal/web/*` and `webui/src/types/api.ts`):

- **`/api/findings` + `/api/findings/summary`** — derived from the already-seeded instance vulns, so the list, the summary widget and the per-scan counts all agree.
- **`/api/instances/:id/events`** — empty (but valid) `WSEvent[]`; the live feed still streams over the WebSocket.
- **`/api/schedules`, `/api/auth/profiles`** — (empty) arrays held in `state`.
- **`/api/providers`** — a small `CatalogEntry[]`.
- **`/api/settings/llm`, `/api/settings/environment`, `/api/legacy-import/status`** — correctly-shaped objects.

And make the fallback safer: an unhandled **GET** `/api/*` now returns `[]` instead of `{ ok: true }`, so a future forgotten endpoint degrades to an empty collection instead of crashing array consumers. Non-GET keeps the neutral `ok` envelope.

## Testing

`node --check webui/mock-backend.mjs` passes. Ran `npm run dev` and walked every page — Overview (live feed + finding mix), New scan, Findings (shows the seeded vulns with consistent severity totals: 1 crit / 2 high / 1 med / 1 low), Reports, Schedules, Settings (all tabs), scan detail — all render with a clean console. **No application code changed.**

Found while smoke-testing the React 19 dependency bump (#267).