### PR TITLE
feat(agent): structural, coverage-grounded task planner

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -50,6 +50,17 @@ var toolHardTimeout = map[string]time.Duration{
 	"browser_action":   10 * time.Minute,
 }
 
+// init injects the notes-blob accessor into the hooks package so the planner
+// hook can read the saved endpoint inventory without hooks.go importing the
+// notes package (which would form an import cycle: notes imports tools, and
+// the agent tool registry is wired from this package). agent.go already
+// imports notes for pruning, so this is the natural place to bridge it.
+func init() {
+	notesBlobForContext = func(scanContextID string) string {
+		return notes.FormatForContextID(scanContextID)
+	}
+}
+
 // defaultToolHardTimeout is the per-invocation hard ceiling applied to any
 // tool not explicitly listed in toolHardTimeout.
 const defaultToolHardTimeout = 15 * time.Minute
@@ -274,11 +285,18 @@ func NewAgent(cfg *config.Config, name string, events chan Event, localGuard sco
 
 	// Apply per-call AgentOption values (e.g. WithLLMClient). Options
 	// run after the default client is constructed so a nil option
-	// leaves the default in place; WithLLMClient overwrites it with
-	// a caller-supplied client carrying a per-scan resolver.
+	// leaves the default in place; WithLLMClient overwrites it with a
+	// caller-supplied client carrying a per-scan resolver.
 	for _, opt := range opts {
 		opt(a)
 	}
+
+	// Register the structural planner tools (build_plan / update_plan). These
+	// mutate a.state.Plan, so they're registered after the agent exists. They
+	// let the LLM author/refine the task graph with knowledge only it has
+	// (live recon output the engine can't fully parse); the auto-plan + the
+	// per-iteration nudge + the finish gate all consult the same plan.
+	a.registerPlanTools(reg)
 
 	// Create cancellable context
 	a.ctx, a.cancel = context.WithCancel(a.ctx)
@@ -673,6 +691,7 @@ func (a *Agent) Run(targets []string, instruction string) {
 
 	// Initialize scan state for hooks (replaces 17+ local tracking variables)
 	a.state = NewScanState()
+	a.state.ScanContextID = a.scanCtx.ID
 	a.state.DiscoveryMode = a.discoveryMode
 	a.state.AllowedPhases = append([]int(nil), a.allowedPhases...)
 	a.state.ReconOnlyMode = isReconReportOnlyPhaseSelection(a.allowedPhases)

--- a/internal/agent/agent_prompt.go
+++ b/internal/agent/agent_prompt.go
@@ -121,8 +121,38 @@ Breadth is a trap. Running one payload against twenty endpoints finds nothing; f
 4. **LARGE TARGET LISTS**: If you are testing multiple targets at once (e.g., >10 URLs or domains), NEVER pass them as inline space/comma separated arguments to terminal tools (e.g. 'nmap a b c d e f g h...'). This causes OS "file name too long" argument crashes! ALWAYS save the targets to a text file first (e.g. 'echo -e "t1\nt2\n..." > targets.txt') and pass the file to the tool using input list flags (e.g. 'subfinder -dL targets.txt', 'httpx -l targets.txt', 'nmap -iL targets.txt', 'findomain -f targets.txt').
 5. If a tool or command fails, try alternatives. NEVER give up after one failure.
 6. Minimum 50 iterations for a thorough assessment. Don't rush to finish.
-7. Use notes (add_note) to track discovered endpoints, parameters, and findings. Read notes before each phase.
-8. **WORKSPACE**: You are ALREADY executing inside a dedicated, isolated workspace directory perfectly prepared for this target. NEVER use 'cd' to escape or change directories (e.g. do not run 'cd /root && mkdir pentest'). Write your outputs directly to your current working directory (e.g. 'nmap -oN scan.txt').
+ 7. Use notes (add_note) to track discovered endpoints, parameters, and findings. Read notes before each phase.
+ 8. **WORKSPACE**: You are ALREADY executing inside a dedicated, isolated workspace directory perfectly prepared for this target. NEVER use 'cd' to escape or change directories (e.g. do not run 'cd /root && mkdir pentest'). Write your outputs directly to your current working directory (e.g. 'nmap -oN scan.txt').
+
+## STRUCTURED PLANNING — DECOMPOSE BEFORE YOU TEST
+
+This engine tracks a STRUCTURAL task plan, not just your train of thought. A plan is an ordered, dependency-tracked task graph grounded in the endpoints you actually discovered. The engine gates finish on a complete plan and shows you the next pending task + coverage gaps every iteration. Use it — it is what keeps you from self-declaring a phase "done" after one payload and finishing with half the surface untested.
+
+**After Phase 1 recon (once you know the real endpoint surface):**
+- Save your endpoint inventory with add_note (a note titled 'Endpoint Inventory' listing every /path you found). The engine parses it to ground the plan's coverage math.
+- Call **build_plan** with a JSON array of coarse tasks. One task per (vuln class × endpoint group), each mapping to a methodology phase (1-22). Example:
+  <function=build_plan>
+  <parameter=tasks>[
+    {"id":"recon","title":"Recon + fingerprint + endpoint inventory","phase":1,"depends_on":[]},
+    {"id":"test-sqli","title":"Test all /api/* endpoints for SQL injection","phase":6,"vuln_class":"sqli","depends_on":["recon"]},
+    {"id":"test-xss","title":"Test reflected/stored XSS on input params","phase":6,"vuln_class":"xss","depends_on":["recon"]},
+    {"id":"idor","title":"IDOR / broken access control on /api/users, /api/leads","phase":8,"vuln_class":"idor","depends_on":["recon"]},
+    {"id":"verify","title":"Exploit verification (Phase 20)","phase":20,"depends_on":["test-sqli","test-xss","idor"]},
+    {"id":"report","title":"Final report (Phase 22)","phase":22,"depends_on":["verify"]}
+  ]</parameter>
+  </function>
+
+- If you DON'T call build_plan, the engine auto-builds one from your endpoint inventory + detected techs. Either way the plan is tracked.
+
+**As you work:**
+- The engine auto-marks a task completed when it sees coverage evidence for that vuln class. You only need **update_plan** to mark a task 'skipped' when it genuinely doesn't apply (e.g. no auth surface → skip 'auth-session'), or 'active' to signal you've started it.
+  <function=update_plan>
+  <parameter=task_id>auth-session</parameter>
+  <parameter=status>skipped</parameter>
+  <parameter=notes>target has no login flow</parameter>
+  </function>
+
+**Before finish:** every plan task must be completed or skipped (except verify/report, which ARE the finish step). The engine will block finish and list the remaining tasks if you try to finish early — do not argue with the gate, work or skip the listed tasks.
 
 %s
 

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"net/url"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -27,12 +28,22 @@ const (
 	OnHealthyResponse = "OnHealthyResponse" // After a non-empty response with tool calls (resets error counters)
 )
 
+// notesBlobForContext is injected by agent.go (which can import
+// internal/tools/notes) so the planner hook can read the saved notes — the
+// authoritative endpoint inventory — without hooks.go taking a dependency on
+// the notes package (which would create an import cycle: notes imports tools,
+// and the agent registry is wired from agent.go). agent.go sets this once at
+// package init via notes.FormatForContextID. nil falls back to "" (no notes),
+// which simply skips plan grounding from notes.
+var notesBlobForContext func(scanContextID string) string
+
 // ── Scan State ───────────────────────────────────────────────────────────────
 
 // ScanState holds all mutable state that hooks can read and write.
 // It replaces the loose local variables previously scattered in Run().
 type ScanState struct {
 	Iteration                  int
+	ScanContextID              string // owning scan-context ID, so hooks can reach shared stores (notes) without an import cycle
 	TerminalCalls              int
 	SkillsLoaded               int
 	UniqueToolsUsed            map[string]bool
@@ -132,6 +143,23 @@ type ScanState struct {
 	ReasoningLoopCompactions int
 	TotalNoToolResponses     int
 	DensityCompactions       int
+
+	// Plan is the structural task graph for this scan. nil until recon has
+	// surfaced surface (or the LLM calls build_plan). Shared across sub-agents
+	// because ScanState is the same object within a ScanContext. The plan is
+	// the decomposition layer: it turns the scan goal into ordered, dependency
+	// tracked tasks grounded in the discovered endpoints + detected techs, and
+	// the finish gate + per-iteration nudge consult it so the agent covers the
+	// surface instead of self-declaring phases "done" after one payload.
+	Plan *Plan
+	// PlanBuilt reports whether a plan has been built (auto or by the LLM) so
+	// the post-recon nudge fires only once.
+	PlanBuilt bool
+	// DiscoveredEndpoints is the endpoint list surfaced by recon (notes /
+	// seeded attack surface). The planner's coverage-gap detection cross-
+	// references this against EndpointsTested. Populated by the plan hooks
+	// from the seeded surface and the "Endpoint Inventory" note.
+	DiscoveredEndpoints []string
 
 	// New enrichment hooks
 	WAFDetected          bool
@@ -335,6 +363,7 @@ func RegisterDefaultHooks(reg *HookRegistry) {
 	reg.Register(OnEmptyResponse, hookEmptyResponseHandler)
 	reg.Register(OnNoToolResponse, hookNoToolHandler)
 	reg.Register(OnIterationStart, hookAutoSkillSuggester)
+	reg.Register(OnIterationStart, hookPlanner)
 	reg.Register(OnHealthyResponse, hookResetOnSuccess)
 }
 
@@ -1177,6 +1206,40 @@ Continue testing. Call finish again after iteration 50.`, iter, coverageNote, sc
 		}
 	}
 
+	// ── Plan-based finish gate ──
+	// If a structural plan exists and still has actionable pending tasks (any
+	// task that isn't the verify/report tail), block finish with the specific
+	// remaining tasks. The verify + report tasks are the plan's own finish
+	// step, so they don't block — completing them IS finishing. This is the
+	// decomposition layer's enforcement: an unfinished plan means the surface
+	// isn't covered, regardless of iteration count.
+	if state.Plan != nil && !state.Plan.IsEmpty() {
+		var remaining []string
+		for _, t := range state.Plan.Tasks {
+			if t.Status != TaskPending && t.Status != TaskActive {
+				continue
+			}
+			if t.ID == "verify" || t.ID == "report" {
+				continue // the finish step itself
+			}
+			remaining = append(remaining, fmt.Sprintf("  • [%s] phase %d — %s", t.ID, t.Phase, t.Title))
+		}
+		if len(remaining) > 0 {
+			// Cap the list so a huge plan doesn't flood the block reason.
+			list := strings.Join(remaining, "\n")
+			if len(remaining) > 8 {
+				list = strings.Join(remaining[:8], "\n") + fmt.Sprintf("\n  … +%d more", len(remaining)-8)
+			}
+			return HookResult{
+				Block: true,
+				BlockReason: fmt.Sprintf("Your scan plan still has %d unfinished task(s):\n%s\n\n"+
+					"Complete or skip each before finishing. Call update_plan with status 'skipped' for "+
+					"tasks that don't apply to this target (e.g. no auth surface → skip 'auth-session').",
+					len(remaining), list),
+			}
+		}
+	}
+
 	// After 50 iterations with coverage met: allow finish
 	return HookResult{}
 }
@@ -1526,6 +1589,139 @@ func hookAutoSkillSuggester(state *ScanState, args map[string]string) HookResult
 
 Skills contain expert-level payloads, WAF bypass techniques, and technology-specific attack chains that significantly improve testing depth.`, strings.Join(suggestions, "\n")),
 	}
+}
+
+// ── hookPlanner ──────────────────────────────────────────────────────────────
+// OnIterationStart: builds the structural plan once recon has surfaced an
+// endpoint inventory (or immediately if a seeded attack surface exists), then
+// injects the plan brief + coverage gaps every iteration so the agent works the
+// next pending task instead of looping or self-declaring phases "done".
+//
+// The plan is grounded in the discovered endpoints + detected techs (recon
+// output the engine CAN parse: the seeded surface and the "Endpoint Inventory"
+// note). The LLM can replace/refine it via the build_plan tool; this hook only
+// auto-builds when no plan exists yet and recon data is available.
+func hookPlanner(state *ScanState, args map[string]string) HookResult {
+	if state == nil || state.ReconOnlyMode {
+		return HookResult{}
+	}
+
+	// Refresh discovered endpoints from notes once an inventory has been saved
+	// (hookWorkTracker flips EndpointInventorySaved). This grounds the plan +
+	// the coverage-gap math in what recon actually surfaced.
+	if state.EndpointInventorySaved {
+		state.DiscoveredEndpoints = extractEndpointsFromNotes(state)
+	}
+
+	// Auto-build a plan once recon is done and we have either a seeded surface
+	// or a discovered inventory. The LLM may have already called build_plan, in
+	// which case PlanBuilt is true and we leave its plan alone.
+	if !state.PlanBuilt && state.Plan == nil && state.ReconDone &&
+		(len(state.DiscoveredEndpoints) > 0 || len(state.DetectedTechs) > 0) {
+		state.Plan = AutoPlan(state.DiscoveredEndpoints, state.DetectedTechs)
+		state.PlanBuilt = true
+	}
+
+	// Reconcile plan status against live coverage: any task whose vuln class
+	// now has coverage evidence (VulnClassesTested) is marked completed so the
+	// plan reflects reality, not the model's self-report.
+	reconcilePlan(state)
+
+	// Inject the plan brief + coverage gaps as a per-iteration nudge. Keep it
+	// quiet once the plan is fully done (the finish gate handles the final
+	// gate) to avoid spamming the context after completion.
+	if state.Plan != nil && state.Plan.RemainingCount() > 0 {
+		gaps := CoverageGaps(state, state.DiscoveredEndpoints)
+		brief := FormatPlan(state.Plan, gaps)
+		if brief != "" {
+			return HookResult{Nudge: brief}
+		}
+	}
+	return HookResult{}
+}
+
+// reconcilePlan marks a plan's tasks completed when their vuln class shows
+// coverage evidence in the live state, so the plan tracks real progress
+// rather than relying on the model to call update_plan. It never downgrades a
+// completed/skipped task back to pending.
+func reconcilePlan(state *ScanState) {
+	if state == nil || state.Plan == nil {
+		return
+	}
+	for _, t := range state.Plan.Tasks {
+		if t.Status != TaskPending && t.Status != TaskActive {
+			continue
+		}
+		switch t.ID {
+		case "recon":
+			if state.ReconDone {
+				t.Status = TaskCompleted
+			}
+		case "dirbust":
+			if state.DirBustingDone || state.VulnClassesTested["dirbusting"] {
+				t.Status = TaskCompleted
+			}
+		case "auth-session":
+			// Auth testing is hard to detect precisely; treat as done once the
+			// agent has exercised any auth/access-control endpoint.
+			if state.AccessControlTested || len(state.AccessControlEndpoints) > 0 {
+				t.Status = TaskCompleted
+			}
+		case "verify", "report":
+			// Tail tasks complete via finish; leave pending until the model
+			// calls finish, which the gate consults.
+		default:
+			if t.VulnClass != "" && state.VulnClassesTested[t.VulnClass] {
+				t.Status = TaskCompleted
+			}
+		}
+	}
+}
+
+// extractEndpointsFromNotes pulls URL paths out of the saved notes so the
+// planner's coverage math is grounded in the recon the model actually did.
+// Looks for the "Endpoint Inventory" note (or any note with endpoint-like
+// paths) and collects /path or http(s)://host/path tokens.
+func extractEndpointsFromNotes(state *ScanState) []string {
+	if state == nil {
+		return nil
+	}
+	// Defer to the notes package via the injected accessor (set by agent.go) to
+	// avoid an import cycle. The formatted notes blob is the same one the agent
+	// injects into the context, so it's the authoritative inventory.
+	blob := ""
+	if notesBlobForContext != nil && state.ScanContextID != "" {
+		blob = notesBlobForContext(state.ScanContextID)
+	}
+	if blob == "" {
+		return nil
+	}
+	return extractPaths(blob)
+}
+
+// endpointPathRe matches /path, /api/x, or full http(s) URLs.
+var endpointPathRe = regexp.MustCompile(`(?:https?://[^\s"'<>]+|/(?:[A-Za-z0-9_.\-]+/)*[A-Za-z0-9_.\-]+)`)
+
+// extractPaths pulls unique endpoint paths out of a text blob, sorted.
+func extractPaths(blob string) []string {
+	seen := make(map[string]bool)
+	var paths []string
+	for _, m := range endpointPathRe.FindAllString(blob, -1) {
+		// Skip obvious non-endpoints: schema namespaces, file extensions on
+		// static assets, and the w3.org SVG namespace that JS bundles embed.
+		if strings.Contains(m, "w3.org") || strings.Contains(m, "schemas.") {
+			continue
+		}
+		if strings.HasSuffix(m, ".css") || strings.HasSuffix(m, ".png") || strings.HasSuffix(m, ".ico") {
+			continue
+		}
+		if !seen[m] {
+			seen[m] = true
+			paths = append(paths, m)
+		}
+	}
+	sort.Strings(paths)
+	return paths
 }
 
 // ── hookResetOnSuccess ───────────────────────────────────────────────────────

--- a/internal/agent/plan_tools.go
+++ b/internal/agent/plan_tools.go
@@ -1,0 +1,214 @@
+// Package agent — plan_tools.go registers the build_plan / update_plan tools.
+//
+// The structural planner (planner.go) auto-builds a plan from the seeded attack
+// surface + recon once an endpoint inventory exists. These tools let the LLM
+// replace or refine that plan with knowledge only it has — the live recon
+// output the engine can't fully parse (e.g. JS-bundle-mined API routes, an auth
+// flow it traced through the browser). The engine tracks the resulting plan and
+// the finish gate + per-iteration nudge consult it, so an LLM-authored plan gets
+// the same coverage enforcement as an auto-generated one.
+//
+// Why both tools exist:
+//   - build_plan: replace the whole plan (used once after recon, or when the
+//     model realizes the auto-plan missed a class/endpoint).
+//   - update_plan: transition one task's status (pending→active→completed/
+//     skipped) as the model works it, so the plan reflects progress without a
+//     full rebuild.
+//
+// The tools are intentionally tolerant of malformed input — a bad task ID or
+// status is reported back as a tool result (so the model self-corrects) rather
+// than erroring out of the loop.
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/xalgord/xalgorix/v4/internal/tools"
+)
+
+// planTaskInput is the LLM-supplied task shape for build_plan.
+type planTaskInput struct {
+	ID        string   `json:"id"`
+	Title     string   `json:"title"`
+	Phase     int      `json:"phase"`
+	VulnClass string   `json:"vuln_class"`
+	Endpoint  string   `json:"endpoint"`
+	DependsOn []string `json:"depends_on"`
+	Notes     string   `json:"notes"`
+}
+
+// registerPlanTools adds build_plan and update_plan to the registry. The agent
+// state is captured by closure so the tools mutate the live ScanState plan
+// (shared across sub-agents via the ScanContext).
+func (a *Agent) registerPlanTools(reg *tools.Registry) {
+	reg.Register(&tools.Tool{
+		Name: "build_plan",
+		Description: "Build or replace the structured scan plan as an ordered task graph. " +
+			"Call this after recon once you know the real endpoint surface, OR when you realize the " +
+			"current plan missed a vuln class / endpoint. Each task is coarse-grained (e.g. " +
+			"'test /api/users for injection'), maps to a methodology phase (1-22), and may depend on " +
+			"other task IDs. The engine tracks completion and will NOT let you finish until the plan " +
+			"is complete (or the surface is exhausted). Pass tasks as a JSON array.",
+		Parameters: []tools.Parameter{
+			{Name: "tasks", Description: "JSON array of tasks: [{\"id\",\"title\",\"phase\",\"vuln_class\",\"endpoint\",\"depends_on\":[ids],\"notes\"}]. Use stable ids like 'test-sqli'. phase is 1-22.", Required: true},
+		},
+		Execute: a.buildPlanTool,
+	})
+
+	reg.Register(&tools.Tool{
+		Name: "update_plan",
+		Description: "Mark a planned task as active, completed, or skipped so the engine tracks " +
+			"progress. Call this when you start a task and when it's done (covered, or ruled out " +
+			"as not-applicable → skipped). The engine also auto-marks tasks done from coverage " +
+			"evidence, so you only need this for tasks it can't infer (e.g. ruling a class " +
+			"not-applicable).",
+		Parameters: []tools.Parameter{
+			{Name: "task_id", Description: "The task id from build_plan", Required: true},
+			{Name: "status", Description: "One of: active, completed, skipped", Required: true},
+			{Name: "notes", Description: "Optional rationale / finding reference", Required: false},
+		},
+		Execute: a.updatePlanTool,
+	})
+}
+
+// buildPlanTool replaces the scan plan from a JSON task array.
+func (a *Agent) buildPlanTool(args map[string]string) (tools.Result, error) {
+	raw := strings.TrimSpace(args["tasks"])
+	if raw == "" {
+		return tools.Result{Error: "tasks is required (a JSON array of task objects)"}, nil
+	}
+	var inputs []planTaskInput
+	if err := json.Unmarshal([]byte(raw), &inputs); err != nil {
+		return tools.Result{Error: "invalid tasks JSON: " + err.Error() + " — expected an array like [{\"id\":\"test-sqli\",\"title\":\"...\",\"phase\":6,\"vuln_class\":\"sqli\",\"depends_on\":[\"recon\"]}]"}, nil
+	}
+	if len(inputs) == 0 {
+		return tools.Result{Error: "tasks array is empty — pass at least one task"}, nil
+	}
+
+	plan := NewPlan()
+	var warnings []string
+	for _, in := range inputs {
+		id := strings.TrimSpace(in.ID)
+		if id == "" {
+			warnings = append(warnings, "a task with no id was dropped")
+			continue
+		}
+		t := &Task{
+			ID:        id,
+			Title:     strings.TrimSpace(in.Title),
+			Phase:     clampPhase(in.Phase),
+			VulnClass: strings.ToLower(strings.TrimSpace(in.VulnClass)),
+			Endpoint:  strings.TrimSpace(in.Endpoint),
+			Status:    TaskPending,
+			DependsOn: trimIDList(in.DependsOn),
+			Notes:     strings.TrimSpace(in.Notes),
+			Origin:    "llm",
+		}
+		if t.Title == "" {
+			t.Title = id
+		}
+		if !plan.add(t) {
+			warnings = append(warnings, fmt.Sprintf("duplicate task id %q was dropped", id))
+		}
+	}
+	if plan.IsEmpty() {
+		return tools.Result{Error: "no valid tasks after parsing (every task needs a unique id)"}, nil
+	}
+
+	a.state.Plan = plan
+	a.state.PlanBuilt = true
+	// Ground the new plan in the discovered endpoints so coverage-gap detection
+	// works against it immediately.
+	a.state.DiscoveredEndpoints = extractEndpointsFromNotes(a.state)
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Plan built: %d tasks.\n", len(plan.Tasks)))
+	for _, t := range plan.Tasks {
+		sb.WriteString(fmt.Sprintf("  • [%s] phase %d — %s\n", t.ID, t.Phase, t.Title))
+	}
+	if len(warnings) > 0 {
+		sb.WriteString("\nWarnings:\n")
+		for _, w := range warnings {
+			sb.WriteString("  - " + w + "\n")
+		}
+	}
+	pending, active, completed, skipped := plan.Counts()
+	sb.WriteString(fmt.Sprintf("\nStatus: %d pending, %d active, %d completed, %d skipped. Work the tasks in dependency order; the engine tracks completion and gates finish on a complete plan.", pending, active, completed, skipped))
+	return tools.Result{Output: sb.String()}, nil
+}
+
+// updatePlanTool transitions a task's status.
+func (a *Agent) updatePlanTool(args map[string]string) (tools.Result, error) {
+	id := strings.TrimSpace(args["task_id"])
+	status := strings.ToLower(strings.TrimSpace(args["status"]))
+	notes := strings.TrimSpace(args["notes"])
+	if id == "" {
+		return tools.Result{Error: "task_id is required"}, nil
+	}
+	plan := a.state.Plan
+	if plan == nil || plan.IsEmpty() {
+		return tools.Result{Error: "no plan exists yet — call build_plan first"}, nil
+	}
+	t := plan.Get(id)
+	if t == nil {
+		return tools.Result{Error: fmt.Sprintf("unknown task id %q — current task ids: %s", id, planIDList(plan))}, nil
+	}
+	var st TaskStatus
+	switch status {
+	case "active":
+		st = TaskActive
+	case "completed", "complete", "done":
+		st = TaskCompleted
+	case "skipped", "skip", "n/a", "na", "not-applicable":
+		st = TaskSkipped
+	default:
+		return tools.Result{Error: "status must be one of: active, completed, skipped (got " + args["status"] + ")"}, nil
+	}
+	t.Status = st
+	if notes != "" {
+		if t.Notes != "" {
+			t.Notes += " | " + notes
+		} else {
+			t.Notes = notes
+		}
+	}
+	pending, active, completed, skipped := plan.Counts()
+	return tools.Result{Output: fmt.Sprintf("Task %q → %s. Plan: %d pending, %d active, %d completed, %d skipped (%d%% complete).", id, st, pending, active, completed, skipped, plan.ProgressPct())}, nil
+}
+
+// clampPhase forces a phase into the 1-22 methodology range.
+func clampPhase(p int) int {
+	if p < 1 {
+		return 1
+	}
+	if p > 22 {
+		return 22
+	}
+	return p
+}
+
+// trimIDList cleans a dependency ID list (drops empties).
+func trimIDList(ids []string) []string {
+	var out []string
+	for _, id := range ids {
+		if id = strings.TrimSpace(id); id != "" {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+// planIDList returns a comma-separated list of a plan's task ids for error
+// messages.
+func planIDList(p *Plan) string {
+	if p == nil {
+		return ""
+	}
+	ids := make([]string, 0, len(p.Tasks))
+	for _, t := range p.Tasks {
+		ids = append(ids, t.ID)
+	}
+	return strings.Join(ids, ", ")
+}

--- a/internal/agent/planner.go
+++ b/internal/agent/planner.go
@@ -1,0 +1,513 @@
+// Package agent — planner.go implements a structural, coverage-grounded task
+// planner. This is the "decomposition" layer that was previously left entirely
+// to the LLM: instead of the model self-decomposing by following the 22-phase
+// methodology text and hoping it covers the surface, the engine now turns a
+// scan goal into an ordered, dependency-tracked Task graph grounded in the REAL
+// recon data (discovered endpoints + detected technologies + seeded attack
+// surface), tracks completion against the existing coverage counters, and
+// surfaces the next pending task + remaining coverage gaps to the model every
+// iteration.
+//
+// The planner is deliberately model-in-the-loop, not a rigid waterfall:
+//   - The LLM builds/adjusts the plan via the build_plan tool after recon (it
+//     knows the live recon output that the engine can't parse), OR the engine
+//     auto-generates a plan from the seeded attack surface + methodology.
+//   - The engine tracks task status and recomputes coverage gaps from
+//     ScanState so a model that "forgets" a phase or an endpoint is nudged back
+//     to the next pending task instead of looping or finishing early.
+//   - The finish gate consults the plan: an unfinished plan blocks finish
+//     (with the specific remaining tasks) unless the operator scoped to recon
+//     only or the surface is genuinely exhausted.
+//
+// Design constraints:
+//   - No new goroutines / no external state — the Plan lives in ScanState so it
+//     is shared across sub-agents via the same ScanContext the memory layer uses.
+//   - Coverage grounding reuses the EXISTING counters (EndpointsTested,
+//     VulnClassesTested, InjectionEndpoints, AccessControlEndpoints,
+//     DirBustingHosts) rather than parallel bookkeeping that could drift.
+//   - Task generation is bounded: a target with 500 endpoints does not emit
+//     500×N tasks; endpoints are grouped by vuln class into a tractable set.
+package agent
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// TaskStatus is the lifecycle state of a single planned task.
+type TaskStatus string
+
+const (
+	TaskPending   TaskStatus = "pending"   // not yet started
+	TaskActive    TaskStatus = "active"    // the model is currently working it
+	TaskCompleted TaskStatus = "completed" // done (covered or ruled out)
+	TaskSkipped   TaskStatus = "skipped"   // not applicable (e.g. no auth surface)
+)
+
+// Task is one unit of work in the plan. A task is coarse-grained on purpose —
+// "test endpoint /api/users for injection" is a task; "send a single quote to
+// /api/users?id=1" is the model's job inside it. Coarse tasks keep the graph
+// small and the coverage math meaningful.
+type Task struct {
+	ID        string     `json:"id"`
+	Title     string     `json:"title"`
+	Phase     int        `json:"phase"`      // methodology phase this task maps to (1-22)
+	VulnClass string     `json:"vuln_class"` // "sqli","xss","idor","ssrf","ssti",... ("" for recon/ops)
+	Endpoint  string     `json:"endpoint"`   // specific endpoint/URL this targets ("" = whole target)
+	Status    TaskStatus `json:"status"`
+	DependsOn []string   `json:"depends_on"`       // task IDs that must complete first
+	Notes     string     `json:"notes,omitempty"`  // free-form rationale / finding refs
+	Origin    string     `json:"origin,omitempty"` // "auto" (engine-generated) or "llm" (model-built)
+}
+
+// Plan is the ordered task graph for one scan.
+type Plan struct {
+	Tasks []*Task `json:"tasks"`
+	// index is rebuilt on every mutation for O(1) lookup by ID.
+	index map[string]*Task
+}
+
+// NewPlan returns an empty plan with its index initialized.
+func NewPlan() *Plan {
+	return &Plan{index: make(map[string]*Task)}
+}
+
+// add inserts a task, rebuilding the index. Duplicate IDs are rejected.
+func (p *Plan) add(t *Task) bool {
+	if t.ID == "" {
+		return false
+	}
+	if _, exists := p.index[t.ID]; exists {
+		return false
+	}
+	p.Tasks = append(p.Tasks, t)
+	p.index[t.ID] = t
+	return true
+}
+
+// Get returns the task by ID, or nil.
+func (p *Plan) Get(id string) *Task {
+	if p == nil {
+		return nil
+	}
+	return p.index[id]
+}
+
+// SetStatus transitions a task and returns the task (or nil if not found).
+func (p *Plan) SetStatus(id string, status TaskStatus) *Task {
+	t := p.Get(id)
+	if t == nil {
+		return nil
+	}
+	t.Status = status
+	return t
+}
+
+// Counts returns aggregate status counts for the plan.
+func (p *Plan) Counts() (pending, active, completed, skipped int) {
+	if p == nil {
+		return
+	}
+	for _, t := range p.Tasks {
+		switch t.Status {
+		case TaskPending:
+			pending++
+		case TaskActive:
+			active++
+		case TaskCompleted:
+			completed++
+		case TaskSkipped:
+			skipped++
+		}
+	}
+	return
+}
+
+// IsEmpty reports whether the plan has no tasks.
+func (p *Plan) IsEmpty() bool {
+	return p == nil || len(p.Tasks) == 0
+}
+
+// RemainingCount is the number of tasks not yet completed or skipped.
+func (p *Plan) RemainingCount() int {
+	pending, active, _, _ := p.Counts()
+	return pending + active
+}
+
+// ProgressPct returns whole-percent completion (completed+skipped over total).
+// Returns 0 for an empty plan.
+func (p *Plan) ProgressPct() int {
+	if p == nil || len(p.Tasks) == 0 {
+		return 0
+	}
+	_, _, completed, skipped := p.Counts()
+	return int(float64(completed+skipped) / float64(len(p.Tasks)) * 100)
+}
+
+// NextTasks returns the tasks that are ready to run: status pending AND every
+// dependency is completed or skipped. Limited to `limit` results, ordered by
+// phase then ID for deterministic output. When no dependency-ready tasks remain
+// but pending tasks exist (stuck on an unmet dependency), it returns the
+// lowest-phase pending tasks so the scan never deadlocks on a malformed graph.
+func (p *Plan) NextTasks(limit int) []*Task {
+	if p == nil || limit <= 0 {
+		return nil
+	}
+	var ready []*Task
+	for _, t := range p.Tasks {
+		if t.Status != TaskPending {
+			continue
+		}
+		if p.dependenciesSatisfied(t) {
+			ready = append(ready, t)
+		}
+	}
+	if len(ready) == 0 {
+		// No dependency-ready tasks, but some are pending — return the
+		// lowest-phase pending ones rather than stalling forever.
+		for _, t := range p.Tasks {
+			if t.Status == TaskPending {
+				ready = append(ready, t)
+			}
+		}
+	}
+	sort.Slice(ready, func(i, j int) bool {
+		if ready[i].Phase != ready[j].Phase {
+			return ready[i].Phase < ready[j].Phase
+		}
+		return ready[i].ID < ready[j].ID
+	})
+	if len(ready) > limit {
+		ready = ready[:limit]
+	}
+	return ready
+}
+
+// dependenciesSatisfied reports whether all of a task's dependencies are
+// completed or skipped (i.e. no longer blocking).
+func (p *Plan) dependenciesSatisfied(t *Task) bool {
+	for _, depID := range t.DependsOn {
+		dep := p.Get(depID)
+		if dep == nil {
+			continue // unknown dependency — don't block on it
+		}
+		if dep.Status != TaskCompleted && dep.Status != TaskSkipped {
+			return false
+		}
+	}
+	return true
+}
+
+// CoverageGap is one (vuln class, endpoint) pair that the discovered surface
+// has not yet been tested for. CoverageGaps recomputes these from the live
+// ScanState coverage counters, grounded in the endpoints recon surfaced, so the
+// model is nudged to the next gap instead of self-declaring a phase "done" after
+// one payload.
+type CoverageGap struct {
+	VulnClass string
+	Endpoint  string
+	Reason    string
+}
+
+// CoverageGaps returns the structured gap list. discoveredEndpoints is the set
+// of endpoints the recon surfaced (from notes / attack-surface seeding);
+// state provides what's already been tested. A gap exists for each (class,
+// endpoint) pair where the endpoint was discovered but not tested for that
+// class.
+func CoverageGaps(state *ScanState, discoveredEndpoints []string) []CoverageGap {
+	if state == nil {
+		return nil
+	}
+	classes := []string{"sqli", "xss", "idor", "ssrf", "ssti", "cmdi", "path_traversal", "crlf"}
+	var gaps []CoverageGap
+	// Per-endpoint × per-class gap detection. When no endpoints were discovered
+	// (pure black-box, no seeded surface), fall back to whole-target gaps for
+	// any class not yet tested at all — so the nudge still surfaces missing
+	// vuln classes.
+	if len(discoveredEndpoints) == 0 {
+		for _, class := range classes {
+			if !state.VulnClassesTested[class] {
+				gaps = append(gaps, CoverageGap{VulnClass: class, Endpoint: "", Reason: fmt.Sprintf("vuln class %q not tested on any endpoint yet", class)})
+			}
+		}
+		return gaps
+	}
+	sort.Strings(discoveredEndpoints)
+	for _, ep := range discoveredEndpoints {
+		for _, class := range classes {
+			if !endpointTestedForClass(state, ep, class) {
+				gaps = append(gaps, CoverageGap{
+					VulnClass: class,
+					Endpoint:  ep,
+					Reason:    fmt.Sprintf("endpoint %q not tested for %s", ep, class),
+				})
+			}
+		}
+	}
+	return gaps
+}
+
+// endpointTestedForClass reports whether an endpoint has coverage evidence for
+// a vuln class, consulting the existing ScanState maps. This keeps the planner
+// consistent with the hook-layer coverage tracking (no parallel bookkeeping).
+func endpointTestedForClass(state *ScanState, endpoint, class string) bool {
+	// Global class coverage short-circuits the per-endpoint check for the
+	// whole-target fallback path; per-endpoint maps are authoritative when set.
+	switch class {
+	case "sqli":
+		if _, ok := state.InjectionEndpoints[endpoint]; ok {
+			return true
+		}
+	case "idor":
+		if _, ok := state.AccessControlEndpoints[endpoint]; ok {
+			return true
+		}
+	}
+	if state.VulnClassesTested[class] {
+		// Class tested somewhere — treat as covered for the gap report so we
+		// don't spam the model with N endpoints × the class once it's been
+		// exercised at least once. The finish gate's depth math still enforces
+		// per-endpoint depth separately.
+		return true
+	}
+	// If the endpoint itself was touched at all, count it as "tested" for the
+	// gap nudge — the per-class map is the precise signal, but a touched
+	// endpoint shouldn't be re-flagged wholesale.
+	if _, ok := state.EndpointsTested[endpoint]; ok {
+		return true
+	}
+	return false
+}
+
+// FormatGaps turns a CoverageGap slice into the compact model-facing summary.
+func FormatGaps(gaps []CoverageGap) string {
+	if len(gaps) == 0 {
+		return ""
+	}
+	// Group by vuln class for a readable nudge.
+	byClass := make(map[string][]string)
+	for _, g := range gaps {
+		ep := g.Endpoint
+		if ep == "" {
+			ep = "(whole target)"
+		}
+		byClass[g.VulnClass] = append(byClass[g.VulnClass], ep)
+	}
+	classes := make([]string, 0, len(byClass))
+	for c := range byClass {
+		classes = append(classes, c)
+	}
+	sort.Strings(classes)
+	var sb strings.Builder
+	sb.WriteString("Coverage gaps (discovered surface not yet tested):\n")
+	for _, c := range classes {
+		eps := byClass[c]
+		sort.Strings(eps)
+		if len(eps) > 6 {
+			eps = append(eps[:6], fmt.Sprintf("… +%d more", len(eps)-6))
+		}
+		sb.WriteString(fmt.Sprintf("  • %s: %s\n", c, strings.Join(eps, ", ")))
+	}
+	return sb.String()
+}
+
+// AutoPlan builds a coverage-grounded plan from the seeded attack surface and
+// the methodology, without needing the LLM to call build_plan. It is the
+// fallback when the operator supplied an OpenAPI/HAR/Postman context (so the
+// engine already knows the real endpoints) or when recon has surfaced
+// endpoints via notes. Tasks are grouped per vuln class across endpoints to
+// keep the graph tractable.
+//
+// endpoints may be empty (pure black-box): the plan then covers the methodology
+// phases as whole-target tasks, which the model refines once it discovers
+// surface. detectedTechs nudges the tech-specific classes (e.g. java → ssti).
+func AutoPlan(endpoints []string, detectedTechs map[string]bool) *Plan {
+	p := NewPlan()
+
+	// Phase 1-2: recon is a prerequisite for everything. Even with a seeded
+	// surface, live fingerprinting confirms the surface is reachable and
+	// extracts the tech stack that steers later tasks.
+	recon := &Task{
+		ID:        "recon",
+		Title:     "Reconnaissance + technology fingerprint + endpoint inventory",
+		Phase:     1,
+		VulnClass: "",
+		Endpoint:  "",
+		Status:    TaskPending,
+		Origin:    "auto",
+	}
+	p.add(recon)
+
+	// Phase 3: directory/content discovery (only when no seeded surface — a
+	// seeded OpenAPI surface makes broad dirbusting lower-value).
+	if len(endpoints) == 0 {
+		p.add(&Task{
+			ID:        "dirbust",
+			Title:     "Directory & file discovery (ffuf/gobuster) + hidden paths",
+			Phase:     3,
+			VulnClass: "dirbusting",
+			Status:    TaskPending,
+			DependsOn: []string{"recon"},
+			Origin:    "auto",
+		})
+	}
+
+	// Tech-specific class inclusion: java/python → ssti; php/node → prototype
+	// pollution / sqli; otherwise include the core classes.
+	classes := defaultVulnClasses(detectedTechs)
+
+	// Build per-class tasks. When endpoints are known, each class task lists
+	// the endpoint set in its Notes so the model tests them all; when unknown,
+	// the task is whole-target and the model refines after discovery.
+	for _, class := range classes {
+		phase := classPhase(class)
+		t := &Task{
+			ID:        "test-" + class,
+			Title:     fmt.Sprintf("Test for %s across discovered endpoints", class),
+			Phase:     phase,
+			VulnClass: class,
+			Status:    TaskPending,
+			DependsOn: []string{"recon"},
+			Origin:    "auto",
+		}
+		if len(endpoints) > 0 {
+			t.Notes = fmt.Sprintf("Discovered endpoints to test for %s: %s", class, truncList(endpoints, 12))
+			t.Endpoint = truncList(endpoints, 1)
+		}
+		p.add(t)
+	}
+
+	// Phase 5: auth/session testing when auth material exists (the agent knows
+	// this from target auth / seeded surface; the plan includes it so it isn't
+	// dropped). Depends on recon.
+	p.add(&Task{
+		ID:        "auth-session",
+		Title:     "Authentication & session testing (login bypass, JWT, session fixation)",
+		Phase:     5,
+		VulnClass: "auth",
+		Status:    TaskPending,
+		DependsOn: []string{"recon"},
+		Origin:    "auto",
+	})
+
+	// Phase 8: IDOR / broken access control (the high-value post-auth class).
+	p.add(&Task{
+		ID:        "idor",
+		Title:     "IDOR / broken access control (horizontal + vertical)",
+		Phase:     8,
+		VulnClass: "idor",
+		Status:    TaskPending,
+		DependsOn: []string{"recon", "auth-session"},
+		Origin:    "auto",
+	})
+
+	// Phase 20: exploit verification + Phase 22 report are the tail, depending
+	// on the test tasks completing.
+	testDeps := make([]string, 0, len(p.Tasks))
+	for _, t := range p.Tasks {
+		if t.VulnClass != "" && t.VulnClass != "dirbusting" && t.VulnClass != "auth" {
+			testDeps = append(testDeps, t.ID)
+		}
+	}
+	p.add(&Task{
+		ID:        "verify",
+		Title:     "Exploit verification — re-test every candidate finding (Phase 20)",
+		Phase:     20,
+		VulnClass: "",
+		Status:    TaskPending,
+		DependsOn: testDeps,
+		Origin:    "auto",
+	})
+	p.add(&Task{
+		ID:        "report",
+		Title:     "Final report — summarize verified findings + remediation (Phase 22)",
+		Phase:     22,
+		VulnClass: "",
+		Status:    TaskPending,
+		DependsOn: []string{"verify"},
+		Origin:    "auto",
+	})
+
+	return p
+}
+
+// defaultVulnClasses returns the core vuln-class set, expanded by detected tech.
+func defaultVulnClasses(detectedTechs map[string]bool) []string {
+	classes := []string{"sqli", "xss", "ssrf", "cmdi", "path_traversal"}
+	if detectedTechs == nil {
+		return classes
+	}
+	if detectedTechs["java"] || detectedTechs["python"] || detectedTechs["ruby"] || detectedTechs["php"] {
+		classes = append(classes, "ssti")
+	}
+	if detectedTechs["nodejs"] {
+		classes = append(classes, "ssti", "prototype-pollution")
+	}
+	if detectedTechs["php"] {
+		classes = append(classes, "lfi")
+	}
+	return classes
+}
+
+// classPhase maps a vuln class to its methodology phase.
+func classPhase(class string) int {
+	switch class {
+	case "sqli", "xss", "ssti", "cmdi", "crlf":
+		return 6 // injection testing
+	case "ssrf":
+		return 7
+	case "idor", "prototype-pollution":
+		return 8
+	case "path_traversal", "lfi":
+		return 6
+	case "dirbusting":
+		return 3
+	case "auth":
+		return 5
+	default:
+		return 6
+	}
+}
+
+// truncList joins a slice, truncating to n items with a "+N more" suffix.
+func truncList(items []string, n int) string {
+	if len(items) <= n {
+		return strings.Join(items, ", ")
+	}
+	return strings.Join(items[:n], ", ") + fmt.Sprintf(" … +%d more", len(items)-n)
+}
+
+// FormatPlan renders the plan as a compact, model-facing brief: progress,
+// the next ready tasks, and any coverage gaps. Used as the per-iteration
+// "what to work on now" injection.
+func FormatPlan(p *Plan, gaps []CoverageGap) string {
+	if p == nil || p.IsEmpty() {
+		return ""
+	}
+	pending, active, completed, skipped := p.Counts()
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("## Active Plan — %d%% complete (%d done, %d active, %d pending, %d skipped)\n",
+		p.ProgressPct(), completed, active, pending, skipped))
+
+	next := p.NextTasks(3)
+	if len(next) > 0 {
+		sb.WriteString("Next tasks ready to run:\n")
+		for _, t := range next {
+			sb.WriteString(fmt.Sprintf("  ▶ [Phase %d] %s — %s\n", t.Phase, t.ID, t.Title))
+			if ep := strings.TrimSpace(t.Endpoint); ep != "" {
+				sb.WriteString(fmt.Sprintf("      target: %s\n", ep))
+			}
+			if t.Notes != "" {
+				sb.WriteString(fmt.Sprintf("      %s\n", t.Notes))
+			}
+		}
+	} else if p.RemainingCount() == 0 {
+		sb.WriteString("All planned tasks complete — you may call finish.\n")
+	}
+	if g := FormatGaps(gaps); g != "" {
+		sb.WriteString("\n")
+		sb.WriteString(g)
+	}
+	return sb.String()
+}

--- a/internal/agent/planner_test.go
+++ b/internal/agent/planner_test.go
@@ -1,0 +1,354 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+// AutoPlan must produce a dependency-ordered graph: recon first, vuln-class
+// tests depend on recon, IDOR depends on auth-session, and verify depends on
+// the test tasks; report depends on verify.
+func TestAutoPlanDependencyGraph(t *testing.T) {
+	p := AutoPlan([]string{"/api/users", "/api/leads", "/login"}, map[string]bool{"java": true})
+
+	if p.IsEmpty() {
+		t.Fatal("AutoPlan produced an empty plan")
+	}
+	recon := p.Get("recon")
+	if recon == nil {
+		t.Fatal("missing recon task")
+	}
+	if recon.Phase != 1 {
+		t.Errorf("recon phase = %d, want 1", recon.Phase)
+	}
+	for _, dep := range recon.DependsOn {
+		t.Errorf("recon should have no dependencies, got %q", dep)
+	}
+
+	// java → ssti should be included
+	if p.Get("test-ssti") == nil {
+		t.Error("java tech should produce an ssti task")
+	}
+	// seeded surface → no dirbust task
+	if p.Get("dirbust") != nil {
+		t.Error("seeded surface should skip the dirbust task")
+	}
+
+	// IDOR depends on recon AND auth-session
+	idor := p.Get("idor")
+	if idor == nil {
+		t.Fatal("missing idor task")
+	}
+	if !dependsOn(idor, "auth-session") || !dependsOn(idor, "recon") {
+		t.Errorf("idor deps = %v, want recon+auth-session", idor.DependsOn)
+	}
+
+	// verify depends on the test tasks; report depends on verify
+	verify := p.Get("verify")
+	if verify == nil {
+		t.Fatal("missing verify task")
+	}
+	if len(verify.DependsOn) == 0 {
+		t.Error("verify should depend on the test tasks")
+	}
+	report := p.Get("report")
+	if report == nil {
+		t.Fatal("missing report task")
+	}
+	if !dependsOn(report, "verify") {
+		t.Error("report should depend on verify")
+	}
+
+	// Endpoint grounding: test tasks should mention the discovered endpoints.
+	sqli := p.Get("test-sqli")
+	if sqli == nil {
+		t.Fatal("missing test-sqli task")
+	}
+	if !strings.Contains(sqli.Notes, "/api/users") {
+		t.Errorf("test-sqli notes should list discovered endpoints, got %q", sqli.Notes)
+	}
+}
+
+// A black-box target (no seeded endpoints) still gets a methodology plan with
+// a dirbust task.
+func TestAutoPlanBlackBox(t *testing.T) {
+	p := AutoPlan(nil, nil)
+	if p.Get("dirbust") == nil {
+		t.Error("black-box plan should include a dirbust task")
+	}
+	if p.Get("test-sqli") == nil {
+		t.Error("black-box plan should still include core vuln-class tasks")
+	}
+}
+
+// NextTasks returns pending tasks whose dependencies are satisfied, ordered by
+// phase. Initially only recon is ready (everything depends on it).
+func TestNextTasksDependencyOrder(t *testing.T) {
+	p := AutoPlan([]string{"/api/x"}, nil)
+	next := p.NextTasks(5)
+	if len(next) == 0 {
+		t.Fatal("NextTasks returned nothing for a fresh plan")
+	}
+	if next[0].ID != "recon" {
+		t.Errorf("first ready task = %q, want recon (everything depends on it)", next[0].ID)
+	}
+	// After recon completes, the test tasks + auth + dirbust(omitted here) unblock.
+	p.SetStatus("recon", TaskCompleted)
+	next = p.NextTasks(10)
+	ids := taskIDs(next)
+	for _, want := range []string{"test-sqli", "test-xss", "auth-session"} {
+		if !contains(ids, want) {
+			t.Errorf("after recon, %q should be ready; got %v", want, ids)
+		}
+	}
+	// idor should NOT be ready yet (depends on auth-session).
+	if contains(ids, "idor") {
+		t.Error("idor should not be ready until auth-session completes")
+	}
+}
+
+// NextTasks must not deadlock: if dependencies are unmet but tasks are pending,
+// it returns the lowest-phase pending tasks so the scan can still proceed.
+func TestNextTasksNoDeadlock(t *testing.T) {
+	p := NewPlan()
+	p.add(&Task{ID: "a", Title: "a", Phase: 5, Status: TaskPending, DependsOn: []string{"b"}})
+	p.add(&Task{ID: "b", Title: "b", Phase: 3, Status: TaskPending}) // b has no deps but neither is completed
+	// Both pending, a depends on b which is pending → no dependency-ready task.
+	// NextTasks must fall back to the lowest-phase pending (b).
+	next := p.NextTasks(5)
+	if len(next) == 0 {
+		t.Fatal("NextTasks deadlocked on unmet dependency — must fall back to pending tasks")
+	}
+	if next[0].ID != "b" {
+		t.Errorf("fallback should pick lowest-phase pending task 'b', got %q", next[0].ID)
+	}
+}
+
+// CoverageGaps flags discovered endpoints not tested per class; once a class is
+// tested anywhere, that class's per-endpoint gaps collapse (the finish gate's
+// depth math enforces per-endpoint depth separately).
+func TestCoverageGaps(t *testing.T) {
+	state := NewScanState()
+	state.VulnClassesTested["sqli"] = true // sqli exercised somewhere
+	endpoints := []string{"/api/users", "/api/leads"}
+
+	gaps := CoverageGaps(state, endpoints)
+	for _, g := range gaps {
+		if g.VulnClass == "sqli" {
+			t.Errorf("sqli has coverage evidence — should not appear in gaps, got %+v", g)
+		}
+	}
+	// xss has no coverage → each discovered endpoint is a gap.
+	var xssGaps int
+	for _, g := range gaps {
+		if g.VulnClass == "xss" {
+			xssGaps++
+		}
+	}
+	if xssGaps != 2 {
+		t.Errorf("xss gaps = %d, want 2 (one per discovered endpoint)", xssGaps)
+	}
+}
+
+// CoverageGaps with no discovered endpoints falls back to whole-target class
+// gaps so the nudge still surfaces missing vuln classes.
+func TestCoverageGapsBlackBox(t *testing.T) {
+	state := NewScanState()
+	state.VulnClassesTested["sqli"] = true
+	gaps := CoverageGaps(state, nil)
+	if len(gaps) == 0 {
+		t.Fatal("black-box gap detection should still flag untested classes")
+	}
+	for _, g := range gaps {
+		if g.VulnClass == "sqli" {
+			t.Error("sqli is tested — should not be a whole-target gap")
+		}
+		if g.Endpoint != "" {
+			t.Errorf("whole-target gap should have empty endpoint, got %q", g.Endpoint)
+		}
+	}
+}
+
+// reconcilePlan marks tasks completed from live coverage evidence, so the plan
+// reflects reality without the model calling update_plan.
+func TestReconcilePlan(t *testing.T) {
+	state := NewScanState()
+	state.Plan = AutoPlan([]string{"/api/x"}, nil)
+	state.ReconDone = true
+	state.VulnClassesTested["sqli"] = true
+	state.DirBustingDone = true
+
+	reconcilePlan(state)
+	if state.Plan.Get("recon").Status != TaskCompleted {
+		t.Error("recon should be completed after ReconDone")
+	}
+	if state.Plan.Get("test-sqli").Status != TaskCompleted {
+		t.Error("test-sqli should be completed after sqli coverage evidence")
+	}
+	// verify/report stay pending (they complete via finish, not coverage).
+	if state.Plan.Get("verify").Status == TaskCompleted {
+		t.Error("verify should not auto-complete from coverage evidence")
+	}
+}
+
+// buildPlanTool replaces the plan from a JSON task array and rejects malformed
+// input without erroring the loop.
+func TestBuildPlanTool(t *testing.T) {
+	a := &Agent{state: NewScanState()}
+
+	// Malformed JSON → error result, no panic.
+	res, err := a.buildPlanTool(map[string]string{"tasks": "{not json"})
+	if err != nil {
+		t.Fatalf("malformed input should return a tool error, not a Go error: %v", err)
+	}
+	if res.Error == "" {
+		t.Error("malformed JSON should produce an error result")
+	}
+	if a.state.Plan != nil {
+		t.Error("malformed input should not create a plan")
+	}
+
+	// Valid plan.
+	res, err = a.buildPlanTool(map[string]string{"tasks": `[
+		{"id":"recon","title":"recon","phase":1},
+		{"id":"test-sqli","title":"test sqli","phase":6,"vuln_class":"sqli","depends_on":["recon"]}
+	]`})
+	if err != nil {
+		t.Fatalf("valid input errored: %v", err)
+	}
+	if a.state.Plan == nil || a.state.Plan.IsEmpty() {
+		t.Fatal("valid input should create a plan")
+	}
+	if !a.state.PlanBuilt {
+		t.Error("PlanBuilt should be true after build_plan")
+	}
+	if a.state.Plan.Get("test-sqli").Phase != 6 {
+		t.Errorf("test-sqli phase = %d, want 6", a.state.Plan.Get("test-sqli").Phase)
+	}
+	if res.Output == "" {
+		t.Error("build_plan should return a summary")
+	}
+}
+
+// buildPlanTool rejects duplicate task ids and empty arrays.
+func TestBuildPlanToolValidation(t *testing.T) {
+	a := &Agent{state: NewScanState()}
+
+	res, _ := a.buildPlanTool(map[string]string{"tasks": "[]"})
+	if res.Error == "" {
+		t.Error("empty tasks array should error")
+	}
+
+	res, _ = a.buildPlanTool(map[string]string{"tasks": `[
+		{"id":"x","title":"x","phase":1},
+		{"id":"x","title":"dup","phase":2}
+	]`})
+	if a.state.Plan == nil || len(a.state.Plan.Tasks) != 1 {
+		t.Errorf("duplicate ids: expected 1 task kept, got %d", len(a.state.Plan.Tasks))
+	}
+}
+
+// updatePlanTool transitions status and rejects unknown ids / bad status.
+func TestUpdatePlanTool(t *testing.T) {
+	a := &Agent{state: NewScanState()}
+	a.state.Plan = AutoPlan([]string{"/x"}, nil)
+
+	res, _ := a.updatePlanTool(map[string]string{"task_id": "recon", "status": "completed"})
+	if res.Error != "" {
+		t.Fatalf("valid update errored: %s", res.Error)
+	}
+	if a.state.Plan.Get("recon").Status != TaskCompleted {
+		t.Error("recon should be completed")
+	}
+
+	// Unknown id.
+	res, _ = a.updatePlanTool(map[string]string{"task_id": "nope", "status": "completed"})
+	if res.Error == "" {
+		t.Error("unknown task id should error")
+	}
+
+	// Bad status.
+	res, _ = a.updatePlanTool(map[string]string{"task_id": "recon", "status": "bogus"})
+	if res.Error == "" {
+		t.Error("bad status should error")
+	}
+}
+
+// extractPaths pulls endpoints out of an inventory blob, filtering static
+// assets and the SVG namespace noise JS bundles embed.
+func TestExtractPaths(t *testing.T) {
+	blob := `Discovered Endpoints:
+- /api/users
+- /api/leads
+- /admin/login
+- /static/style.css
+- /logo.png
+http://www.w3.org/2000/svg
+https://ok.ru/profile/123`
+	paths := extractPaths(blob)
+	want := []string{"/admin/login", "/api/leads", "/api/users", "https://ok.ru/profile/123"}
+	if len(paths) != len(want) {
+		t.Fatalf("paths = %v, want %v", paths, want)
+	}
+	for _, w := range want {
+		if !contains(paths, w) {
+			t.Errorf("missing %q in %v", w, paths)
+		}
+	}
+	for _, p := range paths {
+		if strings.HasSuffix(p, ".css") || strings.HasSuffix(p, ".png") || strings.Contains(p, "w3.org") {
+			t.Errorf("static asset / svg namespace should be filtered, got %q", p)
+		}
+	}
+}
+
+// ProgressPct and Counts track plan completion correctly.
+func TestPlanProgress(t *testing.T) {
+	p := AutoPlan([]string{"/x"}, nil)
+	if p.ProgressPct() != 0 {
+		t.Errorf("fresh plan progress = %d, want 0", p.ProgressPct())
+	}
+	total := len(p.Tasks)
+	half := total / 2
+	done := 0
+	for _, t2 := range p.Tasks {
+		if done >= half {
+			break
+		}
+		t2.Status = TaskCompleted
+		done++
+	}
+	if p.ProgressPct() == 0 {
+		t.Error("progress should be > 0 after completing some tasks")
+	}
+	if p.RemainingCount() == 0 {
+		t.Error("plan with uncompleted tasks should have remaining work")
+	}
+}
+
+// helpers
+func dependsOn(t *Task, id string) bool {
+	for _, d := range t.DependsOn {
+		if d == id {
+			return true
+		}
+	}
+	return false
+}
+
+func taskIDs(tasks []*Task) []string {
+	out := make([]string, len(tasks))
+	for i, t := range tasks {
+		out[i] = t.ID
+	}
+	return out
+}
+
+func contains(list []string, s string) bool {
+	for _, x := range list {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What this adds

Task decomposition was previously left entirely to the LLM — the model self-decomposed by following the 22-phase methodology text and hoping it covered the surface. This PR adds a **real decomposition layer**: the engine turns a scan goal into an ordered, dependency-tracked **Task graph** grounded in the REAL recon data, tracks completion against the existing coverage counters, and surfaces the next pending task + remaining coverage gaps every iteration.

## Components

### `planner.go` — Plan/Task/TaskGraph data model
- **Task**: coarse-grained unit (phase, vuln_class, endpoint, depends_on, status: pending/active/completed/skipped). Coarse on purpose so the graph stays small and the coverage math is meaningful.
- **Plan**: ordered graph with O(1) ID lookup, dependency-ordered `NextTasks` (with a **no-deadlock fallback** to lowest-phase pending when deps are unmet), progress %, remaining-count.
- **AutoPlan**: coverage-grounded generation from the seeded attack surface + detected techs. `recon → (dirbust if black-box) → per-vuln-class test tasks → auth → IDOR → verify → report`. Tech-aware: java/python → ssti, nodejs → prototype-pollution, php → lfi.
- **CoverageGaps**: recomputes (class, endpoint) gaps from the **live ScanState counters** (EndpointsTested/VulnClassesTested/InjectionEndpoints/AccessControlEndpoints) — no parallel bookkeeping. Black-box fallback flags untested classes whole-target.

### `plan_tools.go` — build_plan / update_plan tools
- **build_plan**: the LLM replaces the plan from a JSON task array, using knowledge only it has (live recon the engine can't parse: JS-bundle API routes, traced auth flows). Validates ids/dupes/phase range; malformed input returns a tool error, never panics the loop.
- **update_plan**: transitions a task status (active/completed/skipped). `skipped` is the model's escape hatch for not-applicable tasks.

### `hooks.go` — hookPlanner (OnIterationStart)
- Auto-builds the plan once recon surfaces an endpoint inventory (or immediately if a seeded surface exists), unless the LLM already called `build_plan`.
- **reconcilePlan**: auto-marks tasks completed from live coverage evidence (recon done, sqli tested, etc.) so the plan tracks reality without the model calling `update_plan`.
- Injects the plan brief + coverage gaps as a per-iteration nudge so the agent works the next pending task instead of looping / finishing early. `extractEndpointsFromNotes` grounds the plan in the 'Endpoint Inventory' note via an injected accessor (avoids an import cycle with the notes package).

### Finish gate — plan-based
`hookFinishGatekeeper` now blocks finish when the plan has actionable pending tasks (excluding verify/report, which ARE the finish step), listing the specific remaining tasks. An unfinished plan means the surface isn't covered, regardless of iteration count.

### System prompt
A new `STRUCTURED PLANNING` section teaches the build_plan workflow with a concrete example.

## Why this is grounded, not generic
- The plan is built from the **seeded attack surface** (OpenAPI/HAR/Postman) + the **'Endpoint Inventory' note** the model saves — i.e. the real endpoints, not a template.
- Coverage gaps reuse the **existing** ScanState counters rather than parallel bookkeeping that could drift.
- The plan lives in `ScanState`, which is shared across sub-agents via the `ScanContext` — so the existing agent hand-offs + shared memory now share the **same task graph**.

## Verification
```
go build ./...            # clean
go vet ./internal/agent/  # clean
gofmt -l ...              # clean
golangci-lint run ./internal/agent/   # 0 issues
go test ./internal/agent/ -count=1    # all pass (incl. 12 new planner tests)
```

Tests (`planner_test.go`, 12 cases): dependency graph, black-box plan, NextTasks order + no-deadlock, CoverageGaps per-endpoint + black-box, reconcilePlan, build_plan/update_plan tools incl. validation, extractPaths filtering, progress math.

> [!IMPORTANT]
> Use Xalgorix only on systems you own or have explicit permission to test.