### PR TITLE
feat: list and delete all provider profiles in Settings

### DIFF
--- a/webui/src/pages/settings.tsx
+++ b/webui/src/pages/settings.tsx
@@ -265,6 +265,24 @@ export default function SettingsPage() {
     return (profiles.data ?? []).filter((p) => p.provider === llmForm.provider);
   }, [profiles.data, llmForm.provider]);
 
+  // Every saved profile across ALL providers, enriched with the
+  // catalog display name and an active flag. This is the same list
+  // the schedule / scan "Provider profile" pickers draw from, so the
+  // Settings page can review and delete credentials that belong to a
+  // provider other than the one currently selected above.
+  const allProfiles = useMemo(() => {
+    const byID = new Map((providers.data ?? []).map((e) => [e.id, e]));
+    return (profiles.data ?? []).map((profile) => {
+      const key = profile.key ?? `${profile.provider}:${profile.profileId}`;
+      return {
+        profile,
+        key,
+        display: byID.get(profile.provider)?.displayName ?? profile.provider,
+        active: key === llmForm.activeProfileKey,
+      };
+    });
+  }, [profiles.data, providers.data, llmForm.activeProfileKey]);
+
   function changeTab(value: string) {
     const next = new URLSearchParams(searchParams);
     next.set("tab", value);
@@ -720,6 +738,66 @@ export default function SettingsPage() {
                           </div>
                         );
                       })}
+                    </div>
+                  </div>
+                )}
+
+                {/* All saved provider profiles across every provider —
+                    the same set the schedule / scan "Provider profile"
+                    pickers offer. Lets the operator review and delete
+                    credentials for providers other than the one selected
+                    above (the picker there is scoped to that provider). */}
+                {allProfiles.length > 0 && (
+                  <div className="space-y-2">
+                    <Label>All provider profiles</Label>
+                    <p className="text-xs text-muted-foreground">
+                      Every stored credential across all providers. These
+                      are the profiles available in the schedule and scan
+                      "Provider profile" pickers.
+                    </p>
+                    <div className="divide-y divide-border rounded-md border border-border">
+                      {allProfiles.map(({ profile, key, display, active }) => (
+                        <div
+                          key={key}
+                          className="flex flex-wrap items-center gap-3 px-3 py-2"
+                        >
+                          <div className="min-w-0 flex-1">
+                            <div className="flex items-center gap-2 text-sm font-medium">
+                              {display} · {profile.profileId}
+                              <Badge variant="muted">{profile.type}</Badge>
+                              {active && (
+                                <CheckCircle2 className="h-4 w-4 text-success" />
+                              )}
+                              {profile.requiresReauth && (
+                                <Badge variant="warning">
+                                  <AlertTriangle className="mr-1 h-3 w-3" />
+                                  re-auth required
+                                </Badge>
+                              )}
+                            </div>
+                            <div className="font-mono text-xs text-muted-foreground">
+                              {profile.type === "oauth"
+                                ? maskedTokenLabel(profile)
+                                : maskedAPIKeyLabel(profile)}
+                            </div>
+                            {profile.expiresAt && (
+                              <div className="text-xs text-muted-foreground">
+                                expires {profile.expiresAt}
+                              </div>
+                            )}
+                          </div>
+                          <div className="flex flex-wrap gap-2">
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              disabled={deleteProfile.isPending}
+                              onClick={() => deleteProfile.mutateAsync(key)}
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </Button>
+                          </div>
+                        </div>
+                      ))}
                     </div>
                   </div>
                 )}


### PR DESCRIPTION
## Summary

Settings → LLM has a **"Saved credentials"** picker, but it is scoped to the **currently selected provider** (`providerProfiles` filters `useAuthProfiles()` by `llmForm.provider`). Credentials for any *other* provider — the same profiles listed in the schedule and scan **"Provider profile"** pickers — cannot be seen or deleted from Settings.

This adds an **"All provider profiles"** section beneath the per-provider picker that lists **every** saved profile across all providers, each with its catalog display name, type, masked credential, and a delete button.

## Changes

`webui/src/pages/settings.tsx` (frontend-only, additive — 78 insertions, 0 deletions):

- **New `allProfiles` memo** — maps every `useAuthProfiles()` entry to `{ profile, key, display, active }`, resolving each provider's catalog `displayName` (the same `displayName · profileId` labeling the schedule picker uses) and flagging the active profile.
- **New "All provider profiles" section** — rendered after the per-provider "Saved credentials" picker: each row shows `displayName · profileId`, a type badge, the masked credential (reusing the existing `maskedAPIKeyLabel` / `maskedTokenLabel` helpers), an active indicator, a re-auth badge, and a delete action wired to the existing `useDeleteAuthProfile` mutation.

No backend/API change and no new imports. The existing per-provider picker (Set active / refresh / delete) is left untouched. "Set active" is deliberately **not** offered in the global list — activating a profile from a different provider would leave `provider` and `activeProfileKey` inconsistent, so activation stays in the provider-scoped picker above.

## Test plan

- [x] `npm run typecheck` (`tsc -b`) — clean
- [x] `npm run build` (`tsc -b && vite build`) — clean
- [x] Verified on a running instance: the section lists all saved profiles (DeepSeek, Google/Gemini, Groq), the active one shows the check indicator, and delete removes the profile via `DELETE /api/auth/profiles`.
- [ ] Reviewer note: delete has no confirm dialog, kept consistent with the existing per-provider picker. Happy to add a confirm step if preferred.