### PR TITLE
fix(agent): recover tool calls whose <function> open tag was dropped

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -880,6 +880,24 @@ func (a *Agent) Run(targets []string, instruction string) {
 		a.msgMu.Unlock()
 
 		toolCalls := llm.ParseToolCalls(responseClean)
+		// ── Schema-guided recovery of dropped-open-tag tool calls ──
+		// Some models intermittently drop the <function=NAME> open tag and
+		// emit only <parameter=X>…</parameter> blocks + a trailing
+		// </function>. ParseToolCalls can't recover the tool name from that,
+		// so every such response counts as "no tool call" and the scan
+		// force-stops at 15 (observed on codeant.ai). Recover by matching
+		// the orphaned parameter set against the registered tool schemas:
+		// a tool whose required params are all present is the intended call.
+		// This runs BEFORE the no-tool hook so recovered calls are healthy,
+		// not counted toward the reasoning-loop threshold.
+		if len(toolCalls) == 0 {
+			for _, oc := range llm.ParseOrphanedCalls(responseClean) {
+				if name, ok := a.registry.MatchByParams(oc.ParamNames); ok {
+					a.emit(Event{Type: "message", Content: fmt.Sprintf("🔧 Recovered a tool call whose <function> open tag was dropped — inferred '%s' from parameters %v.", name, oc.ParamNames), TotalTokens: tokenCount()})
+					toolCalls = append(toolCalls, llm.ToolCall{Name: name, Args: oc.Args})
+				}
+			}
+		}
 		// Enforce the tool-call budget WITHIN the batch. overBudget is only
 		// checked at iteration start, so a single response emitting many calls
 		// could otherwise blow past XALGORIX_MAX_TOOL_CALLS. Truncate the batch

--- a/internal/llm/parser.go
+++ b/internal/llm/parser.go
@@ -227,6 +227,64 @@ func FormatToolCall(name string, args map[string]string) string {
 	return b.String()
 }
 
+// OrphanedCall is a block of <parameter=...> values closed by </function> but
+// with no preceding <function=NAME> open tag — the model dropped the open tag.
+// Recoverable when the caller matches the param set against the tool schema.
+type OrphanedCall struct {
+	Args       map[string]string
+	ParamNames []string // ordered, dedup'd param names present
+}
+
+// ParseOrphanedCalls extracts <parameter=X>...</parameter> blocks that are
+// bounded by a </function> close tag but have NO <function=NAME> open tag
+// before them. These are the calls the strict fnRegex misses because the model
+// truncated/dropped the opening tag (observed: `_plan>\n<parameter=task_id>…`
+// and `parameter=method>POST</parameter>…</function>`).
+//
+// It works by:
+//  1. Removing all WELL-FORMED <function=…>…</function> blocks (already parsed
+//     by ParseToolCalls) so only malformed fragments remain.
+//  2. Finding </function> close tags and walking back to collect the contiguous
+//     run of <parameter=…>…</parameter> blocks immediately preceding each close.
+//
+// Returns one OrphanedCall per close tag that has ≥1 parameter. The caller
+// resolves the tool name via registry.MatchByParams; if it can't, the call is
+// dropped (safer than executing an ambiguous guess).
+func ParseOrphanedCalls(content string) []OrphanedCall {
+	content = normalizeFormat(content)
+	// Strip well-formed calls so their params aren't mistaken for orphans.
+	stripped := fnRegex.ReplaceAllString(content, "")
+	// Also drop any lone incomplete <function=…> opens that survived (no body).
+	stripped = incompleteFunc.ReplaceAllString(stripped, "")
+
+	var out []OrphanedCall
+	// Split on </function>; each segment that ends at a close tag may carry
+	// orphaned <parameter> blocks in its tail.
+	for _, frag := range strings.Split(stripped, "</function>") {
+		// Collect the trailing run of <parameter=…>…</parameter> in this fragment.
+		params := paramEqRegex.FindAllStringSubmatch(frag, -1)
+		if len(params) == 0 {
+			continue
+		}
+		args := make(map[string]string, len(params))
+		var names []string
+		seen := make(map[string]bool)
+		for _, pm := range params {
+			name := sanitizeParamName(strings.TrimSpace(pm[1]))
+			if name == "" || seen[name] {
+				continue
+			}
+			seen[name] = true
+			names = append(names, name)
+			args[name] = html.UnescapeString(strings.TrimSpace(pm[2]))
+		}
+		if len(args) > 0 {
+			out = append(out, OrphanedCall{Args: args, ParamNames: names})
+		}
+	}
+	return out
+}
+
 // CleanContent removes tool call XML from content for display.
 func CleanContent(content string) string {
 	content = normalizeFormat(content)

--- a/internal/llm/parser_test.go
+++ b/internal/llm/parser_test.go
@@ -149,3 +149,58 @@ func TestFixIncomplete_PartialEndTag(t *testing.T) {
 		t.Fatalf("expected 1 finish call, got %+v", calls)
 	}
 }
+
+// ParseOrphanedCalls must recover <parameter> blocks that have a trailing
+// </function> but NO <function=NAME> open tag — the malformation that force-
+// stopped the codeant.ai scan. The caller resolves the tool name via the
+// registry schema.
+func TestParseOrphanedCallsDroppedOpenTag(t *testing.T) {
+	// Exact pattern from codeant.ai: open tag truncated to "_plan>", then
+	// well-formed params + close.
+	got := ParseOrphanedCalls("_plan>\n<parameter=task_id>dirbust</parameter>\n<parameter=status>completed</parameter>\n<parameter=notes>Done</parameter>\n</function>")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 orphaned call, got %d", len(got))
+	}
+	if got[0].Args["task_id"] != "dirbust" || got[0].Args["status"] != "completed" || got[0].Args["notes"] != "Done" {
+		t.Errorf("orphaned args = %v, want task_id/status/notes", got[0].Args)
+	}
+	if len(got[0].ParamNames) != 3 {
+		t.Errorf("ParamNames = %v, want 3", got[0].ParamNames)
+	}
+}
+
+// The http_request-style malformation: entire open tag + the "<" of the first
+// <parameter gone, leaving "parameter=method>...</parameter>...</function>".
+func TestParseOrphanedCallsMissingOpenAndParamBracket(t *testing.T) {
+	got := ParseOrphanedCalls("parameter=method>POST</parameter>\n<parameter=url>https://api.x/api/analysis</parameter>\n<parameter=headers>{\"Content-Type\":\"application/json\"}</parameter>\n<parameter=body>{\"repo\":\"foo/bar\"}</parameter>\n</function>")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 orphaned call, got %d", len(got))
+	}
+	// The first param lost its leading "<" so paramEqRegex won't match it;
+	// the remaining well-formed params must still be recovered so the caller
+	// can match the tool by url/headers/body.
+	if got[0].Args["url"] == "" {
+		t.Errorf("url param not recovered: %v", got[0].Args)
+	}
+	if got[0].Args["headers"] == "" {
+		t.Errorf("headers param not recovered: %v", got[0].Args)
+	}
+}
+
+// Well-formed calls must NOT be double-counted as orphans.
+func TestParseOrphanedCallsSkipsWellFormed(t *testing.T) {
+	content := "<function=terminal_execute>\n<parameter=command>id</parameter>\n</function>"
+	got := ParseOrphanedCalls(content)
+	if len(got) != 0 {
+		t.Errorf("well-formed call should not produce orphans, got %d", len(got))
+	}
+}
+
+// Multiple orphaned calls in one response each map to a separate OrphanedCall.
+func TestParseOrphanedCallsMultiple(t *testing.T) {
+	content := "<parameter=command>curl a</parameter>\n</function>\n<parameter=command>curl b</parameter>\n</function>"
+	got := ParseOrphanedCalls(content)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 orphaned calls, got %d", len(got))
+	}
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -166,6 +166,56 @@ func (r *Registry) List() []string {
 	return names
 }
 
+// MatchByParams returns the registered tool whose parameter names best match
+// the supplied set, used to recover tool calls whose <function=NAME> open tag
+// was dropped by the model (leaving orphaned <parameter=X> blocks + a trailing
+// </function>). The match is schema-guided: a tool scores +1 for each of the
+// given param names it declares, and the tool with the highest score wins,
+// provided every REQUIRED parameter of that tool is present in the given set.
+// Returns ("", false) when no tool's required params are all satisfied.
+//
+// This is deliberately conservative: it only ever resolves to a tool when the
+// orphaned parameters are a complete-enough superset of that tool's required
+// schema, so a genuinely ambiguous or partial fragment is left unresolved
+// (caller treats it as no-tool) rather than executing the wrong tool.
+func (r *Registry) MatchByParams(paramNames []string) (string, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if len(paramNames) == 0 {
+		return "", false
+	}
+	got := make(map[string]bool, len(paramNames))
+	for _, p := range paramNames {
+		got[strings.ToLower(strings.TrimSpace(p))] = true
+	}
+	bestName := ""
+	bestScore := 0
+	for _, t := range r.tools {
+		score := 0
+		allRequired := true
+		for _, p := range t.Parameters {
+			pn := strings.ToLower(strings.TrimSpace(p.Name))
+			if got[pn] {
+				score++
+			} else if p.Required {
+				allRequired = false
+			}
+		}
+		// Only candidate tools whose required params are all present, and
+		// that actually matched at least one param. Prefer the tighter match
+		// (higher score / fewer unmatched given params) to disambiguate tools
+		// that share a parameter name.
+		if allRequired && score > bestScore {
+			bestScore = score
+			bestName = t.Name
+		}
+	}
+	if bestName == "" || bestScore == 0 {
+		return "", false
+	}
+	return bestName, true
+}
+
 // Execute runs a tool by name with the given arguments.
 // Note: the caller's args map is never mutated — Execute works on a copy.
 func (r *Registry) Execute(name string, args map[string]string) (Result, error) {

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -194,3 +194,42 @@ func TestSchemaXML_ConcurrentReads(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// MatchByParams resolves a tool whose required params are all present — the
+// recovery path for tool calls whose <function=NAME> open tag was dropped,
+// leaving only <parameter> blocks. Must be conservative: ambiguous/partial
+// sets resolve to nothing.
+func TestMatchByParamsUpdatePlan(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&Tool{Name: "update_plan", Parameters: []Parameter{
+		{Name: "task_id", Required: true}, {Name: "status", Required: true}, {Name: "notes", Required: false},
+	}})
+	r.Register(&Tool{Name: "terminal_execute", Parameters: []Parameter{
+		{Name: "command", Required: true},
+	}})
+
+	// update_plan's required params present → resolves to update_plan.
+	name, ok := r.MatchByParams([]string{"task_id", "status", "notes"})
+	if !ok || name != "update_plan" {
+		t.Errorf("MatchByParams(task_id,status,notes) = %q,%v, want update_plan,true", name, ok)
+	}
+	// Missing a required param (status) → no match (don't execute wrong tool).
+	name, ok = r.MatchByParams([]string{"task_id", "notes"})
+	if ok {
+		t.Errorf("MatchByParams with missing required param should not resolve, got %q", name)
+	}
+	// terminal_execute's single required param → resolves.
+	name, ok = r.MatchByParams([]string{"command"})
+	if !ok || name != "terminal_execute" {
+		t.Errorf("MatchByParams(command) = %q,%v, want terminal_execute,true", name, ok)
+	}
+	// Empty / unknown params → no match.
+	name, ok = r.MatchByParams([]string{"nonsense"})
+	if ok {
+		t.Errorf("MatchByParams(nonsense) should not resolve, got %q", name)
+	}
+	name, ok = r.MatchByParams(nil)
+	if ok {
+		t.Errorf("MatchByParams(nil) should not resolve, got %q", name)
+	}
+}


### PR DESCRIPTION
## Root cause of the persistent abort

The `llm_no_tool_calls` abort recurred on codeant.ai **after** the v4.5.72 reasoning-loop compaction. The compaction fired correctly (line 3732 of the scan log) but couldn't help: the model wasn't stuck reasoning — it was emitting **tool calls with the `<function=NAME>` open tag dropped**, leaving only `<parameter=X>…</parameter>` blocks + a trailing `</function>`.

`ParseToolCalls` can't recover the tool name from that, so every such response counted as 'no tool call' → 15 consecutive → force-stop.

Observed malformations (from the codeant.ai scan log):
```
_plan>\n<parameter=task_id>dirbust</parameter>\n<parameter=status>completed</parameter>\n…</function>
parameter=method>POST</parameter>\n<parameter=url>https://api.x/...</parameter>\n…</function>
```

After the compaction the model kept dropping the open tag → looped back to 15 → aborted. This is a parser gap, not a reasoning-loop problem.

## Fix — schema-guided recovery

1. **`llm.ParseOrphanedCalls`** — extracts `<parameter>` blocks bounded by a `</function>` close tag with NO preceding `<function=NAME>` open tag. Strips well-formed calls first so their params aren't mis-attributed.
2. **`tools.Registry.MatchByParams`** — resolves the orphaned param set to the registered tool whose required params are all present (scored by param overlap). Ambiguous/partial sets resolve to nothing — safer than executing the wrong tool.
3. **agent loop** — when `ParseToolCalls` returns empty, attempts orphaned-call recovery **before** the no-tool hook, so recovered calls are healthy and don't count toward the reasoning-loop threshold. Emits a `🔧 Recovered a tool call…` message so the operator sees the recovery in the live feed.

This is conservative: it only ever resolves to a tool when the orphaned parameters are a complete-enough superset of that tool's required schema.

## Verification
```
go build ./...            # clean
gofmt + golangci-lint     # 0 issues
go test ./internal/llm/ ./internal/tools/ ./internal/agent/   # all pass
```

Tests cover the exact malformations from the codeant.ai log (`_plan>` and `parameter=method>` patterns), plus well-formed calls not being double-counted, and the registry rejecting ambiguous/partial param sets.

> [!IMPORTANT]
> Use Xalgorix only on systems you own or have explicit permission to test.