### PR TITLE
fix(llm): count Google Gemini token usage (usageMetadata)

### DIFF
--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -201,7 +201,19 @@ type geminiCandidate struct {
 }
 
 type geminiResponse struct {
-	Candidates []geminiCandidate `json:"candidates"`
+	Candidates    []geminiCandidate    `json:"candidates"`
+	UsageMetadata *geminiUsageMetadata `json:"usageMetadata,omitempty"`
+}
+
+// geminiUsageMetadata carries token counts returned by the Gemini
+// generateContent and streamGenerateContent endpoints. Unlike the
+// OpenAI-style `usage` object, Gemini reports usage under `usageMetadata`;
+// in a streamed response the counts are cumulative and the final chunk
+// carries the totals.
+type geminiUsageMetadata struct {
+	PromptTokenCount     int `json:"promptTokenCount"`
+	CandidatesTokenCount int `json:"candidatesTokenCount"`
+	TotalTokenCount      int `json:"totalTokenCount"`
 }
 
 // geminiStreamResponse is the same structure but used for SSE streaming responses.
@@ -912,7 +924,10 @@ func (c *Client) ChatStream(messages []Message) <-chan StreamChunk {
 			return
 		}
 
-		// OpenAI/Google streaming: "data: JSON" lines
+		// OpenAI/Google streaming: "data: JSON" lines. Gemini reports token usage
+		// under usageMetadata (cumulative per chunk); keep the latest values and
+		// add them to the running totals once, after the stream ends.
+		var gemPromptTokens, gemCandidateTokens int
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !strings.HasPrefix(line, "data: ") {
@@ -929,6 +944,11 @@ func (c *Client) ChatStream(messages []Message) <-chan StreamChunk {
 				var gemResp geminiStreamResponse
 				if err := json.Unmarshal([]byte(data), &gemResp); err != nil {
 					continue
+				}
+				if gemResp.UsageMetadata != nil {
+					// Gemini streams cumulative usage; remember the latest.
+					gemPromptTokens = gemResp.UsageMetadata.PromptTokenCount
+					gemCandidateTokens = gemResp.UsageMetadata.CandidatesTokenCount
 				}
 				if len(gemResp.Candidates) > 0 && len(gemResp.Candidates[0].Content.Parts) > 0 {
 					content := gemResp.Candidates[0].Content.Parts[0].Text
@@ -956,6 +976,12 @@ func (c *Client) ChatStream(messages []Message) <-chan StreamChunk {
 			}
 		}
 
+		if gemPromptTokens > 0 || gemCandidateTokens > 0 {
+			c.mu.Lock()
+			c.totalIn += gemPromptTokens
+			c.totalOut += gemCandidateTokens
+			c.mu.Unlock()
+		}
 		ch <- StreamChunk{Done: true}
 	})
 
@@ -1091,6 +1117,12 @@ func (c *Client) doChat(messages []Message) (out string, err error) {
 		}
 		if len(gemResp.Candidates) == 0 || len(gemResp.Candidates[0].Content.Parts) == 0 {
 			return "", fmt.Errorf("no content in Gemini response")
+		}
+		if gemResp.UsageMetadata != nil {
+			c.mu.Lock()
+			c.totalIn += gemResp.UsageMetadata.PromptTokenCount
+			c.totalOut += gemResp.UsageMetadata.CandidatesTokenCount
+			c.mu.Unlock()
 		}
 		return gemResp.Candidates[0].Content.Parts[0].Text, nil
 	}

--- a/internal/llm/gemini_usage_test.go
+++ b/internal/llm/gemini_usage_test.go
@@ -1,0 +1,89 @@
+package llm
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/config"
+)
+
+// newGeminiTestClient builds a Client wired to a mock server and forces the
+// Gemini ("google") code path so the token-usage parsing is exercised.
+func newGeminiTestClient(t *testing.T, srvURL string) *Client {
+	t.Helper()
+	cfg := &config.Config{LLM: "gemini-2.5-flash", APIBase: srvURL, APIKey: "test"}
+	c := NewClient(cfg)
+	c.provider = "google" // route through the native Gemini endpoint logic
+	return c
+}
+
+// TestGeminiUsageAccountingNonStreaming proves the non-streaming path (doChat)
+// counts tokens reported under Gemini's usageMetadata. Before the fix these
+// counters stayed at zero because the code only understood the OpenAI-style
+// `usage` object.
+func TestGeminiUsageAccountingNonStreaming(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"pong"}]}}],` +
+			`"usageMetadata":{"promptTokenCount":100,"candidatesTokenCount":40,"totalTokenCount":140}}`))
+	}))
+	defer srv.Close()
+
+	c := newGeminiTestClient(t, srv.URL)
+	out, err := c.Chat([]Message{{Role: "user", Content: "ping"}})
+	if err != nil {
+		t.Fatalf("Chat returned error: %v", err)
+	}
+	if out != "pong" {
+		t.Fatalf("unexpected content: %q", out)
+	}
+
+	in, comp, total := c.GetTokens()
+	if in != 100 || comp != 40 || total != 140 {
+		t.Fatalf("Gemini usage not counted: in=%d completion=%d total=%d (want 100/40/140)", in, comp, total)
+	}
+}
+
+// TestGeminiUsageAccountingStreaming proves the streaming path (ChatStream)
+// adds the FINAL cumulative usageMetadata exactly once. Gemini repeats a
+// growing usageMetadata on every SSE chunk, so a naive per-chunk sum would
+// massively over-count; this asserts the totals equal the last chunk's values.
+func TestGeminiUsageAccountingStreaming(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, _ := w.(http.Flusher)
+		chunks := []string{
+			`{"candidates":[{"content":{"parts":[{"text":"po"}]}}],` +
+				`"usageMetadata":{"promptTokenCount":100,"candidatesTokenCount":10,"totalTokenCount":110}}`,
+			`{"candidates":[{"content":{"parts":[{"text":"ng"}]}}],` +
+				`"usageMetadata":{"promptTokenCount":100,"candidatesTokenCount":40,"totalTokenCount":140}}`,
+		}
+		for _, ch := range chunks {
+			_, _ = w.Write([]byte("data: " + ch + "\n\n"))
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+	}))
+	defer srv.Close()
+
+	c := newGeminiTestClient(t, srv.URL)
+	var sb strings.Builder
+	for chunk := range c.ChatStream([]Message{{Role: "user", Content: "ping"}}) {
+		if chunk.Err != nil {
+			t.Fatalf("stream returned error: %v", chunk.Err)
+		}
+		sb.WriteString(chunk.Content)
+	}
+	if sb.String() != "pong" {
+		t.Fatalf("unexpected streamed content: %q", sb.String())
+	}
+
+	in, comp, total := c.GetTokens()
+	if in != 100 || comp != 40 || total != 140 {
+		t.Fatalf("Gemini streaming usage wrong (must use final cumulative chunk, not a per-chunk sum): "+
+			"in=%d completion=%d total=%d (want 100/40/140)", in, comp, total)
+	}
+}


### PR DESCRIPTION
## Problem

Scans running on a Google **Gemini** model (provider `google`, the native `generativelanguage.googleapis.com` `generateContent` / `streamGenerateContent` endpoints) always reported **0 tokens** in the dashboard TOKENS column — even on successful, multi-iteration scans that clearly consumed tokens.

Root cause: the LLM client only decodes the OpenAI-style `usage` object and Anthropic's usage block. Gemini returns token counts under **`usageMetadata`** (`promptTokenCount` / `candidatesTokenCount` / `totalTokenCount`), which was never parsed. So `c.totalIn` / `c.totalOut` stayed 0 and `GetTokens()` returned 0 for every Gemini call (the value that ends up as `total_tokens` in `scan.json` and the UI).

## Fix

- Add `usageMetadata` to `geminiResponse` (new `geminiUsageMetadata` type).
- Non-streaming (`doChat`): accumulate `promptTokenCount` / `candidatesTokenCount` into the running totals.
- Streaming (`ChatStream`): Gemini repeats a **cumulative** `usageMetadata` on every SSE chunk, so the code remembers the latest values and adds them **once** after the stream ends — never summed per-chunk, which would massively over-count.

No behavior change for OpenAI / Anthropic / DeepSeek / Groq / etc. — their usage parsing is untouched.

## Tests

`internal/llm/gemini_usage_test.go` (httptest-based, both code paths):

- `TestGeminiUsageAccountingNonStreaming` — a Gemini JSON response with `usageMetadata{100,40,140}` ⇒ `GetTokens()` returns `100 / 40 / 140`.
- `TestGeminiUsageAccountingStreaming` — two cumulative SSE chunks (`…candidatesTokenCount:10` then `…:40`) ⇒ totals equal the **final** chunk (`40` completion, not `50`), guarding against per-chunk summation.

```
$ go test ./internal/llm/
ok  	github.com/xalgord/xalgorix/v4/internal/llm
$ go vet ./internal/llm/
```

Full `internal/llm` package passes and `go vet` is clean.