### PR TITLE
fix(agent): recover bare-name dropped-open-tag calls and reject param…

### DIFF
--- a/internal/llm/parser.go
+++ b/internal/llm/parser.go
@@ -37,15 +37,31 @@ var (
 	//     =send_request><parameter=method>GET</parameter></function>               (no "<function")
 	//     function=terminal_execute"><parameter=command>id</parameter></function>  (stray quote before ">")
 	//     <function="terminal_execute"><parameter=...>                             (quoted name)
-	// 15 such responses in a row force-stops the whole scan (observed in
+	// 15 such responses in a row force-stop the whole scan (observed in
 	// production against bitbank.cc). This repair rebuilds the canonical
 	// "<function=name>" form, tolerating an optional leading "<"/"<function",
 	// optional surrounding quotes, and stray quotes/whitespace before the ">".
-	// Requiring a "<parameter" or "</function>" immediately after makes it a
-	// specific, low-false-positive signal (ordinary prose has no
-	// "=word><parameter"), and correct "<function=name>" tags rewrite to the
-	// identical form, so it is idempotent.
-	repairFnOpenRe = regexp.MustCompile(`(?s)<?(?:function)?\s*=\s*["']?([A-Za-z_][A-Za-z0-9_-]*)["'\s]*>(\s*(?:<parameter|</function>))`)
+	// The leading "(^|[^\w/<])" boundary prevents the name from also matching
+	// inside a CLOSING tag ("</parameter>" has no "=", but the name "parameter"
+	// plus its ">" must never be mistaken for an open tag); it is captured so it
+	// can be re-emitted in the replacement. Requiring a "<parameter" or
+	// "</function>" immediately after the name makes this a specific,
+	// low-false-positive signal (ordinary prose never has "=word><parameter"),
+	// and correct "<function=name>" tags rewrite to the identical form, so it is
+	// idempotent.
+	repairFnOpenRe = regexp.MustCompile(`(?s)(^|[^\w/<])<?(?:function\s*)?=\s*["']?([A-Za-z_][A-Za-z0-9_-]*)["'\s]*>(\s*(?:<parameter|</function>))`)
+
+	// Second repair for the codeant.ai shape: the model dropped the ENTIRE
+	// "<function=" prefix, leaving only the bare tool name + a STRAY QUOTE before
+	// the ">", then a well-formed body. E.g.
+	//     terminal_execute"><parameter=command>python3...</parameter></function>
+	// This is distinct from a truncation like "_plan>" (suffix of "<update_plan>")
+	// because the stray quote (a leftover from "<function=\"name\">" or
+	// "function=name\">") is a near-zero-false-positive signal that ordinary
+	// prose never produces. Truncations carry NO quote, so they correctly stay
+	// on the orphaned-call path where MatchByParams resolves them via their
+	// parameter set (e.g. {task_id,status,notes} → update_plan).
+	repairBareNameQuotedRe = regexp.MustCompile(`(?s)(^|[^\w/<])([A-Za-z_][A-Za-z0-9_-]*)["']\s*>(\s*(?:<parameter|</function>))`)
 
 	// Normalize quotes around = in tags: <function = "name"> → <function=name>
 	stripQuotesRe = regexp.MustCompile(`<(function|parameter)\s*=\s*["']?([^>"']+?)["']?\s*>`)
@@ -174,7 +190,10 @@ func normalizeFormat(content string) string {
 	}
 
 	// Repair malformed function-open tags (missing leading "<" / "<function").
-	content = repairFnOpenRe.ReplaceAllString(content, "<function=${1}>${2}")
+	// ${1} is the leading boundary char (re-emitted so we don't eat punctuation).
+	content = repairFnOpenRe.ReplaceAllString(content, "${1}<function=${2}>${3}")
+	// Repair bare-name+quote drops (codeant.ai shape). Same ${1} boundary trick.
+	content = repairBareNameQuotedRe.ReplaceAllString(content, "${1}<function=${2}>${3}")
 
 	// Normalize quotes/spaces around = signs: <function = "name"> → <function=name>
 	content = stripQuotesRe.ReplaceAllStringFunc(content, func(s string) string {

--- a/internal/llm/parser_repair_test.go
+++ b/internal/llm/parser_repair_test.go
@@ -65,6 +65,23 @@ func TestParseToolCalls_RepairsMalformedOpenTag(t *testing.T) {
 			wantVal:  "GET",
 		},
 		{
+			// The codeant.ai incident: the model dropped the ENTIRE "<function="
+			// prefix, leaving the bare tool name + a stray quote, then a
+			// well-formed <parameter> body + </function>. Before the
+			// repairBareNameQuotedRe repair was added, this shape was NOT
+			// recovered, fell through to orphaned-param matching, tied
+			// terminal_execute/browser_action/str_replace_editor/pageagent (all
+			// share a single required "command" param), and the wrong tool
+			// (browser_action) won non-deterministically — failing every call
+			// with "unknown browser action: python3..." and force-stopping the
+			// scan at 15 no-tool responses.
+			name:     "whole function= prefix dropped, bare name + stray quote (codeant.ai)",
+			input:    "terminal_execute\">\n<parameter=command>python3 << 'EOF'\nimport re\nEOF</parameter>\n</function>",
+			wantName: "terminal_execute",
+			wantKey:  "command",
+			wantVal:  "python3 << 'EOF'\nimport re\nEOF",
+		},
+		{
 			name:     "correct tag still parses (idempotent)",
 			input:    "<function=finish>\n<parameter=summary>done</parameter>\n</function>",
 			wantName: "finish",

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -176,8 +176,13 @@ func (r *Registry) List() []string {
 //
 // This is deliberately conservative: it only ever resolves to a tool when the
 // orphaned parameters are a complete-enough superset of that tool's required
-// schema, so a genuinely ambiguous or partial fragment is left unresolved
-// (caller treats it as no-tool) rather than executing the wrong tool.
+// schema AND uniquely identify a single tool, so a genuinely ambiguous or
+// partial fragment is left unresolved (caller treats it as no-tool) rather
+// than executing the wrong tool. A tie between two or more tools at the best
+// score is treated as ambiguous and resolves to nothing — executing a
+// randomly-chosen winner (e.g. browser_action vs terminal_execute when both
+// share a single required "command" param) has caused whole-scan force-stops
+// in production (codeant.ai), because the wrong tool then fails on every call.
 func (r *Registry) MatchByParams(paramNames []string) (string, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -190,6 +195,7 @@ func (r *Registry) MatchByParams(paramNames []string) (string, bool) {
 	}
 	bestName := ""
 	bestScore := 0
+	tie := false
 	for _, t := range r.tools {
 		score := 0
 		allRequired := true
@@ -204,13 +210,22 @@ func (r *Registry) MatchByParams(paramNames []string) (string, bool) {
 		// Only candidate tools whose required params are all present, and
 		// that actually matched at least one param. Prefer the tighter match
 		// (higher score / fewer unmatched given params) to disambiguate tools
-		// that share a parameter name.
-		if allRequired && score > bestScore {
+		// that share a parameter name. If two eligible tools score equally,
+		// mark it a tie — the parameter set does not uniquely identify the
+		// tool, so resolving to either one would be a guess.
+		if !allRequired || score == 0 {
+			continue
+		}
+		switch {
+		case score > bestScore:
 			bestScore = score
 			bestName = t.Name
+			tie = false
+		case score == bestScore:
+			tie = true
 		}
 	}
-	if bestName == "" || bestScore == 0 {
+	if bestName == "" || bestScore == 0 || tie {
 		return "", false
 	}
 	return bestName, true

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -233,3 +233,49 @@ func TestMatchByParamsUpdatePlan(t *testing.T) {
 		t.Errorf("MatchByParams(nil) should not resolve, got %q", name)
 	}
 }
+
+// MatchByParams must NOT resolve a tie. This is the codeant.ai root cause:
+// terminal_execute, browser_action, str_replace_editor and pageagent all share
+// a single required "command" parameter, so a dropped-open-tag call that
+// recovers only {"command"} cannot uniquely identify the tool. The previous
+// implementation picked an arbitrary winner via randomized map iteration
+// (browser_action), executed the wrong tool, and force-stopped the scan.
+// A tie is ambiguity — it must resolve to nothing rather than a guess.
+func TestMatchByParamsRejectsTie(t *testing.T) {
+	r := NewRegistry()
+	for _, def := range []struct {
+		name   string
+		params []Parameter
+	}{
+		{"terminal_execute", []Parameter{{Name: "command", Required: true}}},
+		{"browser_action", []Parameter{
+			{Name: "command", Required: true},
+			{Name: "url", Required: false},
+		}},
+		{"str_replace_editor", []Parameter{
+			{Name: "command", Required: true},
+			{Name: "path", Required: true},
+		}},
+		{"pageagent", []Parameter{
+			{Name: "command", Required: true},
+			{Name: "id", Required: false},
+		}},
+	} {
+		r.Register(&Tool{Name: def.name, Parameters: def.params})
+	}
+
+	// "command" alone ties all four tools at score 1 → ambiguous → no match.
+	if name, ok := r.MatchByParams([]string{"command"}); ok {
+		t.Errorf("MatchByParams(command) with 4 command-param tools = %q,true, want no match (tie)", name)
+	}
+
+	// Adding a browser-only optional param breaks the tie → browser_action wins.
+	if name, ok := r.MatchByParams([]string{"command", "url"}); !ok || name != "browser_action" {
+		t.Errorf("MatchByParams(command,url) = %q,%v, want browser_action,true", name, ok)
+	}
+
+	// Adding pageagent-only "id" → pageagent wins (score 2 vs the others' 1).
+	if name, ok := r.MatchByParams([]string{"command", "id"}); !ok || name != "pageagent" {
+		t.Errorf("MatchByParams(command,id) = %q,%v, want pageagent,true", name, ok)
+	}
+}


### PR DESCRIPTION
… ties

The dropped-open-tag recovery added in cce0561 missed the actual malformed shape from the codeant.ai incident: the model dropped the entire "<function=" prefix, leaving a bare name + stray quote (terminal_execute">). The repair regex required "=", so this fell through to orphaned-param matching, where MatchByParams tied terminal_execute/browser_action/str_replace_editor/pageagent (all share a single required "command" param) and non-deterministically picked browser_action — which failed every call with "unknown browser action: python3" and force-stopped the scan at 15 no-tool responses.

Two fixes:

1. parser: add repairBareNameQuotedRe to recover the bare-name + stray-quote shape with the correct tool name. Scoped to the quoted shape so truncations like "_plan>" (no quote) stay on the orphan path where MatchByParams resolves them via their parameter set. Add a left-boundary (^|[^\w/<]) to both repair regexes so the name can't match inside closing tags.

2. registry: MatchByParams now rejects ties instead of picking an arbitrary winner via randomized map iteration — making its "ambiguous sets resolve to nothing" doc comment actually true, so a future param collision can never execute the wrong tool.

<!--
Thanks for contributing to Xalgorix! Please fill this out so we can review quickly.
`main` is branch-protected — PRs are the only way in. CI runs make lint,
golangci-lint, go vet, and the test suite on every PR.
-->

## What & why

<!-- What does this change and why? Link the issue it addresses. -->

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Refactor / internal
- [ ] Other:

## How was it tested?

<!-- Commands you ran, new tests added, manual verification. -->

- [ ] `make lint` passes
- [ ] `golangci-lint run --config .golangci.yml ./...` passes
- [ ] `go test ./...` passes
- [ ] Added/updated tests for the change

## Checklist

- [ ] I read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md).
- [ ] The tree is `gofmt`-clean.
- [ ] I updated docs (`README`, `docs/`, help text) if behavior changed.
- [ ] This does not weaken a security control (scope guard, verifier, false-positive gate) without explicit discussion.
- [ ] For engine behavior changes: I noted any impact on scan findings/severity.
