### PR TITLE
release: v4.5.75

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.74
+VERSION=4.5.75
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.74" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.75" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.74"
+var version = "4.5.75"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
### Changes

- 09363d0 Merge pull request #280 from ulises2k/fix/gemini-token-usage
- da8c5c3 Merge pull request #281 from xalgord/fix/recover-bare-name-dropped-open-tag
- 82dcd8a fix(agent): recover bare-name dropped-open-tag calls and reject param ties
- 9d83b01 fix(llm): count Google Gemini token usage (usageMetadata)
- 42b80d6 Merge pull request #279 from xalgord/release/v4.5.74