### PR TITLE
fix(web): persist pending scans so they survive a server restart

### DIFF
--- a/internal/web/orchestrator.go
+++ b/internal/web/orchestrator.go
@@ -165,7 +165,7 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 			// decide its fate here.
 			//   - server_shutdown: preserve → the auto-resume goroutine re-queues
 			//     it after restart (the whole point of persisting pending scans).
-			//   - user_stopped / any other reason: clear → a cancelled scan must
+			//   - user_stopped / any other reason: clear → a canceled scan must
 			//     NOT be resurrected on the next boot.
 			instance.mu.RLock()
 			reason := instance.StopReason

--- a/internal/web/orchestrator.go
+++ b/internal/web/orchestrator.go
@@ -102,6 +102,18 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 	s.instances[instanceID] = instance
 	s.instancesMu.Unlock()
 
+	// Persist the queue state immediately, BEFORE the admission wait loop.
+	// Previously the first saveQueueState ran only after admission (well past
+	// the wait loop), so an instance parked at "pending" left ZERO disk trace.
+	// On server restart both rebuildInstancesFromDisk (scan.json) and the
+	// auto-resume goroutine (queue_state_*.json) found nothing → pending scans
+	// were silently dropped instead of re-queued. Writing it here at CurrentIdx=0
+	// means the existing auto-resume path (scanRequestFromQueueState →
+	// runMultiScan) re-enters the admission loop after a restart. Thread the
+	// instance ID onto the request now so the file lands at the right path.
+	req.InstanceID = instanceID
+	s.saveQueueState(0, req)
+
 	// Broadcast to dashboard
 	s.broadcastDashboard(WSEvent{Type: "instance_started", Content: instanceID})
 
@@ -146,6 +158,22 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 				s.clearQueueState(instanceID)
 			} else {
 				log.Printf("[AUTO-RESUME] Preserving queue state after interrupted scan")
+			}
+		} else {
+			// The instance exited pending WITHOUT ever running. A queue_state
+			// file was written at creation so the scan could survive a restart;
+			// decide its fate here.
+			//   - server_shutdown: preserve → the auto-resume goroutine re-queues
+			//     it after restart (the whole point of persisting pending scans).
+			//   - user_stopped / any other reason: clear → a cancelled scan must
+			//     NOT be resurrected on the next boot.
+			instance.mu.RLock()
+			reason := instance.StopReason
+			instance.mu.RUnlock()
+			if reason == "server_shutdown" {
+				log.Printf("[AUTO-RESUME] Preserving pending queue state (server_shutdown) for %s", instanceID)
+			} else {
+				s.clearQueueState(instanceID)
 			}
 		}
 
@@ -318,7 +346,7 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 	// IMPORTANT: This runs AFTER the queue wait. Do not clear the queue file
 	// before the refreshed state is written; resumed scans rely on it if the
 	// process exits during admission/startup.
-	req.InstanceID = instanceID // thread instance ID to all target handlers
+	req.InstanceID = instanceID // (re)thread instance ID; also set before the admission wait
 	s.running.Store(true)
 	s.stopReq.Store(false) // clear global stop so this scan isn't immediately aborted
 	if req.DiscordWebhook != "" {

--- a/internal/web/scan_lifecycle_test.go
+++ b/internal/web/scan_lifecycle_test.go
@@ -113,3 +113,91 @@ func TestHandleInstanceStop_ClearsQueueState(t *testing.T) {
 		t.Errorf("queue state file must be removed after stop (err=%v)", err)
 	}
 }
+
+// A pending scan must leave a resumable queue_state_<id>.json on disk so that,
+// after a server restart, the auto-resume goroutine re-queues it instead of
+// silently dropping it. Before the fix, runMultiScan only wrote queue state
+// AFTER admission, so an instance parked at "pending" left no trace and was
+// lost on restart. This test verifies the persistence + resume round-trip that
+// change relies on: saveQueueState(0, req) produces a file that
+// autoResumeQueueEntries considers resumable and scanRequestFromQueueState
+// rebuilds faithfully.
+func TestPendingScanQueueState_RoundTripsForResume(t *testing.T) {
+	s := newTestServer(t, nil)
+
+	req := ScanRequest{
+		InstanceID: "pending-1",
+		Targets:    []string{"https://pentest-ground.com:9000"},
+		ScanMode:   "quick",
+		Name:       "Pentest ground",
+	}
+	// This is exactly what runMultiScan now does on instance creation.
+	s.saveQueueState(0, req)
+
+	queuePath := s.queueStatePathForInstance("pending-1")
+	if _, err := os.Stat(queuePath); err != nil {
+		t.Fatalf("pending scan must persist queue state on creation: %v", err)
+	}
+
+	// The file must be picked up by the auto-resume path (not filtered out as
+	// inactive/empty/corrupt/completed).
+	entries := autoResumeQueueEntries(s.validQueueStateEntries(true))
+	var found *QueueState
+	for _, e := range entries {
+		if e.state != nil && e.state.InstanceID == "pending-1" {
+			found = e.state
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("pending queue state not resumable via auto-resume path (entries=%d)", len(entries))
+	}
+	if found.CurrentIdx != 0 {
+		t.Errorf("pending scan CurrentIdx = %d, want 0 (never started)", found.CurrentIdx)
+	}
+	if !found.Active {
+		t.Error("pending scan queue state must be Active=true")
+	}
+
+	// scanRequestFromQueueState must rebuild a request that re-enters the
+	// admission loop with all original targets.
+	resumed := scanRequestFromQueueState(found, queuePath)
+	if len(resumed.Targets) != 1 || resumed.Targets[0] != "https://pentest-ground.com:9000" {
+		t.Errorf("resumed targets = %v, want original single target", resumed.Targets)
+	}
+	if resumed.ScanMode != "quick" || resumed.Name != "Pentest ground" {
+		t.Errorf("resumed request lost fields: mode=%q name=%q", resumed.ScanMode, resumed.Name)
+	}
+	if !resumed.IsResume {
+		t.Error("resumed request must have IsResume=true")
+	}
+}
+
+// clearQueueState must remove a pending scan's file — this is the contract the
+// cancel path (user_stopped) relies on so a cancelled scan is not resurrected
+// on the next boot.
+func TestClearQueueState_RemovesPendingScanFile(t *testing.T) {
+	s := newTestServer(t, nil)
+
+	s.saveQueueState(0, ScanRequest{
+		InstanceID: "cancel-1",
+		Targets:    []string{"a.com"},
+	})
+	queuePath := s.queueStatePathForInstance("cancel-1")
+	if _, err := os.Stat(queuePath); err != nil {
+		t.Fatalf("precondition: queue state should exist: %v", err)
+	}
+
+	s.clearQueueState("cancel-1")
+	if _, err := os.Stat(queuePath); !os.IsNotExist(err) {
+		t.Errorf("clearQueueState must remove pending scan file (err=%v)", err)
+	}
+
+	// And it must no longer appear in the auto-resume set (so a restart won't
+	// resurrect it).
+	for _, e := range autoResumeQueueEntries(s.validQueueStateEntries(true)) {
+		if e.state != nil && e.state.InstanceID == "cancel-1" {
+			t.Error("cancelled pending scan must not be resumable after clearQueueState")
+		}
+	}
+}

--- a/internal/web/scan_lifecycle_test.go
+++ b/internal/web/scan_lifecycle_test.go
@@ -174,7 +174,7 @@ func TestPendingScanQueueState_RoundTripsForResume(t *testing.T) {
 }
 
 // clearQueueState must remove a pending scan's file — this is the contract the
-// cancel path (user_stopped) relies on so a cancelled scan is not resurrected
+// cancel path (user_stopped) relies on so a canceled scan is not resurrected
 // on the next boot.
 func TestClearQueueState_RemovesPendingScanFile(t *testing.T) {
 	s := newTestServer(t, nil)
@@ -197,7 +197,7 @@ func TestClearQueueState_RemovesPendingScanFile(t *testing.T) {
 	// resurrect it).
 	for _, e := range autoResumeQueueEntries(s.validQueueStateEntries(true)) {
 		if e.state != nil && e.state.InstanceID == "cancel-1" {
-			t.Error("cancelled pending scan must not be resumable after clearQueueState")
+			t.Error("canceled pending scan must not be resumable after clearQueueState")
 		}
 	}
 }


### PR DESCRIPTION
A pending (not-yet-admitted) scan left zero disk trace: runMultiScan registered the instance in-memory but only wrote queue state AFTER admission, so on restart both rebuildInstancesFromDisk and the auto-resume goroutine found nothing → pending scans were silently dropped instead of re-queued.

Persist the queue state at instance creation (CurrentIdx=0, the same format running scans already use and the existing auto-resume path round-trips), then decide its fate on exit: preserve on server_shutdown so it re-queues after a clean restart; clear on user_stopped so a cancelled scan is never resurrected.

<!--
Thanks for contributing to Xalgorix! Please fill this out so we can review quickly.
`main` is branch-protected — PRs are the only way in. CI runs make lint,
golangci-lint, go vet, and the test suite on every PR.
-->

## What & why

<!-- What does this change and why? Link the issue it addresses. -->

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Refactor / internal
- [ ] Other:

## How was it tested?

<!-- Commands you ran, new tests added, manual verification. -->

- [ ] `make lint` passes
- [ ] `golangci-lint run --config .golangci.yml ./...` passes
- [ ] `go test ./...` passes
- [ ] Added/updated tests for the change

## Checklist

- [ ] I read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md).
- [ ] The tree is `gofmt`-clean.
- [ ] I updated docs (`README`, `docs/`, help text) if behavior changed.
- [ ] This does not weaken a security control (scope guard, verifier, false-positive gate) without explicit discussion.
- [ ] For engine behavior changes: I noted any impact on scan findings/severity.
