### PR TITLE
release: v4.5.76

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.75
+VERSION=4.5.76
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.75" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.76" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -31,7 +31,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.75"
+var version = "4.5.76"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
### Changes

- 4566721 Merge pull request #283 from xalgord/fix/persist-pending-scans-across-restart
- 35b714d fix(web): correct "cancelled" spelling for misspell linter
- 9612bd6 fix(web): persist pending scans so they survive a server restart
- ab72768 Merge pull request #282 from xalgord/release/v4.5.75