### PR TITLE
fix(docker): build ProjectDiscovery httpx on Go 1.26; stop shipping Python httpx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,10 @@ COPY internal/web ./internal/web
 RUN cd webui && npm run build
 
 # ── Stage 2: build the Go binary + the latest Go security toolset ────────────
-FROM golang:1.25-bookworm AS gobuild
+# Go 1.26+ is required: projectdiscovery/httpx v1.10.0 declares `go >= 1.26`, so
+# a 1.25 builder makes `go install httpx@latest` fail (silently, via the `|| WARN`
+# in the tool loop) and the image ships without the ProjectDiscovery scanner.
+FROM golang:1.26-bookworm AS gobuild
 # libpcap-dev is needed to compile naabu (CGO); git for module fetches.
 RUN apt-get update && apt-get install -y --no-install-recommends libpcap-dev git \
     && rm -rf /var/lib/apt/lists/*
@@ -138,6 +141,14 @@ RUN pipx install scrapling || pip3 install --break-system-packages scrapling || 
 
 # Bake nuclei templates so first-run scans don't stall on a template fetch.
 RUN /root/go/bin/nuclei -update-templates >/dev/null 2>&1 || echo "WARN: nuclei template prefetch skipped"
+
+# Make `httpx` resolve to ProjectDiscovery's scanner. Kali/pip ship a Python
+# `httpx` CLI (the HTTP client) at /usr/bin/httpx that otherwise answers `httpx`
+# and breaks the engine's recon (unknown flags like -silent/-title). /root/go/bin
+# is already ahead of /usr/bin on PATH; also point the absolute path at the PD
+# binary so nothing falls back to the Python client.
+RUN if [ -x /root/go/bin/httpx ]; then ln -sf /root/go/bin/httpx /usr/bin/httpx; \
+    else echo "WARN: ProjectDiscovery httpx not baked into /root/go/bin"; fi
 
 ENV XALGORIX_BIND=0.0.0.0 \
     XALGORIX_BROWSER_PATH=/usr/bin/chromium \


### PR DESCRIPTION
## Problem

`go install github.com/projectdiscovery/httpx/cmd/httpx@latest` fails in the `gobuild` stage: httpx `v1.10.0` now declares **`go >= 1.26`**, but the stage builds on `golang:1.25-bookworm`. The failure is swallowed by the `|| echo "WARN..."` in the tool loop, so the image ships **without** ProjectDiscovery httpx.

At runtime, Kali/pip provide a **Python `httpx` CLI** (the HTTP client) at `/usr/bin/httpx`, which then answers `httpx`. The engine's httpx-based recon breaks:

```
httpx -silent -title -tech-detect -status-code ...
Usage: httpx [OPTIONS] URL
Error: No such option: -s
```

`nuclei` and the other Go tools are unaffected (they build fine on 1.25), so only httpx silently goes missing.

## Fix

- Bump the `gobuild` stage to **`golang:1.26-bookworm`** so httpx (and the rest of the `@latest` toolset) builds at image-build time.
- Symlink `/usr/bin/httpx` → the ProjectDiscovery binary so the scanner wins even if a tool invokes it by absolute path (belt-and-suspenders; `/root/go/bin` is already ahead of `/usr/bin` on `PATH`).

No behavior change beyond restoring the intended ProjectDiscovery httpx.

## Verify

```
docker build -t xalgorix .
docker run --rm xalgorix sh -c 'command -v httpx; httpx -version'
# => /root/go/bin/httpx  +  ProjectDiscovery banner (not the Python client's "Usage: httpx [OPTIONS] URL")
```
