### PR TITLE
fix(terminal): install paramspider via pipx, not go install

### DIFF
--- a/internal/tools/terminal/terminal.go
+++ b/internal/tools/terminal/terminal.go
@@ -1612,7 +1612,8 @@ func installPackage(pkg string) string {
 
 	// Special handling for pipx-installed tools
 	pipxTools := map[string]string{
-		"scrapling": "scrapling",
+		"scrapling":   "scrapling",
+		"paramspider": "paramspider",
 	}
 
 	// Special handling for Cargo (Rust) tools
@@ -1640,8 +1641,6 @@ func installPackage(pkg string) string {
 		"assetfinder": "github.com/tomnomnom/assetfinder@latest",
 		// Vulnerability scanners
 		"dalfox": "github.com/hahwul/dalfox/v2@latest",
-		// Parameter discovery
-		"paramspider": "github.com/devanshbatham/paramspider@latest",
 	}
 
 	// npm-installed tools


### PR DESCRIPTION
## Problem

`paramspider` ([devanshbatham/ParamSpider](https://github.com/devanshbatham/ParamSpider)) is a **Python** tool, but `installPackage`'s `goTools` map routes it to `go install github.com/devanshbatham/paramspider@latest`. That module resolves but contains no Go package, so the install always fails:

```
go: github.com/devanshbatham/paramspider@latest: module github.com/devanshbatham/paramspider@latest found (v1.0.1), but does not contain package github.com/devanshbatham/paramspider
```

`installPackage` returns that failure with **no pip fallback** (the `goTools` branch `return`s before the generic path), so `paramspider` can never be auto-installed — even though `packageMap` advertises it and the agent prompt explicitly instructs the model to run `paramspider -d TARGET` for hidden-parameter discovery (`internal/agent/agent_prompt.go`).

## Fix

Move `paramspider` from `goTools` to `pipxTools`, so it installs via `pipx install paramspider` (with the existing `pip3` fallback) — the same way the other Python tool (`scrapling`) is handled. `paramspider` is published on PyPI.

## Verification

- Reproduced the failing `go install` above in a live Kali-based container built from this repo's `Dockerfile`.
- `go build ./internal/tools/terminal/` ✅ · `go vet` ✅ · `gofmt` clean ✅
- `paramspider` present on PyPI (HTTP 200).