### PR TITLE
fix(terminal): apt-get update before auto-installing a package

### DIFF
--- a/internal/tools/terminal/terminal.go
+++ b/internal/tools/terminal/terminal.go
@@ -1726,7 +1726,11 @@ func installPackage(pkg string) string {
 	var installCmd string
 
 	if _, err := exec.LookPath("apt-get"); err == nil {
-		installCmd = fmt.Sprintf("DEBIAN_FRONTEND=noninteractive apt-get install -y -q %s 2>&1", pkg)
+		// Refresh the package index before installing: container and other
+		// minimal images routinely ship with /var/lib/apt/lists wiped, so an
+		// install-only invocation fails with "Unable to locate package" until
+		// `apt-get update` runs. Cheap when the lists are already current.
+		installCmd = fmt.Sprintf("DEBIAN_FRONTEND=noninteractive apt-get update -qq 2>&1 && DEBIAN_FRONTEND=noninteractive apt-get install -y -q %s 2>&1", pkg)
 	} else if _, err := exec.LookPath("dnf"); err == nil {
 		installCmd = fmt.Sprintf("dnf install -y -q %s 2>&1", pkg)
 	} else if _, err := exec.LookPath("yum"); err == nil {


### PR DESCRIPTION
## Problem

`installPackage`'s apt path runs `apt-get install` with no preceding `apt-get update`. On images that wipe the package index — the Kali `Dockerfile` does exactly this (`rm -rf /var/lib/apt/lists/*`) — every apt-based auto-install fails:

```
E: Unable to locate package <pkg>
```

This silently breaks the "automatically installs missing tools" contract for any `packageMap` entry routed to apt (e.g. `httpie`, `iputils-ping`/`ping`, `html2text`, and any Kali tool not baked into the image).

Reproduced in a live container built from this repo's `Dockerfile`: `/var/lib/apt/lists/` is empty and `apt-get install -y -q httpie` returns `E: Unable to locate package httpie` (exit 100). `apt-get update` on its own succeeds (mirrors reachable), so the only missing step is the index refresh.

## Fix

Run `apt-get update -qq` before the install. It's cheap when the lists are already current. The `cargo` path is intentionally left unchanged — it already falls back to `cargo install` when apt misses.

## Verification

- `go build ./internal/tools/terminal/` ✅ · `go vet` ✅ · `gofmt` clean ✅