### PR TITLE
feat(terminal): register arjun, uro, and x8 for auto-install

### DIFF
--- a/internal/tools/terminal/terminal.go
+++ b/internal/tools/terminal/terminal.go
@@ -952,6 +952,10 @@ var packageMap = map[string]string{
 	"feroxbuster": "feroxbuster",
 	// Findomain — Rust binary, installed via package manager or cargo
 	"findomain": "findomain",
+	// Parameter discovery — arjun/uro are Python (pipx), x8 is Rust (cargo)
+	"arjun": "arjun",
+	"uro":   "uro",
+	"x8":    "x8",
 	// Text processing
 	"jq":        "jq",
 	"xmllint":   "libxml2-utils",
@@ -1613,11 +1617,14 @@ func installPackage(pkg string) string {
 	// Special handling for pipx-installed tools
 	pipxTools := map[string]string{
 		"scrapling": "scrapling",
+		"arjun":     "arjun",
+		"uro":       "uro",
 	}
 
 	// Special handling for Cargo (Rust) tools
 	cargoTools := map[string]string{
 		"feroxbuster": "feroxbuster",
+		"x8":          "x8",
 	}
 
 	// Special handling for Go-installed tools


### PR DESCRIPTION
## Problem

The agent prompt tells the model to use `arjun` and `x8` for hidden-parameter discovery and pipes URL lists through `uro` (`internal/agent/agent_prompt.go`), but none of the three are in `packageMap`. `resolvePackage` therefore returns `""` and no install is ever attempted — the commands just fail with `command not found`.

Confirmed in a live Kali-based container: `arjun`, `x8`, and `uro` are all absent, and (being unmapped) the engine never tries to install them.

## Fix

Register all three so `resolvePackage` routes each to the right installer:

| tool | ecosystem | installer |
|------|-----------|-----------|
| `arjun` | Python (PyPI) | `pipxTools` |
| `uro` | Python (PyPI) | `pipxTools` |
| `x8` | Rust (crates.io) | `cargoTools` |

## Verification

- `go build ./internal/tools/terminal/` ✅ · `go vet` ✅ · `gofmt` clean ✅
- `arjun` and `uro` confirmed on PyPI (HTTP 200); `x8` is on crates.io.

## Note

Independent of my two sibling PRs (paramspider → pipx, apt-get update). All three touch adjacent lines in `internal/tools/terminal/terminal.go`, so a trivial rebase may be needed once the first one merges.