### PR TITLE
feat(scan): custom identifying headers for scan traffic (-H, httpx/nuclei)

### DIFF
--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/xalgord/xalgorix/v4/internal/config"
 	"github.com/xalgord/xalgorix/v4/internal/proxy"
 	"github.com/xalgord/xalgorix/v4/internal/resources"
+	"github.com/xalgord/xalgorix/v4/internal/scanheaders"
 	"github.com/xalgord/xalgorix/v4/internal/tui"
 	"github.com/xalgord/xalgorix/v4/internal/web"
 )
@@ -228,6 +229,9 @@ func main() {
 	if args.bind != "" {
 		cfg.BindAddr = args.bind
 	}
+	if len(args.headers) > 0 {
+		cfg.ScanHeaders = scanheaders.Merge(args.headers, cfg.ScanHeaders)
+	}
 
 	// Web UI mode — no target or API config required at launch
 	if args.webUI {
@@ -283,6 +287,7 @@ func main() {
 type cliArgs struct {
 	targets     []string
 	instruction string
+	headers     []string
 	model       string
 	source      string // --source: git URL or local path for code-first scans
 	codeScan    string // --code-scan: "review" or "provision"
@@ -313,6 +318,11 @@ func parseArgs() cliArgs {
 			if i+1 < len(osArgs) {
 				i++
 				args.instruction = osArgs[i]
+			}
+		case "--header", "-H":
+			if i+1 < len(osArgs) {
+				i++
+				args.headers = append(args.headers, osArgs[i])
 			}
 		case "--source", "-s":
 			if i+1 < len(osArgs) {
@@ -368,6 +378,8 @@ func parseArgs() cliArgs {
 				args.targets = append(args.targets, strings.TrimPrefix(osArgs[i], "--target="))
 			} else if strings.HasPrefix(osArgs[i], "--instruction=") {
 				args.instruction = strings.TrimPrefix(osArgs[i], "--instruction=")
+			} else if strings.HasPrefix(osArgs[i], "--header=") {
+				args.headers = append(args.headers, strings.TrimPrefix(osArgs[i], "--header="))
 			} else if strings.HasPrefix(osArgs[i], "--source=") {
 				args.source = strings.TrimPrefix(osArgs[i], "--source=")
 			} else if strings.HasPrefix(osArgs[i], "--code-scan=") {
@@ -411,6 +423,7 @@ func printUsage() {
 	fmt.Println("CLI Flags:")
 	fmt.Println("  -t, --target <url>        Target URL, IP, or local path (repeatable)")
 	fmt.Println("  -i, --instruction <text>  Custom instructions for the agent")
+	fmt.Println("  -H, --header <Name: value>  Identifying header on all target traffic (repeatable)")
 	fmt.Println("  -s, --source <repo|path>  Codebase to scan (git URL or local path)")
 	fmt.Println("      --code-scan <mode>    Code-first scan: 'review' (SAST, no target)")
 	fmt.Println("                            or 'provision' (build+run source, then DAST)")
@@ -446,6 +459,8 @@ func printUsage() {
 	fmt.Println("  XALGORIX_API_KEY           API key")
 	fmt.Println("  XALGORIX_API_BASE          API base URL")
 	fmt.Println("  XALGORIX_MAX_ITERATIONS    Max iterations (0 = unlimited)")
+	fmt.Println("  XALGORIX_SCAN_HEADERS      Identifying header(s) for target traffic; ';' or newline separated")
+	fmt.Println("  XALGORIX_SCAN_HEADERS_FILE File of headers, one 'Name: value' per line")
 	fmt.Println()
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -922,6 +922,7 @@ func (a *Agent) Run(targets []string, instruction string) {
 						contextID = a.scanCtx.ID
 					}
 					normalized, note := terminal.NormalizeCommandForRequestRatePolicy(contextID, command)
+					normalized = terminal.InjectScanHeadersIntoCommand(normalized)
 					if normalized != command {
 						updatedArgs := make(map[string]string, len(tc.Args))
 						for k, v := range tc.Args {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/xalgord/xalgorix/v4/internal/scanheaders"
 )
 
 // Config holds all Xalgorix configuration.
@@ -101,6 +103,17 @@ type Config struct {
 	// (real endpoints + params + example bodies) and harvests any auth material,
 	// turning a blind black-box scan into an informed one. XALGORIX_SCAN_CONTEXT.
 	ScanContext string
+
+	// ScanHeaders are operator-supplied custom HTTP headers ("Name: value")
+	// injected into all TARGET-facing scan traffic to identify an authorized
+	// Xalgorix run: the agent's HTTP client and, via their -H flag, bundled
+	// tools (httpx, nuclei). Built-in equivalent of Nuclei's -H/-header. Bug-
+	// bounty programs often require such a header (e.g. "X-Bug-Bounty: user");
+	// it also lets a target's WAF/SOC allow-list the scan. Never attached to
+	// non-target destinations (LLM APIs, notifications, the dashboard).
+	// XALGORIX_SCAN_HEADERS (';'/newline-separated) and/or
+	// XALGORIX_SCAN_HEADERS_FILE (one per line); repeatable -H on the CLI.
+	ScanHeaders []string
 
 	// Per-scan resource budgets with graceful early-stopping (MAPTA §2.7/§3.3).
 	// A scan halts cleanly (keeping findings already reported) once any cap is
@@ -294,6 +307,7 @@ func load() *Config {
 		OOBDisable:          envOrBool("XALGORIX_OOB_DISABLE", false),
 		SourceRepo:          envOr("XALGORIX_SOURCE_REPO", ""),
 		ScanContext:         envOr("XALGORIX_SCAN_CONTEXT", ""),
+		ScanHeaders:         loadScanHeaders(),
 		MaxToolCalls:        envOrInt("XALGORIX_MAX_TOOL_CALLS", 0),
 		MaxDurationSec:      envOrInt("XALGORIX_MAX_DURATION", 0),
 		MaxTokens:           envOrInt("XALGORIX_MAX_TOKENS", 0),
@@ -548,6 +562,24 @@ func maybeEmitMigrationWarning(cwd, dataDir string, suppressed bool) {
 		"(matched %q). The default data directory has changed in this "+
 		"release to %s. To keep writing to the legacy location, run with "+
 		"XALGORIX_DATA_DIR=%s", cwd, found, dataDir, cwd)
+}
+
+// loadScanHeaders assembles the operator-configured scan/attribution headers
+// from XALGORIX_SCAN_HEADERS (';'/newline-separated) and an optional
+// XALGORIX_SCAN_HEADERS_FILE (one "Name: value" per line), de-duplicated with
+// the env entries taking precedence. A missing/unreadable file is a non-fatal
+// warning so a scan still runs (just without the file's headers).
+func loadScanHeaders() []string {
+	env := scanheaders.Parse(os.Getenv("XALGORIX_SCAN_HEADERS"))
+	var fromFile []string
+	if path := strings.TrimSpace(os.Getenv("XALGORIX_SCAN_HEADERS_FILE")); path != "" {
+		hs, err := scanheaders.ParseFile(path)
+		if err != nil {
+			log.Printf("[config] Warning: XALGORIX_SCAN_HEADERS_FILE %q: %v", path, err)
+		}
+		fromFile = hs
+	}
+	return scanheaders.Merge(env, fromFile)
 }
 
 func envOr(key, fallback string) string {

--- a/internal/config/scanheaders_test.go
+++ b/internal/config/scanheaders_test.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestLoadScanHeaders(t *testing.T) {
+	// Env only: ';'-separated pair parses into two ordered headers.
+	t.Setenv("XALGORIX_SCAN_HEADERS", "X-Bug-Bounty: ulises2k; X-Scan-ID: 42")
+	t.Setenv("XALGORIX_SCAN_HEADERS_FILE", "")
+	got := loadScanHeaders()
+	want := []string{"X-Bug-Bounty: ulises2k", "X-Scan-ID: 42"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("env-only loadScanHeaders() = %#v, want %#v", got, want)
+	}
+
+	// Env + file: env entries win on a name clash (X-Scan-ID); the file adds a
+	// new header (X-Extra) and its comment/blank lines are ignored.
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "headers.txt")
+	if err := os.WriteFile(fp, []byte("# comment\nX-Scan-ID: from-file-ignored\nX-Extra: e\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XALGORIX_SCAN_HEADERS_FILE", fp)
+	got = loadScanHeaders()
+	want = []string{"X-Bug-Bounty: ulises2k", "X-Scan-ID: 42", "X-Extra: e"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("env+file loadScanHeaders() = %#v, want %#v", got, want)
+	}
+
+	// A missing file is non-fatal: the env headers still load.
+	t.Setenv("XALGORIX_SCAN_HEADERS_FILE", filepath.Join(dir, "does-not-exist.txt"))
+	got = loadScanHeaders()
+	want = []string{"X-Bug-Bounty: ulises2k", "X-Scan-ID: 42"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("missing-file loadScanHeaders() = %#v, want %#v", got, want)
+	}
+
+	// Nothing configured -> nil.
+	t.Setenv("XALGORIX_SCAN_HEADERS", "")
+	t.Setenv("XALGORIX_SCAN_HEADERS_FILE", "")
+	if got := loadScanHeaders(); got != nil {
+		t.Fatalf("unset loadScanHeaders() = %#v, want nil", got)
+	}
+}

--- a/internal/scanheaders/scanheaders.go
+++ b/internal/scanheaders/scanheaders.go
@@ -1,0 +1,143 @@
+// Package scanheaders manages operator-supplied custom HTTP headers that
+// identify authorized Xalgorix scan traffic (for example "X-Bug-Bounty: user").
+//
+// The headers mark every target-facing request as an authorized run, so the
+// traffic is attributable in the target's access logs and can be allow-listed
+// by its WAF/SOC. They are applied to the agent's HTTP client and passed
+// through to bundled tools that accept the same -H "Name: value" flag (httpx,
+// nuclei). They are NEVER attached to non-target destinations — LLM/provider
+// APIs, AgentMail, Discord/Telegram, or the dashboard.
+package scanheaders
+
+import (
+	"bufio"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// Parse turns an operator-supplied raw string into a normalized,
+// de-duplicated, order-preserving list of "Name: value" headers. Entries are
+// separated by newlines and/or ';'. Each entry must be a valid
+// "Header-Name: value" pair; malformed entries (missing ':' or an invalid
+// header name) are skipped. A value containing ';' is not supported in this
+// packed form — supply such a header one-per-line via a file or as a separate
+// CLI -H flag.
+func Parse(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	var out []string
+	seen := map[string]struct{}{}
+	for _, line := range strings.Split(raw, "\n") {
+		for _, part := range strings.Split(line, ";") {
+			add(&out, seen, part)
+		}
+	}
+	return out
+}
+
+// ParseFile reads headers from a file, one "Name: value" per line. Blank lines
+// and '#'-comment lines are ignored. Returns (nil, err) if the file cannot be
+// read; callers may treat a missing file as a non-fatal configuration error.
+func ParseFile(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var out []string
+	seen := map[string]struct{}{}
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		add(&out, seen, line)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Merge concatenates header lists, de-duplicating by canonical header name
+// (case-insensitive) while preserving first-seen order. Earlier lists win, so
+// callers can layer sources by precedence (for example env first, then CLI).
+func Merge(lists ...[]string) []string {
+	var out []string
+	seen := map[string]struct{}{}
+	for _, list := range lists {
+		for _, h := range list {
+			add(&out, seen, h)
+		}
+	}
+	return out
+}
+
+// Apply sets each configured header on h, but never overwrites a header the
+// caller already set — a deliberate request header must win over the global
+// attribution header. Empty input is a no-op.
+func Apply(h http.Header, headers []string) {
+	for _, entry := range headers {
+		name, value, ok := split(entry)
+		if !ok {
+			continue
+		}
+		if h.Get(name) != "" {
+			continue
+		}
+		h.Set(name, value)
+	}
+}
+
+// add validates entry and appends its canonical "Name: value" form to out,
+// skipping malformed entries and duplicates (by case-insensitive name).
+func add(out *[]string, seen map[string]struct{}, entry string) {
+	name, value, ok := split(entry)
+	if !ok {
+		return
+	}
+	key := strings.ToLower(name)
+	if _, dup := seen[key]; dup {
+		return
+	}
+	seen[key] = struct{}{}
+	*out = append(*out, name+": "+value)
+}
+
+// split parses "Name: value" into its parts, validating the header name. Only
+// the first ':' separates name from value, so values may contain ':'.
+func split(entry string) (name, value string, ok bool) {
+	entry = strings.TrimSpace(entry)
+	idx := strings.IndexByte(entry, ':')
+	if idx <= 0 {
+		return "", "", false
+	}
+	name = strings.TrimSpace(entry[:idx])
+	value = strings.TrimSpace(entry[idx+1:])
+	if name == "" || value == "" || !isHeaderName(name) {
+		return "", "", false
+	}
+	return name, value, true
+}
+
+// isHeaderName reports whether tok is a valid RFC 7230 header field-name (token
+// characters only), so a value or a stray word is never mistaken for a header
+// name.
+func isHeaderName(tok string) bool {
+	if tok == "" {
+		return false
+	}
+	for _, r := range tok {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case strings.ContainsRune("!#$%&'*+-.^_`|~", r):
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/scanheaders/scanheaders_test.go
+++ b/internal/scanheaders/scanheaders_test.go
@@ -1,0 +1,78 @@
+package scanheaders
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"whitespace only", "   \n  ", nil},
+		{"single", "X-Bug-Bounty: ulises2k", []string{"X-Bug-Bounty: ulises2k"}},
+		{"trims and normalizes spacing", "  X-Bug-Bounty:ulises2k  ", []string{"X-Bug-Bounty: ulises2k"}},
+		{"multiple via newline", "X-Bug-Bounty: u\nX-Scan-ID: 42", []string{"X-Bug-Bounty: u", "X-Scan-ID: 42"}},
+		{"multiple via semicolon", "X-Bug-Bounty: u; X-Scan-ID: 42", []string{"X-Bug-Bounty: u", "X-Scan-ID: 42"}},
+		{"dedup by name keeps first", "X-A: 1\nX-A: 2", []string{"X-A: 1"}},
+		{"dedup case-insensitive", "X-A: 1\nx-a: 2", []string{"X-A: 1"}},
+		{"skips entry without colon", "not-a-header\nX-Ok: 1", []string{"X-Ok: 1"}},
+		{"skips empty value", "X-Empty:\nX-Ok: 1", []string{"X-Ok: 1"}},
+		{"skips invalid header name", "Bad Name: v\nX-Ok: 1", []string{"X-Ok: 1"}},
+		{"value may contain colons", "Authorization: Bearer a:b:c", []string{"Authorization: Bearer a:b:c"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Parse(tc.raw)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("Parse(%q) = %#v, want %#v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMerge(t *testing.T) {
+	got := Merge([]string{"X-A: 1", "X-B: 2"}, []string{"x-a: override-ignored", "X-C: 3"})
+	want := []string{"X-A: 1", "X-B: 2", "X-C: 3"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Merge = %#v, want %#v", got, want)
+	}
+}
+
+func TestApplyDoesNotClobberCallerHeaders(t *testing.T) {
+	h := http.Header{}
+	h.Set("X-Existing", "keep")
+	Apply(h, []string{"X-Bug-Bounty: u", "X-Existing: should-not-win", "malformed"})
+	if got := h.Get("X-Bug-Bounty"); got != "u" {
+		t.Fatalf("X-Bug-Bounty = %q, want u", got)
+	}
+	if got := h.Get("X-Existing"); got != "keep" {
+		t.Fatalf("X-Existing = %q, want keep (attribution must not clobber a caller header)", got)
+	}
+}
+
+func TestParseFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "headers.txt")
+	content := "# comment line\nX-Bug-Bounty: u\n\n  X-Scan-ID: 42  \nno-colon-line\n"
+	if err := os.WriteFile(p, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ParseFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"X-Bug-Bounty: u", "X-Scan-ID: 42"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ParseFile = %#v, want %#v", got, want)
+	}
+	if _, err := ParseFile(filepath.Join(dir, "missing.txt")); err == nil {
+		t.Fatal("ParseFile(missing) should return an error")
+	}
+}

--- a/internal/tools/httpclient/httpclient.go
+++ b/internal/tools/httpclient/httpclient.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/xalgord/xalgorix/v4/internal/config"
 	"github.com/xalgord/xalgorix/v4/internal/proxy"
+	"github.com/xalgord/xalgorix/v4/internal/scanheaders"
 	"github.com/xalgord/xalgorix/v4/internal/tools"
 )
 
@@ -141,6 +142,11 @@ func executeWithContext(contextID string, args map[string]string) (tools.Result,
 			}
 		}
 	}
+
+	// Apply operator-configured scan/attribution headers (XALGORIX_SCAN_HEADERS
+	// / -H). Like session auth, they identify authorized scan traffic and are
+	// never allowed to override a header the caller set explicitly.
+	scanheaders.Apply(req.Header, config.Get().ScanHeaders)
 
 	// Blank overrides: DELETE the header so the request is sent with no such
 	// credential at all. Middleware/apps can treat an empty Authorization or

--- a/internal/tools/terminal/scanheaders.go
+++ b/internal/tools/terminal/scanheaders.go
@@ -1,0 +1,76 @@
+package terminal
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/xalgord/xalgorix/v4/internal/config"
+)
+
+// scanHeaderTools are the bundled tools that accept a repeatable
+// -H "Name: value" flag with the same semantics as the agent's HTTP client, so
+// an operator-configured scan/attribution header can be passed straight
+// through. Both httpx and nuclei document -H / -header for exactly this.
+var scanHeaderTools = []string{"httpx", "nuclei"}
+
+// InjectScanHeadersIntoCommand appends the operator-configured scan headers
+// (XALGORIX_SCAN_HEADERS / -H) as -H "Name: value" flags to every httpx and
+// nuclei invocation in command, so bundled-tool traffic carries the same
+// identifying header as the agent's own requests. It is pipe-aware (each
+// piped stage is handled independently) and idempotent — a header already
+// present on a stage is never duplicated. Returns command unchanged when no
+// scan headers are configured or no matching tool is invoked.
+func InjectScanHeadersIntoCommand(command string) string {
+	return injectScanHeaders(command, config.Get().ScanHeaders)
+}
+
+// injectScanHeaders is the pure core of InjectScanHeadersIntoCommand, taking
+// the header list explicitly so it can be tested without global config.
+func injectScanHeaders(command string, headers []string) string {
+	if len(headers) == 0 {
+		return command
+	}
+	return rewriteShellSegments(command, func(segment string) string {
+		return injectScanHeadersIntoSegment(segment, headers)
+	})
+}
+
+// injectScanHeadersIntoSegment appends -H flags for a single piped stage when
+// that stage invokes a scan-header-aware tool (httpx / nuclei). A stage that
+// invokes no such tool is returned unchanged.
+func injectScanHeadersIntoSegment(segment string, headers []string) string {
+	invokesTool := false
+	for _, tool := range scanHeaderTools {
+		if hasToolCommand(segment, tool) {
+			invokesTool = true
+			break
+		}
+	}
+	if !invokesTool {
+		return segment
+	}
+	for _, h := range headers {
+		if segmentHasHeader(segment, h) {
+			continue
+		}
+		segment = appendCommandArg(segment, "-H "+shellQuote(h))
+	}
+	return segment
+}
+
+// segmentHasHeader reports whether segment already passes a -H / -header /
+// --header flag for the same header name (case-insensitive), so an
+// operator-configured header the agent happened to add itself is not
+// duplicated.
+func segmentHasHeader(segment, header string) bool {
+	idx := strings.IndexByte(header, ':')
+	if idx <= 0 {
+		return false
+	}
+	name := strings.TrimSpace(header[:idx])
+	if name == "" {
+		return false
+	}
+	re := regexp.MustCompile(`(?i)(?:^|\s)-{1,2}(?:h|header)[=\s]+['"]?` + regexp.QuoteMeta(name) + `\s*:`)
+	return re.MatchString(segment)
+}

--- a/internal/tools/terminal/scanheaders_test.go
+++ b/internal/tools/terminal/scanheaders_test.go
@@ -1,0 +1,71 @@
+package terminal
+
+import "testing"
+
+func TestInjectScanHeaders(t *testing.T) {
+	one := []string{"X-Bug-Bounty: ulises2k"}
+	two := []string{"X-Bug-Bounty: ulises2k", "X-Scan-ID: e-42"}
+	tests := []struct {
+		name    string
+		cmd     string
+		headers []string
+		want    string
+	}{
+		{
+			name:    "no headers configured is a no-op",
+			cmd:     "httpx -silent -u https://t.com",
+			headers: nil,
+			want:    "httpx -silent -u https://t.com",
+		},
+		{
+			name:    "httpx gets the header",
+			cmd:     "httpx -silent -u https://t.com",
+			headers: one,
+			want:    "httpx -silent -u https://t.com -H 'X-Bug-Bounty: ulises2k'",
+		},
+		{
+			name:    "nuclei gets the header",
+			cmd:     "nuclei -u https://t.com -severity high",
+			headers: one,
+			want:    "nuclei -u https://t.com -severity high -H 'X-Bug-Bounty: ulises2k'",
+		},
+		{
+			name:    "non-target tool is untouched",
+			cmd:     "curl -s https://t.com",
+			headers: one,
+			want:    "curl -s https://t.com",
+		},
+		{
+			name:    "only the httpx stage of a pipe is rewritten",
+			cmd:     "cat subs.txt | httpx -silent -status-code",
+			headers: one,
+			want:    "cat subs.txt | httpx -silent -status-code -H 'X-Bug-Bounty: ulises2k'",
+		},
+		{
+			name:    "multiple headers each get a -H",
+			cmd:     "httpx -u https://t.com",
+			headers: two,
+			want:    "httpx -u https://t.com -H 'X-Bug-Bounty: ulises2k' -H 'X-Scan-ID: e-42'",
+		},
+		{
+			name:    "an already-present header is not duplicated",
+			cmd:     `httpx -u https://t.com -H "X-Bug-Bounty: someoneelse"`,
+			headers: one,
+			want:    `httpx -u https://t.com -H "X-Bug-Bounty: someoneelse"`,
+		},
+		{
+			name:    "both httpx and nuclei stages are rewritten",
+			cmd:     "httpx -silent | nuclei -silent",
+			headers: one,
+			want:    "httpx -silent -H 'X-Bug-Bounty: ulises2k' | nuclei -silent -H 'X-Bug-Bounty: ulises2k'",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := injectScanHeaders(tc.cmd, tc.headers)
+			if got != tc.want {
+				t.Fatalf("injectScanHeaders(%q) =\n  %q\nwant\n  %q", tc.cmd, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/tools/terminal/terminal.go
+++ b/internal/tools/terminal/terminal.go
@@ -1346,6 +1346,7 @@ func runShellInternal(contextID string, command string) (string, int) {
 
 	// Compute timeout based on command type
 	cleanCmd, ratePolicyNotice := NormalizeCommandForRequestRatePolicy(contextID, command)
+	cleanCmd = InjectScanHeadersIntoCommand(cleanCmd)
 	timeout := computeTimeout(cleanCmd)
 	if timeout > hardMaxTimeout {
 		timeout = hardMaxTimeout


### PR DESCRIPTION
## Summary

Implements #263 and #270: a first-class option to inject operator-configured HTTP header(s) into all **target-facing** scan traffic to identify an authorized Xalgorix run — the built-in equivalent of Nuclei's `-H`/`-header`. Bug-bounty programs (HackerOne/Bugcrowd) often require an identifying header (e.g. `X-Bug-Bounty: <handle>`); it also lets a target's WAF/SOC allow-list the scan so it isn't rate-limited/blocked mid-run or paged as a false incident.

Scope (per the issues): the agent's HTTP client **plus pass-through to httpx and nuclei via their `-H` flag**, and the shared config/CLI/env plumbing. The browser (CDP) layer and other bundled tools (katana/ffuf/…) are intentionally left out here — they're a small addition on top of the shared helper.

## Configuration (the three interfaces from #263)

- **CLI:** `-H` / `--header`, repeatable
  ```bash
  xalgorix --target https://app.example.com \
    -H "X-Bug-Bounty: ulises2k" \
    -H "X-Scan-ID: engagement-42"
  ```
- **Env:** `XALGORIX_SCAN_HEADERS` (`;`- or newline-separated) and/or `XALGORIX_SCAN_HEADERS_FILE` (one `Name: value` per line), mirroring the existing `XALGORIX_PROXY_URL` / `XALGORIX_PROXY_FILE` pair.

CLI `-H` merges over env/file (CLI wins on a name clash), de-duplicated by header name.

## How it works

- **New `internal/scanheaders` package** — parses/validates/normalizes/de-duplicates `Name: value` specs (`Parse`, `ParseFile`, `Merge`, `Apply`).
- **Agent HTTP client** (`http_request`) — applies the headers via `scanheaders.Apply`, which **never overrides** a header the caller/agent set explicitly (same contract as session-auth, so IDOR/unauth diffing still works).
- **httpx / nuclei** — `terminal.InjectScanHeadersIntoCommand` appends `-H "Name: value"` to every httpx/nuclei invocation, reusing the existing `rewriteShellSegments` engine so it is **pipe-aware** (only the httpx/nuclei stage of `cat subs.txt | httpx | nuclei` is rewritten) and **idempotent** (a header the agent already passed isn't duplicated). Injected at the terminal execution point, so it's enforced regardless of how the command was produced.

## Scope / safety

- **Target traffic only** — never attached to LLM/provider APIs, AgentMail, Discord/Telegram, or the dashboard.
- Purely additive: **10 files changed, +471, −0**.
- Documented in `--help` (CLI flag + env vars).

## Tests

- `internal/scanheaders`: parsing, `;`/newline split, dedup (case-insensitive), value-containing-colons, `Apply` no-clobber, file parsing incl. comments / blank lines / missing file.
- `internal/tools/terminal`: httpx/nuclei injection, pipe-awareness, multi-header, no-duplicate, non-target-tool untouched.
- `internal/config`: env + file wiring (`loadScanHeaders`), env-wins-on-clash, missing-file non-fatal.

Verified on Go 1.26: `go build ./...` clean, `gofmt`/`go vet` clean, all touched-package tests pass. Branch is cut from the current fork base and **merges into `main` with no conflicts** (verified with `git merge-tree`).

Closes #263
Closes #270