### PR TITLE
fix(tools): correct auto-install tool mappings and refresh apt lists

### DIFF
--- a/internal/tools/terminal/autoinstall_test.go
+++ b/internal/tools/terminal/autoinstall_test.go
@@ -1,0 +1,77 @@
+package terminal
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestAutoInstallToolMappings locks in the correct installer for tools whose
+// mapping was previously wrong or missing:
+//   - paramspider is a Python tool (pipx), not a Go module, so
+//     "go install github.com/devanshbatham/paramspider@latest" always failed.
+//   - arjun and uro are Python tools (pipx) that were absent from packageMap,
+//     so resolvePackage returned "" and they were never auto-installed even
+//     though the agent prompt recommends them.
+//   - x8 and findomain are Rust tools (cargo): x8 was absent from packageMap;
+//     findomain was documented as a cargo tool but only lived in the generic
+//     apt path (not in apt repos -> install always failed).
+func TestAutoInstallToolMappings(t *testing.T) {
+	// Each tool must resolve via packageMap; otherwise installPackage is never
+	// reached and the tool can never be auto-installed.
+	for _, tool := range []string{"paramspider", "arjun", "x8", "uro", "findomain"} {
+		if resolvePackage(tool) == "" {
+			t.Errorf("resolvePackage(%q) = %q; tool missing from packageMap, so it can never be auto-installed", tool, "")
+		}
+	}
+
+	// paramspider must NOT be a Go tool, and paramspider/arjun/uro must be pipx.
+	if _, ok := goTools["paramspider"]; ok {
+		t.Error(`paramspider must not be in goTools: it is a Python tool and "go install" of that path always fails`)
+	}
+	for _, tool := range []string{"paramspider", "arjun", "uro"} {
+		if _, ok := pipxTools[tool]; !ok {
+			t.Errorf("%s must be in pipxTools (pip/pipx-installed Python tool)", tool)
+		}
+	}
+
+	// x8 and findomain must be cargo tools.
+	for _, tool := range []string{"x8", "findomain"} {
+		if _, ok := cargoTools[tool]; !ok {
+			t.Errorf("%s must be in cargoTools (Rust/cargo tool)", tool)
+		}
+	}
+
+	// A tool must never be classified under two installers at once.
+	all := []map[string]string{pipxTools, cargoTools, goTools, npmTools}
+	for _, tool := range []string{"paramspider", "arjun", "x8", "uro", "findomain"} {
+		hits := 0
+		for _, m := range all {
+			if _, ok := m[tool]; ok {
+				hits++
+			}
+		}
+		if hits != 1 {
+			t.Errorf("%s is classified by %d installer maps; want exactly 1", tool, hits)
+		}
+	}
+}
+
+// TestAptGetInstallRefreshesLists guards the regression where package installs
+// ran `apt-get install` without a preceding `apt-get update`, which fails with
+// "Unable to locate package" on a stale/empty apt cache.
+func TestAptGetInstallRefreshesLists(t *testing.T) {
+	cmd := aptGetInstall("whois")
+
+	updateAt := strings.Index(cmd, "apt-get update")
+	installAt := strings.Index(cmd, "apt-get install -y -q whois")
+
+	if updateAt < 0 {
+		t.Fatalf("aptGetInstall must run `apt-get update` before install; got %q", cmd)
+	}
+	if installAt < 0 {
+		t.Fatalf("aptGetInstall must install the requested package; got %q", cmd)
+	}
+	if updateAt > installAt {
+		t.Errorf("`apt-get update` must precede install; got %q", cmd)
+	}
+}

--- a/internal/tools/terminal/terminal.go
+++ b/internal/tools/terminal/terminal.go
@@ -949,6 +949,9 @@ var packageMap = map[string]string{
 	"naabu":       "naabu",
 	"dalfox":      "dalfox",
 	"paramspider": "paramspider",
+	"arjun":       "arjun",
+	"x8":          "x8",
+	"uro":         "uro",
 	"feroxbuster": "feroxbuster",
 	// Findomain — Rust binary, installed via package manager or cargo
 	"findomain": "findomain",
@@ -1591,6 +1594,59 @@ func sudoPrefix() string {
 	return ""
 }
 
+// Auto-install classification maps. Kept at package scope (rather than inside
+// installPackage) so the tool -> installer mapping is unit-testable.
+
+// pipxTools are Python tools installed via pipx (falling back to pip3).
+var pipxTools = map[string]string{
+	"scrapling":   "scrapling",
+	"paramspider": "paramspider", // Python tool, NOT a Go module
+	"arjun":       "arjun",
+	"uro":         "uro",
+}
+
+// cargoTools are Rust tools: try apt first (fast), then `cargo install`.
+var cargoTools = map[string]string{
+	"feroxbuster": "feroxbuster",
+	"findomain":   "findomain",
+	"x8":          "x8",
+}
+
+// goTools are installed via `go install <path>@latest`.
+var goTools = map[string]string{
+	// ProjectDiscovery suite
+	"nuclei":    "github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest",
+	"httpx":     "github.com/projectdiscovery/httpx/cmd/httpx@latest",
+	"dnsx":      "github.com/projectdiscovery/dnsx/cmd/dnsx@latest",
+	"subfinder": "github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest",
+	"katana":    "github.com/projectdiscovery/katana/cmd/katana@latest",
+	"naabu":     "github.com/projectdiscovery/naabu/v2/cmd/naabu@latest",
+	// Web crawlers & URL discovery
+	"gospider":    "github.com/jaeles-project/gospider@latest",
+	"gau":         "github.com/lc/gau/v2/cmd/gau@latest",
+	"waybackurls": "github.com/tomnomnom/waybackurls@latest",
+	"hakrawler":   "github.com/hakluke/hakrawler@latest",
+	// Fuzzing & enumeration
+	"gobuster":    "github.com/OJ/gobuster/v3@latest",
+	"ffuf":        "github.com/ffuf/ffuf/v2@latest",
+	"assetfinder": "github.com/tomnomnom/assetfinder@latest",
+	// Vulnerability scanners
+	"dalfox": "github.com/hahwul/dalfox/v2@latest",
+}
+
+// npmTools are installed via `npm install -g`.
+var npmTools = map[string]string{
+	"playwright-cli": "@anthropic-ai/playwright-cli",
+}
+
+// aptGetInstall builds the apt-get command used to install pkg. It refreshes
+// the package lists first: a stale or empty apt cache (common on a freshly
+// provisioned container/host) otherwise makes `apt-get install <pkg>` fail
+// with "Unable to locate package" even for valid Debian package names.
+func aptGetInstall(pkg string) string {
+	return fmt.Sprintf("DEBIAN_FRONTEND=noninteractive apt-get update -qq 2>&1 && DEBIAN_FRONTEND=noninteractive apt-get install -y -q %s 2>&1", pkg)
+}
+
 // installPackage installs a system package on demand. Gated behind
 // XALGORIX_ALLOW_AUTO_INSTALL — defaults to true for root and false for
 // non-root, so a stock unprivileged xalgorix invocation can never call
@@ -1608,45 +1664,6 @@ func installPackage(pkg string) string {
 			"[install %s blocked: auto-install is disabled. Set XALGORIX_ALLOW_AUTO_INSTALL=1 in ~/.xalgorix.env to enable, or install manually.]",
 			pkg,
 		)
-	}
-
-	// Special handling for pipx-installed tools
-	pipxTools := map[string]string{
-		"scrapling": "scrapling",
-	}
-
-	// Special handling for Cargo (Rust) tools
-	cargoTools := map[string]string{
-		"feroxbuster": "feroxbuster",
-	}
-
-	// Special handling for Go-installed tools
-	goTools := map[string]string{
-		// ProjectDiscovery suite
-		"nuclei":    "github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest",
-		"httpx":     "github.com/projectdiscovery/httpx/cmd/httpx@latest",
-		"dnsx":      "github.com/projectdiscovery/dnsx/cmd/dnsx@latest",
-		"subfinder": "github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest",
-		"katana":    "github.com/projectdiscovery/katana/cmd/katana@latest",
-		"naabu":     "github.com/projectdiscovery/naabu/v2/cmd/naabu@latest",
-		// Web crawlers & URL discovery
-		"gospider":    "github.com/jaeles-project/gospider@latest",
-		"gau":         "github.com/lc/gau/v2/cmd/gau@latest",
-		"waybackurls": "github.com/tomnomnom/waybackurls@latest",
-		"hakrawler":   "github.com/hakluke/hakrawler@latest",
-		// Fuzzing & enumeration
-		"gobuster":    "github.com/OJ/gobuster/v3@latest",
-		"ffuf":        "github.com/ffuf/ffuf/v2@latest",
-		"assetfinder": "github.com/tomnomnom/assetfinder@latest",
-		// Vulnerability scanners
-		"dalfox": "github.com/hahwul/dalfox/v2@latest",
-		// Parameter discovery
-		"paramspider": "github.com/devanshbatham/paramspider@latest",
-	}
-
-	// npm-installed tools
-	npmTools := map[string]string{
-		"playwright-cli": "@anthropic-ai/playwright-cli",
 	}
 
 	homeDir := os.Getenv("HOME")
@@ -1726,7 +1743,7 @@ func installPackage(pkg string) string {
 	var installCmd string
 
 	if _, err := exec.LookPath("apt-get"); err == nil {
-		installCmd = fmt.Sprintf("DEBIAN_FRONTEND=noninteractive apt-get install -y -q %s 2>&1", pkg)
+		installCmd = aptGetInstall(pkg)
 	} else if _, err := exec.LookPath("dnf"); err == nil {
 		installCmd = fmt.Sprintf("dnf install -y -q %s 2>&1", pkg)
 	} else if _, err := exec.LookPath("yum"); err == nil {
@@ -1740,10 +1757,13 @@ func installPackage(pkg string) string {
 	}
 
 	// Prefix with sudo only when the operator has opted in via
-	// XALGORIX_AUTO_INSTALL_SUDO=1. Without that, this install will fail
-	// for non-root users — which is the safer default than silently
-	// escalating package-manager invocations.
-	installCmd = sudoPrefix() + installCmd
+	// XALGORIX_AUTO_INSTALL_SUDO=1. Wrap in `sh -c` so sudo covers the whole
+	// command — including the apt "update && install" pair — instead of only
+	// the first token. Without the opt-in this install fails for non-root
+	// users, the safer default over silent escalation.
+	if sudoPrefix() != "" {
+		installCmd = "sudo sh -c '" + installCmd + "'"
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 600*time.Second) // 10 min for pkg install
 	defer cancel()


### PR DESCRIPTION
## Summary

The `terminal_execute` auto-install path (`internal/tools/terminal/terminal.go`) mapped several tools to the wrong installer or never registered them at all, so tools the agent's own system prompt recommends could never be auto-installed. Package installs also skipped `apt-get update`, so they failed on a fresh/stale apt cache.

## Bugs fixed

| Tool | Before | Problem | After |
|------|--------|---------|-------|
| `paramspider` | `go install github.com/devanshbatham/paramspider@latest` | ParamSpider is a **Python** tool — there is no Go module at that path, so `go install` **always fails** | `pipx` |
| `arjun` | *(absent from `packageMap`)* | `resolvePackage("arjun")` returned `""` → `installPackage` never reached → never auto-installed, though `agent_prompt.go` tells the model to run `arjun -u URL` | `packageMap` + `pipx` |
| `uro` | *(absent from `packageMap`)* | same as arjun (recommended in the prompt, never installable) | `packageMap` + `pipx` |
| `x8` | *(absent from `packageMap`)* | same — recommended in the prompt, never installable | `packageMap` + `cargo` |
| `findomain` | generic apt path | Documented as a cargo tool, but Findomain is **not in Debian/Kali apt repos**, so `apt-get install findomain` **always fails** | `cargo` (apt-first, cargo fallback) |
| *(all apt installs)* | `apt-get install …` | No preceding `apt-get update` → `"Unable to locate package"` on a stale/empty cache (first run on a clean box) | `apt-get update -qq && apt-get install …` |

## Changes

- **`paramspider` → `pipxTools`** (removed from `goTools`); **`arjun`/`uro` → `pipxTools`**; **`x8`/`findomain` → `cargoTools`**.
- Registered **`arjun`, `x8`, `uro`** in `packageMap` so `resolvePackage` returns them.
- New `aptGetInstall(pkg)` helper runs `apt-get update -qq` before `apt-get install`.
- Hoisted the `pipxTools`/`cargoTools`/`goTools`/`npmTools` maps to **package scope** so the tool→installer mapping is unit-testable (no behavior change to `installPackage`, same variable names).
- The sudo opt-in (`XALGORIX_AUTO_INSTALL_SUDO=1`) now wraps the command in `sh -c` so `sudo` covers the whole `update && install` pair instead of only the first token.

## Tests

New `internal/tools/terminal/autoinstall_test.go`:

- `TestAutoInstallToolMappings` — asserts each of `paramspider/arjun/x8/uro/findomain` resolves via `packageMap`; that `paramspider` is **not** a Go tool and is pipx; that `arjun/uro` are pipx and `x8/findomain` are cargo; and that no tool is classified by more than one installer map.
- `TestAptGetInstallRefreshesLists` — asserts `apt-get update` runs **before** `apt-get install` for the requested package.

```
$ go test ./internal/tools/terminal/
ok      github.com/xalgord/xalgorix/v4/internal/tools/terminal
```

`go vet ./internal/tools/terminal/` is clean and the full binary builds.

## Notes

Behavior-preserving for every tool that was already correct (the ProjectDiscovery/Go suite, `feroxbuster`, `scrapling`, etc.). The only runtime change for those is that generic **apt** installs now refresh package lists first.