### PR TITLE
fix(llm): send generationConfig (max tokens + temperature) to Gemini

### DIFF
--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -189,9 +189,20 @@ type geminiContent struct {
 	Parts []geminiPart `json:"parts"`
 }
 
+// geminiGenerationConfig carries the per-request generation controls Gemini
+// accepts under "generationConfig". Without it Gemini applies its own
+// server-side defaults, ignoring the operator's configured max output tokens
+// (which truncates large tool calls such as report_vulnerability) and the
+// agent's per-role temperature overrides (e.g. the validator running at 0).
+type geminiGenerationConfig struct {
+	MaxOutputTokens int      `json:"maxOutputTokens,omitempty"`
+	Temperature     *float64 `json:"temperature,omitempty"`
+}
+
 type geminiRequest struct {
-	Contents          []geminiContent `json:"contents,omitempty"`
-	SystemInstruction *geminiContent  `json:"system_instruction,omitempty"`
+	Contents          []geminiContent         `json:"contents,omitempty"`
+	SystemInstruction *geminiContent          `json:"system_instruction,omitempty"`
+	GenerationConfig  *geminiGenerationConfig `json:"generationConfig,omitempty"`
 }
 
 type geminiCandidate struct {
@@ -819,6 +830,10 @@ func (c *Client) ChatStream(messages []Message) <-chan StreamChunk {
 			if len(systemParts) > 0 {
 				gemReq.SystemInstruction = &geminiContent{Role: "user", Parts: systemParts}
 			}
+			gemReq.GenerationConfig = &geminiGenerationConfig{
+				MaxOutputTokens: c.maxOutputTokens(),
+				Temperature:     c.effectiveTemperature(),
+			}
 			body, _ = json.Marshal(gemReq)
 		} else if isAnthropic {
 			var systemPrompt string
@@ -1051,6 +1066,10 @@ func (c *Client) doChat(messages []Message) (out string, err error) {
 		gemReq := geminiRequest{Contents: contents}
 		if len(systemParts) > 0 {
 			gemReq.SystemInstruction = &geminiContent{Role: "user", Parts: systemParts}
+		}
+		gemReq.GenerationConfig = &geminiGenerationConfig{
+			MaxOutputTokens: c.maxOutputTokens(),
+			Temperature:     c.effectiveTemperature(),
 		}
 		body, err = json.Marshal(gemReq)
 		if err != nil {

--- a/internal/llm/gemini_genconfig_test.go
+++ b/internal/llm/gemini_genconfig_test.go
@@ -1,0 +1,56 @@
+package llm
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/config"
+)
+
+// TestGeminiRequestSendsGenerationConfig proves that a Gemini request carries a
+// generationConfig object with the operator's configured max output tokens and
+// the effective temperature. Before the fix, geminiRequest had no
+// GenerationConfig field, so Gemini silently used its own server-side defaults —
+// truncating large tool calls (report_vulnerability) and ignoring the agent's
+// per-role temperature overrides (e.g. the validator forcing temperature 0).
+func TestGeminiRequestSendsGenerationConfig(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"ok"}]}}]}`))
+	}))
+	defer srv.Close()
+
+	temp := 0.0
+	cfg := &config.Config{
+		LLM:             "gemini-2.5-flash",
+		APIBase:         srv.URL,
+		APIKey:          "test",
+		MaxOutputTokens: 4096,
+		Temperature:     &temp,
+	}
+	c := NewClient(cfg)
+	c.provider = "google" // route through the native Gemini endpoint logic
+
+	if _, err := c.Chat([]Message{{Role: "user", Content: "ping"}}); err != nil {
+		t.Fatalf("Chat returned error: %v", err)
+	}
+
+	var req geminiRequest
+	if err := json.Unmarshal(gotBody, &req); err != nil {
+		t.Fatalf("request body is not valid geminiRequest JSON: %v\nbody=%s", err, gotBody)
+	}
+	if req.GenerationConfig == nil {
+		t.Fatalf("Gemini request is missing generationConfig; body=%s", gotBody)
+	}
+	if req.GenerationConfig.MaxOutputTokens != 4096 {
+		t.Errorf("generationConfig.maxOutputTokens = %d; want 4096 (operator config ignored)", req.GenerationConfig.MaxOutputTokens)
+	}
+	if req.GenerationConfig.Temperature == nil || *req.GenerationConfig.Temperature != 0.0 {
+		t.Errorf("generationConfig.temperature = %v; want 0 (per-role override ignored)", req.GenerationConfig.Temperature)
+	}
+}


### PR DESCRIPTION
## Summary

`geminiRequest` (`internal/llm/client.go`) had only `Contents` and `SystemInstruction` — no `generationConfig`. So Gemini requests never carried `maxOutputTokens` or `temperature`, and Gemini fell back to its own server-side defaults on **every** call.

This is a sibling of #280 (which added `usageMetadata` **response** parsing): that fixed token *accounting*; this fixes the *request* controls that were never sent.

## Impact

- **Max output tokens ignored.** The operator's `MaxOutputTokens` (via `c.maxOutputTokens()`, sent on the OpenAI-compatible and Anthropic paths) was never sent to Gemini, so large tool calls — e.g. `report_vulnerability` with embedded evidence — get truncated at Google's default cap. This is exactly the truncation the `maxOutputTokens()` doc comment warns about, guaranteed for Gemini.
- **Per-role temperature ignored.** `c.effectiveTemperature()` / `SetTemperature()` (e.g. the validator role forcing `temperature: 0` to cut false positives) had no effect — every Gemini call ran at Google's default temperature.

## Fix

- Add `geminiGenerationConfig { MaxOutputTokens int; Temperature *float64 }` and a `GenerationConfig *geminiGenerationConfig` field (`json:"generationConfig,omitempty"`) to `geminiRequest`.
- Populate it from `c.maxOutputTokens()` and `c.effectiveTemperature()` at **both** Gemini build sites — `doChat` (non-streaming) and `ChatStream` — mirroring how `req.MaxTokens`/`req.Temperature` are set on the OpenAI/Anthropic paths.

`Temperature` is a `*float64` so `effectiveTemperature()` returning `nil` (models that only accept the default) omits the field, exactly like the OpenAI path.

## Tests

New `internal/llm/gemini_genconfig_test.go` — `TestGeminiRequestSendsGenerationConfig` spins up an `httptest` server, captures the request body, and asserts it decodes to a `geminiRequest` whose `generationConfig` carries the configured `maxOutputTokens` (4096) and `temperature` (0).

```
$ go test ./internal/llm/
ok      github.com/xalgord/xalgorix/v4/internal/llm
```

All existing `llm` tests (including #280's `TestGeminiUsageAccounting*`) still pass; `go vet ./internal/llm/` is clean.