### PR TITLE
fix(tools/python): kill the whole process group on timeout

### DIFF
--- a/internal/tools/python/procgroup_test.go
+++ b/internal/tools/python/procgroup_test.go
@@ -1,0 +1,48 @@
+//go:build unix
+
+package python
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// TestConfigureProcessGroupKill reproduces the orphaned-child hang: a shell
+// stays alive (via `wait`) while a background child inherits the command's
+// stdout pipe. When the context deadline fires, exec.CommandContext's default
+// cancel would SIGKILL only the shell PID, leaving the child holding the pipe
+// so cmd.Wait() blocks until the child's own 60s sleep ends. With
+// configureProcessGroupKill the whole process group is SIGKILLed, so both die
+// and Wait() returns promptly.
+func TestConfigureProcessGroupKill(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	// `sleep 60 & wait` keeps the shell alive until the deadline (so Cancel
+	// actually fires) with a backgrounded child holding the inherited stdout
+	// pipe — the classic orphan-holds-the-pipe case.
+	cmd := exec.CommandContext(ctx, "sh", "-c", "sleep 60 & wait")
+	configureProcessGroupKill(cmd)
+
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	select {
+	case <-done:
+		// Returned promptly after the 300ms deadline — process group was killed.
+	case <-time.After(10 * time.Second):
+		t.Fatal("cmd.Wait() did not return within 10s of the 300ms timeout: " +
+			"orphaned child still holds the pipe (process group not killed)")
+	}
+}

--- a/internal/tools/python/python.go
+++ b/internal/tools/python/python.go
@@ -21,6 +21,25 @@ import (
 	"github.com/xalgord/xalgorix/v4/internal/tools/terminal"
 )
 
+// configureProcessGroupKill starts cmd in its own process group and installs a
+// Cancel that SIGKILLs the whole group when the context is canceled/times out.
+//
+// Without this, exec.CommandContext's default cancel sends SIGKILL only to the
+// direct python3 PID. Because the child runs in a new process group (Setpgid),
+// any grandchild the script spawns (subprocess.Popen/os.system/fork) survives
+// as an orphan and keeps the inherited stdout/stderr pipes open, so cmd.Wait()
+// blocks well past the timeout. Killing the negative PID (the whole group)
+// reaps those orphans and lets Wait() return. Mirrors internal/tools/terminal.
+func configureProcessGroupKill(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process != nil {
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		}
+		return os.ErrProcessDone
+	}
+}
+
 // Register adds the python_action tool to the registry.
 func Register(r *tools.Registry) {
 	r.Register(&tools.Tool{
@@ -112,7 +131,7 @@ func executePythonForContext(contextID string, args map[string]string) (tools.Re
 	// at cmd.Dir, which is now guaranteed to be sc.ScanDir or
 	// cfg.WorkspaceRoot — both Allow_List descendants. That satisfies R8.8.
 	cmd.Env = pythonWorkspaceEnv(cmd.Dir)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	configureProcessGroupKill(cmd)
 
 	stdout := iolimit.New(1 << 20)
 	stderr := iolimit.New(1 << 19)


### PR DESCRIPTION
## Summary

`python_action` (`internal/tools/python/python.go`) starts the `python3` child in its own process group (`SysProcAttr{Setpgid: true}`) but never overrides `cmd.Cancel`. So on a context timeout, `exec.CommandContext`'s default cancel sends `SIGKILL` **only to the direct `python3` PID**, not to the group.

## Impact

Any grandchild the script spawns — `subprocess.Popen`, `os.system`, a forked helper — survives as an orphan, keeps the inherited `stdout`/`stderr` pipes open, and makes `cmd.Wait()` block **well past the timeout** (default 1800s, up to 7200s). While it blocks it holds a `resources` tool lease and a goroutine, and the orphan process keeps running untracked. This is realistic: an agent running a Python exploit that shells out to a helper.

## Fix

`internal/tools/terminal` already solves this exact class of bug by SIGKILLing the **negative PID** (the whole process group) via `cmd.Cancel`. This mirrors that pattern:

```go
func configureProcessGroupKill(cmd *exec.Cmd) {
	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
	cmd.Cancel = func() error {
		if cmd.Process != nil {
			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
		}
		return os.ErrProcessDone
	}
}
```

The one call site swaps `cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}` for `configureProcessGroupKill(cmd)` — same Setpgid behavior, plus the group-kill Cancel.

## Tests

New `internal/tools/python/procgroup_test.go` (`//go:build unix`) — `TestConfigureProcessGroupKill` launches `sh -c "sleep 60 & wait"` (shell stays alive so `Cancel` fires; the backgrounded child holds the inherited stdout pipe), applies `configureProcessGroupKill`, and asserts `cmd.Wait()` returns within seconds of the 300 ms deadline. Without the group kill, `Wait()` would block for the child's full 60 s.

```
$ go test ./internal/tools/python/
ok      github.com/xalgord/xalgorix/v4/internal/tools/python    0.366s
```

## Note

This covers the timeout-while-python3-is-running case (mirroring terminal.go). The complementary case — `python3` exits quickly but leaves an orphan holding the pipe — is bounded by `cmd.WaitDelay`, which is still unset; I left that out to keep this a focused mirror of the accepted terminal.go pattern, but happy to add it if you'd prefer the belt-and-suspenders version.