### PR TITLE
fix(web): retention only skips ACTIVE scans, not every known instance

### DIFF
--- a/internal/web/retention.go
+++ b/internal/web/retention.go
@@ -99,6 +99,34 @@ func scanReferenceTime(rec ScanRecord) (time.Time, bool) {
 	return time.Time{}, false
 }
 
+// runningInstanceIDs returns the set of instance IDs whose scan is actually in
+// flight (Status "running"/"paused"). Retention uses it so it never deletes a
+// live scan's directory.
+//
+// It reads each instance's Status under inst.mu (the lock its writers hold).
+// The previous snapshot treated EVERY non-nil instance as running, but
+// completed instances are never removed from s.instances (and
+// rebuildInstancesFromDisk repopulates them for every on-disk scan at startup),
+// so scanIsRunning returned true for essentially every scan that ever existed —
+// silently turning the whole retention feature into a no-op.
+func (s *Server) runningInstanceIDs() map[string]bool {
+	running := make(map[string]bool)
+	s.instancesMu.RLock()
+	defer s.instancesMu.RUnlock()
+	for id, inst := range s.instances {
+		if inst == nil {
+			continue
+		}
+		inst.mu.RLock()
+		active := instanceIsActive(inst.Status)
+		inst.mu.RUnlock()
+		if active {
+			running[id] = true
+		}
+	}
+	return running
+}
+
 // pruneExpiredScans deletes scan directories whose reference time is
 // older than `days` days. It is safe to call repeatedly and never
 // touches reserved/system directories under dataDir (anything outside a
@@ -125,14 +153,7 @@ func (s *Server) pruneExpiredScans(days int) int {
 
 	// Snapshot the set of currently-running instance IDs so we never
 	// delete a scan that is mid-flight.
-	running := make(map[string]bool)
-	s.instancesMu.Lock()
-	for id, inst := range s.instances {
-		if inst != nil {
-			running[id] = true
-		}
-	}
-	s.instancesMu.Unlock()
+	running := s.runningInstanceIDs()
 
 	entries := s.findAllScans()
 	removed := 0

--- a/internal/web/retention_running_test.go
+++ b/internal/web/retention_running_test.go
@@ -1,0 +1,38 @@
+package web
+
+import "testing"
+
+// TestRunningInstanceIDsOnlyActive guards the retention no-op regression: only
+// instances whose Status is active ("running"/"paused") count as running. A
+// completed/stopped/saved instance still living in s.instances must NOT be
+// treated as running, otherwise pruneExpiredScans skips it forever and the
+// configured retention window never deletes anything.
+func TestRunningInstanceIDsOnlyActive(t *testing.T) {
+	s := &Server{instances: map[string]*ScanInstance{
+		"run":    {Status: "running"},
+		"pause":  {Status: "paused"},
+		"RUN":    {Status: "Running"}, // case-insensitive per instanceIsActive
+		"done":   {Status: "finished"},
+		"stop":   {Status: "stopped"},
+		"saved":  {Status: "saved"},
+		"empty":  {Status: ""},
+		"nilent": nil,
+	}}
+
+	got := s.runningInstanceIDs()
+
+	wantActive := []string{"run", "pause", "RUN"}
+	for _, id := range wantActive {
+		if !got[id] {
+			t.Errorf("instance %q should be treated as running", id)
+		}
+	}
+	for _, id := range []string{"done", "stop", "saved", "empty", "nilent"} {
+		if got[id] {
+			t.Errorf("inactive instance %q must NOT be treated as running (retention no-op bug)", id)
+		}
+	}
+	if len(got) != len(wantActive) {
+		t.Errorf("runningInstanceIDs() = %v; want exactly %v", got, wantActive)
+	}
+}


### PR DESCRIPTION
## Summary

`pruneExpiredScans` (`internal/web/retention.go`) builds a snapshot it calls "currently-running instance IDs", but it marks **every** non-nil entry in `s.instances` as running — it never checks `Status`:

```go
running := make(map[string]bool)
s.instancesMu.Lock()
for id, inst := range s.instances {
    if inst != nil {
        running[id] = true   // <-- no Status check
    }
}
s.instancesMu.Unlock()
```

## Impact — retention is a silent no-op

Completed scans are **never removed** from `s.instances` (the only `delete(s.instances, …)` sites are the manual delete / stop / resume paths — none fire on scan completion), and `rebuildInstancesFromDisk` repopulates an in-memory instance for **every** on-disk `scan.json` at startup. So `running[id]` ends up true for essentially every scan that ever existed, `scanIsRunning` returns true for all of them, and `pruneExpiredScans` skips every candidate at the age check.

Net effect: `XALGORIX_SCAN_RETENTION_DAYS` / `cfg.ScanRetentionDays` **deletes nothing, ever** — unbounded disk growth (reports, notes, credential-adjacent artifacts) and an unmet retention/compliance expectation, with no error or log to signal the failure.

## Fix

Extract `runningInstanceIDs()`, which includes an instance **only** when `instanceIsActive(inst.Status)` is true (`"running"`/`"paused"`), reading `Status` under `inst.mu` (the lock its writers hold):

```go
func (s *Server) runningInstanceIDs() map[string]bool {
	running := make(map[string]bool)
	s.instancesMu.RLock()
	defer s.instancesMu.RUnlock()
	for id, inst := range s.instances {
		if inst == nil {
			continue
		}
		inst.mu.RLock()
		active := instanceIsActive(inst.Status)
		inst.mu.RUnlock()
		if active {
			running[id] = true
		}
	}
	return running
}
```

`pruneExpiredScans` now calls it. Genuinely in-flight scans (running/paused) are still protected; finished/stopped/saved scans become eligible once past the retention window.

## Tests

New `internal/web/retention_running_test.go` — `TestRunningInstanceIDsOnlyActive` builds a `Server` with instances across every status (running, paused, finished, stopped, saved, empty, nil) and asserts only the active ones are reported as running.

```
$ go test ./internal/web/
ok      github.com/xalgord/xalgorix/v4/internal/web
```

`go vet ./internal/web/` is clean and the full package test suite passes.