### PR TITLE
fix(scopeguard): infer scheme default port so implicit-port URLs cannot bypass the dashboard exclusion

### DIFF
--- a/internal/scopeguard/implicit_port_test.go
+++ b/internal/scopeguard/implicit_port_test.go
@@ -1,0 +1,79 @@
+package scopeguard
+
+import "testing"
+
+// TestImplicitPortDoesNotBypassDashboardExclusion covers the case where a target
+// URL omits an explicit port. url.Port() returns "" there, which previously made
+// localTargetsAllowed("") pass unconditionally and skipped the self-listener
+// fast-path (gated on hostPort != ""), so IsLocalOrListener returned false
+// (not-self) for the dashboard's own listener when it ran on port 80/443.
+func TestImplicitPortDoesNotBypassDashboardExclusion(t *testing.T) {
+	tests := []struct {
+		name   string
+		cfg    Config
+		target string
+		want   bool
+	}{
+		{
+			name:   "https no port, dashboard on 443, loopback bind -> self (blocked)",
+			cfg:    Config{Port: 443, AllowLocalTargets: true},
+			target: "https://127.0.0.1/",
+			want:   true,
+		},
+		{
+			name:   "https no port, dashboard on 443, 0.0.0.0 bind (docker) -> self (blocked)",
+			cfg:    Config{BindAddr: "0.0.0.0", Port: 443, AllowLocalTargets: true},
+			target: "https://127.0.0.1/",
+			want:   true,
+		},
+		{
+			name:   "http no port, dashboard on 80 -> self (blocked)",
+			cfg:    Config{Port: 80, AllowLocalTargets: true},
+			target: "http://127.0.0.1/",
+			want:   true,
+		},
+		{
+			// Regression guard: with the default dashboard port, an implicit
+			// :443 does NOT collide with the listener, so a genuinely-local
+			// target stays allowed (the point of AllowLocalTargets). The fix
+			// must not over-block.
+			name:   "https no port, dashboard on 9137 -> allowed local target",
+			cfg:    Config{Port: 9137, AllowLocalTargets: true},
+			target: "https://127.0.0.1/",
+			want:   false,
+		},
+		{
+			name:   "explicit non-dashboard port stays allowed",
+			cfg:    Config{Port: 443, AllowLocalTargets: true},
+			target: "https://127.0.0.1:8080/",
+			want:   false,
+		},
+		{
+			name:   "explicit dashboard port blocked",
+			cfg:    Config{Port: 443, AllowLocalTargets: true},
+			target: "https://127.0.0.1:443/",
+			want:   true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsLocalOrListener(tc.cfg, tc.target); got != tc.want {
+				t.Errorf("IsLocalOrListener(%+v, %q) = %v; want %v", tc.cfg, tc.target, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSchemeDefaultPort(t *testing.T) {
+	cases := map[string]string{
+		"http": "80", "https": "443",
+		"HTTP": "80", "HTTPS": "443",
+		"ws": "80", "wss": "443",
+		"ftp": "", "": "",
+	}
+	for scheme, want := range cases {
+		if got := schemeDefaultPort(scheme); got != want {
+			t.Errorf("schemeDefaultPort(%q) = %q; want %q", scheme, got, want)
+		}
+	}
+}

--- a/internal/scopeguard/scopeguard.go
+++ b/internal/scopeguard/scopeguard.go
@@ -107,6 +107,21 @@ func (c Config) loopbackPortAllowed(hostPort string) bool {
 	return false
 }
 
+// schemeDefaultPort returns the well-known default port for a URL scheme, so a
+// scheme://host URL with no explicit port is still compared against the
+// dashboard's listener port. Returns "" for schemes with no port convention we
+// should assume.
+func schemeDefaultPort(scheme string) string {
+	switch strings.ToLower(scheme) {
+	case "http", "ws":
+		return "80"
+	case "https", "wss":
+		return "443"
+	default:
+		return ""
+	}
+}
+
 // LookupHost is the package-level resolver indirection. Tests
 // overwrite this var to feed deterministic resolutions; production
 // uses net.LookupHost. Single var, single call site (inside
@@ -130,6 +145,13 @@ func IsLocalOrListener(cfg Config, target string) bool {
 	if u, err := url.Parse(target); err == nil && u.Host != "" {
 		host = u.Hostname()
 		hostPort = u.Port()
+		// url.Port() is "" when the URL omits an explicit port. Fall back to
+		// the scheme's default (http->80, https->443) so the dashboard-port
+		// checks below — which compare hostPort against cfg.Port — are not
+		// silently bypassed for URLs like "https://127.0.0.1/".
+		if hostPort == "" {
+			hostPort = schemeDefaultPort(u.Scheme)
+		}
 	}
 	// Also handle host:port without scheme
 	if h, p, err := net.SplitHostPort(host); err == nil {


### PR DESCRIPTION
## Summary

`IsLocalOrListener` (`internal/scopeguard/scopeguard.go`) derives the target port from `url.Port()`, which returns `""` whenever the URL omits an explicit port — it never infers 80/443:

```go
if u, err := url.Parse(target); err == nil && u.Host != "" {
    host = u.Hostname()
    hostPort = u.Port()   // "" for "https://127.0.0.1/"
}
```

## Impact — dashboard-exclusion bypass

For a URL like `https://127.0.0.1/`, `hostPort` is `""`, so:

- `localTargetsAllowed("")` returns `true` unconditionally (`hostPort == ""` short-circuit), and
- the self-listener fast-path is skipped entirely (it is gated on `hostPort != ""`).

So `IsLocalOrListener` returns `false` (not-self) for the dashboard's **own** listener when the dashboard runs on port **80 or 443** with `AllowLocalTargets` enabled — directly contradicting the documented invariant that `AllowLocalTargets` *"NEVER exposes the dashboard's own listener"*. Since `internal/agent/agent_guard.go` uses `IsLocalOrListener` to gate `terminal_execute` / `browser_action`, the agent can be pointed at the operator's own dashboard.

Running the dashboard on 80/443 (a clean URL for a self-hosted install) plus the documented `AllowLocalTargets` opt-in is a realistic combination; with the default 9137 port the bug is latent (an implicit `:443` ≠ 9137), which is why it slips existing tests.

## Fix

Infer the scheme's default port when `url.Port()` is empty, so the existing dashboard-port comparisons see the effective port:

```go
if hostPort == "" {
    hostPort = schemeDefaultPort(u.Scheme) // http/ws->80, https/wss->443, else ""
}
```

Behavior is unchanged for explicit-port URLs, bare hosts (no scheme → no `u.Host`, unaffected), and external targets (an inferred `:80`/`:443` only matters when the host is loopback/local *and* the port equals `cfg.Port`).

## Tests

New `internal/scopeguard/implicit_port_test.go`:

- Implicit-port URLs against a dashboard on **443** (both loopback and `0.0.0.0`/Docker binds) and **80** → classified **self / blocked**.
- Regression guard: implicit `:443` against the **default 9137** dashboard → still an **allowed** local target (the fix must not over-block).
- Explicit non-dashboard port → allowed; explicit dashboard port → blocked.
- `TestSchemeDefaultPort` unit-covers the helper.

```
$ go test ./internal/scopeguard/
ok      github.com/xalgord/xalgorix/v4/internal/scopeguard
```

All existing `scopeguard` tests still pass; `go vet` is clean.