### PR TITLE
fix(terminal): install findomain via cargo, not the generic apt path

### DIFF
--- a/internal/tools/terminal/terminal.go
+++ b/internal/tools/terminal/terminal.go
@@ -1618,6 +1618,7 @@ func installPackage(pkg string) string {
 	// Special handling for Cargo (Rust) tools
 	cargoTools := map[string]string{
 		"feroxbuster": "feroxbuster",
+		"findomain":   "findomain",
 	}
 
 	// Special handling for Go-installed tools


### PR DESCRIPTION
## Problem

`findomain` is in `packageMap` but not in any installer map, so `installPackage` falls through to `apt-get install findomain`. Findomain is a **Rust** tool and is **not in the Debian/Kali apt repositories**, so that install always fails:

```
E: Unable to locate package findomain
```

…even though the `packageMap` comment already says *"Findomain — Rust binary, installed via package manager or cargo"*.

## Fix

Add `findomain` to `cargoTools` so it uses the apt-first / `cargo install` fallback path (the same one `feroxbuster` uses). Findomain is on crates.io.

```diff
 cargoTools := map[string]string{
     "feroxbuster": "feroxbuster",
+    "findomain":   "findomain",
 }
```

## Verification

- `go build ./internal/tools/terminal/` ✅ · `go vet` ✅ · `gofmt` clean ✅ (Go 1.26.5)

## Note

This is the one auto-install tool bug **not** covered by the sibling PRs (#286 paramspider→pipx, #287 apt-get update, #288 arjun/uro/x8). It touches the same `cargoTools` literal as #288, so a trivial rebase may be needed once one merges. (Filed separately after #290 — the combined version — was closed in favor of keeping these focused, per-bug PRs.)