### PR TITLE
feat(terminal): register arjun, uro, and x8 for auto-install

### DIFF
--- a/internal/tools/terminal/terminal.go
+++ b/internal/tools/terminal/terminal.go
@@ -952,6 +952,10 @@ var packageMap = map[string]string{
 	"feroxbuster": "feroxbuster",
 	// Findomain — Rust binary, installed via package manager or cargo
 	"findomain": "findomain",
+	// Parameter discovery — arjun/uro are Python (pipx), x8 is Rust (cargo)
+	"arjun": "arjun",
+	"uro":   "uro",
+	"x8":    "x8",
 	// Text processing
 	"jq":        "jq",
 	"xmllint":   "libxml2-utils",
@@ -1613,14 +1617,17 @@ func installPackage(pkg string) string {
 
 	// Special handling for pipx-installed tools
 	pipxTools := map[string]string{
-		"scrapling":   "scrapling",
+		"arjun":       "arjun",
 		"paramspider": "paramspider",
+		"scrapling":   "scrapling",
+		"uro":         "uro",
 	}
 
 	// Special handling for Cargo (Rust) tools
 	cargoTools := map[string]string{
 		"feroxbuster": "feroxbuster",
 		"findomain":   "findomain",
+		"x8":          "x8",
 	}
 
 	// Special handling for Go-installed tools


### PR DESCRIPTION
Resolves #288 (re-applied on top of main after a map-literal conflict with #286/#297).

Adds packageMap + install sub-map entries so `resolvePackage` returns these tools and `installPackage` routes them to the correct package manager:
- `arjun`, `uro` → `pipxTools` (Python, pipx)
- `x8` → `cargoTools` (Rust, cargo)

Original PR by @ulises2k — logic unchanged; only the map entries were unioned with the now-merged `paramspider`/`findomain` entries and re-gofmt-aligned.

Verified: `go build`, `go vet`, `golangci-lint` (0 issues), `go test ./internal/tools/terminal/` all pass.