### PR TITLE
release: v4.5.77

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.76
+VERSION=4.5.77
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.76" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.77" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.76"
+var version = "4.5.77"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
### Changes

- abb7b01 feat(terminal): register arjun, uro, and x8 for auto-install (#299)
- 373be4b fix(terminal): install findomain via cargo, not the generic apt path (#297)
- 7ae8296 fix(terminal): install paramspider via pipx, not go install (#286)
- 1a497de feat(scan): custom identifying headers for scan traffic (-H, httpx/nuclei) (#289)
- e8610c9 fix(llm): send generationConfig (max tokens + temperature) to Gemini (#291)
- 2d54597 fix(tools/python): kill the whole process group on timeout (#292)
- b6cca22 fix(web): retention only skips ACTIVE scans, not every known instance (#293)
- 2739122 fix(scopeguard): infer scheme default port so implicit-port URLs cannot bypass the dashboard exclusion (#294)
- d26f2a7 fix(docker): build ProjectDiscovery httpx on Go 1.26; stop shipping Python httpx (#285)
- 99157c3 Merge pull request #284 from xalgord/release/v4.5.76