### PR TITLE
fix(web): make stop signaling per-instance + honest /api/scan ack

### DIFF
--- a/internal/web/orchestrator.go
+++ b/internal/web/orchestrator.go
@@ -258,24 +258,20 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 	admissionTicker := time.NewTicker(2 * time.Second)
 	defer admissionTicker.Stop()
 	for {
-		// Check if THIS instance was stopped (via per-instance stop API)
+		// Check if THIS instance was stopped (via per-instance stop API,
+		// Stop All, pause, or delete — all of which flip instance.Status).
+		// We intentionally do NOT check the global stopReq here: it is a
+		// shared flag whose lifetime is decoupled from this scan (it stays
+		// true after a Stop All / SIGTERM until some other scan clears it).
+		// Checking it here caused pending scans to mark themselves
+		// "user_stopped" with no user action against THIS scan (the
+		// stopReq.Store(false) clear-at-start hack was a workaround that in
+		// turn broke Stop All). The per-instance status is the authoritative
+		// signal: every stop path sets it, and we observe it on every wake.
 		instance.mu.RLock()
 		stopped := instance.Status == "stopped"
 		instance.mu.RUnlock()
 		if stopped {
-			// Early return — defer is already registered and will clean up
-			return
-		}
-
-		// Also check global stop (user clicked "stop all")
-		if s.stopReq.Load() {
-			instance.mu.Lock()
-			if instance.Status == "pending" {
-				instance.Status = "stopped"
-				instance.StopReason = "user_stopped"
-				instance.FinishedAt = time.Now().Format(time.RFC3339)
-			}
-			instance.mu.Unlock()
 			// Early return — defer is already registered and will clean up
 			return
 		}
@@ -348,7 +344,6 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 	// process exits during admission/startup.
 	req.InstanceID = instanceID // (re)thread instance ID; also set before the admission wait
 	s.running.Store(true)
-	s.stopReq.Store(false) // clear global stop so this scan isn't immediately aborted
 	if req.DiscordWebhook != "" {
 		s.discordWebhook = req.DiscordWebhook
 	}
@@ -392,11 +387,13 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 
 	interruptedQueue := false
 	for i, target := range req.Targets {
-		// Check both global stop and per-instance stop
+		// Per-instance stop/pause: Stop All, single-stop, pause, and delete
+		// all flip instance.Status, which we observe here. The global stopReq
+		// is intentionally not consulted (see the admission-loop note above).
 		instance.mu.RLock()
 		instStatus := instance.Status
 		instance.mu.RUnlock()
-		if s.stopReq.Load() || instStatus == "stopped" || instStatus == "paused" {
+		if instStatus == "stopped" || instStatus == "paused" {
 			interruptedQueue = true
 			if instStatus == "paused" {
 				s.broadcastToInstance(instanceID, WSEvent{Type: "paused", Content: "Scan queue paused"})
@@ -434,7 +431,10 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 		instance.mu.RLock()
 		instStatusAfterTarget := instance.Status
 		instance.mu.RUnlock()
-		if shouldAdvanceQueueAfterTarget(s.stopReq.Load(), instStatusAfterTarget) {
+		// stopRequested=false: the global flag is not consulted for per-scan
+		// queue advancement (see admission-loop note). instStatusAfterTarget
+		// already reflects any per-instance stop/pause.
+		if shouldAdvanceQueueAfterTarget(false, instStatusAfterTarget) {
 			s.saveQueueState(i+1, req)
 		} else {
 			interruptedQueue = true
@@ -959,8 +959,9 @@ func (s *Server) runWildcardTarget(_ context.Context, scanCfg *config.Config, re
 	wildcardStopped := false
 	for j := resumeFromSubIndex; j < len(subdomains); j++ {
 		subdomain := subdomains[j]
-		// Check both global stop and per-instance stop
-		if s.stopReq.Load() || s.instanceInterrupted(req.InstanceID) {
+		// Per-instance stop only (Stop All / single-stop / pause / delete all
+		// flip the instance status, which instanceInterrupted observes).
+		if s.instanceInterrupted(req.InstanceID) {
 			log.Printf("[INFO] Subdomain loop stopped by user at %d/%d for %s", j+1, len(subdomains), target)
 			s.broadcastToInstance(req.InstanceID, WSEvent{Type: "stopped", Content: "Scan queue stopped by user"})
 			wildcardStopped = true
@@ -1113,8 +1114,9 @@ func (s *Server) runWildcardTarget(_ context.Context, scanCfg *config.Config, re
 		saveWildcardProgress(j+1, -1, "", "")
 
 		// ── Cooldown between subdomain scans ──
-		// Prevents LLM API rate-limiting and gives GC time to reclaim memory
-		if j < len(subdomains)-1 && !s.stopReq.Load() && !s.instanceInterrupted(req.InstanceID) {
+		// Prevents LLM API rate-limiting and gives GC time to reclaim memory.
+		// instanceInterrupted covers per-instance stop/pause/delete.
+		if j < len(subdomains)-1 && !s.instanceInterrupted(req.InstanceID) {
 			log.Printf("[INFO] Cooldown: 10s pause before next subdomain (memory recovery + rate limit prevention)")
 			time.Sleep(10 * time.Second)
 		}
@@ -1123,7 +1125,9 @@ func (s *Server) runWildcardTarget(_ context.Context, scanCfg *config.Config, re
 		parentRecord, _ = loadScanRecordFromDir(scanDir)
 	}
 	if parentRecord != nil {
-		if wildcardStopped || s.stopReq.Load() {
+		// wildcardStopped already incorporates instanceInterrupted (set when
+		// the per-instance stop is observed in the subdomain loop above).
+		if wildcardStopped {
 			if status, stopReason := s.instanceRunStatus(req.InstanceID); isInterruptedInstanceStatus(status) {
 				parentRecord.Status = status
 				parentRecord.StopReason = stopReason

--- a/internal/web/scan_lifecycle_test.go
+++ b/internal/web/scan_lifecycle_test.go
@@ -1,9 +1,11 @@
 package web
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -199,5 +201,87 @@ func TestClearQueueState_RemovesPendingScanFile(t *testing.T) {
 		if e.state != nil && e.state.InstanceID == "cancel-1" {
 			t.Error("canceled pending scan must not be resumable after clearQueueState")
 		}
+	}
+}
+
+// Regression: a PENDING scan must NOT be marked "stopped by user" merely
+// because the global stopReq flag is true. Before the fix, stopReq was a
+// shared flag whose lifetime was decoupled from any one scan (set true by
+// Stop All / SIGTERM, cleared only when some OTHER scan started). The
+// admission loop read it directly and killed pending scans that observed a
+// stale-true value — producing "stopped by user" with no user action against
+// that scan. The fix made stop signaling per-instance: the admission/target
+// loops now consult instanceInterrupted / instance.Status only, never the
+// global flag. This test pins that contract: a stale stopReq MUST NOT
+// interrupt a pending instance; only the instance's own status change does.
+func TestStopReqGlobalFlagDoesNotInterruptPendingScan(t *testing.T) {
+	s := newTestServer(t, nil)
+
+	inst := &ScanInstance{ID: "pend-1", Status: "pending"}
+	s.instancesMu.Lock()
+	s.instances["pend-1"] = inst
+	s.instancesMu.Unlock()
+
+	// Simulate the exact cause of the bug: a stale/Stop-All/SIGTERM global
+	// stopReq left true while this scan is parked pending.
+	s.stopReq.Store(true)
+
+	// instanceInterrupted is what the loops now consult. A pending scan must
+	// NOT be considered interrupted just because stopReq is true.
+	if s.instanceInterrupted("pend-1") {
+		t.Error("a pending scan must NOT be interrupted by a stale global stopReq (per-instance signal only)")
+	}
+
+	// And the instance's status must be untouched.
+	inst.mu.RLock()
+	if inst.Status != "pending" {
+		t.Errorf("pending scan status changed to %q with no per-instance stop", inst.Status)
+	}
+	inst.mu.RUnlock()
+
+	// The correct stop channel: flip the instance's OWN status. Now it IS
+	// interrupted, and stopReq is irrelevant.
+	inst.mu.Lock()
+	inst.Status = "stopped"
+	inst.mu.Unlock()
+	if !s.instanceInterrupted("pend-1") {
+		t.Error("a stopped instance must be reported interrupted via its own status")
+	}
+
+	// And a deleted instance (removed from the map) is interrupted regardless.
+	s.instancesMu.Lock()
+	delete(s.instances, "pend-1")
+	s.instancesMu.Unlock()
+	if !s.instanceInterrupted("pend-1") {
+		t.Error("a deleted instance must be reported interrupted")
+	}
+}
+
+// Regression: the /api/scan dispatch ack must report the scan's actual local
+// state ("pending" — queued until the admission gate grants a slot), not
+// "started". The old "started" ack was read by external callers (e.g. a SaaS
+// control plane) as "running", producing a SaaS=running / worker=pending
+// desync whenever the worker was at its concurrency cap.
+func TestHandleScanAckIsPendingNotStarted(t *testing.T) {
+	s := newTestServer(t, nil)
+
+	body := `{"targets":["https://example.com"],"scan_mode":"quick"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/scan", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.handleScan(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status code = %d, want 200", rr.Code)
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON response: %v body=%q", err, rr.Body.String())
+	}
+	if resp["status"] != "pending" {
+		t.Errorf("ack status = %q, want \"pending\" (must reflect queued state, not \"started\")", resp["status"])
+	}
+	if resp["instance_id"] == "" {
+		t.Error("ack must include an instance_id")
 	}
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1602,16 +1602,20 @@ func (s *Server) handleScan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Clear global stop flag so the new scan isn't immediately aborted
-	// (fixes starvation bug where scans stay "pending" after Stop All)
-	s.stopReq.Store(false)
-
 	instanceID := randomSlug()
 	req.Name = strings.TrimSpace(req.Name) // propagate name to running scans too
 	go s.runMultiScan(req, &scanCfg, instanceID)
 
+	// The ack reflects the scan's actual local state: it is QUEUED as
+	// "pending" (orchestrator.go registers it pending, then the admission
+	// gate flips it to "running" only once a concurrency slot is granted).
+	// Previously this returned "started", which external callers (e.g. a SaaS
+	// control plane) misread as "running" — producing a SaaS=running /
+	// worker=pending desync whenever the worker was at its RAM-derived cap.
+	// Callers wanting the authoritative status should poll GET /api/instances
+	// (or /api/scans), whose "status" field is pending until admission.
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]string{"status": "started", "instance_id": instanceID})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "pending", "instance_id": instanceID})
 }
 
 func (s *Server) handleStop(w http.ResponseWriter, r *http.Request) {
@@ -2322,10 +2326,6 @@ func (s *Server) handleInstanceAction(w http.ResponseWriter, r *http.Request) {
 		scanContext := inst.ScanContext
 		inst.mu.RUnlock()
 
-		// Clear global stop flag so the restarted scan isn't immediately aborted
-		// by the queue wait loop checking stopReq.
-		s.stopReq.Store(false)
-
 		// Build a new ScanRequest from stored config
 		req := ScanRequest{
 			Targets:             targets,
@@ -2399,7 +2399,6 @@ func (s *Server) handleInstanceAction(w http.ResponseWriter, r *http.Request) {
 			_ = os.RemoveAll(savedDir)
 		}
 
-		s.stopReq.Store(false)
 		scanCfg := *s.cfg
 		newID := randomSlug()
 		go s.runMultiScan(req, &scanCfg, newID)
@@ -2463,7 +2462,6 @@ func (s *Server) handleInstanceAction(w http.ResponseWriter, r *http.Request) {
 		delete(s.instances, instanceID)
 		s.instancesMu.Unlock()
 
-		s.stopReq.Store(false)
 		scanCfg := *s.cfg
 		newID := randomSlug()
 		go s.runMultiScan(req, &scanCfg, newID)


### PR DESCRIPTION
## Summary

Two related fixes for scan-state bugs observed in production.

### 1. `stopReq` global-flag race → "stopped by user" with no user action

`stopReq` was a **single global atomic flag** shared by every scan, with a broken lifecycle. Once set `true` (by **Stop All** or the **SIGTERM** handler), nothing cleared it except a *new scan starting*. Pending scans wake every 2s and read the flag directly in the admission loop — so a stale-`true` value (left over from a prior Stop All or a restart) made them mark themselves `stopped`/`user_stopped` with **no user action against that scan**. The `Store(false)` clear-at-start workaround (commented "fixes starvation bug where scans stay pending after Stop All") in turn clobbered legitimate Stop Alls when a pending scan was admitted right after one.

**Fix:** stop signaling is now **per-instance**. The admission, per-target, queue-advance, and subdomain loops consult `instanceInterrupted` / `instance.Status` only — which every stop path (Stop All, single-stop, pause, delete) already flips. The global `stopReq` stays write-only (set by SIGTERM/Stop All for the drain of in-flight LLM/tool calls) and is no longer read for per-scan decisions. The five `Store(false)` clear-at-start hacks are deleted.

No semantic loss: every behavior the global flag provided is already achievable via per-instance status, which all the stop handlers already set.

### 2. `/api/scan` dispatch ack returns `pending`, not `started`

`POST /api/scan` ACKed `{"status":"started"}` synchronously — but the scan is actually registered as `pending` and only flips to `running` after the admission gate grants a concurrency slot. External callers (e.g. a SaaS control plane) read "started" as "running", producing a **SaaS=running / worker=pending desync** whenever the worker was at its cap. Changed to `{"status":"pending"}` to reflect reality; callers wanting authoritative status should poll `GET /api/instances`.

## Tests
- `TestStopReqGlobalFlagDoesNotInterruptPendingScan` — pins the contract: a stale global `stopReq=true` must NOT interrupt a pending scan; only the instance's own status change (or deletion) does.
- `TestHandleScanAckIsPendingNotStarted` — the `/api/scan` ack must be `pending`.
- Existing stop/pause tests remain green.

## Verification
`go build ./...`, `go vet ./internal/web/`, `go test ./internal/web/`, `golangci-lint` — all clean.