### PR TITLE
fix(agent): accurate scan termination, robust tool-call parsing, spac…

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -709,7 +709,8 @@ func (a *Agent) Run(targets []string, instruction string) {
 	// Running total of tool calls, for the optional resource budget.
 	toolCallsTotal := 0
 
-	for iter := 0; (a.maxIter == 0 || iter < a.maxIter) && !a.stopped.Load() && (a.ctx == nil || a.ctx.Err() == nil); iter++ {
+	iter := 0
+	for ; (a.maxIter == 0 || iter < a.maxIter) && !a.stopped.Load() && (a.ctx == nil || a.ctx.Err() == nil); iter++ {
 		// Reset activity watchdog on each iteration — IMMEDIATELY, no delay
 		a.touchActivity()
 		a.state.Iteration = iter
@@ -1115,7 +1116,24 @@ func (a *Agent) Run(targets []string, instruction string) {
 		// ZERO DELAY — immediately proceed to next iteration
 	}
 
-	a.emit(Event{Type: "finished", Content: "Agent reached maximum iterations", TotalTokens: tokenCount()})
+	// The loop exited. Report the ACTUAL termination reason instead of always
+	// blaming "maximum iterations". With the default unlimited iteration budget
+	// (maxIter == 0) the loop can ONLY end here via an external Stop() or a
+	// canceled context — mislabeling every such exit as "maximum iterations"
+	// hid the real cause (user stop, shutdown, watchdog kill, or upstream
+	// context cancellation) and made healthy scans look like they'd blown a cap.
+	var finishReason string
+	switch {
+	case a.maxIter > 0 && iter >= a.maxIter:
+		finishReason = fmt.Sprintf("Agent reached maximum iterations (%d)", a.maxIter)
+	case a.stopped.Load():
+		finishReason = "Scan stopped"
+	case a.ctx != nil && a.ctx.Err() != nil:
+		finishReason = "Scan canceled: " + a.ctx.Err().Error()
+	default:
+		finishReason = "Scan ended"
+	}
+	a.emit(Event{Type: "finished", Content: finishReason, TotalTokens: tokenCount()})
 }
 
 // Stop signals the agent to stop and kills all running processes.

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -1401,7 +1401,17 @@ Resume the assessment NOW by calling a tool. For example, to run a command:
 	// against the consecutive budget (and vice versa). Without this, a
 	// density compact (1) + two consecutive compacts (2) = 3 compactions,
 	// violating MaxReasoningCompactions.
+	// Second (later) consecutive compaction — fires at ReasoningLoopCompactAt2
+	// and ONLY once the first consecutive compaction has already been spent.
+	// Gating on ReasoningLoopCompactions (not merely the combined total) keeps
+	// the two compactions SPACED at their intended thresholds (6 and 10). The
+	// previous code gated only on totalCompactions, so the `>= ReasoningLoopCompactAt`
+	// block below stayed true at count 7 and fired the second compaction
+	// back-to-back at 6 and 7 — burning the whole budget before the model had
+	// any turns to recover, then leaving it un-helped from 8 until the abort at
+	// 15 (ReasoningLoopCompactAt2 was effectively dead).
 	if state.NoToolCount >= ReasoningLoopCompactAt2 &&
+		state.ReasoningLoopCompactions >= 1 &&
 		totalCompactions < MaxReasoningCompactions {
 		state.ReasoningLoopCompactions++
 		return HookResult{
@@ -1409,7 +1419,12 @@ Resume the assessment NOW by calling a tool. For example, to run a command:
 			Nudge:        reasoningLoopResumePrompt(state, "consecutive"),
 		}
 	}
+	// First consecutive compaction — fires once when the count first reaches
+	// ReasoningLoopCompactAt, and remains the only consecutive compaction until
+	// the count climbs to ReasoningLoopCompactAt2 (the `== 0` guard prevents it
+	// re-firing every turn between the two thresholds).
 	if state.NoToolCount >= ReasoningLoopCompactAt &&
+		state.ReasoningLoopCompactions == 0 &&
 		totalCompactions < MaxReasoningCompactions {
 		state.ReasoningLoopCompactions++
 		return HookResult{

--- a/internal/agent/reasoning_loop_test.go
+++ b/internal/agent/reasoning_loop_test.go
@@ -65,6 +65,37 @@ func TestNoToolHandlerCompactsBeforeAbort(t *testing.T) {
 	}
 }
 
+// The two consecutive compactions must be SPACED at ReasoningLoopCompactAt (6)
+// and ReasoningLoopCompactAt2 (10) — NOT fired back-to-back at 6 and 7. The
+// back-to-back bug consumed the whole compaction budget immediately, leaving
+// the model un-helped from count 8 until the abort at 15 (observed on the
+// pentest-ground.com scan: compactions at iters 79/80, then dead air to 88).
+func TestNoToolHandlerCompactionsAreSpaced(t *testing.T) {
+	state := NewScanState()
+
+	compactedAt := []int{}
+	for state.NoToolCount < NoToolAbortAt {
+		res := hookNoToolHandler(state, map[string]string{"response": "let me think"})
+		if res.ForceCompact {
+			compactedAt = append(compactedAt, state.NoToolCount)
+		}
+		if res.ForceSkip {
+			break
+		}
+	}
+
+	if len(compactedAt) != 2 {
+		t.Fatalf("expected exactly 2 compactions, got %d at counts %v", len(compactedAt), compactedAt)
+	}
+	if compactedAt[0] != ReasoningLoopCompactAt {
+		t.Errorf("first compaction at count %d, want %d", compactedAt[0], ReasoningLoopCompactAt)
+	}
+	if compactedAt[1] != ReasoningLoopCompactAt2 {
+		t.Errorf("second compaction at count %d, want %d (spaced, not back-to-back at %d)",
+			compactedAt[1], ReasoningLoopCompactAt2, ReasoningLoopCompactAt+1)
+	}
+}
+
 // The density path must catch a model that makes occasional tool calls —
 // enough to reset the consecutive counter but not enough to make progress —
 // which would otherwise run for hours. This is the exact 48-hour pattern:

--- a/internal/llm/parser.go
+++ b/internal/llm/parser.go
@@ -219,13 +219,33 @@ func fixIncomplete(content string) string {
 		return content
 	}
 
-	// At least one open tag has no matching close. Append a single closing
-	// tag — even if multiple tags are unclosed, the regex is non-greedy and
-	// will pick up the well-formed pairs first.
+	// At least one open tag has no matching close.
 	content = strings.TrimRight(content, " \t\n\r")
+
+	// Truncated CLOSING tag ("...</") — the body already exists, just finish
+	// the close so the well-formed pair parses.
 	if strings.HasSuffix(content, "</") {
 		return content + "function>"
 	}
+
+	// A trailing OPEN tag is unclosed. Decide whether to RECOVER it (it carries
+	// a partial body worth parsing) or DROP it (it is a bare, param-less open).
+	// Completing a param-less open would fabricate an empty, argument-less call
+	// (e.g. `<function=terminal_execute></function>`) that fails with
+	// "missing required parameter" and, when the model repeats the truncation,
+	// trips the repeated-call guard and burns iterations. We inspect the tail
+	// from the last "<function=" open: if it has no matching close AND no
+	// <parameter, it is truncation noise — strip it. Otherwise close it so the
+	// partial params are recovered.
+	if lastOpen := strings.LastIndex(content, "<function="); lastOpen >= 0 {
+		tail := content[lastOpen:]
+		if !strings.Contains(tail, "</function>") && !strings.Contains(tail, "<parameter") {
+			return strings.TrimRight(content[:lastOpen], " \t\n\r")
+		}
+	}
+
+	// Append a single closing tag — even if multiple tags are unclosed, the
+	// regex is non-greedy and will pick up the well-formed pairs first.
 	return content + "\n</function>"
 }
 

--- a/internal/llm/parser_test.go
+++ b/internal/llm/parser_test.go
@@ -150,6 +150,33 @@ func TestFixIncomplete_PartialEndTag(t *testing.T) {
 	}
 }
 
+// TestFixIncomplete_TrailingBareOpenDropped is the regression for the
+// MiniMax-M3 case: a valid call followed by a trailing, param-less
+// "<function=terminal_execute>" open tag (the model truncated before emitting
+// params). Previously fixIncomplete closed it into a phantom empty call that
+// failed "missing required parameter 'command'" and tripped the repeated-call
+// guard. The bare open must now be dropped, leaving only the real call.
+func TestFixIncomplete_TrailingBareOpenDropped(t *testing.T) {
+	in := "<function=terminal_execute>\n<parameter=command>id</parameter>\n</function>\n" +
+		"<function=terminal_execute>"
+	calls := ParseToolCalls(in)
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly 1 call (phantom empty dropped), got %d: %+v", len(calls), calls)
+	}
+	if calls[0].Name != "terminal_execute" || calls[0].Args["command"] != "id" {
+		t.Fatalf("expected the real terminal_execute(command=id), got %+v", calls[0])
+	}
+}
+
+// TestFixIncomplete_TrailingBareOpenWithCloseOnly guards the "empty but fully
+// closed" open the model sometimes emits standalone. A single bare open with
+// no body and no close is truncation noise — it must not become a call.
+func TestFixIncomplete_LoneBareOpenDropped(t *testing.T) {
+	if calls := ParseToolCalls("<function=terminal_execute>"); len(calls) != 0 {
+		t.Fatalf("expected 0 calls from a lone bare open tag, got %+v", calls)
+	}
+}
+
 // ParseOrphanedCalls must recover <parameter> blocks that have a trailing
 // </function> but NO <function=NAME> open tag — the malformation that force-
 // stopped the codeant.ai scan. The caller resolves the tool name via the


### PR DESCRIPTION
…ed reasoning-loop compaction

Three fixes for scans that appeared to "fail at maximum iterations":

1. agent loop reported "Agent reached maximum iterations" on every exit, even when the real cause was an external Stop() or a canceled context (the default iteration budget is unlimited, so the cap is never the actual reason). Report the true termination reason instead.

2. llm parser fixIncomplete fabricated a phantom empty tool call from a trailing, param-less "<function=NAME>" open tag (model truncation), which failed "missing required parameter" and tripped the repeated-call guard. Drop bare body-less trailing opens; still recover partial bodies.

3. reasoning-loop recovery fired both context compactions back-to-back at consecutive no-tool counts 6 and 7 instead of the intended 6 and 10, burning the budget before the model could recover and leaving ReasoningLoopCompactAt2 dead. Gate the two compactions on ReasoningLoopCompactions so they land at 6 and 10 as designed.

Adds regression tests for the parser and compaction-spacing behavior.

<!--
Thanks for contributing to Xalgorix! Please fill this out so we can review quickly.
`main` is branch-protected — PRs are the only way in. CI runs make lint,
golangci-lint, go vet, and the test suite on every PR.
-->

## What & why

<!-- What does this change and why? Link the issue it addresses. -->

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Refactor / internal
- [ ] Other:

## How was it tested?

<!-- Commands you ran, new tests added, manual verification. -->

- [ ] `make lint` passes
- [ ] `golangci-lint run --config .golangci.yml ./...` passes
- [ ] `go test ./...` passes
- [ ] Added/updated tests for the change

## Checklist

- [ ] I read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md).
- [ ] The tree is `gofmt`-clean.
- [ ] I updated docs (`README`, `docs/`, help text) if behavior changed.
- [ ] This does not weaken a security control (scope guard, verifier, false-positive gate) without explicit discussion.
- [ ] For engine behavior changes: I noted any impact on scan findings/severity.
