### PR TITLE
fix(agent): recover dropped-open-tag tool calls by the emitted name (fixes reasoning-loop regression)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -893,8 +893,24 @@ func (a *Agent) Run(targets []string, instruction string) {
 		// not counted toward the reasoning-loop threshold.
 		if len(toolCalls) == 0 {
 			for _, oc := range llm.ParseOrphanedCalls(responseClean) {
-				if name, ok := a.registry.MatchByParams(oc.ParamNames); ok {
-					a.emit(Event{Type: "message", Content: fmt.Sprintf("🔧 Recovered a tool call whose <function> open tag was dropped — inferred '%s' from parameters %v.", name, oc.ParamNames), TotalTokens: tokenCount()})
+				// Prefer the tool name the model actually emitted (it dropped only
+				// the "<function=" prefix, e.g. `terminal_execute>`), validated
+				// against the registry. This rescues the common case that
+				// MatchByParams cannot resolve: a call carrying only {command},
+				// which ties across terminal_execute / browser_action / pageagent
+				// and is rejected as ambiguous — the exact regression that turned
+				// dropped-tag shell calls into "no tool call" → reasoning loops.
+				name, ok := "", false
+				if oc.NameHint != "" {
+					if _, exists := a.registry.Get(oc.NameHint); exists {
+						name, ok = oc.NameHint, true
+					}
+				}
+				if !ok {
+					name, ok = a.registry.MatchByParams(oc.ParamNames)
+				}
+				if ok {
+					a.emit(Event{Type: "message", Content: fmt.Sprintf("🔧 Recovered a tool call whose <function> open tag was dropped — resolved to '%s' (params %v).", name, oc.ParamNames), TotalTokens: tokenCount()})
 					toolCalls = append(toolCalls, llm.ToolCall{Name: name, Args: oc.Args})
 				}
 			}

--- a/internal/llm/parser.go
+++ b/internal/llm/parser.go
@@ -77,6 +77,17 @@ var (
 	lenientParamRe = regexp.MustCompile(`(?s)<parameter[^>]*?(\w+)\s*>(.*?)</parameter>`)
 	// Split identifier on punctuation/whitespace
 	identSplitRe = regexp.MustCompile(`[.\s,;:!?]+`)
+
+	// nameHintRe captures a bare tool name emitted right before an orphaned
+	// parameter run, i.e. the model dropped the "<function=" prefix but kept the
+	// name: `terminal_execute>\n<parameter=command>…`. We match the trailing
+	// `identifier>` at the end of the text preceding the first <parameter block.
+	// The captured name is only a HINT — the caller validates it against the
+	// registered tools before using it — so a false capture (e.g. the tail of a
+	// closing tag) is harmless. This rescues the common case that MatchByParams
+	// cannot: a call carrying only {command}, which ties across terminal_execute
+	// / browser_action / pageagent and is therefore rejected as ambiguous.
+	nameHintRe = regexp.MustCompile(`(?s)([A-Za-z_][A-Za-z0-9_-]*)\s*>\s*$`)
 )
 
 // ParseToolCalls extracts tool calls from LLM XML output.
@@ -272,6 +283,12 @@ func FormatToolCall(name string, args map[string]string) string {
 type OrphanedCall struct {
 	Args       map[string]string
 	ParamNames []string // ordered, dedup'd param names present
+	// NameHint is the bare tool name the model emitted immediately before the
+	// parameter run when it dropped only the "<function=" prefix (e.g.
+	// "terminal_execute" from `terminal_execute>\n<parameter=command>…`). Empty
+	// when no such token precedes the params. The caller MUST validate it
+	// against the registered tools before trusting it.
+	NameHint string
 }
 
 // ParseOrphanedCalls extracts <parameter=X>...</parameter> blocks that are
@@ -305,6 +322,15 @@ func ParseOrphanedCalls(content string) []OrphanedCall {
 		if len(params) == 0 {
 			continue
 		}
+		// Capture the bare tool name emitted right before the first parameter
+		// block, if any (the model dropped only "<function="): e.g.
+		// `terminal_execute>\n<parameter=command>…`. Validated by the caller.
+		nameHint := ""
+		if firstParam := strings.Index(frag, "<parameter"); firstParam > 0 {
+			if m := nameHintRe.FindStringSubmatch(frag[:firstParam]); m != nil {
+				nameHint = sanitizeParamName(m[1])
+			}
+		}
 		args := make(map[string]string, len(params))
 		var names []string
 		seen := make(map[string]bool)
@@ -318,7 +344,7 @@ func ParseOrphanedCalls(content string) []OrphanedCall {
 			args[name] = html.UnescapeString(strings.TrimSpace(pm[2]))
 		}
 		if len(args) > 0 {
-			out = append(out, OrphanedCall{Args: args, ParamNames: names})
+			out = append(out, OrphanedCall{Args: args, ParamNames: names, NameHint: nameHint})
 		}
 	}
 	return out

--- a/internal/llm/parser_test.go
+++ b/internal/llm/parser_test.go
@@ -214,6 +214,38 @@ func TestParseOrphanedCallsMissingOpenAndParamBracket(t *testing.T) {
 	}
 }
 
+// Regression (v4.5.50 → v4.5.79): the model dropped only "<function=" but kept
+// the tool NAME, e.g. `terminal_execute>\n<parameter=command>curl…`. Its param
+// set is just {command}, which ties across terminal_execute/browser_action/
+// pageagent, so MatchByParams rejects it and the call became "no tool call" →
+// reasoning loop. ParseOrphanedCalls must surface the emitted name as NameHint
+// so the agent can resolve it directly (validated against the registry).
+func TestParseOrphanedCallsCapturesNameHint(t *testing.T) {
+	got := ParseOrphanedCalls("terminal_execute>\n<parameter=command>curl -v https://portal.flare.network/ 2>&1 | head -40</parameter>\n</function>")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 orphaned call, got %d", len(got))
+	}
+	if got[0].NameHint != "terminal_execute" {
+		t.Errorf("NameHint = %q, want terminal_execute", got[0].NameHint)
+	}
+	if got[0].Args["command"] == "" {
+		t.Errorf("command param not recovered: %v", got[0].Args)
+	}
+}
+
+// A pure orphaned block with NO preceding bare name must yield an empty
+// NameHint (so the caller falls back to MatchByParams rather than trusting a
+// spurious hint).
+func TestParseOrphanedCallsNoNameHintWhenAbsent(t *testing.T) {
+	got := ParseOrphanedCalls("<parameter=command>id</parameter>\n</function>")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 orphaned call, got %d", len(got))
+	}
+	if got[0].NameHint != "" {
+		t.Errorf("NameHint = %q, want empty", got[0].NameHint)
+	}
+}
+
 // Well-formed calls must NOT be double-counted as orphans.
 func TestParseOrphanedCallsSkipsWellFormed(t *testing.T) {
 	content := "<function=terminal_execute>\n<parameter=command>id</parameter>\n</function>"


### PR DESCRIPTION
## Regression
Scans that ran clean at **v4.5.50** started force-stopping with "15 consecutive responses with no tool call" (reasoning loop) by v4.5.79 — **same settings**, and with the **service stable** (no restart during the scan, e.g. portal.flare.network on 2026-07-25).

## Root cause
The model intermittently drops the `<function=` prefix but keeps the name + a well-formed body:
```
terminal_execute>
<parameter=command>curl -v https://target/ 2>&1 | head</parameter>
</function>
```
The dropped-open-tag recovery (added after v4.5.50) resolves these via `MatchByParams` on the parameter set. But `MatchByParams` rejects ties (a safety fix, #281), and **`{command}` is shared by `terminal_execute`, `browser_action`, and `pageagent`** — so the single most common call shape (a bare shell command) is ambiguous → rejected → "no tool call" → reasoning loop → force stop.

Confirmed not the cause: the tool-call **format is unchanged since v4.5.50**, and response preprocessing (`stripThink`) doesn't mangle `<function=`. So the model's malformation is the trigger; the **fixable engine regression** is that recovery stopped handling `{command}`.

## Fix
`ParseOrphanedCalls` now captures the bare tool name emitted right before the parameter run (`NameHint`). The agent prefers that name — **validated against the registry** — and falls back to `MatchByParams` only when there's no valid hint. This recovers the `{command}` case the param-set matcher can't, while keeping the tie-rejection safety for genuinely nameless fragments.

## Tests
- `NameHint` captured for `terminal_execute>…{command}` and resolved directly.
- Empty `NameHint` when no bare name precedes the params (falls back to `MatchByParams`).
- Existing orphaned-call / truncation (`_plan>`) / stray-quote cases unchanged.
- `go build`, `go vet`, `internal/llm`, `internal/tools`, `internal/agent` all green.

## Still open (separate)
This makes the engine resilient regardless of *why* the model started dropping tags more after v4.5.50. The prime suspects are the context-management changes landed after v4.5.50 — token-based auto-compaction (#258), tool-output capping (#256), reasoning-loop compaction (#269), larger planner prompt (#274). A version bisect (deploy v4.5.60 / v4.5.70 / v4.5.73) would pin the exact one.