### PR TITLE
fix(agent): stop malformed-tool-call drift + make no-tool abort optional (keep trying)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -406,6 +406,30 @@ func (a *Agent) SetActivityPolicy(reconMode, scanIntensity string, targets []str
 	a.refreshPassiveReconGuard()
 }
 
+// canonicalizeAssistantTurn renders an assistant turn in the canonical tool-
+// call format: the model's clean prose (tool XML already stripped) followed by
+// one well-formed <function=NAME>…</function> block per parsed/recovered call.
+// Persisting this instead of the model's raw (possibly malformed) output keeps
+// the conversation self-consistent, so the model — which few-shot-mimics its
+// own prior turns — stays on-format instead of drifting into dropped-tag
+// malformations that eventually become unrecoverable and stall the scan.
+func canonicalizeAssistantTurn(cleanText string, toolCalls []llm.ToolCall) string {
+	var b strings.Builder
+	// Strip any malformed tool-call residue (orphaned <parameter> blocks, a
+	// bare `name>` line, stray </function>) so the rebuilt turn is clean prose
+	// only — otherwise the very malformation we're canonicalizing away leaks
+	// back in via the prose.
+	if prose := llm.StripToolResidue(cleanText); prose != "" {
+		b.WriteString(prose)
+		b.WriteString("\n")
+	}
+	for _, tc := range toolCalls {
+		b.WriteString(llm.FormatToolCall(tc.Name, tc.Args))
+		b.WriteString("\n")
+	}
+	return strings.TrimSpace(b.String())
+}
+
 // stripThink removes <think>...</think> blocks from the response.
 func stripThink(s string) string {
 	return thinkRegex.ReplaceAllString(s, "")
@@ -691,6 +715,11 @@ func (a *Agent) Run(targets []string, instruction string) {
 
 	// Initialize scan state for hooks (replaces 17+ local tracking variables)
 	a.state = NewScanState()
+	if a.cfg != nil {
+		// Thread the configurable no-tool abort threshold (0 = never give up).
+		a.state.NoToolAbortLimit = a.cfg.NoToolAbortAt
+		a.state.NoToolAbortConfigured = true
+	}
 	a.state.ScanContextID = a.scanCtx.ID
 	a.state.DiscoveryMode = a.discoveryMode
 	a.state.AllowedPhases = append([]int(nil), a.allowedPhases...)
@@ -876,10 +905,6 @@ func (a *Agent) Run(targets []string, instruction string) {
 			a.emit(Event{Type: "message", Content: cleanText, TotalTokens: tokenCount()})
 		}
 
-		a.msgMu.Lock()
-		a.messages = append(a.messages, llm.Message{Role: "assistant", Content: response})
-		a.msgMu.Unlock()
-
 		toolCalls := llm.ParseToolCalls(responseClean)
 		// ── Schema-guided recovery of dropped-open-tag tool calls ──
 		// Some models intermittently drop the <function=NAME> open tag and
@@ -931,6 +956,24 @@ func (a *Agent) Run(targets []string, instruction string) {
 			}
 		}
 		toolCallsTotal += len(toolCalls)
+
+		// ── Persist the assistant turn ──
+		// When tool calls were parsed OR recovered, store a CANONICAL rendering
+		// (clean prose + well-formed <function=…> blocks) instead of the raw
+		// response. The model few-shot-mimics its own prior turns, so persisting
+		// malformed tool-call XML (e.g. a dropped "<function=" tag) teaches it to
+		// keep malforming — the format drifts and escalates until it emits an
+		// unrecoverable shape and the scan reasoning-loops. Rewriting to the
+		// canonical form keeps the conversation self-consistent so the model
+		// stays on-format. When NO tool call was found, store the raw response so
+		// the no-tool hook's format nudge reflects the real (malformed) output.
+		assistantContent := response
+		if len(toolCalls) > 0 {
+			assistantContent = canonicalizeAssistantTurn(cleanText, toolCalls)
+		}
+		a.msgMu.Lock()
+		a.messages = append(a.messages, llm.Message{Role: "assistant", Content: assistantContent})
+		a.msgMu.Unlock()
 
 		// ── Hook: OnNoToolResponse ──
 		if len(toolCalls) == 0 {

--- a/internal/agent/canonicalize_test.go
+++ b/internal/agent/canonicalize_test.go
@@ -1,0 +1,75 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/llm"
+)
+
+// A recovered/parsed call must be persisted in canonical <function=…> form so
+// the model doesn't few-shot-mimic malformed tool-call XML. The rendered turn
+// must round-trip back through ParseToolCalls to the same call.
+func TestCanonicalizeAssistantTurn_RoundTrips(t *testing.T) {
+	calls := []llm.ToolCall{
+		{Name: "terminal_execute", Args: map[string]string{"command": "curl -sI https://t/"}},
+	}
+	got := canonicalizeAssistantTurn("Let me probe the target.", calls)
+
+	if !strings.Contains(got, "Let me probe the target.") {
+		t.Errorf("clean prose not preserved: %q", got)
+	}
+	if !strings.Contains(got, "<function=terminal_execute>") {
+		t.Errorf("canonical open tag missing: %q", got)
+	}
+
+	reparsed := llm.ParseToolCalls(got)
+	if len(reparsed) != 1 || reparsed[0].Name != "terminal_execute" {
+		t.Fatalf("canonical form did not round-trip: %+v", reparsed)
+	}
+	if reparsed[0].Args["command"] != "curl -sI https://t/" {
+		t.Errorf("command arg lost in round-trip: %v", reparsed[0].Args)
+	}
+}
+
+// The exact flare-network shape: the model dropped "<function=" so CleanContent
+// leaves the malformed residue (`terminal_execute>` + orphaned <parameter> +
+// stray </function>) in the prose. The canonical turn must NOT contain that
+// residue — only the clean canonical call — else the malformation leaks back
+// into history and the model keeps mimicking it.
+func TestCanonicalizeAssistantTurn_StripsMalformedResidue(t *testing.T) {
+	residue := "terminal_execute>\n<parameter=command>curl -v https://portal.flare.network/ 2>&1 | head</parameter>\n</function>"
+	calls := []llm.ToolCall{
+		{Name: "terminal_execute", Args: map[string]string{"command": "curl -v https://portal.flare.network/ 2>&1 | head"}},
+	}
+	got := canonicalizeAssistantTurn(residue, calls)
+
+	// Residue would show up as a DUPLICATED param block (orphaned one + the
+	// canonical one) or a bare name line not preceded by "<function=".
+	if strings.Count(got, "<parameter=command>") != 1 {
+		t.Errorf("residue leaked — expected exactly one <parameter=command>: %q", got)
+	}
+	if strings.HasPrefix(got, "terminal_execute>") {
+		t.Errorf("bare tool-name residue leaked at start: %q", got)
+	}
+	// Exactly one well-formed open tag, and it round-trips to a single call.
+	if strings.Count(got, "<function=terminal_execute>") != 1 {
+		t.Errorf("expected exactly one canonical open tag: %q", got)
+	}
+	if calls := llm.ParseToolCalls(got); len(calls) != 1 || calls[0].Args["command"] == "" {
+		t.Fatalf("canonical turn did not round-trip cleanly: %+v", calls)
+	}
+}
+
+// With no clean prose, the turn is just the canonical call(s), no leading blank.
+func TestCanonicalizeAssistantTurn_NoProse(t *testing.T) {
+	got := canonicalizeAssistantTurn("", []llm.ToolCall{
+		{Name: "finish", Args: map[string]string{"summary": "done"}},
+	})
+	if strings.HasPrefix(got, "\n") || strings.TrimSpace(got) != got {
+		t.Errorf("unexpected leading/trailing whitespace: %q", got)
+	}
+	if calls := llm.ParseToolCalls(got); len(calls) != 1 || calls[0].Name != "finish" {
+		t.Fatalf("expected 1 finish call, got %+v", calls)
+	}
+}

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -144,6 +144,17 @@ type ScanState struct {
 	TotalNoToolResponses     int
 	DensityCompactions       int
 
+	// NoToolAbortLimit is the consecutive no-tool-call count at which the scan
+	// force-stops (from config XALGORIX_NO_TOOL_ABORT_AT). 0 = never give up:
+	// the agent keeps nudging and periodically re-compacting so the model can
+	// fix its own malformed output and resume. Set from cfg when the agent
+	// initializes ScanState; falls back to NoToolAbortAt when zero-valued only
+	// if the operator did not explicitly disable it (see abortLimit()).
+	NoToolAbortLimit int
+	// NoToolAbortConfigured records that NoToolAbortLimit was explicitly set
+	// from config (so a value of 0 means "disabled", not "unset default").
+	NoToolAbortConfigured bool
+
 	// Plan is the structural task graph for this scan. nil until recon has
 	// surfaced surface (or the LLM calls build_plan). Shared across sub-agents
 	// because ScanState is the same object within a ScanContext. The plan is
@@ -1319,6 +1330,18 @@ func hookEmptyResponseHandler(state *ScanState, args map[string]string) HookResu
 // refusal is not a formatting problem, so the generic "use the XML format"
 // nudge does nothing — instead we re-assert the authorized-engagement
 // context, which reliably gets safety-tuned models back on task.
+// noToolAbortLimit returns the effective consecutive no-tool-call abort
+// threshold. A value <= 0 means "never abort" — the scan keeps nudging and
+// periodically re-compacting so the model can fix its own output and resume.
+// Uses the operator's configured value when set (so an explicit 0 disables the
+// abort); otherwise the NoToolAbortAt default.
+func noToolAbortLimit(state *ScanState) int {
+	if state != nil && state.NoToolAbortConfigured {
+		return state.NoToolAbortLimit
+	}
+	return NoToolAbortAt
+}
+
 func hookNoToolHandler(state *ScanState, args map[string]string) HookResult {
 	state.NoToolCount++
 	state.TotalNoToolResponses++
@@ -1329,10 +1352,14 @@ func hookNoToolHandler(state *ScanState, args map[string]string) HookResult {
 		state.RefusalCount = 0
 	}
 
-	if state.NoToolCount >= NoToolAbortAt {
-		msg := "⛔ Model returned 15 consecutive responses with no tool call — it stopped taking actions (likely context flooded by a large tool output, or a reasoning loop). Force finishing."
+	// abortAt <= 0 means "never give up": the scan keeps nudging + periodically
+	// re-compacting (below) so the model can fix its own malformed output and
+	// resume, bounded only by the other budgets (iterations/duration/tokens).
+	abortAt := noToolAbortLimit(state)
+	if abortAt > 0 && state.NoToolCount >= abortAt {
+		msg := fmt.Sprintf("⛔ Model returned %d consecutive responses with no tool call — it stopped taking actions (likely context flooded by a large tool output, or a reasoning loop). Force finishing.", abortAt)
 		if state.RefusalCount >= 3 {
-			msg = "⛔ Model declined to act for 15 consecutive responses (safety refusal). Force finishing — try a model that permits authorized security testing."
+			msg = fmt.Sprintf("⛔ Model declined to act for %d consecutive responses (safety refusal). Force finishing — try a model that permits authorized security testing.", abortAt)
 		}
 		return HookResult{
 			ForceSkip:   true,
@@ -1374,7 +1401,7 @@ Resume the assessment NOW by calling a tool. For example, to run a command:
 		// here — for the pure non-consecutive pattern the consecutive path can
 		// never supply a second compaction, so gating on it would make this
 		// abort unreachable (the exact 48-hour bug this path exists to catch).
-		if ratio > ReasoningDensityAbortRatio && iters >= ReasoningDensityAbortMinIters &&
+		if abortAt > 0 && ratio > ReasoningDensityAbortRatio && iters >= ReasoningDensityAbortMinIters &&
 			totalCompactions >= 1 {
 			return HookResult{
 				ForceSkip: true,
@@ -1393,6 +1420,21 @@ Resume the assessment NOW by calling a tool. For example, to run a command:
 				ForceCompact: true,
 				Nudge:        reasoningLoopResumePrompt(state, "density"),
 			}
+		}
+	}
+
+	// ── Never-give-up recovery (abort disabled) ──
+	// When the operator disabled the abort (abortAt <= 0), the two-shot
+	// compaction budget would leave a stuck model with nothing but nudges after
+	// count 10 — spinning instead of "fixing itself". Keep re-compacting on a
+	// fixed cadence (every ReasoningLoopCompactAt2 consecutive no-tool
+	// responses) so the model keeps getting a fresh, focused context to recover
+	// in, uncapped. This branch is unreachable in the default bounded mode.
+	if abortAt <= 0 && state.NoToolCount > 0 && state.NoToolCount%ReasoningLoopCompactAt2 == 0 {
+		state.ReasoningLoopCompactions++
+		return HookResult{
+			ForceCompact: true,
+			Nudge:        reasoningLoopResumePrompt(state, "consecutive"),
 		}
 	}
 

--- a/internal/agent/reasoning_loop_test.go
+++ b/internal/agent/reasoning_loop_test.go
@@ -65,6 +65,31 @@ func TestNoToolHandlerCompactsBeforeAbort(t *testing.T) {
 	}
 }
 
+// With the abort disabled (XALGORIX_NO_TOOL_ABORT_AT=0), the handler must NEVER
+// ForceSkip on a no-tool loop, and must keep re-compacting on a cadence so the
+// model keeps getting fresh context to fix itself — not just spin on nudges.
+func TestNoToolHandler_AbortDisabledNeverGivesUp(t *testing.T) {
+	state := NewScanState()
+	state.NoToolAbortConfigured = true
+	state.NoToolAbortLimit = 0 // disabled → never give up
+
+	compactions := 0
+	for i := 0; i < 100; i++ {
+		res := hookNoToolHandler(state, map[string]string{"response": "thinking, no tool"})
+		if res.ForceSkip {
+			t.Fatalf("ForceSkip fired at NoToolCount=%d with abort disabled", state.NoToolCount)
+		}
+		if res.ForceCompact {
+			compactions++
+		}
+	}
+	// Recurring compaction (every ReasoningLoopCompactAt2) — not capped at the
+	// default MaxReasoningCompactions=2 — so it keeps actively trying to recover.
+	if compactions <= MaxReasoningCompactions {
+		t.Errorf("expected recurring compactions with abort disabled, got %d (want > %d)", compactions, MaxReasoningCompactions)
+	}
+}
+
 // The two consecutive compactions must be SPACED at ReasoningLoopCompactAt (6)
 // and ReasoningLoopCompactAt2 (10) — NOT fired back-to-back at 6 and 7. The
 // back-to-back bug consumed the whole compaction budget immediately, leaving

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,13 @@ type Config struct {
 	DisableBrowser bool   // XALGORIX_DISABLE_BROWSER
 	MaxIterations  int    // XALGORIX_MAX_ITERATIONS — 0 = unlimited
 
+	// NoToolAbortAt is how many CONSECUTIVE no-tool-call responses force-stop a
+	// scan (the "reasoning loop" abort). XALGORIX_NO_TOOL_ABORT_AT, default 15.
+	// Set to 0 to NEVER give up: the agent keeps nudging + periodically
+	// compacting context so the model can fix its own malformed output and
+	// resume, bounded only by the other budgets (iterations/duration/tokens).
+	NoToolAbortAt int
+
 	// TargetAuth carries operator-supplied authenticated-session credentials
 	// for the target(s), so the agent can test post-authentication attack
 	// surface (IDOR/BOLA, privilege escalation, business logic) — where the
@@ -298,6 +305,7 @@ func load() *Config {
 		legacyCWD:           cwd,
 		DisableBrowser:      envOrBool("XALGORIX_DISABLE_BROWSER", false),
 		MaxIterations:       envOrInt("XALGORIX_MAX_ITERATIONS", 0),
+		NoToolAbortAt:       envOrInt("XALGORIX_NO_TOOL_ABORT_AT", 15),
 		TargetAuth:          envOr("XALGORIX_TARGET_AUTH", ""),
 		TargetAuthSecondary: envOr("XALGORIX_TARGET_AUTH_B", ""),
 		OOBPublicURL:        envOr("XALGORIX_OOB_PUBLIC_URL", ""),

--- a/internal/llm/parser.go
+++ b/internal/llm/parser.go
@@ -350,6 +350,30 @@ func ParseOrphanedCalls(content string) []OrphanedCall {
 	return out
 }
 
+var (
+	// Residue left after CleanContent when the model MALFORMED a tool call:
+	// orphaned `<parameter=…>…</parameter>` blocks (open tag dropped), stray
+	// `<function…>`/`</function>` tags, and a lone `name>` line (the bare tool
+	// name from a dropped-open-tag call). CleanContent only strips well-formed
+	// `<function=…>…</function>` pairs, so these survive into the prose.
+	orphanParamResidueRe = regexp.MustCompile(`(?s)<parameter\b[^>]*>.*?</parameter>`)
+	strayFuncTagRe       = regexp.MustCompile(`</?function[^>]*>`)
+	danglingNameLineRe   = regexp.MustCompile(`(?m)^\s*[A-Za-z_][A-Za-z0-9_-]*>\s*$`)
+)
+
+// StripToolResidue removes tool-call XML — well-formed OR malformed — from
+// prose so a rebuilt (canonical) assistant turn carries no leftover markup.
+// Used when persisting a turn whose tool calls were parsed/recovered, so the
+// model never sees its own malformed tool-call fragments and mimic them.
+func StripToolResidue(content string) string {
+	content = toolPattern.ReplaceAllString(content, "")
+	content = orphanParamResidueRe.ReplaceAllString(content, "")
+	content = strayFuncTagRe.ReplaceAllString(content, "")
+	content = danglingNameLineRe.ReplaceAllString(content, "")
+	content = multiBlankRe.ReplaceAllString(content, "\n\n")
+	return strings.TrimSpace(content)
+}
+
 // CleanContent removes tool call XML from content for display.
 func CleanContent(content string) string {
 	content = normalizeFormat(content)


### PR DESCRIPTION
Deep root-cause hardening for the reasoning-loop regression (clean at v4.5.50, force-stopping by v4.5.79 with the same settings). Builds on #306 (recover dropped-open-tag calls by the emitted name).

## Why the model kept malforming
The tool-call format is unchanged since v4.5.50, and the engine doesn't mangle output. The driver is a **feedback loop**: the agent stored the model's **raw** response as the assistant turn (`agent.go`), so a single dropped-`<function=` malformation got mirrored back into history — and the model **few-shot-mimics its own prior turns**, so the malformation drifted and escalated until it emitted an unrecoverable shape → "15 no-tool responses" → force stop. The recovery added after v4.5.50 also *silently* accepted malformed calls, removing the format-nudge that used to re-anchor the model at v4.5.50.

## Changes
1. **Canonicalize the persisted assistant turn.** When a turn's tool calls are parsed OR recovered, store a canonical rendering — clean prose (tool residue stripped via new `llm.StripToolResidue`) + one well-formed `<function=…>` block per call — instead of the raw (possibly malformed) text. History stays self-consistent, so the model stays on-format. Raw output is still stored when no tool call was found (so the no-tool nudge reflects reality).

2. **Make the no-tool abort optional (`XALGORIX_NO_TOOL_ABORT_AT`, default 15; `0` = never give up).** When disabled, the scan never force-stops on a reasoning loop — it keeps nudging **and re-compacts context on a fixed cadence (uncapped)** so the model keeps getting a fresh window to fix itself, bounded only by the other budgets (iterations/duration/tokens). The density abort is gated off too when disabled.

**To never give up on a scan, set `XALGORIX_NO_TOOL_ABORT_AT=0`.**

## Tests
- Canonicalization round-trips and strips the exact flare-network malformed residue.
- Abort-disabled mode never `ForceSkip`s and keeps re-compacting (> the default 2-compaction cap).
- Existing spacing / density / abort / classify tests unchanged.
- `go build`, `go vet`, `gofmt`, and `internal/agent` + `internal/llm` + `internal/config` suites all green.

## Note on the trigger
This makes the engine resilient regardless of *why* MiniMax started dropping tags more after v4.5.50. Pinning the exact commit still wants a version bisect of the context-management changes (#256/#258/#269/#274).