### PR TITLE
fix(terminal): refresh apt index at most once per process

### DIFF
--- a/internal/tools/terminal/apt_cache_test.go
+++ b/internal/tools/terminal/apt_cache_test.go
@@ -1,0 +1,59 @@
+package terminal
+
+import (
+	"testing"
+)
+
+// Regression for the issue fixed in supersession of PR #287: the apt package
+// index refresh must run at most once per process. Previously every
+// installPackage call re-ran `apt-get update`, so a command installing N
+// missing apt tools triggered N sequential full-mirror round-trips.
+//
+// maybeRefreshAptLists is guarded by aptListsRefreshed (set on the first call
+// regardless of outcome, so a flaky mirror does not cause unbounded retries).
+// This test pins that contract: after the first call the flag is set and
+// subsequent calls are no-ops (they return "" without re-running anything).
+func TestMaybeRefreshAptListsRunsAtMostOncePerProcess(t *testing.T) {
+	// Reset to a known state (other tests in this package may have flipped it).
+	aptListsMu.Lock()
+	aptListsRefreshed = false
+	aptListsMu.Unlock()
+
+	// First call: performs the refresh work (or skips it on a non-apt / fresh
+	// host) and marks the gate so it never runs again this process.
+	_ = maybeRefreshAptLists()
+
+	aptListsMu.Lock()
+	refreshed := aptListsRefreshed
+	aptListsMu.Unlock()
+	if !refreshed {
+		t.Fatal("aptListsRefreshed must be true after the first maybeRefreshAptLists call")
+	}
+
+	// Subsequent calls must be no-ops (return "" immediately). We cannot
+	// observe the skipped work directly, but a no-op returns the empty string
+	// without touching the network — assert the contract.
+	for i := 0; i < 5; i++ {
+		if got := maybeRefreshAptLists(); got != "" {
+			t.Errorf("maybeRefreshAptLists() call #%d = %q, want \"\" (must be a no-op after the first refresh)", i+2, got)
+		}
+	}
+}
+
+// Resetting the gate returns it to the "will refresh" state — this guards the
+// reset semantics used by the test above and documents the flag's lifecycle.
+func TestAptListsRefreshedFlagIsResettable(t *testing.T) {
+	aptListsMu.Lock()
+	aptListsRefreshed = false
+	aptListsMu.Unlock()
+
+	_ = maybeRefreshAptLists()
+
+	aptListsMu.Lock()
+	aptListsRefreshed = false // reset
+	got := aptListsRefreshed
+	aptListsMu.Unlock()
+	if got {
+		t.Error("aptListsRefreshed must read false immediately after reset")
+	}
+}

--- a/internal/tools/terminal/terminal.go
+++ b/internal/tools/terminal/terminal.go
@@ -1596,6 +1596,56 @@ func sudoPrefix() string {
 	return ""
 }
 
+// aptListsRefreshed gates `apt-get update` so it runs at most once per
+// process. Container and minimal images routinely ship with
+// /var/lib/apt/lists wiped, so the first apt install in a session would
+// otherwise fail with "Unable to locate package" until the index is
+// refreshed. Without this guard, an agent command installing N missing apt
+// tools (e.g. `httpx | jq | html2text`) triggered N sequential full-mirror
+// `apt-get update` round-trips. Once one update has run, subsequent installs
+// reuse the now-populated lists. The empty-lists check makes the refresh a
+// true no-op on systems that already carry fresh lists.
+var (
+	aptListsMu        sync.Mutex
+	aptListsRefreshed bool
+)
+
+// maybeRefreshAptLists runs `apt-get update` once per process, and only when
+// the package lists look empty/stale. It returns the combined output (for
+// diagnostics) and is a no-op on non-apt systems or after the first success.
+func maybeRefreshAptLists() string {
+	aptListsMu.Lock()
+	defer aptListsMu.Unlock()
+	if aptListsRefreshed {
+		return ""
+	}
+	aptListsRefreshed = true // mark first regardless of outcome so a failing mirror doesn't retry forever
+	if _, err := exec.LookPath("apt-get"); err != nil {
+		return ""
+	}
+	// Skip the network round-trip entirely when the lists dir already
+	// contains index files (host system, or an image that kept them).
+	if entries, err := os.ReadDir("/var/lib/apt/lists"); err == nil {
+		hasIndex := false
+		for _, e := range entries {
+			if strings.HasSuffix(e.Name(), "_Packages") || strings.HasSuffix(e.Name(), "_InRelease") {
+				hasIndex = true
+				break
+			}
+		}
+		if hasIndex {
+			return ""
+		}
+	}
+	// Plain `apt-get update` (no -qq): the output is captured and surfaced
+	// to the LLM on failure, so suppressing diagnostics here would hide the
+	// mirror-unreachable vs. package-absent distinction needed to debug.
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	out, _ := exec.CommandContext(ctx, "bash", "-c", sudoPrefix()+"apt-get update 2>&1").CombinedOutput()
+	return string(out)
+}
+
 // installPackage installs a system package on demand. Gated behind
 // XALGORIX_ALLOW_AUTO_INSTALL — defaults to true for root and false for
 // non-root, so a stock unprivileged xalgorix invocation can never call
@@ -1734,6 +1784,11 @@ func installPackage(pkg string) string {
 	var installCmd string
 
 	if _, err := exec.LookPath("apt-get"); err == nil {
+		// Refresh the package index once per process (see maybeRefreshAptLists).
+		// Minimal/container images ship with /var/lib/apt/lists wiped, so an
+		// install-only call fails with "Unable to locate package" until the
+		// index is populated.
+		maybeRefreshAptLists()
 		installCmd = fmt.Sprintf("DEBIAN_FRONTEND=noninteractive apt-get install -y -q %s 2>&1", pkg)
 	} else if _, err := exec.LookPath("dnf"); err == nil {
 		installCmd = fmt.Sprintf("dnf install -y -q %s 2>&1", pkg)


### PR DESCRIPTION
## Summary

Supersedes #287 — same underlying bug (apt installs fail in containers with wiped \`/var/lib/apt/lists\`), better implementation.

### The bug (#287's correct diagnosis)
Container/minimal images ship with \`/var/lib/apt/lists\` wiped, so the first \`apt-get install\` in a session fails with \`Unable to locate package\` until \`apt-get update\` runs.

### Why #287 was held (#287's two problems)
1. **Uncached \`apt-get update\` on every install.** \`installPackage\` is called per missing tool with no memoization. A command like \`httpx | jq | html2text\` with all three missing → 3 sequential full-mirror \`apt-get update\` round-trips.
2. **\`-qq\` hides diagnostics.** The failure output is captured (\`2>&1\`) and surfaced to the LLM via \`truncate(string(out))\`, but \`-qq\` suppresses exactly the mirror-unreachable vs. package-absent distinction needed to debug.

### This fix
Adds \`maybeRefreshAptLists\` — a process-level gate that:
- Runs \`apt-get update\` **at most once per process** (\`aptListsRefreshed\` under \`aptListsMu\`). After the first call, subsequent installs reuse the now-populated lists.
- **Skips the network round-trip entirely** when \`/var/lib/apt/lists\` already carries index files (\`_Packages\`/\`_InRelease\`) — so it's a true no-op on host systems / images that kept fresh lists.
- Uses **plain \`apt-get update\`** (no \`-qq\`) so failures stay diagnosable.
- Marks the gate on the first call **regardless of outcome**, so a flaky mirror does not cause unbounded retries.

Wired into the apt branch of \`installPackage\` (the only caller).

## Tests
\`TestMaybeRefreshAptListsRunsAtMostOncePerProcess\` — pins the at-most-once contract: after the first call the gate is set and subsequent calls return \`""\` without re-running anything.
\`TestAptListsRefreshedFlagIsResettable\` — guards the flag lifecycle.

## Verification
\`go build\`, \`go vet\`, \`golangci-lint\` (0 issues), \`go test ./internal/tools/terminal/\` — all clean.