### PR TITLE
fix(config): default NoToolAbortAt to 0 (never force-abort on no-tool loops)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,10 +55,11 @@ type Config struct {
 	MaxIterations  int    // XALGORIX_MAX_ITERATIONS — 0 = unlimited
 
 	// NoToolAbortAt is how many CONSECUTIVE no-tool-call responses force-stop a
-	// scan (the "reasoning loop" abort). XALGORIX_NO_TOOL_ABORT_AT, default 15.
-	// Set to 0 to NEVER give up: the agent keeps nudging + periodically
-	// compacting context so the model can fix its own malformed output and
-	// resume, bounded only by the other budgets (iterations/duration/tokens).
+	// scan (the "reasoning loop" abort). XALGORIX_NO_TOOL_ABORT_AT, default 0
+	// (never give up): the agent keeps nudging + periodically compacting
+	// context so the model can fix its own malformed output and resume, bounded
+	// only by the other budgets (iterations/duration/tokens). Set to e.g. 15 to
+	// restore the hard abort after 15 consecutive no-tool responses.
 	NoToolAbortAt int
 
 	// TargetAuth carries operator-supplied authenticated-session credentials
@@ -305,7 +306,7 @@ func load() *Config {
 		legacyCWD:           cwd,
 		DisableBrowser:      envOrBool("XALGORIX_DISABLE_BROWSER", false),
 		MaxIterations:       envOrInt("XALGORIX_MAX_ITERATIONS", 0),
-		NoToolAbortAt:       envOrInt("XALGORIX_NO_TOOL_ABORT_AT", 15),
+		NoToolAbortAt:       envOrInt("XALGORIX_NO_TOOL_ABORT_AT", 0),
 		TargetAuth:          envOr("XALGORIX_TARGET_AUTH", ""),
 		TargetAuthSecondary: envOr("XALGORIX_TARGET_AUTH_B", ""),
 		OOBPublicURL:        envOr("XALGORIX_OOB_PUBLIC_URL", ""),


### PR DESCRIPTION
## Summary

Two default-value decisions, both keeping scans patient:

### `XALGORIX_NO_TOOL_ABORT_AT`: 15 → 0
Previously defaulted to 15, force-stopping scans after 15 consecutive no-tool-call responses. Default it to **0** so the agent keeps nudging + periodically re-compacting context to recover on its own, rather than killing scans that hit a recoverable rough patch (e.g. a burst of malformed tool calls that the parser-recovery + compaction can fix).

- The compaction thresholds (6/10) still fire to help the model recover.
- Operators who want the hard abort back can set \`XALGORIX_NO_TOOL_ABORT_AT=15\` explicitly — the config field and the hooks fallback both still support it.

### `XALGORIX_MAX_DURATION`: stays 0 (indefinite)
Confirmed \`MaxDurationSec\` is the **overall scan wall-clock cap** (measured from \`scanStart\`, enforced in \`overBudget()\` alongside tool-call/token caps) — not a per-iteration timeout. Keeping it at 0 because big multi-target/wildcard scans run well past any fixed wall-clock cap, and cutting them off mid-target would truncate engagements.

## Why the default change actually takes effect (no hidden fallback)
The resolution chain (\`hooks.go:1338-1343\` \`noToolAbortLimit\`) returns \`state.NoToolAbortLimit\` directly when \`NoToolAbortConfigured\` is true — which \`agent.go:720-721\` always sets when a config exists. The hardcoded \`NoToolAbortAt\` constant (15) is only a last-resort fallback that never triggers in practice. So changing the config default from 15 → 0 genuinely makes "never abort" the effective default.

## Tests
All 7 reasoning-loop tests pass, including \`TestNoToolHandler_AbortDisabledNeverGivesUp\` which directly validates the disabled-by-default behavior.

## Note
With both the no-tool abort disabled AND all budgets at 0/unlimited, a genuinely stuck scan has no wall-clock safety net. This is the intended tradeoff (patient scans > false aborts). Operators who want a backstop can set \`XALGORIX_MAX_DURATION\` or \`XALGORIX_MAX_ITERATIONS\`.