### PR TITLE
release: v4.5.82

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.81
+VERSION=4.5.82
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.81" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.82" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.81"
+var version = "4.5.82"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
### Changes

- 8eb1fa3 fix(config): default NoToolAbortAt to 0 (never force-abort on no-tool loops) (#316)
- e8e8656 fix(terminal): refresh apt index at most once per process (#315)
- 0abab9f feat(web): expose scan attribution headers (-H) in the dashboard settings (#310)
- 99b0d55 feat(docker): add redeploy.sh to update the container without losing auth/data (#311)
- 4ee55a8 fix(security): bump golang.org/x/crypto v0.48.0 → v0.52.0 and x/net v0.49.0 → v0.55.0 (#314)
- 1bf8772 ci: bump Go to 1.26 (#298)
- 4ffb97f feat(tools): bake docs/tools.md coverage into image + register for runtime auto-install (#301)
- 4f42680 release: v4.5.81 (#309)