### PR TITLE
fix(agent): drop empty-Args tool calls that can never satisfy required params

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -906,6 +906,28 @@ func (a *Agent) Run(targets []string, instruction string) {
 		}
 
 		toolCalls := llm.ParseToolCalls(responseClean)
+		// ── Drop empty-Args calls for tools that require parameters ──
+		// When a model drifts and splits a multi-parameter call's fields
+		// across separate <function=NAME> blocks, the parser produces
+		// well-formed calls with EMPTY bodies (e.g. <function=update_plan>
+		// </function> → ToolCall{Name:"update_plan", Args:{}}). Such a call
+		// can never satisfy the tool's required params, so sending it to the
+		// registry just wastes an iteration on a guaranteed "missing required
+		// parameter" error (observed ~10× near the end of the z-text.com
+		// scan). Drop these fragments here so they fall through to the
+		// orphan-recovery path (which can re-associate stray params) or the
+		// no-tool compaction path. Tools whose params are ALL optional (e.g.
+		// code_search) legitimately accept an empty body and are kept.
+		if len(toolCalls) > 0 {
+			kept := toolCalls[:0]
+			for _, tc := range toolCalls {
+				if len(tc.Args) == 0 && a.registry.RequiresParams(tc.Name) {
+					continue
+				}
+				kept = append(kept, tc)
+			}
+			toolCalls = kept
+		}
 		// ── Schema-guided recovery of dropped-open-tag tool calls ──
 		// Some models intermittently drop the <function=NAME> open tag and
 		// emit only <parameter=X>…</parameter> blocks + a trailing

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -155,6 +155,30 @@ func (r *Registry) Get(name string) (*Tool, bool) {
 	return t, ok
 }
 
+// RequiresParams reports whether the named tool declares any REQUIRED
+// parameter. Used by the agent loop to decide whether an empty-Args tool call
+// (a well-formed <function=NAME></function> body the parser matched but that
+// yielded zero <parameter> children — observed when models drift and split a
+// multi-param call's fields across separate calls) is a real invocation or a
+// malformed fragment. For a tool with required params, an empty body can never
+// be a valid call, so the caller drops it (letting orphan-recovery or the
+// no-tool compaction path handle it) instead of wasting an iteration on a
+// guaranteed "missing required parameter" registry error. A tool whose params
+// are all optional (e.g. code_search) legitimately accepts an empty body, so
+// this returns false and the call proceeds.
+func (r *Registry) RequiresParams(name string) bool {
+	t, ok := r.Get(name)
+	if !ok {
+		return false
+	}
+	for _, p := range t.Parameters {
+		if p.Required {
+			return true
+		}
+	}
+	return false
+}
+
 // List returns all registered tool names.
 func (r *Registry) List() []string {
 	r.mu.RLock()

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -279,3 +279,42 @@ func TestMatchByParamsRejectsTie(t *testing.T) {
 		t.Errorf("MatchByParams(command,id) = %q,%v, want pageagent,true", name, ok)
 	}
 }
+
+// RequiresParams reports whether a tool declares any REQUIRED parameter. The
+// agent loop uses it to drop empty-Args calls (well-formed <function=NAME>
+// </function> bodies that the parser matched but that yielded zero params —
+// produced when a model splits a multi-param call's fields across separate
+// calls). Such a call can never satisfy required params, so it's dropped
+// rather than wasting an iteration on a guaranteed registry error. Critically,
+// a tool whose params are ALL optional (e.g. code_search) legitimately accepts
+// an empty body and must report RequiresParams=false so its calls are kept.
+func TestRequiresParams(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&Tool{Name: "update_plan", Parameters: []Parameter{
+		{Name: "task_id", Required: true}, {Name: "status", Required: true}, {Name: "notes", Required: false},
+	}})
+	r.Register(&Tool{Name: "code_search", Parameters: []Parameter{
+		{Name: "query", Required: false}, {Name: "sinks", Required: false}, {Name: "glob", Required: false},
+	}})
+	r.Register(&Tool{Name: "terminal_execute", Parameters: []Parameter{
+		{Name: "command", Required: true},
+	}})
+
+	// Tools with ≥1 required param → true (empty body is never a valid call).
+	if !r.RequiresParams("update_plan") {
+		t.Error("update_plan requires task_id+status → RequiresParams must be true")
+	}
+	if !r.RequiresParams("terminal_execute") {
+		t.Error("terminal_execute requires command → RequiresParams must be true")
+	}
+
+	// Tool with ALL-optional params → false (empty body is legitimate).
+	if r.RequiresParams("code_search") {
+		t.Error("code_search has no required params → RequiresParams must be false (empty body is valid)")
+	}
+
+	// Unknown tool → false (don't block calls to tools we don't know about).
+	if r.RequiresParams("does_not_exist") {
+		t.Error("unknown tool → RequiresParams must be false")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the iteration-waste bug observed in the z-text.com scan feed, where the model emitted ~10 malformed \`update_plan\` calls near the end that each failed with \`missing required parameters for tool 'update_plan': task_id, status\`.

### Root cause
When a model drifts and splits a multi-parameter call's fields across separate \`<function=NAME>\` blocks, the parser produces **well-formed calls with empty bodies**:

\`\`\`
<function=update_plan></function>   →   ToolCall{Name:"update_plan", Args:{}}
\`\`\`

Reproduced and confirmed: \`ParseToolCalls("<function=update_plan></function>")\` returns a call with \`args=map[]\`. That call reaches the registry, which correctly errors "missing required parameter" — but only after burning a full iteration on a guaranteed failure. The z-text scan wasted ~10 iterations this way near completion.

### Fix
The agent loop now drops an empty-Args call **when the named tool declares any required param** (new \`Registry.RequiresParams\` helper). Such a call can never be valid, so dropping it lets the response fall through to:
- **orphan recovery** (which can re-associate stray \`<parameter>\` blocks from the same response), or
- the **no-tool compaction path** (which nudges the model to retry correctly).

### Critical edge case handled
A tool whose params are **all optional** (e.g. \`code_search\` — \`query\`/\`sinks\`/\`glob\`/\`path\`/\`max\` all \`Required: false\`) legitimately accepts an empty body. \`RequiresParams\` returns \`false\` for those, so their empty-body calls are **kept** and dispatched normally.

## Tests
- \`TestRequiresParams\` — pins the contract: \`update_plan\`/\`terminal_execute\` (have required params) → true; \`code_search\` (all optional) → false; unknown tool → false.
- Full \`internal/tools\`, \`internal/agent\`, \`internal/llm\` test suites pass.

## Note on local lint
Local \`golangci-lint\` is stale (built with Go 1.25, can't load the 1.26 config from #298) — CI runs v2.12.2 which supports 1.26. Build + vet + all tests green locally.