### PR TITLE
fix(agent): hide loop-guardrail nudges from user-facing feed

### DIFF
--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -873,10 +873,12 @@ Your next tool call MUST differ from the last one.`, verb, state.LastToolName, s
 		// Reset so the nudge doesn't fire every iteration; a new identical
 		// run will re-accumulate.
 		state.ConsecutiveSameCall = 0
+		// LLM-only: this is an instruction TO the model (it also rides on
+		// Nudge, which is what steers the conversation). Do NOT emit it to
+		// the user-facing feed — end users would read it as an error.
 		return HookResult{
-			Nudge:       msg,
-			ForceSkip:   true,
-			EmitMessage: msg,
+			Nudge:     msg,
+			ForceSkip: true,
 		}
 	}
 
@@ -890,10 +892,11 @@ Change your approach: target a different endpoint, use a different payload/techn
 
 Do not repeat the action that produced this output.`, state.ConsecutiveSameResult)
 		state.ConsecutiveSameResult = 0
+		// LLM-only: instruction TO the model (rides on Nudge). Not emitted
+		// to the feed — see the REPEATED CALL note above.
 		return HookResult{
-			Nudge:       msg,
-			ForceSkip:   true,
-			EmitMessage: msg,
+			Nudge:     msg,
+			ForceSkip: true,
 		}
 	}
 
@@ -912,11 +915,12 @@ Move on now — other targets may have lower defenses.`, state.StuckIterations, 
 		state.ConsecutiveBrowser = 0
 		state.ConsecutiveSearch = 0
 
+		// LLM-only: instruction TO the model (rides on Nudge). Not emitted
+		// to the feed — see the REPEATED CALL note above.
 		return HookResult{
 			Nudge:          forceMsg,
 			ForceSkip:      true,
 			CleanupBrowser: true,
-			EmitMessage:    forceMsg,
 		}
 	}
 
@@ -937,9 +941,10 @@ DO NOT give up without trying at least 3 different bypass techniques from the lo
 		state.ConsecutiveBrowser = 0
 		state.ConsecutiveSearch = 0
 
+		// LLM-only: instruction TO the model (rides on Nudge). Not emitted
+		// to the feed — see the REPEATED CALL note above.
 		return HookResult{
-			Nudge:       nudge,
-			EmitMessage: nudge,
+			Nudge: nudge,
 		}
 	}
 

--- a/internal/agent/hooks_test.go
+++ b/internal/agent/hooks_test.go
@@ -897,6 +897,70 @@ func TestRepeatDetector_IdenticalResultForceSkips(t *testing.T) {
 	}
 }
 
+// TestStuckNudgesAreLLMOnly asserts that all four hookStuckNudge guardrail
+// messages (REPEATED CALL, NO PROGRESS, EXHAUSTION LIMIT, PIVOT REQUIRED) are
+// LLM-only: they steer the model via Nudge + ForceSkip but never reach the
+// user-facing feed (EmitMessage must stay empty). Otherwise end users see
+// "instructions to the AI" mislabeled as red errors in the STDOUT panel.
+func TestStuckNudgesAreLLMOnly(t *testing.T) {
+	args := map[string]string{"tool_name": "terminal_execute", "command": "curl https://example.com"}
+
+	// ── REPEATED CALL: identical (tool,args) repeated past the threshold ──
+	state := NewScanState()
+	for i := 0; i < RepeatCallSoftNudge; i++ {
+		hookStuckTracker(state, args)
+	}
+	res := hookStuckNudge(state, args)
+	if res.Nudge == "" || !strings.Contains(res.Nudge, "REPEATED CALL") {
+		t.Fatalf("REPEATED CALL: expected non-empty Nudge, got %q", res.Nudge)
+	}
+	if res.EmitMessage != "" {
+		t.Errorf("REPEATED CALL must be LLM-only, got EmitMessage=%q", res.EmitMessage)
+	}
+
+	// ── NO PROGRESS: byte-identical tool output across calls ──
+	state = NewScanState()
+	for i := 0; i < RepeatResultHardSkip; i++ {
+		hookResultRepeatTracker(state, map[string]string{
+			"tool_name": "terminal_execute",
+			"output":    "identical-output",
+			"error":     "",
+		})
+	}
+	res = hookStuckNudge(state, args)
+	if res.Nudge == "" || !strings.Contains(res.Nudge, "NO PROGRESS") {
+		t.Fatalf("NO PROGRESS: expected non-empty Nudge, got %q", res.Nudge)
+	}
+	if res.EmitMessage != "" {
+		t.Errorf("NO PROGRESS must be LLM-only, got EmitMessage=%q", res.EmitMessage)
+	}
+
+	// ── EXHAUSTION LIMIT: StuckIterations past the hard limit ──
+	state = NewScanState()
+	state.StuckIterations = StuckHardLimit
+	state.StuckDomain = "example.com"
+	res = hookStuckNudge(state, args)
+	if res.Nudge == "" || !strings.Contains(res.Nudge, "EXHAUSTION LIMIT") {
+		t.Fatalf("EXHAUSTION LIMIT: expected non-empty Nudge, got %q", res.Nudge)
+	}
+	if res.EmitMessage != "" {
+		t.Errorf("EXHAUSTION LIMIT must be LLM-only, got EmitMessage=%q", res.EmitMessage)
+	}
+
+	// ── PIVOT REQUIRED: browser/search stuck past the soft threshold ──
+	state = NewScanState()
+	state.ConsecutiveBrowser = StuckBrowserThreshold
+	state.StuckIterations = StuckBrowserThreshold
+	state.StuckDomain = "example.com"
+	res = hookStuckNudge(state, args)
+	if res.Nudge == "" || !strings.Contains(res.Nudge, "PIVOT REQUIRED") {
+		t.Fatalf("PIVOT REQUIRED: expected non-empty Nudge, got %q", res.Nudge)
+	}
+	if res.EmitMessage != "" {
+		t.Errorf("PIVOT REQUIRED must be LLM-only, got EmitMessage=%q", res.EmitMessage)
+	}
+}
+
 func TestRepeatDetector_ResultTrackerIgnoresNotesAndFinish(t *testing.T) {
 	state := NewScanState()
 	for _, tool := range []string{"add_note", "read_notes", "finish"} {


### PR DESCRIPTION
The hookStuckNudge guardrails (REPEATED CALL, NO PROGRESS, EXHAUSTION LIMIT, PIVOT REQUIRED) returned each message on BOTH Nudge and EmitMessage. Nudge injects it into the LLM conversation (steering the model) — that part must stay. EmitMessage streams it to the UI feed as a red Type:"error" line, landing in the live view, the reconnect replay buffer, and the persisted ScanRecord.Events — that part exposed internal "instructions to the AI" to end users, who read them as scan errors.

Drop EmitMessage from all four returns so they are LLM-only. Behavior is unchanged: Nudge still steers the model, ForceSkip still cancels the redundant call, CleanupBrowser still fires. The consumption site at agent.go is already guarded by `EmitMessage != ""`, so no edit needed there.

Genuine operator-facing messages (WAF/tech-stack detection, empty/no- tool/reasoning-loop aborts) are untouched — they have no Nudge and operators need them, so escalation still surfaces.

Adds TestStuckNudgesAreLLMOnly asserting all four returns have non-empty Nudge but empty EmitMessage.

<!--
Thanks for contributing to Xalgorix! Please fill this out so we can review quickly.
`main` is branch-protected — PRs are the only way in. CI runs make lint,
golangci-lint, go vet, and the test suite on every PR.
-->

## What & why

<!-- What does this change and why? Link the issue it addresses. -->

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Refactor / internal
- [ ] Other:

## How was it tested?

<!-- Commands you ran, new tests added, manual verification. -->

- [ ] `make lint` passes
- [ ] `golangci-lint run --config .golangci.yml ./...` passes
- [ ] `go test ./...` passes
- [ ] Added/updated tests for the change

## Checklist

- [ ] I read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md).
- [ ] The tree is `gofmt`-clean.
- [ ] I updated docs (`README`, `docs/`, help text) if behavior changed.
- [ ] This does not weaken a security control (scope guard, verifier, false-positive gate) without explicit discussion.
- [ ] For engine behavior changes: I noted any impact on scan findings/severity.
