### PR TITLE
fix(web): don't let a stale instance downgrade a completed scan to running

### DIFF
--- a/internal/web/scan_query.go
+++ b/internal/web/scan_query.go
@@ -450,9 +450,27 @@ func (s *Server) applyInstanceSnapshot(rec *ScanRecord, includeEvents bool) {
 	if rec.InstanceID == "" {
 		rec.InstanceID = snapshot.InstanceID
 	}
-	rec.Status = snapshot.Status
-	rec.FinishedAt = snapshot.FinishedAt
-	rec.StopReason = snapshot.StopReason
+	// Terminal states are FINAL. A stale in-memory instance — e.g. one left in
+	// the map after an engine restart + auto-resume, or an orphaned pre-resume
+	// instance — can report "running" for a scan that already reached a
+	// terminal state on disk. Overwriting the persisted terminal status with
+	// that live "running" made GET /api/scans/{id} report the scan as running
+	// forever, so a poller (the SaaS reaper) never reconciled it (the
+	// crowdproof.id desync). Only adopt the snapshot's status when we are NOT
+	// downgrading an already-terminal persisted status to a non-terminal one.
+	// Only guard genuinely-FINAL states (completed/finished). "stopped" is
+	// resumable and "failed" is re-runnable, so a live "running" instance must
+	// still win for those (see TestApplyInstanceSnapshotDoesNotErasePersistedResumeData).
+	// But a completed scan is done forever: a stale in-memory instance left
+	// after a restart/auto-resume must not downgrade it back to "running".
+	if isCompletedScanStatus(rec.Status) && !isCompletedScanStatus(snapshot.Status) {
+		log.Printf("[scan] %s (instance %s): kept completed disk status %q over stale in-memory instance status %q — not downgrading a finished scan to running",
+			rec.ID, rec.InstanceID, rec.Status, snapshot.Status)
+	} else {
+		rec.Status = snapshot.Status
+		rec.FinishedAt = snapshot.FinishedAt
+		rec.StopReason = snapshot.StopReason
+	}
 	if snapshot.Iterations > rec.Iterations {
 		rec.Iterations = snapshot.Iterations
 	}
@@ -465,7 +483,10 @@ func (s *Server) applyInstanceSnapshot(rec *ScanRecord, includeEvents bool) {
 	for _, vuln := range snapshot.Vulns {
 		appendVulnSummaryUnique(&rec.Vulns, vuln)
 	}
-	if snapshot.CurrentPhase > 0 {
+	// Phase is monotonic progress — only ever advance it. A stale in-memory
+	// instance (post-restart/resume) could otherwise drag a finished scan's
+	// phase back down (e.g. 22 → 11), same root cause as the status downgrade.
+	if snapshot.CurrentPhase > rec.CurrentPhase {
 		rec.CurrentPhase = snapshot.CurrentPhase
 	}
 	if includeEvents && len(snapshot.Events) >= len(rec.Events) {

--- a/internal/web/scan_snapshot_test.go
+++ b/internal/web/scan_snapshot_test.go
@@ -1,0 +1,46 @@
+package web
+
+import "testing"
+
+// A stale in-memory instance (left after an engine restart + auto-resume) must
+// NOT downgrade an already-terminal on-disk scan status back to "running", nor
+// regress its phase. This is the crowdproof.id desync: the scan finished on
+// disk but a leftover instance reported "running", so GET /api/scans/{id}
+// showed it running forever and the SaaS never reconciled it.
+func TestApplyInstanceSnapshot_KeepsTerminalOverStaleRunning(t *testing.T) {
+	s := newTestServer(t, nil)
+
+	s.instancesMu.Lock()
+	s.instances["inst-crowd"] = &ScanInstance{ID: "inst-crowd", Status: "running", CurrentPhase: 11}
+	s.instancesMu.Unlock()
+
+	rec := &ScanRecord{ID: "scan-crowd", InstanceID: "inst-crowd", Status: "completed", CurrentPhase: 22}
+	s.applyInstanceSnapshot(rec, false)
+
+	if rec.Status != "completed" {
+		t.Fatalf("terminal status was downgraded to %q by a stale running instance", rec.Status)
+	}
+	if rec.CurrentPhase != 22 {
+		t.Errorf("phase regressed from 22 to %d", rec.CurrentPhase)
+	}
+}
+
+// Conversely, when the record is NOT terminal, the live instance status still
+// wins (an instance that just reached a terminal state must update the record).
+func TestApplyInstanceSnapshot_LiveInstanceStillWinsForNonTerminal(t *testing.T) {
+	s := newTestServer(t, nil)
+
+	s.instancesMu.Lock()
+	s.instances["inst-live"] = &ScanInstance{ID: "inst-live", Status: "failed", CurrentPhase: 14, StopReason: "idle_timeout"}
+	s.instancesMu.Unlock()
+
+	rec := &ScanRecord{ID: "scan-live", InstanceID: "inst-live", Status: "running", CurrentPhase: 12}
+	s.applyInstanceSnapshot(rec, false)
+
+	if rec.Status != "failed" {
+		t.Fatalf("live terminal instance status not applied: rec.Status=%q", rec.Status)
+	}
+	if rec.CurrentPhase != 14 {
+		t.Errorf("phase did not advance to 14: %d", rec.CurrentPhase)
+	}
+}


### PR DESCRIPTION
## Problem (the crowdproof.id desync)
A scan showed **completed on the scanner but running on the SaaS**, forever. The SaaS reaper polls `GET /api/scans/{id}`; that handler overlays the in-memory instance status onto the persisted record via `applyInstanceSnapshot`, which **unconditionally** did `rec.Status = snapshot.Status` and `rec.CurrentPhase = snapshot.CurrentPhase`.

After an engine **restart + auto-resume** (your ~7×/day deploys), a leftover/orphaned in-memory instance can report `running` / phase 11 for a scan that already **finished on disk** (phase 22). The overlay then reports the scan running forever, so the SaaS never reconciles it.

## Fix
- **Never downgrade a genuinely-final persisted status** (`completed`/`finished`) to a non-final live status. `stopped` (resumable) and `failed` (re-runnable) still adopt the live instance status, so resume/re-run keep working — `TestApplyInstanceSnapshotDoesNotErasePersistedResumeData` stays green.
- **CurrentPhase is now monotonic** (advance-only) so a stale instance can't drag a finished scan's phase backward (22 → 11).
- Diagnostic log when the guard trips, so residual cases are visible.

This is the engine-side half of the fix; the manually-reconciled crowdproof scan is already `completed`. Going forward, a finished scan's terminal state on disk wins over a stale post-restart instance, so `GET /api/scans/{id}` returns `completed` and the SaaS reconciles.

## Tests
- New `TestApplyInstanceSnapshot_KeepsTerminalOverStaleRunning` (completed disk + stale running instance → stays completed, phase not regressed).
- New `TestApplyInstanceSnapshot_LiveInstanceStillWinsForNonTerminal` (running disk + failed instance → failed).
- Full `internal/web` suite + `go vet` + `gofmt` green.

## Related follow-up
The deeper mitigation is still: avoid restarting scanner2 mid-scan (deploys), and/or preserve the instance ID across auto-resume so the SaaS↔engine link never drifts.