### PR TITLE
fix(docker): strip file caps so nmap runs under default docker run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,10 +120,29 @@ RUN apt-get update && apt-get install -y \
       python3 python3-pip python3-venv pipx \
       cargo \
       nodejs npm \
-      build-essential pkg-config libpcap-dev \
+      build-essential pkg-config libpcap-dev libcap2-bin \
       chromium \
       findomain dirsearch \
     && rm -rf /var/lib/apt/lists/*
+
+# Strip file capabilities from every bundled tool so a plain `docker run` works.
+#
+# Kali ships several tools (nmap most notably, at /usr/lib/nmap/nmap) with file
+# capabilities set with the EFFECTIVE bit, e.g. cap_net_raw,cap_net_admin,
+# cap_net_bind_service+eip. Under Docker's DEFAULT security profile the
+# capability bounding set drops NET_ADMIN, and the kernel fails execve() with
+# EPERM ("Operation not permitted") whenever a binary requests an effective
+# capability that isn't in the bounding set — so `nmap` won't even start under a
+# default `docker run`, with no cap-add/seccomp overrides.
+#
+# The engine runs as ROOT on purpose, and root already holds NET_RAW in Docker's
+# default bounding set, so these file caps are redundant: removing them lets the
+# binaries exec cleanly and fall back to root's own capabilities for raw-socket
+# scans. This clears the entire class of "Operation not permitted" exec errors
+# (nmap, masscan, arping, dumpcap, …) for containerized deployments.
+RUN getcap -r / 2>/dev/null | awk '{print $1}' | while read -r f; do \
+      setcap -r "$f" 2>/dev/null || true; \
+    done || true
 
 # Go toolchain at runtime so the agent can `go install` anything not baked in.
 COPY --from=gobuild /usr/local/go /usr/local/go

--- a/internal/web/autonomous.go
+++ b/internal/web/autonomous.go
@@ -398,7 +398,7 @@ If you determine this is a duplicate/parking/redirect subdomain, call finish wit
 
 ### Step 1: QUICK TECH FINGERPRINT
 - whatweb ` + subdomain + ` — identify technologies
-- nmap -sV -T2 --top-ports 100 ` + subdomain + ` — find open ports while respecting the active request-rate policy
+- nmap -sV -T2 --top-ports 100 ` + subdomain + ` — find open ports while respecting the active request-rate policy. If nmap errors with "Operation not permitted", a raw-socket/root requirement, or a dnet/socket failure (common in restricted containers), retry as an unprivileged TCP connect scan: nmap -sT -Pn -sV --top-ports 100 ` + subdomain + `, or use naabu (TCP connect, no raw sockets needed).
 - curl -sI https://` + subdomain + ` — check headers
 
 ### Step 2: DISCOVER CONTENT  


### PR DESCRIPTION
## Problem

A plain `docker run ghcr.io/xalgord/xalgorix:latest` fails port-scan steps with:

```
bash: line 40: /usr/lib/nmap/nmap: Operation not permitted
```

This is an `EPERM` from `execve()`, not an nmap bug or a missing file.

## Root cause

Kali bundles nmap (and a few other tools) with **file capabilities set with the effective bit**, e.g. `cap_net_raw,cap_net_admin,cap_net_bind_service+eip`. Docker's **default** capability bounding set **drops `NET_ADMIN`**. When a binary requests an *effective* capability that isn't in the bounding set, the kernel refuses `execve` with EPERM — so nmap never even starts under a default `docker run`, with no `--cap-add`/`--security-opt` overrides.

The engine runs as **root** on purpose, and root already holds `NET_RAW` in Docker's default bounding set, so those file caps are redundant.

## Fix

- Strip **all** file capabilities image-wide at build time (`getcap -r / | setcap -r`). Since everything runs as root, tools fall back to root's own capabilities for raw-socket scans. This clears the whole class of exec-EPERM errors (nmap, masscan, arping, dumpcap, …) for containerized deployments.
- Add `libcap2-bin` so `setcap`/`getcap` are available.
- Agent resilience: steer the LLM to retry with an unprivileged TCP connect scan (`nmap -sT -Pn`) or naabu if it still hits a raw-socket restriction (e.g. on a PaaS that also strips `NET_RAW`).

## Testing

- `go build ./...` passes.
- Dockerfile change is build-time only; makes default `docker run` port scans work without extra flags.