### PR TITLE
docker: run with full permissions by default (compose privileged + docs)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,21 @@
 #
 # Build:  docker build -t xalgorix .
 # Run:    docker run --rm -p 9137:9137 \
+#           --privileged \
 #           -e XALGORIX_LLM=minimax/MiniMax-M3 \
 #           -e XALGORIX_API_KEY=your_provider_api_key \
 #           -v xalgorix-data:/data \
 #           ghcr.io/xalgord/xalgorix:latest
+#
+# --privileged gives the toolset the same host-like access it has when run
+# natively as root. Docker's DEFAULT sandbox drops capabilities (NET_ADMIN, …)
+# and applies a seccomp/AppArmor filter that breaks low-level tools (iptables,
+# route/interface changes, ARP-spoof/MITM, tun/tap VPNs, ptrace debuggers,
+# masscan interface tuning). An image CANNOT grant itself capabilities — they
+# are set at run time — so pass --privileged (or the narrower
+# --cap-add=NET_ADMIN --cap-add=NET_RAW --cap-add=SYS_PTRACE
+# --security-opt seccomp=unconfined), or just use docker-compose.yml which
+# sets privileged mode for you.
 #
 # Then open http://127.0.0.1:9137
 #

--- a/README.md
+++ b/README.md
@@ -60,9 +60,12 @@ xalgorix --web
 
 ```bash
 docker run --rm -p 9137:9137 \
+  --privileged \
   -v xalgorix-data:/data \
   xalgord/xalgorix:latest
 ```
+
+`--privileged` gives the toolset the same host-like access it has when run natively as root. Docker's default sandbox drops capabilities (like `NET_ADMIN`) and applies a seccomp filter, which breaks low-level tools (iptables/route changes, ARP-spoof/MITM, tun/tap VPNs, ptrace-based debuggers, masscan interface tuning). Since an image can't grant itself these, they must be set at run time. The container is a disposable, network-isolated scanning sandbox running as root — privileged is the intended posture; never expose the dashboard publicly without auth. Prefer least-privilege? Swap `--privileged` for `--cap-add=NET_ADMIN --cap-add=NET_RAW --cap-add=SYS_PTRACE --security-opt seccomp=unconfined`.
 
 Open `http://localhost:9137`. You **don't need an LLM key to start** — the dashboard launches without one; set the model + API key under **Settings → LLM** (it persists to the `/data` volume). If you don't pass `XALGORIX_USERNAME`/`XALGORIX_PASSWORD`, a random admin password is generated and printed to the container logs on first run.
 
@@ -215,11 +218,14 @@ Downloads the latest release binary for your platform (Linux `amd64`/`arm64`) an
 
 ```bash
 docker run --rm -p 9137:9137 \
+  --privileged \
   -e XALGORIX_LLM=minimax/MiniMax-M3 \
   -e XALGORIX_API_KEY=your_provider_api_key \
   -v xalgorix-data:/data \
   ghcr.io/xalgord/xalgorix:latest
 ```
+
+`--privileged` (or the narrower `--cap-add=NET_ADMIN --cap-add=NET_RAW --cap-add=SYS_PTRACE --security-opt seccomp=unconfined`) gives the toolset host-like access. Docker's default sandbox drops capabilities and filters syscalls, which breaks low-level tooling (iptables/route/interface changes, ARP-spoof/MITM, tun/tap VPNs, ptrace-based debuggers). An image can't grant these to itself — they're a run-time decision — so pass the flag, or use the provided `docker-compose.yml`, which sets it for you.
 
 The image is **batteries-included**: an extensive offensive-security toolset is preinstalled (nmap, nuclei, httpx, subfinder, dnsx, naabu, katana, ffuf, gobuster, dalfox, feroxbuster, sqlmap, masscan, nikto, whatweb, hydra, and more), plus Chromium for browser-assisted DAST. It also keeps the full package-manager set (apt, go, cargo, pipx, npm) available, so the agent auto-installs anything missing at runtime. Scan data persists to the `/data` volume, and the server binds `0.0.0.0` inside the container — set `XALGORIX_USERNAME`/`XALGORIX_PASSWORD` before exposing it beyond localhost.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,30 @@ services:
   xalgorix:
     image: xalgord/xalgorix:latest
     # Or build locally instead of pulling:  build: .
+    #
+    # Full host-like permissions so the engine's toolset behaves as it does when
+    # run natively as root. Docker's DEFAULT sandbox drops capabilities
+    # (e.g. NET_ADMIN) and applies a seccomp/AppArmor filter, which breaks
+    # low-level tools: iptables/route/interface changes, ARP-spoof/MITM
+    # (ettercap/bettercap), tun/tap VPNs, ptrace-based debuggers (gdb/strace),
+    # masscan interface tuning, and tools that create their own namespaces.
+    #
+    # NOTE: an image cannot grant itself these — they MUST be set at run time.
+    # This compose file is the recommended launch path precisely so you get them
+    # by default with no extra flags. The container is meant to be a disposable,
+    # network-isolated scanning sandbox running as root; privileged mode is the
+    # intended posture. Never expose the dashboard publicly without auth.
+    privileged: true
+    # ── Prefer least-privilege instead of `privileged: true`? Comment the line
+    #    above and uncomment this targeted set (covers the pentest toolset while
+    #    stopping short of full device access):
+    # cap_add:
+    #   - NET_ADMIN      # iptables/nftables, routes, interfaces, ARP/MITM, VPN
+    #   - NET_RAW        # raw sockets / SYN scans (in Docker's default set too)
+    #   - SYS_PTRACE     # gdb / strace / debug attach
+    # security_opt:
+    #   - seccomp=unconfined     # allow mount/unshare/bpf/perf_event_open/keyctl
+    #   - apparmor=unconfined
     ports:
       - "9137:9137"
     # Uncomment to bake in credentials / LLM (all optional). If you omit the


### PR DESCRIPTION
Follow-up to #324. That PR stripped the file caps so nmap execs under a default `docker run`. This one closes the *remaining* native-vs-container gaps by making the recommended launch paths grant host-like access with no manual flags.

## Why this can't be baked into the image

Capabilities, seccomp, and AppArmor are a **run-time** decision — an image cannot grant them to itself. So a plain `docker run image` can never be fully privileged from inside the Dockerfile. The fix is to ship the recommended run paths with the grants already set.

## Changes

- **docker-compose.yml**: `privileged: true` (the one-command path now gives full perms). Commented least-privilege alternative included: `cap_add: NET_ADMIN/NET_RAW/SYS_PTRACE` + `security_opt: seccomp=unconfined`.
- **README + Dockerfile header**: `docker run` examples now include `--privileged`, with the narrower cap-add form documented.

## What this unblocks

Tools that Docker's default sandbox breaks: iptables/route/interface changes, ARP-spoof/MITM (ettercap/bettercap), tun/tap VPNs, ptrace-based debuggers (gdb/strace), masscan interface tuning, and namespace/kernel-level operations (mount/unshare/bpf/perf_event_open).

The container is a disposable, network-isolated scanning sandbox running as root — privileged is the intended posture. Docs reiterate: never expose the dashboard publicly without auth.

Docs/config only; no Go changes.