### PR TITLE
feat(agent): window-relative context compaction (don't compact too early)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1192,8 +1192,13 @@ func (a *Agent) Run(targets []string, instruction string) {
 				a.client.SetTemperature(TempScanner)
 			}
 		}
-		// Prune message history to prevent context window overflow
-		a.pruneMessages()
+		// Prune message history to prevent context window overflow — but only
+		// once the buffer has grown past the window-relative compaction ceiling
+		// (pruneMessages self-guards on the same threshold; this check just
+		// avoids the lock/scan when we're nowhere near it).
+		if a.shouldPruneBeforeLLM() {
+			a.pruneMessages()
+		}
 		// ZERO DELAY — immediately proceed to next iteration
 	}
 

--- a/internal/agent/agent_messages.go
+++ b/internal/agent/agent_messages.go
@@ -149,22 +149,45 @@ const perMessageOverheadBytes = 50
 // English + JSON + code text that dominates scan transcripts.
 const bytesPerTokenEstimate = 4
 
+// defaultCompactRatio is the fraction of the model's context window at which
+// window-relative auto-compaction fires when the operator hasn't set an
+// explicit token budget. Kept in the 0.7–0.8 band on purpose: compacting much
+// earlier throws away useful working context and degrades outcome quality,
+// while going higher risks hitting the provider's hard limit before we prune.
+const defaultCompactRatio = 0.75
+
 // compactThresholdBytes resolves the effective byte ceiling for auto-compaction
-// from config (token budget × ~4 bytes), falling back to the built-in default
-// when config is absent (tests/CLI). A configured budget of 0 disables
-// proactive compaction — the last-resort forcePruneMessages on a hard context
-// overflow still applies.
+// (token budget × ~4 bytes/token). Resolution order:
+//
+//   - cfg absent (tests/CLI):     built-in pruneThresholdBytes default.
+//   - ContextCompactTokens == 0:  disabled (0) — only the last-resort
+//     forcePruneMessages on a hard context overflow still applies.
+//   - ContextCompactTokens  > 0:  explicit absolute token-budget override.
+//   - ContextCompactTokens  < 0:  AUTO (default) — a fraction
+//     (ContextCompactRatio, ~0.75) of the model's configured context window
+//     (LLMContextWindow). This is the intended behavior: we only compact once
+//     the window is genuinely filling up, not at an arbitrary fixed budget, so
+//     large-context models keep their full working context for longer.
 func (a *Agent) compactThresholdBytes() int {
-	if a.cfg != nil {
-		if a.cfg.ContextCompactTokens < 0 {
-			return pruneThresholdBytes
-		}
-		if a.cfg.ContextCompactTokens == 0 {
-			return 0 // disabled
-		}
+	if a.cfg == nil {
+		return pruneThresholdBytes
+	}
+	if a.cfg.ContextCompactTokens == 0 {
+		return 0 // disabled
+	}
+	if a.cfg.ContextCompactTokens > 0 {
 		return a.cfg.ContextCompactTokens * bytesPerTokenEstimate
 	}
-	return pruneThresholdBytes
+	// Auto / window-relative mode.
+	window := a.cfg.LLMContextWindow
+	if window <= 0 {
+		return pruneThresholdBytes
+	}
+	ratio := a.cfg.ContextCompactRatio
+	if ratio < 0.5 || ratio > 0.9 {
+		ratio = defaultCompactRatio
+	}
+	return int(float64(window)*ratio) * bytesPerTokenEstimate
 }
 
 // shouldPruneBeforeLLM reports whether the agent's current message buffer
@@ -197,9 +220,23 @@ func (a *Agent) pruneMessages() {
 	a.msgMu.Lock()
 	defer a.msgMu.Unlock()
 
-	const maxMessages = 100
-
-	if len(a.messages) <= maxMessages {
+	// Compact only when the serialized buffer has actually grown past the
+	// configured ceiling — a fraction (ContextCompactRatio, ~0.75) of the
+	// model's context window (LLMContextWindow), or an explicit
+	// ContextCompactTokens budget. This replaces the old fixed 100-message
+	// trigger, which compacted far too early on large-context models and
+	// degraded output quality by discarding useful working context. The size
+	// scan mirrors shouldPruneBeforeLLM but is inlined here because msgMu is
+	// already held (shouldPruneBeforeLLM would re-lock and deadlock).
+	threshold := a.compactThresholdBytes()
+	if threshold <= 0 {
+		return // auto-compaction disabled
+	}
+	size := 0
+	for i := range a.messages {
+		size += len(a.messages[i].Content) + perMessageOverheadBytes
+	}
+	if size <= threshold {
 		return
 	}
 
@@ -207,6 +244,11 @@ func (a *Agent) pruneMessages() {
 	keepRecent := 40
 	if keepRecent > len(a.messages)-1 {
 		keepRecent = len(a.messages) - 1
+	}
+	// Nothing older than the recent window to compact — bail rather than
+	// rebuild an identical buffer.
+	if len(a.messages)-keepRecent <= 1 {
+		return
 	}
 
 	originalLen := len(a.messages)

--- a/internal/agent/context_compact_test.go
+++ b/internal/agent/context_compact_test.go
@@ -53,3 +53,41 @@ func TestShouldPruneBeforeLLM_DefaultFallback(t *testing.T) {
 		t.Error("should prune above the default ceiling when cfg is absent")
 	}
 }
+
+// In AUTO mode (ContextCompactTokens < 0) the trigger is derived from the
+// model's context window × ratio, NOT the old fixed budget. This is the
+// behavior that keeps large-context models from compacting too early.
+func TestShouldPruneBeforeLLM_AutoWindowRelative(t *testing.T) {
+	// 1M-token window × 0.75 = 750K tokens ≈ 3,000,000 bytes threshold.
+	a := &Agent{cfg: &config.Config{
+		ContextCompactTokens: -1,
+		LLMContextWindow:     1_000_000,
+		ContextCompactRatio:  0.75,
+	}}
+
+	// A buffer that would have tripped the old 120K-token default must NOT
+	// compact now — we're nowhere near 75% of a 1M window.
+	a.messages = msgsOfSize(600_000) // ~150K tokens
+	if a.shouldPruneBeforeLLM() {
+		t.Error("must NOT compact well below 75% of the context window")
+	}
+
+	// Past ~75% of the window it should compact.
+	a.messages = msgsOfSize(3_200_000)
+	if !a.shouldPruneBeforeLLM() {
+		t.Error("should compact once past the window-relative ceiling")
+	}
+}
+
+// An out-of-range ratio falls back to the safe default (0.75).
+func TestCompactThreshold_RatioClamp(t *testing.T) {
+	a := &Agent{cfg: &config.Config{
+		ContextCompactTokens: -1,
+		LLMContextWindow:     100_000,
+		ContextCompactRatio:  9, // nonsense → default 0.75
+	}}
+	want := int(float64(100_000)*0.75) * bytesPerTokenEstimate
+	if got := a.compactThresholdBytes(); got != want {
+		t.Fatalf("threshold = %d, want %d (ratio should clamp to default)", got, want)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,13 +37,31 @@ type Config struct {
 	// budget so the full call fits. XALGORIX_MAX_OUTPUT_TOKENS, default 8192.
 	MaxOutputTokens int
 
-	// ContextCompactTokens is the approximate token budget for the agent's
-	// running message history. Once the buffer is estimated to exceed this, the
-	// agent auto-compacts older turns into a structured digest (+ saved notes)
-	// before the next LLM call. Set below your model's context window so the
-	// model never loses focus / stops calling tools as context fills up.
-	// XALGORIX_CONTEXT_COMPACT_TOKENS, default 120000. 0 disables auto-compaction.
+	// ContextCompactTokens is an OPTIONAL absolute override for the compaction
+	// trigger. When > 0, the agent auto-compacts older turns into a structured
+	// digest (+ saved notes) once the running message history is estimated to
+	// exceed this many tokens. When 0, auto-compaction is DISABLED. When < 0
+	// (the default "auto" mode), the trigger is derived from the model's
+	// context window instead — LLMContextWindow × ContextCompactRatio — so
+	// compaction only fires when the window is genuinely filling up rather than
+	// at an arbitrary fixed budget. XALGORIX_CONTEXT_COMPACT_TOKENS, default -1
+	// (auto / window-relative).
 	ContextCompactTokens int
+
+	// LLMContextWindow is the total context window (in tokens) of the
+	// configured model, used as the basis for window-relative auto-compaction.
+	// XALGORIX_LLM_CONTEXT_WINDOW, default 128000. Set this to your model's real
+	// window (e.g. 1000000 for a 1M-token model) so compaction waits until the
+	// window is actually filling up instead of compacting far too early.
+	LLMContextWindow int
+
+	// ContextCompactRatio is the fraction of LLMContextWindow at which
+	// window-relative auto-compaction triggers (only used when
+	// ContextCompactTokens is in auto mode). XALGORIX_CONTEXT_COMPACT_RATIO,
+	// default 0.75 — i.e. compact once the running context reaches ~75% of the
+	// window. Clamped to a sane 0.5–0.9 range. Compacting earlier than this
+	// tends to discard useful working context and hurt output quality.
+	ContextCompactRatio float64
 
 	// Runtime settings
 	RuntimeBackend string // XALGORIX_RUNTIME_BACKEND — always "native"
@@ -295,7 +313,9 @@ func load() *Config {
 		Temperature:          envOrFloatPtr("XALGORIX_TEMPERATURE", 0.2),
 		LLMMaxRetries:        envOrInt("XALGORIX_LLM_MAX_RETRIES", 5),
 		MaxOutputTokens:      envOrInt("XALGORIX_MAX_OUTPUT_TOKENS", 8192),
-		ContextCompactTokens: envOrInt("XALGORIX_CONTEXT_COMPACT_TOKENS", 120000),
+		ContextCompactTokens: envOrInt("XALGORIX_CONTEXT_COMPACT_TOKENS", -1),
+		LLMContextWindow:     envOrInt("XALGORIX_LLM_CONTEXT_WINDOW", 128000),
+		ContextCompactRatio:  envOrFloat("XALGORIX_CONTEXT_COMPACT_RATIO", 0.75),
 		MemCompTimeout:       envOrInt("XALGORIX_MEMORY_COMPRESSOR_TIMEOUT", 30),
 
 		// Runtime

--- a/internal/web/settings_env.go
+++ b/internal/web/settings_env.go
@@ -129,7 +129,9 @@ func allEnvSettingDefinitions() []envSettingDefinition {
 		{Key: "XALGORIX_OLLAMA_COMPATIBLE", Label: "Ollama-compatible endpoint", Category: "LLM", Description: "Force Ollama reasoning semantics for a custom endpoint that does not use port 11434.", DefaultValue: "false", InputType: "boolean"},
 		{Key: "XALGORIX_LLM_MAX_RETRIES", Label: "LLM max retries", Category: "LLM", Description: "Retry count for transient LLM provider failures.", DefaultValue: "5", InputType: "number"},
 		{Key: "XALGORIX_MAX_OUTPUT_TOKENS", Label: "Max output tokens", Category: "LLM", Description: "Per-call completion cap (max_tokens). Reasoning models spend part of this on hidden thinking before a tool call, so a small provider default can truncate large calls. Clamped to a 1024 floor.", DefaultValue: "8192", InputType: "number"},
-		{Key: "XALGORIX_CONTEXT_COMPACT_TOKENS", Label: "Context compaction budget (tokens)", Category: "LLM", Description: "Auto-compact older conversation turns into a structured digest once the running context is estimated to exceed this many tokens. Set below your model's context window so it never loses focus / stops calling tools as context fills. 0 disables. Default 120000.", DefaultValue: "120000", InputType: "number"},
+		{Key: "XALGORIX_LLM_CONTEXT_WINDOW", Label: "LLM context window (tokens)", Category: "LLM", Description: "Total context window of your model, in tokens. Auto-compaction fires at a fraction of this (see compaction ratio) so the running context is only compacted when the window is genuinely filling up. Set to your model's real window (e.g. 1000000 for a 1M-token model). Default 128000.", DefaultValue: "128000", InputType: "number"},
+		{Key: "XALGORIX_CONTEXT_COMPACT_RATIO", Label: "Context compaction ratio", Category: "LLM", Description: "Fraction of the context window at which to auto-compact (0.5–0.9). Default 0.75 = compact at ~75% full. Compacting earlier discards useful working context and hurts output quality; going higher risks hitting the provider's hard limit first.", DefaultValue: "0.75", InputType: "number"},
+		{Key: "XALGORIX_CONTEXT_COMPACT_TOKENS", Label: "Context compaction budget (tokens, override)", Category: "LLM", Description: "Optional ABSOLUTE override for the compaction trigger. Leave at -1 (auto) to derive the trigger from the context window × ratio above. Set a positive token count to force a fixed budget instead. 0 disables auto-compaction. Default -1 (auto).", DefaultValue: "-1", InputType: "number"},
 		{Key: "XALGORIX_MEMORY_COMPRESSOR_TIMEOUT", Label: "Memory compressor timeout", Category: "LLM", Description: "Timeout in seconds for context compression.", DefaultValue: "30", InputType: "number"},
 		{Key: "XALGORIX_MAX_ITERATIONS", Label: "Max iterations", Category: "Runtime", Description: "Maximum agent iterations per scan. 0 means unlimited.", DefaultValue: "0", InputType: "number"},
 		{Key: "XALGORIX_MAX_TOOL_CALLS", Label: "Max tool calls (budget)", Category: "Runtime", Description: "Per-scan tool-call cap; the scan stops cleanly when reached (findings preserved). 0 = unlimited.", DefaultValue: "0", InputType: "number", RequiresRestart: true},
@@ -745,7 +747,11 @@ func (s *Server) applyEnvironmentToRuntimeConfig(values map[string]string) {
 		case "XALGORIX_MAX_OUTPUT_TOKENS":
 			s.cfg.MaxOutputTokens = parseIntSetting(value, 8192)
 		case "XALGORIX_CONTEXT_COMPACT_TOKENS":
-			s.cfg.ContextCompactTokens = parseIntSetting(value, 120000)
+			s.cfg.ContextCompactTokens = parseIntSetting(value, -1)
+		case "XALGORIX_LLM_CONTEXT_WINDOW":
+			s.cfg.LLMContextWindow = parseIntSetting(value, 128000)
+		case "XALGORIX_CONTEXT_COMPACT_RATIO":
+			s.cfg.ContextCompactRatio = parseFloatSetting(value, 0.75)
 		case "XALGORIX_MEMORY_COMPRESSOR_TIMEOUT":
 			s.cfg.MemCompTimeout = parseIntSetting(value, 30)
 		case "XALGORIX_MAX_ITERATIONS":
@@ -856,6 +862,10 @@ func (s *Server) envSettingValue(key string) string {
 		return strconv.Itoa(s.cfg.MaxOutputTokens)
 	case "XALGORIX_CONTEXT_COMPACT_TOKENS":
 		return strconv.Itoa(s.cfg.ContextCompactTokens)
+	case "XALGORIX_LLM_CONTEXT_WINDOW":
+		return strconv.Itoa(s.cfg.LLMContextWindow)
+	case "XALGORIX_CONTEXT_COMPACT_RATIO":
+		return strconv.FormatFloat(s.cfg.ContextCompactRatio, 'g', -1, 64)
 	case "XALGORIX_MEMORY_COMPRESSOR_TIMEOUT":
 		return strconv.Itoa(s.cfg.MemCompTimeout)
 	case "XALGORIX_MAX_ITERATIONS":
@@ -1094,13 +1104,26 @@ func normalizeEnvSettingValue(def envSettingDefinition, value string) (string, e
 	case "XALGORIX_MAX_OUTPUT_TOKENS":
 		return strconv.Itoa(clampInt(parseIntSetting(value, 8192), 1024, 200000)), nil
 	case "XALGORIX_CONTEXT_COMPACT_TOKENS":
-		// 0 disables; otherwise clamp to a sane range (avoid a tiny value that
-		// would compact on every turn, or an absurd one that never fires).
-		ct := parseIntSetting(value, 120000)
-		if ct != 0 {
+		// Negative = auto (window-relative, normalized to -1); 0 disables;
+		// positive = explicit absolute budget clamped to a sane range (avoid a
+		// tiny value that would compact every turn, or an absurd one).
+		ct := parseIntSetting(value, -1)
+		if ct < 0 {
+			ct = -1
+		} else if ct != 0 {
 			ct = clampInt(ct, 20000, 2000000)
 		}
 		return strconv.Itoa(ct), nil
+	case "XALGORIX_LLM_CONTEXT_WINDOW":
+		return strconv.Itoa(clampInt(parseIntSetting(value, 128000), 8000, 2000000)), nil
+	case "XALGORIX_CONTEXT_COMPACT_RATIO":
+		r := parseFloatSetting(value, 0.75)
+		if r < 0.5 {
+			r = 0.5
+		} else if r > 0.9 {
+			r = 0.9
+		}
+		return strconv.FormatFloat(r, 'g', -1, 64), nil
 	case "XALGORIX_MEMORY_COMPRESSOR_TIMEOUT":
 		return strconv.Itoa(clampInt(parseIntSetting(value, 30), 5, 600)), nil
 	case "XALGORIX_MAX_ITERATIONS":


### PR DESCRIPTION
## Problem

Compaction was firing too early and degrading output quality. Two triggers, both window-agnostic:

1. A fixed **120K-token** budget (`XALGORIX_CONTEXT_COMPACT_TOKENS`, default 120000).
2. A fixed **100-message count** inside `pruneMessages()`, which was called **unconditionally at the end of every iteration**.

On a large-context model (e.g. a 1M-token window), compacting at 120K tokens / 100 messages throws away useful working context long before the window is anywhere near full.

## Fix

Compaction is now **window-relative** by default: it triggers at a configurable fraction of the model's context window, so the running context is only compacted once the window is genuinely filling up (~70–80%).

- **New settings:**
  - `XALGORIX_LLM_CONTEXT_WINDOW` — your model's total context window in tokens (default 128000). **Set this to your model's real window** (e.g. 1000000 for a 1M model).
  - `XALGORIX_CONTEXT_COMPACT_RATIO` — fraction of the window at which to compact (default 0.75, clamped 0.5–0.9).
- **`XALGORIX_CONTEXT_COMPACT_TOKENS` is now an optional override**, default `-1` (auto):
  - `< 0` → auto / window-relative (window × ratio),
  - `0` → disabled,
  - `> 0` → explicit absolute token budget (back-compat).
- `compactThresholdBytes()` resolves auto mode as `window × ratio × ~4 bytes/token`.
- `pruneMessages()` drops the fixed 100-message trigger for the same token-budget check (inlined — `msgMu` is already held). The end-of-iteration prune is now gated on `shouldPruneBeforeLLM()` instead of running every turn.

The last-resort `forcePruneMessages()` on a hard provider context-overflow (413) and the reasoning-loop recovery path are unchanged.

## Migration note

Existing deployments that explicitly saved `XALGORIX_CONTEXT_COMPACT_TOKENS=120000` will keep that absolute budget. To get the new behavior, set it back to `-1` (auto) and set `XALGORIX_LLM_CONTEXT_WINDOW` to the model's real window.

## Tests

`go build ./...` clean; `go test ./internal/agent ./internal/config ./internal/web` pass, including new auto/window-relative and ratio-clamp coverage.