### PR TITLE
fix(agent): decouple compaction from reasoning-loop recovery; detect later

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1006,20 +1006,15 @@ func (a *Agent) Run(targets []string, instruction string) {
 				a.emit(Event{Type: "finished", Content: detail, TotalTokens: tokenCount(), Aborted: true, AbortReason: reason})
 				return
 			}
-			// Reasoning-loop recovery: the hook asked for an aggressive
-			// context compaction to break a think-only loop. Collapse the
-			// message history into a digest BEFORE injecting the nudge so
-			// the focused "call a tool now" prompt lands in a clean window
-			// rather than on top of the noisy output that caused the loop.
-			// We intentionally do NOT reset NoToolCount here — the hook
-			// already incremented ReasoningLoopCompactions / DensityCompactions,
-			// and the count climbing toward NoToolAbortAt is what gives a
-			// model that ignores the compaction a bounded number of turns
-			// before the scan gives up.
-			if noToolResult.ForceCompact {
-				a.emit(Event{Type: "message", Content: "🧹 Reasoning loop detected — compacting context to refocus. The model stopped calling tools; collapsing old output into a digest and prompting a concrete next action.", TotalTokens: tokenCount()})
-				a.forcePruneMessages()
-			}
+			// Reasoning-loop recovery is NUDGE-ONLY: we inject a focused
+			// "resume and call a tool" prompt and let the model recover on
+			// its own. We deliberately do NOT compact the context here —
+			// compaction is a context-size concern, unrelated to reasoning
+			// loops, and collapsing the model's own working notes mid-thought
+			// tends to make a stall worse. Proactive size-based compaction
+			// still happens independently in the main loop (shouldPruneBeforeLLM).
+			// NoToolCount is not reset here; the count climbing is what drives
+			// the escalating nudges (and, in bounded mode, the eventual abort).
 			if noToolResult.Nudge != "" {
 				a.msgMu.Lock()
 				a.messages = append(a.messages, llm.Message{Role: "user", Content: noToolResult.Nudge})

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -124,30 +124,21 @@ type ScanState struct {
 	CumulativeRateLimitWait time.Duration
 
 	// Reasoning-loop recovery tracking. A "reasoning loop" is the model
-	// emitting think-only responses (or prose) with no tool calls. The
-	// consecutive counter (NoToolCount) is reset to 0 by OnHealthyResponse
-	// the instant the model makes one tool call — so a model that reasons
-	// for 10 turns then calls a tool once, repeatedly, never reaches the 15
-	// abort threshold and the scan runs for hours. The density counters
-	// below are NEVER reset, so they catch the non-consecutive pattern:
-	//
-	//   - ReasoningLoopCompactions: how many times we've force-compacted the
-	//     context to break a reasoning loop. Caps recovery attempts so a
-	//     model that simply won't act eventually aborts instead of looping
-	//     forever between compact + reset.
+	// emitting think-only responses (or prose) with no tool calls. Recovery is
+	// NUDGE-ONLY — we never compact the context to break a loop (compaction is
+	// a context-size concern, unrelated to reasoning loops). The consecutive
+	// counter (NoToolCount) is reset to 0 by OnHealthyResponse the instant the
+	// model makes one tool call. TotalNoToolResponses is NEVER reset, so the
+	// density safety net can still catch a non-consecutive pattern (a model
+	// that calls a tool just often enough to keep resetting NoToolCount).
 	//   - TotalNoToolResponses: every no-tool response since scan start.
-	//     Compared against TotalIterations to compute the reasoning ratio.
-	//   - DensityCompactions: compactions triggered by the density check
-	//     (distinct from the consecutive-count compactions) so the two
-	//     recovery paths don't double-compact on the same stall.
-	ReasoningLoopCompactions int
-	TotalNoToolResponses     int
-	DensityCompactions       int
+	//     Compared against total iterations to compute the reasoning ratio.
+	TotalNoToolResponses int
 
 	// NoToolAbortLimit is the consecutive no-tool-call count at which the scan
 	// force-stops (from config XALGORIX_NO_TOOL_ABORT_AT). 0 = never give up:
-	// the agent keeps nudging and periodically re-compacting so the model can
-	// fix its own malformed output and resume. Set from cfg when the agent
+	// the agent keeps nudging so the model can fix its own malformed output and
+	// resume. Set from cfg when the agent
 	// initializes ScanState; falls back to NoToolAbortAt when zero-valued only
 	// if the operator did not explicitly disable it (see abortLimit()).
 	NoToolAbortLimit int
@@ -203,14 +194,6 @@ type HookResult struct {
 	ForceSkip      bool   // skip current tool call
 	EmitMessage    string // emit to UI without injecting into conversation
 	CleanupBrowser bool   // signal to force-close browser
-	// ForceCompact signals the loop to aggressively compact the message
-	// history (forcePruneMessages) before injecting Nudge. Used by the
-	// reasoning-loop recovery path: a model stuck emitting think-only
-	// responses is far more likely to resume acting once the noisy
-	// context (raw tool output, loaded skill docs) is collapsed into a
-	// compact digest. The Nudge returned alongside it must be a focused
-	// "resume from here and call a tool" prompt, not a generic nudge.
-	ForceCompact bool
 }
 
 // ── Hook Registry ────────────────────────────────────────────────────────────
@@ -264,9 +247,6 @@ func (r *HookRegistry) Fire(event string, state *ScanState, args map[string]stri
 		if result.CleanupBrowser {
 			merged.CleanupBrowser = true
 		}
-		if result.ForceCompact {
-			merged.ForceCompact = true
-		}
 	}
 	return merged
 }
@@ -290,33 +270,35 @@ const (
 	BlockedCallSoftNudge = 3 // consecutive guard-blocked calls → soft corrective nudge
 	BlockedCallHardNudge = 6 // consecutive guard-blocked calls → hard "stop / pivot / finish" nudge
 
-	// ReasoningLoopCompactAt and the related thresholds govern reasoning-loop
-	// recovery. A reasoning loop is the model emitting think-only / prose
-	// responses with NO tool calls. The two recovery paths are:
+	// Reasoning-loop recovery is NUDGE-ONLY. A reasoning loop is the model
+	// emitting think-only / prose responses with NO tool call. We do NOT
+	// compact the context to break a loop — compaction is a context-size
+	// concern, unrelated to reasoning, and collapsing the model's own working
+	// notes mid-thought tends to make a stall worse rather than better. Instead
+	// we nudge the model to resume acting, escalating as the stall persists,
+	// and only abort as a last-resort safety net in bounded mode.
 	//
-	//   1. Consecutive: NoToolCount climbs to ReasoningLoopCompactAt, we
-	//      force-compact the context (collapsing noisy raw output + loaded
-	//      skill docs into a digest) and inject a focused "resume from here"
-	//      prompt. A second compact fires at ReasoningLoopCompactAt2. The
-	//      scan only aborts at NoToolAbortAt (15) if both compaction
-	//      attempts failed to break the loop.
+	// The thresholds are deliberately generous: a model may legitimately reason
+	// across several turns to work out a plan or repair its own malformed
+	// output, so we don't cry "loop" at the first few no-tool responses.
 	//
-	//   2. Density (non-consecutive): if the model makes an occasional
-	//      tool call — just often enough to reset NoToolCount — the
-	//      consecutive path never trips. ReasoningDensityMinResponses +
-	//      ReasoningDensityRatio catch this: once enough iterations have
-	//      elapsed, a high no-tool ratio (>60%) means the scan is burning
-	//      most of its turns reasoning; we compact once, and if the ratio
-	//      stays high we abort rather than running for hours.
-	ReasoningLoopCompactAt  = 6  // consecutive no-tool → 1st context compaction
-	ReasoningLoopCompactAt2 = 10 // consecutive no-tool → 2nd context compaction
-	NoToolAbortAt           = 15 // consecutive no-tool → force-stop scan
+	//   1. Consecutive: NoToolCount climbs. A gentle reminder fires at
+	//      NoToolSoftNudgeAt, a firm "resume and call a tool" nudge at
+	//      NoToolStrongNudgeAt (and every turn after). In bounded mode the scan
+	//      aborts at NoToolAbortAt; the default is "never give up" (abort
+	//      disabled), so it keeps nudging indefinitely.
+	//
+	//   2. Density (non-consecutive): if the model makes an occasional tool
+	//      call — just often enough to reset NoToolCount — the consecutive path
+	//      never trips. In BOUNDED mode only, a sustained high no-tool ratio
+	//      well past a warm-up window aborts rather than running for hours.
+	NoToolSoftNudgeAt   = 8  // consecutive no-tool → gentle "use tools" reminder
+	NoToolStrongNudgeAt = 16 // consecutive no-tool → firm "resume, call a tool NOW" nudge (re-fires every turn after)
+	NoToolAbortAt       = 30 // consecutive no-tool → force-stop scan (bounded mode only; default disabled)
 
-	ReasoningDensityMinResponses  = 20   // need ≥ this many no-tool responses before the density check applies
-	ReasoningDensityCompactRatio  = 0.6  // >60% no-tool responses → compact
-	ReasoningDensityAbortRatio    = 0.75 // >75% no-tool responses after a compact → abort
-	ReasoningDensityAbortMinIters = 40   // ...only once ≥40 iterations elapsed
-	MaxReasoningCompactions       = 2    // cap total recovery compactions (consecutive + density combined)
+	ReasoningDensityMinResponses  = 40   // need ≥ this many no-tool responses before the density safety net applies
+	ReasoningDensityAbortRatio    = 0.85 // > this fraction of no-tool responses …
+	ReasoningDensityAbortMinIters = 80   // … once ≥ this many iterations elapsed → abort (bounded mode only)
 )
 
 // noteBlockedToolCall records that a Gated_Tool call was rejected by a block
@@ -1309,37 +1291,36 @@ func hookEmptyResponseHandler(state *ScanState, args map[string]string) HookResu
 }
 
 // ── hookNoToolHandler ────────────────────────────────────────────────────────
-// Handles LLM responding without any tool calls. This is the single biggest
-// cause of failed scans: the model degrades into a "reasoning loop" — emitting
-// think-only or prose responses with no tool calls — and the scan force-stops.
+// Handles the LLM responding without any tool call — the model emitting
+// think-only or prose responses. Recovery is NUDGE-ONLY: we never compact the
+// context to break a loop (compaction is a context-size concern, unrelated to
+// reasoning, and collapsing the model's own working notes mid-thought tends to
+// make a stall worse). We also start gently and escalate slowly, because a
+// model may legitimately reason across several turns to plan or to repair its
+// own malformed output — treating that as a "loop" too early is harmful.
 //
-// Two recovery paths, both backed by CONTEXT COMPACTION (not just nudges):
+//  1. Consecutive — NoToolCount climbs. A gentle "use tools" reminder fires at
+//     NoToolSoftNudgeAt (8), a firm "resume and call a tool NOW" nudge at
+//     NoToolStrongNudgeAt (16) and every turn after. In BOUNDED mode the scan
+//     aborts at NoToolAbortAt (30); the default is "never give up" (abort
+//     disabled), so it keeps nudging indefinitely and never force-stops.
 //
-//  1. Consecutive — the model emits ReasoningLoopCompactAt (6) no-tool
-//     responses in a row. We force-compact the context (collapsing the
-//     raw tool output / loaded skill docs that likely triggered the loop
-//     into a structured digest) and inject a focused resume prompt. A
-//     second compaction fires at ReasoningLoopCompactAt2 (10). The scan
-//     only aborts at NoToolAbortAt (15) if both compactions failed.
-//
-//  2. Density (non-consecutive) — the model makes an occasional tool
-//     call, just often enough to reset the consecutive counter, so the
-//     consecutive path never trips and the scan runs for hours. Once
-//     enough no-tool responses have accumulated (ReasoningDensityMinResponses),
-//     a no-tool ratio above ReasoningDensityCompactRatio triggers a
-//     compaction; if the ratio stays above ReasoningDensityAbortRatio
-//     past ReasoningDensityAbortMinIters iterations, the scan aborts.
+//  2. Density (non-consecutive) — the model makes an occasional tool call,
+//     just often enough to reset the consecutive counter. In BOUNDED mode
+//     only, a sustained high no-tool ratio well past a warm-up window aborts
+//     rather than running for hours. Abort-only — no compaction.
 //
 // Special-cases model-side safety refusals (e.g. Gemini replying "Sorry, I
 // cannot fulfill your request to perform a security assessment..."). A
 // refusal is not a formatting problem, so the generic "use the XML format"
 // nudge does nothing — instead we re-assert the authorized-engagement
 // context, which reliably gets safety-tuned models back on task.
+
 // noToolAbortLimit returns the effective consecutive no-tool-call abort
-// threshold. A value <= 0 means "never abort" — the scan keeps nudging and
-// periodically re-compacting so the model can fix its own output and resume.
-// Uses the operator's configured value when set (so an explicit 0 disables the
-// abort); otherwise the NoToolAbortAt default.
+// threshold. A value <= 0 means "never abort" — the scan keeps nudging so the
+// model can fix its own output and resume. Uses the operator's configured
+// value when set (so an explicit 0 disables the abort); otherwise the
+// NoToolAbortAt default.
 func noToolAbortLimit(state *ScanState) int {
 	if state != nil && state.NoToolAbortConfigured {
 		return state.NoToolAbortLimit
@@ -1357,9 +1338,9 @@ func hookNoToolHandler(state *ScanState, args map[string]string) HookResult {
 		state.RefusalCount = 0
 	}
 
-	// abortAt <= 0 means "never give up": the scan keeps nudging + periodically
-	// re-compacting (below) so the model can fix its own malformed output and
-	// resume, bounded only by the other budgets (iterations/duration/tokens).
+	// abortAt <= 0 means "never give up": the scan keeps nudging so the model
+	// can fix its own malformed output and resume, bounded only by the other
+	// budgets (iterations/duration/tokens).
 	abortAt := noToolAbortLimit(state)
 	if abortAt > 0 && state.NoToolCount >= abortAt {
 		msg := fmt.Sprintf("⛔ Model returned %d consecutive responses with no tool call — it stopped taking actions (likely context flooded by a large tool output, or a reasoning loop). Force finishing.", abortAt)
@@ -1388,99 +1369,37 @@ Resume the assessment NOW by calling a tool. For example, to run a command:
 		}
 	}
 
-	// ── Density-based recovery (non-consecutive reasoning loops) ──
-	// Catches a model that makes occasional tool calls — enough to reset
-	// NoToolCount but not enough to make real progress — and would
-	// otherwise run for hours. The consecutive path only fires at
-	// NoToolCount >= 6, so a model that calls a tool every ~5 turns keeps
-	// NoToolCount ≤ 4 and the consecutive path NEVER trips. This path uses
-	// the cumulative (never-reset) counters so it sees the real picture.
-	totalCompactions := state.ReasoningLoopCompactions + state.DensityCompactions
-	if iters := state.Iteration + 1; iters > 0 &&
-		state.TotalNoToolResponses >= ReasoningDensityMinResponses {
-		ratio := float64(state.TotalNoToolResponses) / float64(iters)
-		// Abort once the density is sustained past the min-iteration gate,
-		// AFTER at least one recovery compaction has been attempted (so a
-		// genuinely slow-but-progressing scan gets a chance to recover first).
-		// We deliberately do NOT require totalCompactions >= MaxReasoningCompactions
-		// here — for the pure non-consecutive pattern the consecutive path can
-		// never supply a second compaction, so gating on it would make this
-		// abort unreachable (the exact 48-hour bug this path exists to catch).
-		if abortAt > 0 && ratio > ReasoningDensityAbortRatio && iters >= ReasoningDensityAbortMinIters &&
-			totalCompactions >= 1 {
-			return HookResult{
-				ForceSkip: true,
-				EmitMessage: fmt.Sprintf(
-					"⛔ Scan aborted: reasoning loop — %d of %d iterations (%.0f%%) produced no tool call after %d context compaction(s). The model is not making progress; switch model or lower reasoning effort.",
-					state.TotalNoToolResponses, iters, ratio*100, totalCompactions),
-			}
-		}
-		// Recovery: compact while we still have budget. Bound by the
-		// COMBINED total (consecutive + density) so the two paths share the
-		// MaxReasoningCompactions cap instead of each getting its own.
-		if ratio > ReasoningDensityCompactRatio &&
-			totalCompactions < MaxReasoningCompactions {
-			state.DensityCompactions++
-			return HookResult{
-				ForceCompact: true,
-				Nudge:        reasoningLoopResumePrompt(state, "density"),
+	// ── Density safety net (non-consecutive loops) — BOUNDED MODE ONLY ──
+	// Catches a model that makes an occasional tool call — enough to reset
+	// NoToolCount but not enough to make real progress — which the consecutive
+	// path never trips. Abort-only (no compaction), and only once the operator
+	// has opted into a hard abort AND the ratio has stayed high well past a
+	// generous warm-up window, so a genuinely slow-but-progressing scan is
+	// never cut short. Uses the cumulative (never-reset) counter.
+	if abortAt > 0 {
+		if iters := state.Iteration + 1; iters >= ReasoningDensityAbortMinIters &&
+			state.TotalNoToolResponses >= ReasoningDensityMinResponses {
+			ratio := float64(state.TotalNoToolResponses) / float64(iters)
+			if ratio > ReasoningDensityAbortRatio {
+				return HookResult{
+					ForceSkip: true,
+					EmitMessage: fmt.Sprintf(
+						"⛔ Scan aborted: reasoning loop — %d of %d iterations (%.0f%%) produced no tool call. The model is not making progress; switch model or lower reasoning effort.",
+						state.TotalNoToolResponses, iters, ratio*100),
+				}
 			}
 		}
 	}
 
-	// ── Never-give-up recovery (abort disabled) ──
-	// When the operator disabled the abort (abortAt <= 0), the two-shot
-	// compaction budget would leave a stuck model with nothing but nudges after
-	// count 10 — spinning instead of "fixing itself". Keep re-compacting on a
-	// fixed cadence (every ReasoningLoopCompactAt2 consecutive no-tool
-	// responses) so the model keeps getting a fresh, focused context to recover
-	// in, uncapped. This branch is unreachable in the default bounded mode.
-	if abortAt <= 0 && state.NoToolCount > 0 && state.NoToolCount%ReasoningLoopCompactAt2 == 0 {
-		state.ReasoningLoopCompactions++
-		return HookResult{
-			ForceCompact: true,
-			Nudge:        reasoningLoopResumePrompt(state, "consecutive"),
-		}
+	// ── Strong nudge: firm "resume and act" push once the stall is well
+	// established. Re-fires every turn after NoToolStrongNudgeAt so the model
+	// keeps getting pushed until it acts. Never compacts. ──
+	if state.NoToolCount >= NoToolStrongNudgeAt {
+		return HookResult{Nudge: reasoningLoopResumePrompt(state, "consecutive")}
 	}
 
-	// ── Consecutive recovery: compact the context to break the loop ──
-	// Guard by the COMBINED compaction total so a density compaction counts
-	// against the consecutive budget (and vice versa). Without this, a
-	// density compact (1) + two consecutive compacts (2) = 3 compactions,
-	// violating MaxReasoningCompactions.
-	// Second (later) consecutive compaction — fires at ReasoningLoopCompactAt2
-	// and ONLY once the first consecutive compaction has already been spent.
-	// Gating on ReasoningLoopCompactions (not merely the combined total) keeps
-	// the two compactions SPACED at their intended thresholds (6 and 10). The
-	// previous code gated only on totalCompactions, so the `>= ReasoningLoopCompactAt`
-	// block below stayed true at count 7 and fired the second compaction
-	// back-to-back at 6 and 7 — burning the whole budget before the model had
-	// any turns to recover, then leaving it un-helped from 8 until the abort at
-	// 15 (ReasoningLoopCompactAt2 was effectively dead).
-	if state.NoToolCount >= ReasoningLoopCompactAt2 &&
-		state.ReasoningLoopCompactions >= 1 &&
-		totalCompactions < MaxReasoningCompactions {
-		state.ReasoningLoopCompactions++
-		return HookResult{
-			ForceCompact: true,
-			Nudge:        reasoningLoopResumePrompt(state, "consecutive"),
-		}
-	}
-	// First consecutive compaction — fires once when the count first reaches
-	// ReasoningLoopCompactAt, and remains the only consecutive compaction until
-	// the count climbs to ReasoningLoopCompactAt2 (the `== 0` guard prevents it
-	// re-firing every turn between the two thresholds).
-	if state.NoToolCount >= ReasoningLoopCompactAt &&
-		state.ReasoningLoopCompactions == 0 &&
-		totalCompactions < MaxReasoningCompactions {
-		state.ReasoningLoopCompactions++
-		return HookResult{
-			ForceCompact: true,
-			Nudge:        reasoningLoopResumePrompt(state, "consecutive"),
-		}
-	}
-
-	if state.NoToolCount >= 3 {
+	// ── Soft nudge: gentle reminder to use tools. ──
+	if state.NoToolCount >= NoToolSoftNudgeAt {
 		return HookResult{
 			Nudge: `You MUST use tools to interact with the target. Do not just explain — take action NOW.
 
@@ -1504,17 +1423,17 @@ Call a tool NOW in your next response.`,
 }
 
 // reasoningLoopResumePrompt builds the focused "break out of the reasoning
-// loop" nudge injected alongside a context compaction. It is deliberately
-// short and action-oriented: the compaction already preserved a digest of
-// prior work + saved notes, so the prompt only needs to point the model at
-// the single most-likely next action and forbid more prose-only turns.
+// loop" nudge. It is deliberately short and action-oriented: your prior work
+// and saved notes are preserved in context, so the prompt only needs to point
+// the model at the single most-likely next action and forbid more prose-only
+// turns. It does NOT compact the context — the transcript is left intact.
 //
 // `trigger` is "consecutive" or "density" and only affects the framing line
 // so the operator-facing log / emitted message can distinguish the two paths.
 func reasoningLoopResumePrompt(state *ScanState, trigger string) string {
-	prefix := "⚠️ REASONING LOOP DETECTED — you have produced several responses with no tool call."
+	prefix := "⚠️ You have produced several responses with no tool call."
 	if trigger == "density" {
-		prefix = "⚠️ REASONING LOOP DETECTED — most of your recent responses produced no tool call."
+		prefix = "⚠️ Most of your recent responses produced no tool call."
 	}
 	// Surface a concrete next action when we have endpoint coverage data;
 	// otherwise keep it generic so the prompt never lies about state.
@@ -1522,7 +1441,7 @@ func reasoningLoopResumePrompt(state *ScanState, trigger string) string {
 	if n := len(state.EndpointsTested); n > 0 {
 		next = fmt.Sprintf("You have mapped %d endpoint(s). Pick one you have NOT tested for injection / IDOR / XSS and test it NOW.", n)
 	}
-	return prefix + ` The conversation context has just been COMPACTED — old tool output was collapsed into the digest above so you can focus.
+	return prefix + `
 
 STOP planning. STOP reasoning aloud. Your NEXT response MUST contain exactly one tool call. ` + next + `
 
@@ -1547,7 +1466,7 @@ Call a tool in your very next message. For example:
 //     context exhaustion / reasoning loop, not a target problem).
 func classifyNoToolAbort(state *ScanState) (reason, detail string) {
 	if state != nil && state.RefusalCount >= 3 {
-		return "llm_safety_refusal", "Agent stopped: the model repeatedly declined to run the assessment (safety refusal) across 15 responses. This is a model-side refusal, not a target or scanner issue — switch to a model that permits authorized security testing."
+		return "llm_safety_refusal", "Agent stopped: the model repeatedly declined to run the assessment (safety refusal). This is a model-side refusal, not a target or scanner issue — switch to a model that permits authorized security testing."
 	}
 	if state != nil && state.TotalNoToolResponses >= ReasoningDensityMinResponses {
 		iters := state.Iteration + 1
@@ -1555,12 +1474,13 @@ func classifyNoToolAbort(state *ScanState) (reason, detail string) {
 			ratio := float64(state.TotalNoToolResponses) / float64(iters)
 			if ratio > ReasoningDensityAbortRatio {
 				return "llm_reasoning_loop", fmt.Sprintf(
-					"Agent stopped: reasoning loop — %d of %d iterations (%.0f%%) produced no tool call after %d context compactions. The model spent most of its turns reasoning without acting. Lower the reasoning effort (XALGORIX_REASONING_EFFORT), switch to a less reasoning-heavy model, or reduce the amount of raw output fed back (grep/head instead of cat).",
-					state.TotalNoToolResponses, iters, ratio*100, state.ReasoningLoopCompactions+state.DensityCompactions)
+					"Agent stopped: reasoning loop — %d of %d iterations (%.0f%%) produced no tool call. The model spent most of its turns reasoning without acting. Lower the reasoning effort (XALGORIX_REASONING_EFFORT), switch to a less reasoning-heavy model, or reduce the amount of raw output fed back (grep/head instead of cat).",
+					state.TotalNoToolResponses, iters, ratio*100)
 			}
 		}
 	}
-	return "llm_no_tool_calls", "Agent stopped: the model returned 15 consecutive responses with NO tool call — it stopped taking actions. This is typically caused by a very large tool output flooding the context (e.g. dumping a whole JS bundle or page instead of grepping it) or a reasoning loop — not by the target being unscannable."
+	abortAt := noToolAbortLimit(state)
+	return "llm_no_tool_calls", fmt.Sprintf("Agent stopped: the model returned %d consecutive responses with NO tool call — it stopped taking actions. This is typically caused by a very large tool output flooding the context (e.g. dumping a whole JS bundle or page instead of grepping it) or a reasoning loop — not by the target being unscannable.", abortAt)
 }
 
 // isRefusal reports whether the model's text looks like a safety/ethics refusal

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -270,13 +270,14 @@ const (
 	BlockedCallSoftNudge = 3 // consecutive guard-blocked calls → soft corrective nudge
 	BlockedCallHardNudge = 6 // consecutive guard-blocked calls → hard "stop / pivot / finish" nudge
 
-	// Reasoning-loop recovery is NUDGE-ONLY. A reasoning loop is the model
-	// emitting think-only / prose responses with NO tool call. We do NOT
-	// compact the context to break a loop — compaction is a context-size
-	// concern, unrelated to reasoning, and collapsing the model's own working
-	// notes mid-thought tends to make a stall worse rather than better. Instead
-	// we nudge the model to resume acting, escalating as the stall persists,
-	// and only abort as a last-resort safety net in bounded mode.
+	// NoToolSoftNudgeAt and the related thresholds govern reasoning-loop
+	// recovery, which is NUDGE-ONLY. A reasoning loop is the model emitting
+	// think-only / prose responses with NO tool call. We do NOT compact the
+	// context to break a loop — compaction is a context-size concern, unrelated
+	// to reasoning, and collapsing the model's own working notes mid-thought
+	// tends to make a stall worse rather than better. Instead we nudge the
+	// model to resume acting, escalating as the stall persists, and only abort
+	// as a last-resort safety net in bounded mode.
 	//
 	// The thresholds are deliberately generous: a model may legitimately reason
 	// across several turns to work out a plan or repair its own malformed

--- a/internal/agent/reasoning_loop_test.go
+++ b/internal/agent/reasoning_loop_test.go
@@ -5,200 +5,147 @@ import (
 	"testing"
 )
 
-// hookNoToolHandler must trigger a context compaction (ForceCompact) at the
-// first consecutive threshold (6), not wait until the abort at 15. This is the
-// reasoning-loop recovery path — without it the scan force-stops on the exact
-// "llm_no_tool_calls" failure the reaper-search.biz scan hit.
-func TestNoToolHandlerCompactsBeforeAbort(t *testing.T) {
-	state := NewScanState()
+// Reasoning-loop recovery is NUDGE-ONLY: the handler must NEVER abort before
+// the (generous) consecutive threshold, and in bounded mode it force-stops only
+// once NoToolCount reaches NoToolAbortAt. Compaction is no longer coupled to
+// reasoning loops at all, so there is nothing to assert about it here.
+func TestNoToolHandler_NudgeThenBoundedAbort(t *testing.T) {
+	state := NewScanState() // abort enabled via the NoToolAbortAt default
 
-	// Iterations 1-5: plain nudges, no compaction yet.
-	for i := 0; i < ReasoningLoopCompactAt-1; i++ {
+	// Every response below the abort threshold must be a nudge, never a stop.
+	for state.NoToolCount < NoToolAbortAt-1 {
 		res := hookNoToolHandler(state, map[string]string{"response": "let me think"})
 		if res.ForceSkip {
-			t.Fatalf("iter %d: ForceSkip before the abort threshold", i)
+			t.Fatalf("ForceSkip at NoToolCount=%d, well before the abort threshold %d",
+				state.NoToolCount, NoToolAbortAt)
 		}
-		if res.ForceCompact {
-			t.Fatalf("iter %d: ForceCompact fired before ReasoningLoopCompactAt (%d)", i, ReasoningLoopCompactAt)
-		}
-		if state.ReasoningLoopCompactions != 0 {
-			t.Fatalf("iter %d: compaction counter incremented too early", i)
+		if res.Nudge == "" {
+			t.Fatalf("expected a nudge at NoToolCount=%d", state.NoToolCount)
 		}
 	}
 
-	// Iteration 6 (NoToolCount == ReasoningLoopCompactAt): first compaction.
-	res := hookNoToolHandler(state, map[string]string{"response": "let me think"})
-	if !res.ForceCompact {
-		t.Fatalf("NoToolCount=%d: expected ForceCompact, got %+v", state.NoToolCount, res)
-	}
-	if state.ReasoningLoopCompactions != 1 {
-		t.Fatalf("after first compact: ReasoningLoopCompactions=%d, want 1", state.ReasoningLoopCompactions)
-	}
-	if res.Nudge == "" {
-		t.Fatal("ForceCompact result must carry a focused resume nudge")
-	}
-	if !strings.Contains(res.Nudge, "tool call") && !strings.Contains(res.Nudge, "terminal_execute") {
-		t.Errorf("resume nudge should demand a tool call, got %q", res.Nudge)
-	}
-	if res.ForceSkip {
-		t.Fatal("first compaction must NOT abort the scan")
-	}
-
-	// The abort at 15 only fires after the compaction cap is exhausted. Walk
-	// the count up past the second compaction (at 10) and toward the abort.
-	// NoToolCount is NOT reset by the compaction, so it keeps climbing.
-	for i := state.NoToolCount; i < ReasoningLoopCompactAt2; i++ {
-		hookNoToolHandler(state, map[string]string{"response": "thinking"})
-	}
-	res = hookNoToolHandler(state, map[string]string{"response": "thinking"})
-	if state.ReasoningLoopCompactions > MaxReasoningCompactions {
-		t.Fatalf("ReasoningLoopCompactions=%d exceeds MaxReasoningCompactions=%d", state.ReasoningLoopCompactions, MaxReasoningCompactions)
-	}
-
-	// Drive to the abort. After MaxReasoningCompactions, ForceCompact stops
-	// firing and the count climbs to NoToolAbortAt, which ForceSkips.
-	for state.NoToolCount < NoToolAbortAt {
-		res = hookNoToolHandler(state, map[string]string{"response": "thinking"})
-	}
+	// The next response reaches NoToolAbortAt → force-stop (bounded mode).
+	res := hookNoToolHandler(state, map[string]string{"response": "thinking"})
 	if !res.ForceSkip {
-		t.Fatalf("NoToolCount=%d: expected ForceSkip (abort), got %+v", state.NoToolCount, res)
+		t.Fatalf("expected ForceSkip at NoToolCount=%d (abort=%d), got %+v",
+			state.NoToolCount, NoToolAbortAt, res)
+	}
+}
+
+// The nudge must escalate: a gentle reminder at NoToolSoftNudgeAt, and the firm
+// "resume and act" prompt at NoToolStrongNudgeAt — but not before.
+func TestNoToolHandler_NudgeEscalation(t *testing.T) {
+	state := NewScanState()
+
+	// Below the soft threshold: only the generic format reminder.
+	for state.NoToolCount < NoToolSoftNudgeAt-1 {
+		res := hookNoToolHandler(state, map[string]string{"response": "x"})
+		if strings.Contains(res.Nudge, "MUST use tools") || strings.Contains(res.Nudge, "STOP planning") {
+			t.Fatalf("escalated nudge fired too early at NoToolCount=%d: %q", state.NoToolCount, res.Nudge)
+		}
+	}
+
+	// At the soft threshold: the "MUST use tools" reminder.
+	res := hookNoToolHandler(state, map[string]string{"response": "x"}) // NoToolCount == NoToolSoftNudgeAt
+	if state.NoToolCount != NoToolSoftNudgeAt {
+		t.Fatalf("test setup: NoToolCount=%d, want %d", state.NoToolCount, NoToolSoftNudgeAt)
+	}
+	if !strings.Contains(res.Nudge, "MUST use tools") {
+		t.Fatalf("soft nudge missing at NoToolCount=%d: %q", state.NoToolCount, res.Nudge)
+	}
+
+	// At the strong threshold: the firm resume prompt.
+	for state.NoToolCount < NoToolStrongNudgeAt {
+		res = hookNoToolHandler(state, map[string]string{"response": "x"})
+	}
+	if !strings.Contains(res.Nudge, "STOP planning") {
+		t.Fatalf("strong resume nudge missing at NoToolCount=%d: %q", state.NoToolCount, res.Nudge)
+	}
+	// The strong nudge must NOT claim the context was compacted (it isn't).
+	if strings.Contains(res.Nudge, "COMPACTED") {
+		t.Errorf("resume nudge must not claim a compaction happened: %q", res.Nudge)
 	}
 }
 
 // With the abort disabled (XALGORIX_NO_TOOL_ABORT_AT=0), the handler must NEVER
-// ForceSkip on a no-tool loop, and must keep re-compacting on a cadence so the
-// model keeps getting fresh context to fix itself — not just spin on nudges.
+// ForceSkip on a no-tool loop — it keeps nudging indefinitely so the model can
+// fix its own output and resume. Neither the consecutive nor the density path
+// may abort.
 func TestNoToolHandler_AbortDisabledNeverGivesUp(t *testing.T) {
 	state := NewScanState()
 	state.NoToolAbortConfigured = true
 	state.NoToolAbortLimit = 0 // disabled → never give up
 
-	compactions := 0
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 300; i++ {
+		state.Iteration++
 		res := hookNoToolHandler(state, map[string]string{"response": "thinking, no tool"})
 		if res.ForceSkip {
-			t.Fatalf("ForceSkip fired at NoToolCount=%d with abort disabled", state.NoToolCount)
+			t.Fatalf("ForceSkip fired at NoToolCount=%d/Iteration=%d with abort disabled",
+				state.NoToolCount, state.Iteration)
 		}
-		if res.ForceCompact {
-			compactions++
+		if res.Nudge == "" {
+			t.Fatalf("expected a nudge at NoToolCount=%d with abort disabled", state.NoToolCount)
 		}
-	}
-	// Recurring compaction (every ReasoningLoopCompactAt2) — not capped at the
-	// default MaxReasoningCompactions=2 — so it keeps actively trying to recover.
-	if compactions <= MaxReasoningCompactions {
-		t.Errorf("expected recurring compactions with abort disabled, got %d (want > %d)", compactions, MaxReasoningCompactions)
 	}
 }
 
-// The two consecutive compactions must be SPACED at ReasoningLoopCompactAt (6)
-// and ReasoningLoopCompactAt2 (10) — NOT fired back-to-back at 6 and 7. The
-// back-to-back bug consumed the whole compaction budget immediately, leaving
-// the model un-helped from count 8 until the abort at 15 (observed on the
-// pentest-ground.com scan: compactions at iters 79/80, then dead air to 88).
-func TestNoToolHandlerCompactionsAreSpaced(t *testing.T) {
-	state := NewScanState()
+// The density safety net catches a NON-consecutive loop (occasional tool call
+// keeps resetting NoToolCount so the consecutive path never trips) — but only
+// in BOUNDED mode and only after a sustained high ratio past the warm-up gate.
+func TestNoToolHandler_DensityAbortBoundedOnly(t *testing.T) {
+	state := NewScanState() // abort enabled
 
-	compactedAt := []int{}
-	for state.NoToolCount < NoToolAbortAt {
-		res := hookNoToolHandler(state, map[string]string{"response": "let me think"})
-		if res.ForceCompact {
-			compactedAt = append(compactedAt, state.NoToolCount)
-		}
-		if res.ForceSkip {
-			break
-		}
-	}
-
-	if len(compactedAt) != 2 {
-		t.Fatalf("expected exactly 2 compactions, got %d at counts %v", len(compactedAt), compactedAt)
-	}
-	if compactedAt[0] != ReasoningLoopCompactAt {
-		t.Errorf("first compaction at count %d, want %d", compactedAt[0], ReasoningLoopCompactAt)
-	}
-	if compactedAt[1] != ReasoningLoopCompactAt2 {
-		t.Errorf("second compaction at count %d, want %d (spaced, not back-to-back at %d)",
-			compactedAt[1], ReasoningLoopCompactAt2, ReasoningLoopCompactAt+1)
-	}
-}
-
-// The density path must catch a model that makes occasional tool calls —
-// enough to reset the consecutive counter but not enough to make progress —
-// which would otherwise run for hours. This is the exact 48-hour pattern:
-// NoToolCount never reaches the consecutive threshold (6) so the consecutive
-// recovery never fires, and without the density abort the scan runs forever.
-func TestNoToolHandlerDensityRecovery(t *testing.T) {
-	state := NewScanState()
-
-	// Simulate the non-consecutive pattern: a tool call every 5 turns resets
-	// NoToolCount to ≤4, so the consecutive compact (needs ≥6) never fires.
-	// 4 of 5 turns are no-tool → ratio 0.8, which clears both the compact
-	// (>0.6) and abort (>0.75) thresholds. Drive enough iterations that the
-	// cumulative density crosses compact, then (after a compaction) abort.
-	var sawCompact, sawAbort bool
-	for i := 0; i < 200; i++ {
-		// Reset the consecutive counter on a tool call (mimics OnHealthyResponse).
-		if i%5 == 0 {
+	var sawAbort bool
+	for i := 0; i < 600; i++ {
+		state.Iteration++
+		// Simulate a tool call (healthy turn) every 12th iteration: resets the
+		// consecutive counter, keeping NoToolCount well below the consecutive
+		// thresholds while the cumulative no-tool ratio stays ~0.92 (> 0.85).
+		if i%12 == 0 {
 			state.NoToolCount = 0
-			state.Iteration++
 			continue
 		}
-		state.Iteration++
 		res := hookNoToolHandler(state, map[string]string{"response": "thinking"})
-
-		if res.ForceCompact {
-			sawCompact = true
-		}
 		if res.ForceSkip {
 			sawAbort = true
 			break
 		}
 	}
-	if !sawCompact {
-		t.Fatalf("density path never compacted — TotalNoToolResponses=%d Iteration=%d (recovery should fire at ratio > %.2f)",
-			state.TotalNoToolResponses, state.Iteration, ReasoningDensityCompactRatio)
-	}
 	if !sawAbort {
-		t.Fatalf("density abort never fired for a non-consecutive reasoning loop — NoToolCount stayed ≤%d so the consecutive path never tripped, and the density abort was expected to catch it. TotalNoToolResponses=%d Iteration=%d",
+		t.Fatalf("density abort never fired in bounded mode: NoToolCount=%d TotalNoTool=%d Iteration=%d",
 			state.NoToolCount, state.TotalNoToolResponses, state.Iteration)
 	}
-	// The abort reason must classify as the reasoning loop, not the generic stall.
-	reason, _ := classifyNoToolAbort(state)
-	if reason != "llm_reasoning_loop" {
+	if reason, _ := classifyNoToolAbort(state); reason != "llm_reasoning_loop" {
 		t.Errorf("classifyNoToolAbort reason = %q, want llm_reasoning_loop", reason)
 	}
 }
 
-// classifyNoToolAbort must report the density-based reasoning loop as a
-// distinct reason from the consecutive stall, so operators can tell a
-// "ran for hours making no progress" scan from a "flooded context" scan.
-func TestClassifyNoToolAbortDensityReason(t *testing.T) {
-	state := &ScanState{
-		NoToolCount:          NoToolAbortAt,
-		RefusalCount:         0,
-		TotalNoToolResponses: 60,
-		Iteration:            49, // 50 iters
-	}
-	reason, detail := classifyNoToolAbort(state)
-	if reason != "llm_reasoning_loop" {
-		t.Errorf("reason = %q, want llm_reasoning_loop", reason)
-	}
-	if !strings.Contains(strings.ToLower(detail), "reasoning loop") {
-		t.Errorf("density detail should mention reasoning loop, got %q", detail)
+// The same non-consecutive pattern must NOT abort when the operator disabled
+// the hard abort — the density net is a bounded-mode-only safety valve.
+func TestNoToolHandler_DensityNoAbortWhenUnbounded(t *testing.T) {
+	state := NewScanState()
+	state.NoToolAbortConfigured = true
+	state.NoToolAbortLimit = 0 // disabled
+
+	for i := 0; i < 600; i++ {
+		state.Iteration++
+		if i%12 == 0 {
+			state.NoToolCount = 0
+			continue
+		}
+		if res := hookNoToolHandler(state, map[string]string{"response": "thinking"}); res.ForceSkip {
+			t.Fatalf("density abort fired with abort disabled at Iteration=%d", state.Iteration)
+		}
 	}
 }
 
-// A safety refusal must still take priority over both recovery paths.
-func TestNoToolHandlerRefusalPriority(t *testing.T) {
+// A safety refusal must take priority over the recovery nudges.
+func TestNoToolHandler_RefusalPriority(t *testing.T) {
 	state := NewScanState()
-	// Three refusals → RefusalCount climbs; the authorization nudge must fire,
-	// not a compaction or abort.
 	for i := 0; i < 3; i++ {
 		res := hookNoToolHandler(state, map[string]string{"response": "I cannot fulfill this request"})
 		if res.ForceSkip {
-			t.Fatal("refusal should nudge, not abort, before the 15 threshold")
-		}
-		if res.ForceCompact {
-			t.Fatal("refusal should not trigger compaction")
+			t.Fatal("refusal should nudge, not abort, this early")
 		}
 		if !strings.Contains(res.Nudge, "AUTHORIZED") {
 			t.Errorf("refusal nudge should re-assert authorization, got %q", res.Nudge)
@@ -206,5 +153,28 @@ func TestNoToolHandlerRefusalPriority(t *testing.T) {
 	}
 	if state.RefusalCount != 3 {
 		t.Errorf("RefusalCount=%d, want 3", state.RefusalCount)
+	}
+}
+
+// classifyNoToolAbort must distinguish the density reasoning loop, a safety
+// refusal, and the generic consecutive stall.
+func TestClassifyNoToolAbort_Reasons(t *testing.T) {
+	// Sustained non-consecutive loop → reasoning loop.
+	dens := &ScanState{TotalNoToolResponses: 90, Iteration: 99} // 100 iters, ratio 0.9
+	if reason, detail := classifyNoToolAbort(dens); reason != "llm_reasoning_loop" ||
+		!strings.Contains(strings.ToLower(detail), "reasoning loop") {
+		t.Errorf("density: reason=%q detail=%q, want llm_reasoning_loop", reason, detail)
+	}
+
+	// Repeated safety refusal → refusal.
+	ref := &ScanState{RefusalCount: 3}
+	if reason, _ := classifyNoToolAbort(ref); reason != "llm_safety_refusal" {
+		t.Errorf("refusal: reason=%q, want llm_safety_refusal", reason)
+	}
+
+	// Short consecutive stall → generic no-tool-calls.
+	stall := &ScanState{TotalNoToolResponses: 5, Iteration: 5}
+	if reason, _ := classifyNoToolAbort(stall); reason != "llm_no_tool_calls" {
+		t.Errorf("stall: reason=%q, want llm_no_tool_calls", reason)
 	}
 }


### PR DESCRIPTION
## Problem

Two issues with reasoning-loop handling:

1. **Detection triggered too early.** A model may legitimately reason across several turns to work out a plan or repair its own malformed output. Treating that as a "loop" after just 3–6 no-tool responses punished normal behavior and interrupted the model mid-solve.
2. **Compaction was coupled to reasoning loops.** On a no-tool stall the handler force-compacted the transcript to "break the loop." But compaction is a context-*size* concern, unrelated to reasoning — and collapsing the model's own working notes mid-thought often made the stall worse, not better.

## Fix

Reasoning-loop recovery is now **nudge-only**, and detection triggers much later.

**Decouple compaction** (`hooks.go`, `agent.go`):
- Remove all `ForceCompact` plumbing — the `HookResult` field, the merge, and the agent-loop force-prune on no-tool responses.
- Proactive size-based compaction still runs independently via the window-relative path (`shouldPruneBeforeLLM`, #327). Hard provider-overflow (413) recovery is unchanged.
- Strip the "the context has just been COMPACTED" claim from the resume prompt (it no longer compacts).

**Trigger later, nudge-only:**
- Soft "use tools" reminder at `NoToolSoftNudgeAt = 8` (was 3).
- Firm "resume and call a tool NOW" nudge at `NoToolStrongNudgeAt = 16`, re-firing every turn after.
- Bounded-mode abort at `NoToolAbortAt = 30` (was 15). Default remains **never-give-up** (abort disabled) — it just keeps nudging.
- Density safety net is **abort-only** and **bounded-mode-only**, with a much wider warm-up: ≥ 40 no-tool responses, ratio > 0.85, ≥ 80 iterations (was 20 / 0.75 / 40, and it used to compact).
- Drop the now-unused `ScanState.ReasoningLoopCompactions` / `DensityCompactions` counters.

## Tests

`go build ./...` clean; `go test ./internal/agent` passes. Reasoning-loop tests rewritten for nudge-only behavior (escalation thresholds, never-give-up, bounded density abort, refusal priority, abort classification).