### PR TITLE
fix(agent): add loop limit ceilings and sanitize internal LLM instruc…

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1001,9 +1001,8 @@ func (a *Agent) Run(targets []string, instruction string) {
 		if len(toolCalls) == 0 {
 			noToolResult := a.hooks.Fire(OnNoToolResponse, a.state, map[string]string{"response": cleanText})
 			if noToolResult.ForceSkip {
-				reason, detail := classifyNoToolAbort(a.state)
-				a.emit(Event{Type: "error", Content: noToolResult.EmitMessage, TotalTokens: tokenCount()})
-				a.emit(Event{Type: "finished", Content: detail, TotalTokens: tokenCount(), Aborted: true, AbortReason: reason})
+				reason, _ := classifyNoToolAbort(a.state)
+				a.emit(Event{Type: "finished", Content: "Scan execution reached automated safety boundaries", TotalTokens: tokenCount(), Aborted: true, AbortReason: reason})
 				return
 			}
 			// Reasoning-loop recovery is NUDGE-ONLY: we inject a focused
@@ -1105,7 +1104,10 @@ func (a *Agent) Run(targets []string, instruction string) {
 			// ── Hook: OnStuckCheck (nudge/force-skip based on stuck counters) ──
 			stuckResult := a.hooks.Fire(OnStuckCheck, a.state, toolArgs)
 			if stuckResult.EmitMessage != "" {
-				a.emit(Event{Type: "error", Content: stuckResult.EmitMessage, TotalTokens: tokenCount()})
+				if strings.Contains(stuckResult.EmitMessage, "Force finishing") || strings.Contains(stuckResult.EmitMessage, "Loop limit reached") {
+					a.emit(Event{Type: "finished", Content: "Scan execution reached automated safety boundaries", TotalTokens: tokenCount(), Aborted: true, AbortReason: "stuck_loop_limit"})
+					return
+				}
 			}
 			if stuckResult.Nudge != "" {
 				a.msgMu.Lock()

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -97,11 +97,14 @@ type ScanState struct {
 	// browser/search stuck logic, so it cannot conflict with StuckDomain.
 	// These counters are NOT reset by OnHealthyResponse: a "healthy" response
 	// that re-issues the same call is exactly the loop we want to catch.
-	LastToolName          string
-	LastToolArgsHash      string
-	ConsecutiveSameCall   int // same (tool, normalized args) called back-to-back
-	LastResultFP          string
-	ConsecutiveSameResult int // same result-output fingerprint back-to-back
+	LastToolName                string
+	LastToolArgsHash            string
+	ConsecutiveSameCall         int // same (tool, normalized args) called back-to-back
+	ConsecutiveSameCallNudges   int // consecutive repeat-call nudges without a different call
+	LastResultFP                string
+	ConsecutiveSameResult       int // same result-output fingerprint back-to-back
+	ConsecutiveSameResultNudges int // consecutive repeat-result nudges without a different result
+	ConsecutiveNoOpCalls        int // consecutive trivial/no-op terminal calls (e.g. echo done/ok/a, pwd)
 
 	// Blocked-call loop detection. The three block guards (activity policy,
 	// phase restriction, out-of-scope) short-circuit the dispatch BEFORE the
@@ -794,11 +797,36 @@ func hookStuckTracker(state *ScanState, args map[string]string) HookResult {
 				state.LastToolName = toolName
 				state.LastToolArgsHash = argsHash
 				state.ConsecutiveSameCall = 1
+				state.ConsecutiveSameCallNudges = 0
+			}
+
+			if toolName == "terminal_execute" {
+				if isTrivialCommand(args["command"]) {
+					state.ConsecutiveNoOpCalls++
+				} else {
+					state.ConsecutiveNoOpCalls = 0
+				}
+			} else {
+				state.ConsecutiveNoOpCalls = 0
 			}
 		}
 	}
 
 	return HookResult{}
+}
+
+func isTrivialCommand(cmd string) bool {
+	c := strings.TrimSpace(strings.ToLower(cmd))
+	if c == "pwd" || c == "whoami" || c == "true" || c == "echo" {
+		return true
+	}
+	if strings.HasPrefix(c, "echo ") {
+		arg := strings.Trim(strings.TrimPrefix(c, "echo "), "\"' ")
+		if len(arg) <= 10 && !strings.ContainsAny(arg, "|&;$><`") {
+			return true
+		}
+	}
+	return false
 }
 
 // ── hookResultRepeatTracker ──────────────────────────────────────────────────
@@ -820,6 +848,7 @@ func hookResultRepeatTracker(state *ScanState, args map[string]string) HookResul
 	} else {
 		state.LastResultFP = fp
 		state.ConsecutiveSameResult = 1
+		state.ConsecutiveSameResultNudges = 0
 	}
 	return HookResult{}
 }
@@ -832,6 +861,20 @@ func hookStuckNudge(state *ScanState, args map[string]string) HookResult {
 		return HookResult{}
 	}
 
+	// ── Trivial / No-Op command loop ──
+	if state.ConsecutiveNoOpCalls >= 8 {
+		return HookResult{
+			ForceSkip:   true,
+			EmitMessage: fmt.Sprintf("⛔ Loop limit reached: Agent executed %d consecutive no-op echo/dummy commands without taking real testing action. Force finishing to prevent infinite loop.", state.ConsecutiveNoOpCalls),
+		}
+	}
+	if state.ConsecutiveNoOpCalls >= 3 {
+		return HookResult{
+			Nudge:     fmt.Sprintf("⚠️ NO-OP COMMAND DETECTED: You have executed %d trivial/no-op commands in a row (e.g. echo/pwd). Do NOT run dummy commands — take real security testing action or call finish.", state.ConsecutiveNoOpCalls),
+			ForceSkip: true,
+		}
+	}
+
 	// ── Repeated identical tool call (issue #158) ──
 	// The agent re-issued the same tool with the same args across consecutive
 	// iterations. This is never productive — repeating an identical action
@@ -839,6 +882,13 @@ func hookStuckNudge(state *ScanState, args map[string]string) HookResult {
 	// redundant call. Checked BEFORE the browser hard-limit so a terminal/
 	// http/other-tool loop is caught regardless of StuckIterations.
 	if state.ConsecutiveSameCall >= RepeatCallSoftNudge {
+		state.ConsecutiveSameCallNudges++
+		if state.ConsecutiveSameCallNudges >= 4 {
+			return HookResult{
+				ForceSkip:   true,
+				EmitMessage: fmt.Sprintf("⛔ Loop limit reached: Agent repeatedly re-issued identical %q call %d times despite warnings. Force finishing scan to prevent infinite loop.", state.LastToolName, state.ConsecutiveSameCallNudges),
+			}
+		}
 		hard := state.ConsecutiveSameCall >= RepeatCallHardSkip
 		verb := "repeated"
 		if hard {
@@ -853,8 +903,6 @@ DO NOT call %q with those same arguments again. Instead:
 
 Your next tool call MUST differ from the last one.`, verb, state.LastToolName, state.ConsecutiveSameCall, state.LastToolName)
 
-		// Reset so the nudge doesn't fire every iteration; a new identical
-		// run will re-accumulate.
 		state.ConsecutiveSameCall = 0
 		// LLM-only: this is an instruction TO the model (it also rides on
 		// Nudge, which is what steers the conversation). Do NOT emit it to
@@ -869,6 +917,13 @@ Your next tool call MUST differ from the last one.`, verb, state.LastToolName, s
 	// Args vary but the result is byte-identical several times in a row — the
 	// agent is spinning without progress. Force a pivot.
 	if state.ConsecutiveSameResult >= RepeatResultHardSkip {
+		state.ConsecutiveSameResultNudges++
+		if state.ConsecutiveSameResultNudges >= 4 {
+			return HookResult{
+				ForceSkip:   true,
+				EmitMessage: fmt.Sprintf("⛔ Loop limit reached: Agent tool calls produced byte-identical output %d times despite warnings. Force finishing scan to prevent infinite loop.", state.ConsecutiveSameResultNudges),
+			}
+		}
 		msg := fmt.Sprintf(`⛔ NO PROGRESS: Your last %d tool calls produced byte-identical output. You are looping without making progress.
 
 Change your approach: target a different endpoint, use a different payload/technique, or consult a skill (read_skill). If this avenue is exhausted, add_note your findings and move on.

--- a/internal/agent/hooks_test.go
+++ b/internal/agent/hooks_test.go
@@ -1001,3 +1001,52 @@ func TestRepeatDetector_ResetOnSuccessLeavesRepeatCounters(t *testing.T) {
 		t.Error("ConsecutiveErrors/NoToolCount should be reset by OnHealthyResponse")
 	}
 }
+
+func TestRepeatDetector_CeilingAbortsLoop(t *testing.T) {
+	state := NewScanState()
+	args := map[string]string{"tool_name": "terminal_execute", "command": "curl -sk https://example.com/api"}
+
+	var finalMessage string
+	for i := 0; i < 25; i++ {
+		hookStuckTracker(state, args)
+		res := hookStuckNudge(state, args)
+		if res.EmitMessage != "" {
+			finalMessage = res.EmitMessage
+			break
+		}
+	}
+
+
+	if finalMessage == "" || !strings.Contains(finalMessage, "Loop limit reached") {
+		t.Fatalf("expected loop limit abort message, got: %q", finalMessage)
+	}
+}
+
+func TestTrivialNoOpCommand_LoopDetector(t *testing.T) {
+	state := NewScanState()
+
+	// Initial no-op calls should trigger a nudge at 3
+	for i := 1; i <= 3; i++ {
+		hookStuckTracker(state, map[string]string{"tool_name": "terminal_execute", "command": "echo done"})
+	}
+	res := hookStuckNudge(state, map[string]string{"tool_name": "terminal_execute", "command": "echo done"})
+	if !res.ForceSkip || !strings.Contains(res.Nudge, "NO-OP COMMAND DETECTED") {
+		t.Fatalf("expected NO-OP COMMAND DETECTED nudge, got: %+v", res)
+	}
+
+	// Sustained no-op calls should trigger an abort at 8
+	var abortMessage string
+	for i := 4; i <= 8; i++ {
+		hookStuckTracker(state, map[string]string{"tool_name": "terminal_execute", "command": fmt.Sprintf("echo %d", i)})
+		nudge := hookStuckNudge(state, map[string]string{"tool_name": "terminal_execute", "command": fmt.Sprintf("echo %d", i)})
+		if nudge.EmitMessage != "" {
+			abortMessage = nudge.EmitMessage
+			break
+		}
+	}
+
+	if abortMessage == "" || !strings.Contains(abortMessage, "Loop limit reached") {
+		t.Fatalf("expected Loop limit reached for no-ops, got %q", abortMessage)
+	}
+}
+

--- a/webui/src/components/live-feed.tsx
+++ b/webui/src/components/live-feed.tsx
@@ -60,8 +60,29 @@ function matchFilter(e: FeedEvent, f: FeedFilter): boolean {
     case "llm":
       return t === "llm" || t === "token" || t === "llm_output";
     default:
+      if (isInternalLLMInstruction(e.content || e.error || e.output)) {
+        return false;
+      }
       return true;
   }
+}
+
+function isInternalLLMInstruction(text?: string | null): boolean {
+  if (!text) return false;
+  const t = text.toLowerCase();
+  return (
+    t.includes("authorization reminder") ||
+    t.includes("do not call") ||
+    t.includes("your next tool call must") ||
+    t.includes("must use tools") ||
+    t.includes("repeated call:") ||
+    t.includes("no progress:") ||
+    t.includes("pivot required:") ||
+    t.includes("force finishing") ||
+    t.includes("loop limit reached") ||
+    t.includes("consecutive responses with no tool call") ||
+    t.includes("consecutive empty responses")
+  );
 }
 
 const TYPE_COLOR: Record<string, string> = {


### PR DESCRIPTION
…tions from UI feed

<!--
Thanks for contributing to Xalgorix! Please fill this out so we can review quickly.
`main` is branch-protected — PRs are the only way in. CI runs make lint,
golangci-lint, go vet, and the test suite on every PR.
-->

## What & why

<!-- What does this change and why? Link the issue it addresses. -->

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Refactor / internal
- [ ] Other:

## How was it tested?

<!-- Commands you ran, new tests added, manual verification. -->

- [ ] `make lint` passes
- [ ] `golangci-lint run --config .golangci.yml ./...` passes
- [ ] `go test ./...` passes
- [ ] Added/updated tests for the change

## Checklist

- [ ] I read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md).
- [ ] The tree is `gofmt`-clean.
- [ ] I updated docs (`README`, `docs/`, help text) if behavior changed.
- [ ] This does not weaken a security control (scope guard, verifier, false-positive gate) without explicit discussion.
- [ ] For engine behavior changes: I noted any impact on scan findings/severity.
