### PR TITLE
fix(agent): allow finish after 3 attempts to prevent gatekeeper deadlocks

### DIFF
--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -1071,6 +1071,13 @@ func hookTechDetector(state *ScanState, args map[string]string) HookResult {
 func hookFinishGatekeeper(state *ScanState, args map[string]string) HookResult {
 	state.FinishAttempts++
 
+	// Allow finish if the agent has repeatedly attempted to finish (>= 3 attempts)
+	// to prevent infinite finish-rejection deadlocks when the model refuses or is unable
+	// to execute further commands.
+	if state.FinishAttempts >= 3 {
+		return HookResult{}
+	}
+
 	// Discovery mode (Phase 1 enumeration): allow finish after minimum work
 	if state.DiscoveryMode {
 		if state.TerminalCalls < 3 {

--- a/internal/agent/hooks_test.go
+++ b/internal/agent/hooks_test.go
@@ -334,6 +334,28 @@ func TestFinishGatekeeper_BlocksLowCommands(t *testing.T) {
 	}
 }
 
+func TestFinishGatekeeper_AllowsAfterRepeatedAttempts(t *testing.T) {
+	state := NewScanState()
+	state.Iteration = 10
+	state.TerminalCalls = 2 // normally blocked (< 5)
+
+	// First two attempts should block
+	res1 := hookFinishGatekeeper(state, nil)
+	if !res1.Block {
+		t.Error("Attempt 1 should block")
+	}
+	res2 := hookFinishGatekeeper(state, nil)
+	if !res2.Block {
+		t.Error("Attempt 2 should block")
+	}
+
+	// 3rd attempt should be allowed to prevent infinite deadlock
+	res3 := hookFinishGatekeeper(state, nil)
+	if res3.Block {
+		t.Error("Attempt 3 should be allowed to prevent deadlock loop")
+	}
+}
+
 func TestFinishGatekeeper_BlocksNoRecon(t *testing.T) {
 	state := NewScanState()
 	state.Iteration = 10


### PR DESCRIPTION
Bypasses finish gatekeeper block when state.FinishAttempts >= 3 to prevent infinite finish rejection deadlocks.