### PR TITLE
fix(config): default NoToolAbortAt to 30 to prevent infinite reasoning loop spins

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -326,7 +326,7 @@ func load() *Config {
 		legacyCWD:           cwd,
 		DisableBrowser:      envOrBool("XALGORIX_DISABLE_BROWSER", false),
 		MaxIterations:       envOrInt("XALGORIX_MAX_ITERATIONS", 0),
-		NoToolAbortAt:       envOrInt("XALGORIX_NO_TOOL_ABORT_AT", 0),
+		NoToolAbortAt:       envOrInt("XALGORIX_NO_TOOL_ABORT_AT", 30),
 		TargetAuth:          envOr("XALGORIX_TARGET_AUTH", ""),
 		TargetAuthSecondary: envOr("XALGORIX_TARGET_AUTH_B", ""),
 		OOBPublicURL:        envOr("XALGORIX_OOB_PUBLIC_URL", ""),


### PR DESCRIPTION
Sets default NoToolAbortAt to 30 (from 0/disabled) so models stuck in reasoning loops outputting no tool calls for 30 consecutive iterations are automatically force-finished rather than spinning endlessly.