### PR TITLE
fix(web): prevent stale running in-memory instance from overwriting failed disk scan status

### DIFF
--- a/internal/web/scan_query.go
+++ b/internal/web/scan_query.go
@@ -382,6 +382,15 @@ func isCompletedScanStatus(status string) bool {
 	}
 }
 
+func isFinalScanStatus(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "finished", "completed", "failed":
+		return true
+	default:
+		return false
+	}
+}
+
 func isTerminalScanStatus(status string) bool {
 	switch strings.ToLower(strings.TrimSpace(status)) {
 	case "finished", "completed", "stopped", "failed":
@@ -463,8 +472,8 @@ func (s *Server) applyInstanceSnapshot(rec *ScanRecord, includeEvents bool) {
 	// still win for those (see TestApplyInstanceSnapshotDoesNotErasePersistedResumeData).
 	// But a completed scan is done forever: a stale in-memory instance left
 	// after a restart/auto-resume must not downgrade it back to "running".
-	if isCompletedScanStatus(rec.Status) && !isCompletedScanStatus(snapshot.Status) {
-		log.Printf("[scan] %s (instance %s): kept completed disk status %q over stale in-memory instance status %q — not downgrading a finished scan to running",
+	if isFinalScanStatus(rec.Status) && !isFinalScanStatus(snapshot.Status) {
+		log.Printf("[scan] %s (instance %s): kept final disk status %q over stale in-memory instance status %q — not downgrading a final scan to running",
 			rec.ID, rec.InstanceID, rec.Status, snapshot.Status)
 	} else {
 		rec.Status = snapshot.Status

--- a/internal/web/scan_snapshot_test.go
+++ b/internal/web/scan_snapshot_test.go
@@ -14,14 +14,16 @@ func TestApplyInstanceSnapshot_KeepsTerminalOverStaleRunning(t *testing.T) {
 	s.instances["inst-crowd"] = &ScanInstance{ID: "inst-crowd", Status: "running", CurrentPhase: 11}
 	s.instancesMu.Unlock()
 
-	rec := &ScanRecord{ID: "scan-crowd", InstanceID: "inst-crowd", Status: "completed", CurrentPhase: 22}
-	s.applyInstanceSnapshot(rec, false)
+	for _, status := range []string{"completed", "finished", "failed"} {
+		rec := &ScanRecord{ID: "scan-crowd", InstanceID: "inst-crowd", Status: status, CurrentPhase: 22}
+		s.applyInstanceSnapshot(rec, false)
 
-	if rec.Status != "completed" {
-		t.Fatalf("terminal status was downgraded to %q by a stale running instance", rec.Status)
-	}
-	if rec.CurrentPhase != 22 {
-		t.Errorf("phase regressed from 22 to %d", rec.CurrentPhase)
+		if rec.Status != status {
+			t.Fatalf("terminal status %q was downgraded to %q by a stale running instance", status, rec.Status)
+		}
+		if rec.CurrentPhase != 22 {
+			t.Errorf("phase regressed from 22 to %d", rec.CurrentPhase)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes status desync where GET /api/scans/{id} restored a stale in-memory 'running' status over a scan that was already marked 'failed' on disk, causing SaaS to show dead scans as running.