### PR TITLE
feat(agent): increase finish rejection attempt limit to 15

### DIFF
--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -1071,10 +1071,10 @@ func hookTechDetector(state *ScanState, args map[string]string) HookResult {
 func hookFinishGatekeeper(state *ScanState, args map[string]string) HookResult {
 	state.FinishAttempts++
 
-	// Allow finish if the agent has repeatedly attempted to finish (>= 3 attempts)
+	// Allow finish if the agent has repeatedly attempted to finish (>= 16 attempts, i.e. rejected 15 times)
 	// to prevent infinite finish-rejection deadlocks when the model refuses or is unable
 	// to execute further commands.
-	if state.FinishAttempts >= 3 {
+	if state.FinishAttempts >= 16 {
 		return HookResult{}
 	}
 
@@ -1207,7 +1207,7 @@ func hookFinishGatekeeper(state *ScanState, args map[string]string) HookResult {
 	// Matches the system prompt: "Minimum 50 iterations for a thorough assessment"
 	// Only applies to large surface areas (> 15 endpoints) or when depth is low.
 	if iter < 50 {
-		if state.FinishAttempts <= 2 {
+		if state.FinishAttempts <= 15 {
 			scannerNote := ""
 			if !state.ScannerUsed {
 				scannerNote = "\n- You haven't used any automated scanners (nuclei/ffuf) yet — consider running them on promising endpoints"

--- a/internal/agent/hooks_test.go
+++ b/internal/agent/hooks_test.go
@@ -339,20 +339,18 @@ func TestFinishGatekeeper_AllowsAfterRepeatedAttempts(t *testing.T) {
 	state.Iteration = 10
 	state.TerminalCalls = 2 // normally blocked (< 5)
 
-	// First two attempts should block
-	res1 := hookFinishGatekeeper(state, nil)
-	if !res1.Block {
-		t.Error("Attempt 1 should block")
-	}
-	res2 := hookFinishGatekeeper(state, nil)
-	if !res2.Block {
-		t.Error("Attempt 2 should block")
+	// First 15 attempts should block
+	for i := 1; i <= 15; i++ {
+		res := hookFinishGatekeeper(state, nil)
+		if !res.Block {
+			t.Errorf("Attempt %d should block", i)
+		}
 	}
 
-	// 3rd attempt should be allowed to prevent infinite deadlock
-	res3 := hookFinishGatekeeper(state, nil)
-	if res3.Block {
-		t.Error("Attempt 3 should be allowed to prevent deadlock loop")
+	// 16th attempt should be allowed to prevent infinite deadlock
+	res16 := hookFinishGatekeeper(state, nil)
+	if res16.Block {
+		t.Error("Attempt 16 should be allowed to prevent deadlock loop")
 	}
 }
 


### PR DESCRIPTION
Increases the finish attempt gatekeeper threshold so the agent's finish calls are rejected at least 15 times before allowing a deadlock bypass, enforcing deeper testing coverage.