### PR TITLE
feat(config): make max finish rejections configurable via XALGORIX_MAX_FINISH_REJECTIONS

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -719,6 +719,7 @@ func (a *Agent) Run(targets []string, instruction string) {
 		// Thread the configurable no-tool abort threshold (0 = never give up).
 		a.state.NoToolAbortLimit = a.cfg.NoToolAbortAt
 		a.state.NoToolAbortConfigured = true
+		a.state.MaxFinishRejections = a.cfg.MaxFinishRejections
 	}
 	a.state.ScanContextID = a.scanCtx.ID
 	a.state.DiscoveryMode = a.discoveryMode

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -50,6 +50,7 @@ type ScanState struct {
 	ReconDone                  bool
 	ScannerUsed                bool
 	FinishAttempts             int
+	MaxFinishRejections        int
 	DiscoveryMode              bool
 	ReconOnlyMode              bool
 	AllowedPhases              []int
@@ -1071,10 +1072,14 @@ func hookTechDetector(state *ScanState, args map[string]string) HookResult {
 func hookFinishGatekeeper(state *ScanState, args map[string]string) HookResult {
 	state.FinishAttempts++
 
-	// Allow finish if the agent has repeatedly attempted to finish (>= 16 attempts, i.e. rejected 15 times)
+	// Allow finish if the agent has repeatedly attempted to finish (>= MaxFinishRejections + 1 attempts)
 	// to prevent infinite finish-rejection deadlocks when the model refuses or is unable
 	// to execute further commands.
-	if state.FinishAttempts >= 16 {
+	maxRejections := state.MaxFinishRejections
+	if maxRejections <= 0 {
+		maxRejections = 15
+	}
+	if state.FinishAttempts > maxRejections {
 		return HookResult{}
 	}
 
@@ -1207,7 +1212,7 @@ func hookFinishGatekeeper(state *ScanState, args map[string]string) HookResult {
 	// Matches the system prompt: "Minimum 50 iterations for a thorough assessment"
 	// Only applies to large surface areas (> 15 endpoints) or when depth is low.
 	if iter < 50 {
-		if state.FinishAttempts <= 15 {
+		if state.FinishAttempts <= maxRejections {
 			scannerNote := ""
 			if !state.ScannerUsed {
 				scannerNote = "\n- You haven't used any automated scanners (nuclei/ffuf) yet — consider running them on promising endpoints"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,6 +80,11 @@ type Config struct {
 	// restore the hard abort after 15 consecutive no-tool responses.
 	NoToolAbortAt int
 
+	// MaxFinishRejections is how many times the agent's finish call will be
+	// rejected by the gatekeeper before allowing a deadlock bypass.
+	// XALGORIX_MAX_FINISH_REJECTIONS, default 15.
+	MaxFinishRejections int
+
 	// TargetAuth carries operator-supplied authenticated-session credentials
 	// for the target(s), so the agent can test post-authentication attack
 	// surface (IDOR/BOLA, privilege escalation, business logic) — where the
@@ -327,6 +332,7 @@ func load() *Config {
 		DisableBrowser:      envOrBool("XALGORIX_DISABLE_BROWSER", false),
 		MaxIterations:       envOrInt("XALGORIX_MAX_ITERATIONS", 0),
 		NoToolAbortAt:       envOrInt("XALGORIX_NO_TOOL_ABORT_AT", 30),
+		MaxFinishRejections: envOrInt("XALGORIX_MAX_FINISH_REJECTIONS", 15),
 		TargetAuth:          envOr("XALGORIX_TARGET_AUTH", ""),
 		TargetAuthSecondary: envOr("XALGORIX_TARGET_AUTH_B", ""),
 		OOBPublicURL:        envOr("XALGORIX_OOB_PUBLIC_URL", ""),

--- a/internal/web/settings_env.go
+++ b/internal/web/settings_env.go
@@ -134,6 +134,7 @@ func allEnvSettingDefinitions() []envSettingDefinition {
 		{Key: "XALGORIX_CONTEXT_COMPACT_TOKENS", Label: "Context compaction budget (tokens, override)", Category: "LLM", Description: "Optional ABSOLUTE override for the compaction trigger. Leave at -1 (auto) to derive the trigger from the context window × ratio above. Set a positive token count to force a fixed budget instead. 0 disables auto-compaction. Default -1 (auto).", DefaultValue: "-1", InputType: "number"},
 		{Key: "XALGORIX_MEMORY_COMPRESSOR_TIMEOUT", Label: "Memory compressor timeout", Category: "LLM", Description: "Timeout in seconds for context compression.", DefaultValue: "30", InputType: "number"},
 		{Key: "XALGORIX_MAX_ITERATIONS", Label: "Max iterations", Category: "Runtime", Description: "Maximum agent iterations per scan. 0 means unlimited.", DefaultValue: "0", InputType: "number"},
+		{Key: "XALGORIX_MAX_FINISH_REJECTIONS", Label: "Max finish rejections", Category: "Runtime", Description: "Number of times the agent's finish call will be rejected by the gatekeeper before allowing a deadlock bypass, enforcing deeper testing coverage.", DefaultValue: "15", InputType: "number"},
 		{Key: "XALGORIX_MAX_TOOL_CALLS", Label: "Max tool calls (budget)", Category: "Runtime", Description: "Per-scan tool-call cap; the scan stops cleanly when reached (findings preserved). 0 = unlimited.", DefaultValue: "0", InputType: "number", RequiresRestart: true},
 		{Key: "XALGORIX_MAX_DURATION", Label: "Max duration seconds (budget)", Category: "Runtime", Description: "Per-scan wall-clock cap in seconds; the scan stops cleanly when reached. 0 = unlimited.", DefaultValue: "0", InputType: "number", RequiresRestart: true},
 		{Key: "XALGORIX_MAX_TOKENS", Label: "Max LLM tokens (budget)", Category: "Runtime", Description: "Per-scan total-token cap; the scan stops cleanly when reached. 0 = unlimited.", DefaultValue: "0", InputType: "number", RequiresRestart: true},
@@ -756,6 +757,8 @@ func (s *Server) applyEnvironmentToRuntimeConfig(values map[string]string) {
 			s.cfg.MemCompTimeout = parseIntSetting(value, 30)
 		case "XALGORIX_MAX_ITERATIONS":
 			s.cfg.MaxIterations = parseIntSetting(value, 0)
+		case "XALGORIX_MAX_FINISH_REJECTIONS":
+			s.cfg.MaxFinishRejections = parseIntSetting(value, 15)
 		case "XALGORIX_WORKSPACE":
 			if value != "" {
 				s.cfg.Workspace = value
@@ -870,6 +873,8 @@ func (s *Server) envSettingValue(key string) string {
 		return strconv.Itoa(s.cfg.MemCompTimeout)
 	case "XALGORIX_MAX_ITERATIONS":
 		return strconv.Itoa(s.cfg.MaxIterations)
+	case "XALGORIX_MAX_FINISH_REJECTIONS":
+		return strconv.Itoa(s.cfg.MaxFinishRejections)
 	case "XALGORIX_WORKSPACE":
 		return s.cfg.Workspace
 	case "XALGORIX_DISABLE_BROWSER":
@@ -1128,6 +1133,8 @@ func normalizeEnvSettingValue(def envSettingDefinition, value string) (string, e
 		return strconv.Itoa(clampInt(parseIntSetting(value, 30), 5, 600)), nil
 	case "XALGORIX_MAX_ITERATIONS":
 		return strconv.Itoa(clampInt(parseIntSetting(value, 0), 0, 1000)), nil
+	case "XALGORIX_MAX_FINISH_REJECTIONS":
+		return strconv.Itoa(clampInt(parseIntSetting(value, 15), 1, 100)), nil
 	}
 	return value, nil
 }


### PR DESCRIPTION
Exposes XALGORIX_MAX_FINISH_REJECTIONS (default: 15) in Settings so operators can customize or tune the gatekeeper finish-rejection limit via UI or environment configuration.