### PR TITLE
feat(agent): add configurable XALGORIX_MIN_ITERATIONS and enforce strict plan task skip validation

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -720,6 +720,7 @@ func (a *Agent) Run(targets []string, instruction string) {
 		a.state.NoToolAbortLimit = a.cfg.NoToolAbortAt
 		a.state.NoToolAbortConfigured = true
 		a.state.MaxFinishRejections = a.cfg.MaxFinishRejections
+		a.state.MinIterations = a.cfg.MinIterations
 	}
 	a.state.ScanContextID = a.scanCtx.ID
 	a.state.DiscoveryMode = a.discoveryMode

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -51,6 +51,7 @@ type ScanState struct {
 	ScannerUsed                bool
 	FinishAttempts             int
 	MaxFinishRejections        int
+	MinIterations              int
 	DiscoveryMode              bool
 	ReconOnlyMode              bool
 	AllowedPhases              []int
@@ -1208,10 +1209,14 @@ func hookFinishGatekeeper(state *ScanState, args map[string]string) HookResult {
 		}
 	}
 
-	// ── Iteration floor: 50 ──
-	// Matches the system prompt: "Minimum 50 iterations for a thorough assessment"
-	// Only applies to large surface areas (> 15 endpoints) or when depth is low.
-	if iter < 50 {
+	minIter := state.MinIterations
+	if minIter <= 0 {
+		minIter = 50
+	}
+
+	// ── Iteration floor ──
+	// Matches the system prompt: "Minimum iterations for a thorough assessment"
+	if iter < minIter {
 		if state.FinishAttempts <= maxRejections {
 			scannerNote := ""
 			if !state.ScannerUsed {
@@ -1223,7 +1228,7 @@ func hookFinishGatekeeper(state *ScanState, args map[string]string) HookResult {
 			}
 			coverageNote := fmt.Sprintf("\n- Endpoints tested: %d (injection: %d, access control: %d, dirbusting hosts: %d, depth: %.1f/endpoint)",
 				totalEndpoints, injectionCount, accessControlCount, dirBustingCount, depth)
-			nudgeMsg := fmt.Sprintf(`⚠️ Only %d/50 iterations completed. You still have capacity to test more.
+			nudgeMsg := fmt.Sprintf(`⚠️ Only %d/%d iterations completed. You still have capacity to test more.
 
 Before finishing, verify you have covered:
 - All discovered endpoints and parameters tested MANUALLY
@@ -1231,7 +1236,7 @@ Before finishing, verify you have covered:
 - Technology-specific CVEs
 - API endpoints found in JavaScript files%s%s%s
 
-Continue testing. Call finish again after iteration 50.`, iter, coverageNote, scannerNote, skillNote)
+Continue testing. Call finish again after iteration %d.`, iter, minIter, coverageNote, scannerNote, skillNote, minIter)
 
 			return HookResult{
 				Block:       true,
@@ -1261,7 +1266,7 @@ Continue testing. Call finish again after iteration 50.`, iter, coverageNote, sc
 		}
 	}
 
-	// Only nudge once (first finish attempt after iter 50) and only if ≥3 classes missing
+	// Only nudge once (first finish attempt after minIter) and only if ≥3 classes missing
 	if len(missingClasses) >= 3 && state.FinishAttempts <= 1 {
 		sort.Strings(missingClasses) // deterministic order
 		return HookResult{
@@ -1273,23 +1278,41 @@ Continue testing. Call finish again after iteration 50.`, iter, coverageNote, sc
 	}
 
 	// ── Plan-based finish gate ──
-	// If a structural plan exists and still has actionable pending tasks (any
-	// task that isn't the verify/report tail), block finish with the specific
-	// remaining tasks. The verify + report tasks are the plan's own finish
-	// step, so they don't block — completing them IS finishing. This is the
-	// decomposition layer's enforcement: an unfinished plan means the surface
-	// isn't covered, regardless of iteration count.
+	// If a structural plan exists, block finish if there are pending/active tasks,
+	// OR if tasks were skipped using invalid early-abort excuses (e.g. "RCE already found").
 	if state.Plan != nil && !state.Plan.IsEmpty() {
 		var remaining []string
+		var invalidSkips []string
+
 		for _, t := range state.Plan.Tasks {
-			if t.Status != TaskPending && t.Status != TaskActive {
-				continue
-			}
 			if t.ID == "verify" || t.ID == "report" {
 				continue // the finish step itself
 			}
-			remaining = append(remaining, fmt.Sprintf("  • [%s] phase %d — %s", t.ID, t.Phase, t.Title))
+			if t.Status == TaskPending || t.Status == TaskActive {
+				remaining = append(remaining, fmt.Sprintf("  • [%s] phase %d — %s", t.ID, t.Phase, t.Title))
+				continue
+			}
+			if t.Status == TaskSkipped && state.FinishAttempts <= maxRejections {
+				note := strings.ToLower(t.Notes)
+				if strings.Contains(note, "rce") || strings.Contains(note, "sqli") ||
+					strings.Contains(note, "already achieved") || strings.Contains(note, "already found") ||
+					strings.Contains(note, "already bypass") {
+					invalidSkips = append(invalidSkips, fmt.Sprintf("  • [%s] skipped with excuse: %q", t.ID, t.Notes))
+				}
+			}
 		}
+
+		if len(invalidSkips) > 0 {
+			list := strings.Join(invalidSkips, "\n")
+			return HookResult{
+				Block: true,
+				BlockReason: fmt.Sprintf("⚠️ INVALID PLAN TASK SKIPS DETECTED:\n%s\n\n"+
+					"Finding RCE or SQLi on one endpoint does NOT justify skipping vulnerability testing on other endpoints or classes.\n"+
+					"A comprehensive penetration test requires auditing all attack surface tasks. Re-open and execute these tasks before finishing.",
+					list),
+			}
+		}
+
 		if len(remaining) > 0 {
 			// Cap the list so a huge plan doesn't flood the block reason.
 			list := strings.Join(remaining, "\n")

--- a/internal/agent/hooks_test.go
+++ b/internal/agent/hooks_test.go
@@ -474,6 +474,35 @@ func TestFinishGatekeeper_DiscoveryModeBlocksTooFew(t *testing.T) {
 	}
 }
 
+func TestFinishGatekeeper_BlocksInvalidPlanTaskSkips(t *testing.T) {
+	state := NewScanState()
+	state.Iteration = 55
+	state.TerminalCalls = 30
+	state.ReconDone = true
+	state.EndpointInventorySaved = true
+	state.VulnClassesTested["sqli"] = true
+	state.VulnClassesTested["xss"] = true
+	state.VulnClassesTested["ssti"] = true
+	state.VulnClassesTested["cmdi"] = true
+	state.VulnClassesTested["path_traversal"] = true
+	state.VulnClassesTested["ssrf"] = true
+	state.VulnClassesTested["crlf"] = true
+	state.FinishAttempts = 2 // > 1 so vuln class soft nudge is past
+	plan := NewPlan()
+	plan.add(&Task{ID: "recon", Phase: 1, Title: "Recon", Status: TaskCompleted})
+	plan.add(&Task{ID: "test-dirbust", Phase: 2, Title: "Dirbust", Status: TaskSkipped, Notes: "RCE already found on /eval"})
+	plan.add(&Task{ID: "test-xss", Phase: 3, Title: "XSS", Status: TaskSkipped, Notes: "SQLi already achieved auth bypass"})
+	state.Plan = plan
+
+	result := hookFinishGatekeeper(state, nil)
+	if !result.Block {
+		t.Error("Gatekeeper should block when tasks are skipped with invalid early RCE/SQLi shortcuts")
+	}
+	if !strings.Contains(result.BlockReason, "INVALID PLAN TASK SKIPS DETECTED") {
+		t.Errorf("Unexpected block reason: %s", result.BlockReason)
+	}
+}
+
 // ── minInt / maxInt tests ────────────────────────────────────────────────────
 
 func TestMinMaxInt(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -71,6 +71,7 @@ type Config struct {
 	legacyCWD      string // Captured os.Getwd() at config load time. Used only by the migration warning.
 	DisableBrowser bool   // XALGORIX_DISABLE_BROWSER
 	MaxIterations  int    // XALGORIX_MAX_ITERATIONS — 0 = unlimited
+	MinIterations  int    // XALGORIX_MIN_ITERATIONS — minimum testing floor (default 50)
 
 	// NoToolAbortAt is how many CONSECUTIVE no-tool-call responses force-stop a
 	// scan (the "reasoning loop" abort). XALGORIX_NO_TOOL_ABORT_AT, default 0
@@ -331,6 +332,7 @@ func load() *Config {
 		legacyCWD:           cwd,
 		DisableBrowser:      envOrBool("XALGORIX_DISABLE_BROWSER", false),
 		MaxIterations:       envOrInt("XALGORIX_MAX_ITERATIONS", 0),
+		MinIterations:       envOrInt("XALGORIX_MIN_ITERATIONS", 50),
 		NoToolAbortAt:       envOrInt("XALGORIX_NO_TOOL_ABORT_AT", 30),
 		MaxFinishRejections: envOrInt("XALGORIX_MAX_FINISH_REJECTIONS", 15),
 		TargetAuth:          envOr("XALGORIX_TARGET_AUTH", ""),

--- a/internal/web/settings_env.go
+++ b/internal/web/settings_env.go
@@ -134,6 +134,7 @@ func allEnvSettingDefinitions() []envSettingDefinition {
 		{Key: "XALGORIX_CONTEXT_COMPACT_TOKENS", Label: "Context compaction budget (tokens, override)", Category: "LLM", Description: "Optional ABSOLUTE override for the compaction trigger. Leave at -1 (auto) to derive the trigger from the context window × ratio above. Set a positive token count to force a fixed budget instead. 0 disables auto-compaction. Default -1 (auto).", DefaultValue: "-1", InputType: "number"},
 		{Key: "XALGORIX_MEMORY_COMPRESSOR_TIMEOUT", Label: "Memory compressor timeout", Category: "LLM", Description: "Timeout in seconds for context compression.", DefaultValue: "30", InputType: "number"},
 		{Key: "XALGORIX_MAX_ITERATIONS", Label: "Max iterations", Category: "Runtime", Description: "Maximum agent iterations per scan. 0 means unlimited.", DefaultValue: "0", InputType: "number"},
+		{Key: "XALGORIX_MIN_ITERATIONS", Label: "Min iterations (testing floor)", Category: "Runtime", Description: "Minimum testing floor in iterations before the gatekeeper permits finish. Ensures deep probing (OAST, ReDoS, fuzzing) before concluding.", DefaultValue: "50", InputType: "number"},
 		{Key: "XALGORIX_MAX_FINISH_REJECTIONS", Label: "Max finish rejections", Category: "Runtime", Description: "Number of times the agent's finish call will be rejected by the gatekeeper before allowing a deadlock bypass, enforcing deeper testing coverage.", DefaultValue: "15", InputType: "number"},
 		{Key: "XALGORIX_MAX_TOOL_CALLS", Label: "Max tool calls (budget)", Category: "Runtime", Description: "Per-scan tool-call cap; the scan stops cleanly when reached (findings preserved). 0 = unlimited.", DefaultValue: "0", InputType: "number", RequiresRestart: true},
 		{Key: "XALGORIX_MAX_DURATION", Label: "Max duration seconds (budget)", Category: "Runtime", Description: "Per-scan wall-clock cap in seconds; the scan stops cleanly when reached. 0 = unlimited.", DefaultValue: "0", InputType: "number", RequiresRestart: true},
@@ -757,6 +758,8 @@ func (s *Server) applyEnvironmentToRuntimeConfig(values map[string]string) {
 			s.cfg.MemCompTimeout = parseIntSetting(value, 30)
 		case "XALGORIX_MAX_ITERATIONS":
 			s.cfg.MaxIterations = parseIntSetting(value, 0)
+		case "XALGORIX_MIN_ITERATIONS":
+			s.cfg.MinIterations = parseIntSetting(value, 50)
 		case "XALGORIX_MAX_FINISH_REJECTIONS":
 			s.cfg.MaxFinishRejections = parseIntSetting(value, 15)
 		case "XALGORIX_WORKSPACE":
@@ -873,6 +876,8 @@ func (s *Server) envSettingValue(key string) string {
 		return strconv.Itoa(s.cfg.MemCompTimeout)
 	case "XALGORIX_MAX_ITERATIONS":
 		return strconv.Itoa(s.cfg.MaxIterations)
+	case "XALGORIX_MIN_ITERATIONS":
+		return strconv.Itoa(s.cfg.MinIterations)
 	case "XALGORIX_MAX_FINISH_REJECTIONS":
 		return strconv.Itoa(s.cfg.MaxFinishRejections)
 	case "XALGORIX_WORKSPACE":
@@ -1133,6 +1138,8 @@ func normalizeEnvSettingValue(def envSettingDefinition, value string) (string, e
 		return strconv.Itoa(clampInt(parseIntSetting(value, 30), 5, 600)), nil
 	case "XALGORIX_MAX_ITERATIONS":
 		return strconv.Itoa(clampInt(parseIntSetting(value, 0), 0, 1000)), nil
+	case "XALGORIX_MIN_ITERATIONS":
+		return strconv.Itoa(clampInt(parseIntSetting(value, 50), 1, 500)), nil
 	case "XALGORIX_MAX_FINISH_REJECTIONS":
 		return strconv.Itoa(clampInt(parseIntSetting(value, 15), 1, 100)), nil
 	}


### PR DESCRIPTION
Adds XALGORIX_MIN_ITERATIONS (default 50) to configuration and Settings UI. Rejects finish attempts when plan tasks are skipped with early RCE/SQLi shortcuts to guarantee exhaustive pentest coverage.