### PR TITLE
feat(agent): mandate Out-of-Band (OAST) probing for blind vuln classes and bump to v4.5.95

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.94
+VERSION=4.5.95
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.94" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.95" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.94"
+var version = "4.5.95"
 
 const defaultWebPort = 9137
 

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -52,6 +52,7 @@ type ScanState struct {
 	FinishAttempts             int
 	MaxFinishRejections        int
 	MinIterations              int
+	OASTProbesExecuted         int
 	DiscoveryMode              bool
 	ReconOnlyMode              bool
 	AllowedPhases              []int
@@ -454,6 +455,15 @@ func hookWorkTracker(state *ScanState, args map[string]string) HookResult {
 		if strings.Contains(cmd, "169.254") || strings.Contains(cmd, "metadata") ||
 			strings.Contains(cmd, "ssrf") || strings.Contains(cmd, "127.0.0.1") {
 			state.VulnClassesTested["ssrf"] = true
+		}
+		if strings.Contains(cmd, "xml") || strings.Contains(cmd, "doctype") ||
+			strings.Contains(cmd, "entity") || strings.Contains(cmd, "xxe") {
+			state.VulnClassesTested["xxe"] = true
+		}
+		if strings.Contains(cmd, "interactsh") || strings.Contains(cmd, "oob_callback") ||
+			strings.Contains(cmd, "interact.sh") || strings.Contains(cmd, "oast") ||
+			strings.Contains(cmd, "oob_url") || strings.Contains(cmd, "burpcollaborator") {
+			state.OASTProbesExecuted++
 		}
 		if strings.Contains(cmd, "ffuf") || strings.Contains(cmd, "gobuster") ||
 			strings.Contains(cmd, "dirsearch") || strings.Contains(cmd, "feroxbuster") {
@@ -1101,6 +1111,20 @@ func hookFinishGatekeeper(state *ScanState, args map[string]string) HookResult {
 		return HookResult{}
 	}
 
+	// ── Mandatory Out-of-Band (OAST) Probing Gate ──
+	// Blind vulnerability classes (Blind XXE, Blind SSRF, Blind SQLi/RCE) cannot be proven non-existent
+	// using in-band HTTP responses alone. Require at least one OAST/interactsh callback payload attempt
+	// when blind classes (XXE/SSRF) are tested.
+	if state.OASTProbesExecuted == 0 && (state.VulnClassesTested["xxe"] || state.VulnClassesTested["ssrf"]) && state.FinishAttempts <= 2 {
+		return HookResult{
+			Block: true,
+			BlockReason: "⚠️ MANDATORY OUT-OF-BAND (OAST) PROBING REQUIRED:\n" +
+				"You tested blind vulnerability classes (XXE/SSRF), but executed 0 Out-of-Band (OAST/interactsh) callback payload probes.\n" +
+				"In-band HTTP responses alone cannot prove the non-existence of blind XXE or blind SSRF (e.g. egress DNS/HTTP requests).\n" +
+				"Generate an OAST domain (using interactsh / oob_callback) and send external DTD/SSRF payload requests before finishing.",
+		}
+	}
+
 	iter := state.Iteration
 	totalEndpoints := len(state.EndpointsTested)
 	injectionCount := len(state.InjectionEndpoints)
@@ -1257,6 +1281,7 @@ Continue testing. Call finish again after iteration %d.`, iter, minIter, coverag
 		"path_traversal": "Path Traversal: try ../../../etc/passwd, ..%2f..%2f in file/path params",
 		"ssrf":           "SSRF: try http://169.254.169.254, http://127.0.0.1 in URL params",
 		"crlf":           "CRLF: try %0d%0aInjected-Header:true in URL params and headers",
+		"xxe":            "XXE: try <!DOCTYPE test [<!ENTITY xxe SYSTEM \"http://...\">]> in XML endpoints",
 	}
 
 	var missingClasses []string
@@ -1271,9 +1296,23 @@ Continue testing. Call finish again after iteration %d.`, iter, minIter, coverag
 		sort.Strings(missingClasses) // deterministic order
 		return HookResult{
 			Block: true,
-			BlockReason: fmt.Sprintf("⚠️ Coverage gap: you haven't tested %d/7 mandatory vulnerability classes:\n\n%s\n\n"+
+			BlockReason: fmt.Sprintf("⚠️ Coverage gap: you haven't tested %d/8 mandatory vulnerability classes:\n\n%s\n\n"+
 				"Run at least ONE test for each missing class on the most promising endpoints, then call finish again.",
 				len(missingClasses), strings.Join(missingClasses, "\n")),
+		}
+	}
+
+	// ── Mandatory Out-of-Band (OAST) Probing Gate ──
+	// Blind vulnerability classes (Blind XXE, Blind SSRF, Blind SQLi/RCE) cannot be proven non-existent
+	// using in-band HTTP responses alone. Require at least one OAST/interactsh callback payload attempt
+	// when blind classes (XXE/SSRF) are tested.
+	if state.OASTProbesExecuted == 0 && (state.VulnClassesTested["xxe"] || state.VulnClassesTested["ssrf"]) && state.FinishAttempts <= 2 {
+		return HookResult{
+			Block: true,
+			BlockReason: "⚠️ MANDATORY OUT-OF-BAND (OAST) PROBING REQUIRED:\n" +
+				"You tested blind vulnerability classes (XXE/SSRF), but executed 0 Out-of-Band (OAST/interactsh) callback payload probes.\n" +
+				"In-band HTTP responses alone cannot prove the non-existence of blind XXE or blind SSRF (e.g. egress DNS/HTTP requests).\n" +
+				"Generate an OAST domain (using interactsh / oob_callback) and send external DTD/SSRF payload requests before finishing.",
 		}
 	}
 

--- a/internal/agent/hooks_test.go
+++ b/internal/agent/hooks_test.go
@@ -487,6 +487,8 @@ func TestFinishGatekeeper_BlocksInvalidPlanTaskSkips(t *testing.T) {
 	state.VulnClassesTested["path_traversal"] = true
 	state.VulnClassesTested["ssrf"] = true
 	state.VulnClassesTested["crlf"] = true
+	state.VulnClassesTested["xxe"] = true
+	state.OASTProbesExecuted = 1
 	state.FinishAttempts = 2 // > 1 so vuln class soft nudge is past
 	plan := NewPlan()
 	plan.add(&Task{ID: "recon", Phase: 1, Title: "Recon", Status: TaskCompleted})
@@ -499,6 +501,32 @@ func TestFinishGatekeeper_BlocksInvalidPlanTaskSkips(t *testing.T) {
 		t.Error("Gatekeeper should block when tasks are skipped with invalid early RCE/SQLi shortcuts")
 	}
 	if !strings.Contains(result.BlockReason, "INVALID PLAN TASK SKIPS DETECTED") {
+		t.Errorf("Unexpected block reason: %s", result.BlockReason)
+	}
+}
+
+func TestFinishGatekeeper_BlocksMissingOASTProbes(t *testing.T) {
+	state := NewScanState()
+	state.Iteration = 55
+	state.TerminalCalls = 30
+	state.ReconDone = true
+	state.EndpointInventorySaved = true
+	state.VulnClassesTested["sqli"] = true
+	state.VulnClassesTested["xss"] = true
+	state.VulnClassesTested["ssti"] = true
+	state.VulnClassesTested["cmdi"] = true
+	state.VulnClassesTested["path_traversal"] = true
+	state.VulnClassesTested["ssrf"] = true
+	state.VulnClassesTested["crlf"] = true
+	state.VulnClassesTested["xxe"] = true
+	state.OASTProbesExecuted = 0 // Tested XXE/SSRF but 0 OAST probes!
+	state.FinishAttempts = 1     // becomes 2 inside hookFinishGatekeeper (after FinishAttempts++)
+
+	result := hookFinishGatekeeper(state, nil)
+	if !result.Block {
+		t.Error("Gatekeeper should block finish when blind classes (XXE/SSRF) are tested with 0 OAST probes")
+	}
+	if !strings.Contains(result.BlockReason, "MANDATORY OUT-OF-BAND (OAST) PROBING REQUIRED") {
 		t.Errorf("Unexpected block reason: %s", result.BlockReason)
 	}
 }


### PR DESCRIPTION
Requires at least one Out-of-Band (OAST/interactsh) callback payload attempt when blind vulnerability classes (XXE/SSRF) are tested before allowing scan completion.