### PR TITLE
fix(agent): harden reasoning loop recovery with 1st-turn instant XML tool call nudge and non-pentest IDE tool restrictions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.98
+VERSION=4.5.99
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.98" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.99" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.98"
+var version = "4.5.99"
 
 const defaultWebPort = 9137
 

--- a/internal/agent/agent_prompt.go
+++ b/internal/agent/agent_prompt.go
@@ -109,8 +109,8 @@ Breadth is a trap. Running one payload against twenty endpoints finds nothing; f
 ## CRITICAL RULES — FOLLOW THESE OR FAIL
 
 ### Execution Rules
-1. You MUST call tools using the XML format below. NEVER describe what you would do — DO IT.
-2. Every response MUST contain at least one tool call. NO EXCEPTIONS.
+1. You MUST call tools using the XML format below. NEVER describe what you would do without calling a tool — DO IT IMMEDIATELY IN THE SAME RESPONSE.
+2. Every response MUST contain at least one valid XML tool call tag (e.g. <function=terminal_execute>...). Text-only responses talking about using a tool without including the XML call tag are REJECTED BY THE RUNTIME ENGINE.
 3. **Use bounded, resource-safe concurrency with comprehensive flags.** Examples:
    - subfinder -d TARGET -all -recursive -rl %d -t %d
    - dnsx -silent -a -resp -rl %d -threads %d
@@ -121,8 +121,8 @@ Breadth is a trap. Running one payload against twenty endpoints finds nothing; f
 4. **LARGE TARGET LISTS**: If you are testing multiple targets at once (e.g., >10 URLs or domains), NEVER pass them as inline space/comma separated arguments to terminal tools (e.g. 'nmap a b c d e f g h...'). This causes OS "file name too long" argument crashes! ALWAYS save the targets to a text file first (e.g. 'echo -e "t1\nt2\n..." > targets.txt') and pass the file to the tool using input list flags (e.g. 'subfinder -dL targets.txt', 'httpx -l targets.txt', 'nmap -iL targets.txt', 'findomain -f targets.txt').
 5. If a tool or command fails, try alternatives. NEVER give up after one failure.
 6. Minimum 50 iterations for a thorough assessment. Don't rush to finish.
- 7. Use notes (add_note) to track discovered endpoints, parameters, and findings. Read notes before each phase.
  8. **WORKSPACE**: You are ALREADY executing inside a dedicated, isolated workspace directory perfectly prepared for this target. NEVER use 'cd' to escape or change directories (e.g. do not run 'cd /root && mkdir pentest'). Write your outputs directly to your current working directory (e.g. 'nmap -oN scan.txt').
+ 9. **TOOL SELECTION**: Use ONLY standard pentesting tools (terminal_execute, http_request, browser_action, add_note, read_notes). NEVER attempt to call IDE editing tools (e.g. str_replace_editor, view, replace_file_content). Use terminal_execute with cat, grep, or head to view temporary files.
 
 ## STRUCTURED PLANNING — DECOMPOSE BEFORE YOU TEST
 

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -299,9 +299,9 @@ const (
 	//      call — just often enough to reset NoToolCount — the consecutive path
 	//      never trips. In BOUNDED mode only, a sustained high no-tool ratio
 	//      well past a warm-up window aborts rather than running for hours.
-	NoToolSoftNudgeAt   = 8  // consecutive no-tool → gentle "use tools" reminder
-	NoToolStrongNudgeAt = 16 // consecutive no-tool → firm "resume, call a tool NOW" nudge (re-fires every turn after)
-	NoToolAbortAt       = 30 // consecutive no-tool → force-stop scan (bounded mode only; default disabled)
+	NoToolSoftNudgeAt   = 1   // consecutive no-tool → instant "use XML tools NOW" nudge on 1st prose response
+	NoToolStrongNudgeAt = 3   // consecutive no-tool → firm "resume, call a tool NOW" nudge (re-fires every turn after)
+	NoToolAbortAt       = 100 // consecutive no-tool → force-stop scan safety ceiling (bounded mode only)
 
 	ReasoningDensityMinResponses  = 40   // need ≥ this many no-tool responses before the density safety net applies
 	ReasoningDensityAbortRatio    = 0.85 // > this fraction of no-tool responses …
@@ -1281,14 +1281,15 @@ Continue testing. Call finish again after iteration %d.`, iter, minIter, coverag
 	// This is a soft nudge (not a hard block) — fires once per scan to tell the agent
 	// what it missed, then allows subsequent finish attempts through.
 	mandatoryClasses := map[string]string{
-		"sqli":           "SQLi: try ' OR 1=1--, sqlmap -u, UNION SELECT on input params",
-		"xss":            "XSS: try <script>alert(1)</script>, \"><img src=x onerror=alert(1)> in inputs",
-		"ssti":           "SSTI: try {{7*7}}, ${7*7}, <%=7*7%> in template-rendered inputs",
-		"cmdi":           "Command Injection: try ;id, |id, $(id) in parameters processed server-side",
-		"path_traversal": "Path Traversal: try ../../../etc/passwd, ..%2f..%2f in file/path params",
-		"ssrf":           "SSRF: try http://169.254.169.254, http://127.0.0.1 in URL params",
-		"crlf":           "CRLF: try %0d%0aInjected-Header:true in URL params and headers",
-		"xxe":            "XXE: try <!DOCTYPE test [<!ENTITY xxe SYSTEM \"http://...\">]> in XML endpoints",
+		"sqli":             "SQLi: try ' OR 1=1--, sqlmap -u, UNION SELECT on input params",
+		"xss":              "XSS: try <script>alert(1)</script>, \"><img src=x onerror=alert(1)> in inputs",
+		"ssti":             "SSTI: try {{7*7}}, ${7*7}, <%=7*7%> in template-rendered inputs",
+		"cmdi":             "Command Injection: try ;id, |id, $(id) in parameters processed server-side",
+		"path_traversal":   "Path Traversal: try ../../../etc/passwd, ..%2f..%2f in file/path params",
+		"ssrf":             "SSRF: try http://169.254.169.254, http://127.0.0.1 in URL params",
+		"crlf":             "CRLF: try %0d%0aInjected-Header:true in URL params and headers",
+		"xxe":              "XXE: try <!DOCTYPE test [<!ENTITY xxe SYSTEM \"http://...\">]> in XML endpoints",
+		"parameter_mining": "Parameter Mining: try arjun -u, x8, or ffuf parameter key discovery on endpoint URLs",
 	}
 
 	var missingClasses []string
@@ -1303,7 +1304,7 @@ Continue testing. Call finish again after iteration %d.`, iter, minIter, coverag
 		sort.Strings(missingClasses) // deterministic order
 		return HookResult{
 			Block: true,
-			BlockReason: fmt.Sprintf("⚠️ Coverage gap: you haven't tested %d/8 mandatory vulnerability classes:\n\n%s\n\n"+
+			BlockReason: fmt.Sprintf("⚠️ Coverage gap: you haven't tested %d/9 mandatory vulnerability classes:\n\n%s\n\n"+
 				"Run at least ONE test for each missing class on the most promising endpoints, then call finish again.",
 				len(missingClasses), strings.Join(missingClasses, "\n")),
 		}


### PR DESCRIPTION
Eliminates reasoning loop stalls by triggering an instant XML tool call syntax recovery prompt on the 1st text-only turn and forbidding IDE editing tools inside the scan environment.