### PR TITLE
feat(agent): set TempScanner baseline to 0.0 with adaptive retry temperature boost and deterministic recon sorting (v4.5.101)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.100
+VERSION=4.5.101
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.100" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.101" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.100"
+var version = "4.5.101"
 
 const defaultWebPort = 9137
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -799,7 +799,14 @@ func (a *Agent) Run(targets []string, instruction string) {
 		a.msgMu.Lock()
 		msgsSnapshot := make([]llm.Message, len(a.messages))
 		copy(msgsSnapshot, a.messages)
-		a.msgMu.Unlock()
+		// Adaptive Temperature Control:
+		// Default to TempScanner (0.0) for 100% deterministic, consistent scan behavior.
+		// Dynamically boost to 0.2 when stuck or retrying failed calls to allow creative payload variation.
+		scannerTemp := 0.0
+		if a.state.ConsecutiveSameCall >= 2 || a.state.ConsecutiveSameResult >= 2 || a.state.ConsecutiveErrors > 0 {
+			scannerTemp = 0.2
+		}
+		a.client.SetTemperature(&scannerTemp)
 
 		response, err := a.client.Chat(msgsSnapshot)
 		// Update activity after LLM response

--- a/internal/agent/agent_prompt.go
+++ b/internal/agent/agent_prompt.go
@@ -438,13 +438,13 @@ for chunk in $(cat /tmp/js_chunks.txt); do
   curl -s "https://TARGET/$chunk" -A "Mozilla/5.0" --max-time 10 >> /tmp/bundle.js 2>/dev/null
 done
 
-# Deep grep across all combined JS source:
+# Deep grep across all combined JS source (deduplicated & sorted for consistent iteration order):
 grep -oE '"https?://[^"]+' /tmp/bundle.js | sort -u > /tmp/js_urls.txt       # Full URLs
 grep -oE '"/api/[^"]*"' /tmp/bundle.js | sort -u > /tmp/js_api_paths.txt      # API paths
-grep -oE '"/(v[0-9]+|access|admin|auth|connect|user|internal)/[^"]*"' /tmp/bundle.js | sort -u  # Versioned paths
-grep -oE '[a-z0-9-]+\.(TARGET_DOMAIN)\.[a-z]+' /tmp/bundle.js | sort -u   # Subdomains
-grep -oE '(apiUrl|baseURL|API_URL|apiBase)[^,]*' /tmp/bundle.js | head -10     # API base URLs
-grep -oE '(token|secret|key|password|api_key|jwt|bearer)\s*[:=]\s*"[^"]*"' /tmp/bundle.js # Leaked secrets
+grep -oE '"/(v[0-9]+|access|admin|auth|connect|user|internal)/[^"]*"' /tmp/bundle.js | sort -u > /tmp/js_versioned_paths.txt # Versioned paths
+grep -oE '[a-z0-9-]+\.(TARGET_DOMAIN)\.[a-z]+' /tmp/bundle.js | sort -u > /tmp/js_subdomains.txt # Subdomains (sorted)
+grep -oE '(apiUrl|baseURL|API_URL|apiBase)[^,]*' /tmp/bundle.js | sort -u | head -10     # API base URLs
+grep -oE '(token|secret|key|password|api_key|jwt|bearer)\s*[:=]\s*"[^"]*"' /tmp/bundle.js | sort -u # Leaked secrets
 ` + "`" + `
 
 **Iteration 4: Test ALL subdomains, API bases, HTTP Verbs & Header Bypasses**

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -340,7 +340,7 @@ func noteBlockedToolCall(state *ScanState, name string, args map[string]string) 
 // Each agent role has an optimal temperature tuned for its purpose.
 
 var (
-	TempScanner   = floatPtr(0.2) // creative enough for novel attack paths, structured enough for methodology
+	TempScanner   = floatPtr(0.0) // 100% deterministic baseline for max run-to-run consistency
 	TempReasoner  = floatPtr(0.2) // structured analysis with slight flexibility for nuanced verdicts
 	TempValidator = floatPtr(0.0) // fully deterministic — same input must produce same verdict
 	TempReporter  = floatPtr(0.3) // natural prose without risking fabricated technical details

--- a/internal/agent/hooks_test.go
+++ b/internal/agent/hooks_test.go
@@ -556,7 +556,7 @@ func TestRoleTemperatures(t *testing.T) {
 		temp *float64
 		want float64
 	}{
-		{"Scanner", TempScanner, 0.2},
+		{"Scanner", TempScanner, 0.0},
 		{"Reasoner", TempReasoner, 0.2},
 		{"Validator", TempValidator, 0.0},
 		{"Reporter", TempReporter, 0.3},

--- a/internal/agent/verifier.go
+++ b/internal/agent/verifier.go
@@ -122,8 +122,11 @@ func (a *Agent) verifyFinding(req reporting.VerificationRequest) reporting.Verif
 
 		resp, err := a.client.Chat(msgs)
 		if err != nil {
-			// One retry, then give up (inconclusive — never auto-confirm on error).
-			resp, err = a.client.Chat(msgs)
+			// Up to 2 retries on temporary network/LLM errors before marking inconclusive.
+			for retry := 0; retry < 2 && err != nil; retry++ {
+				time.Sleep(500 * time.Millisecond)
+				resp, err = a.client.Chat(msgs)
+			}
 			if err != nil {
 				return reporting.VerificationVerdict{Inconclusive: true, Reason: "verifier LLM error: " + err.Error()}
 			}


### PR DESCRIPTION
Ensures maximum run-to-run scan consistency by defaulting TempScanner to 0.0 baseline while dynamically boosting to 0.2 when retrying failed calls, adding deterministic recon list sorting, and 2-round verifier error retries.