### PR TITLE
fix(agent): unlock msgMu before chat call to eliminate scan stall deadlock (v4.5.102)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.101
+VERSION=4.5.102
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.101" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.102" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.101"
+var version = "4.5.102"
 
 const defaultWebPort = 9137
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -799,6 +799,8 @@ func (a *Agent) Run(targets []string, instruction string) {
 		a.msgMu.Lock()
 		msgsSnapshot := make([]llm.Message, len(a.messages))
 		copy(msgsSnapshot, a.messages)
+		a.msgMu.Unlock()
+
 		// Adaptive Temperature Control:
 		// Default to TempScanner (0.0) for 100% deterministic, consistent scan behavior.
 		// Dynamically boost to 0.2 when stuck or retrying failed calls to allow creative payload variation.


### PR DESCRIPTION
Fixes a critical deadlock introduced in v4.5.101 where a.msgMu remained locked during outbound Chat requests, freezing scan sessions on iteration 1.