### PR TITLE
feat(agent): refactor minIter gatekeeper nudge to drive deep parameter fuzzing & skill loading (v4.5.103)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.102
+VERSION=4.5.103
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.102" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.103" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.102"
+var version = "4.5.103"
 
 const defaultWebPort = 9137
 

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -1300,15 +1300,13 @@ func hookFinishGatekeeper(state *ScanState, args map[string]string) HookResult {
 			}
 			coverageNote := fmt.Sprintf("\n- Endpoints tested: %d (injection: %d, access control: %d, dirbusting hosts: %d, depth: %.1f/endpoint)",
 				totalEndpoints, injectionCount, accessControlCount, dirBustingCount, depth)
-			nudgeMsg := fmt.Sprintf(`⚠️ Only %d/%d iterations completed. You still have capacity to test more.
+			nudgeMsg := fmt.Sprintf(`⚠️ You are at iteration %d/%d. Do NOT stop early — perform DEEP FUZZING on discovered endpoints now:
 
-Before finishing, verify you have covered:
-- All discovered endpoints and parameters tested MANUALLY
-- Common vulnerability classes (SQLi, XSS, SSRF, IDOR, broken auth)
-- Technology-specific CVEs
-- API endpoints found in JavaScript files%s%s%s
+1. **Parameter & Payload Fuzzing**: Perform boundary testing, parameter key discovery (arjun/x8), and ReDoS regex fuzzing on input parameters.
+2. **Load Deep Knowledge Skills**: Use read_skill to load vulnerability-specific bypass techniques for the target's stack.
+3. **Automated Scanning**: Run nuclei or ffuf on discovered API routes for hidden endpoints.%s%s%s
 
-Continue testing. Call finish again after iteration %d.`, iter, minIter, coverageNote, scannerNote, skillNote, minIter)
+Execute your next tool call NOW.`, iter, minIter, coverageNote, scannerNote, skillNote)
 
 			return HookResult{
 				Block:       true,


### PR DESCRIPTION
Re-frames iteration floor rejection messages to give action-oriented fuzzing directives (ReDoS, parameter mining, skill loading) instead of telling the LLM to wait for an iteration counter.