### PR TITLE
fix(verifier,agentsgraph): clamp verifier tool timeout to deadline (fixes #295) & gate async agent tools (fixes #296) (v4.5.105)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.104
+VERSION=4.5.105
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.104" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.105" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.104"
+var version = "4.5.105"
 
 const defaultWebPort = 9137
 

--- a/internal/agent/verifier.go
+++ b/internal/agent/verifier.go
@@ -149,7 +149,7 @@ func (a *Agent) verifyFinding(req reporting.VerificationRequest) reporting.Verif
 			// Route through the SAME scope guard + hard-timeout the main agent
 			// applies, so the verifier cannot probe out-of-scope/local hosts and
 			// a hung re-test cannot outlive the report_vulnerability call.
-			res := a.execVerifierToolGuarded(vreg, tc.Name, tc.Args)
+			res := a.execVerifierToolGuarded(vreg, tc.Name, tc.Args, deadline)
 			out := res.Output
 			if res.Error != "" {
 				out = "error: " + res.Error
@@ -219,7 +219,7 @@ func (a *Agent) verifyFinding(req reporting.VerificationRequest) reporting.Verif
 // localhost/RFC1918/dashboard-listener guard and the per-tool watchdog —
 // letting it probe hosts the main agent blocks and leaving a hung tool running
 // past the report_vulnerability ceiling.
-func (a *Agent) execVerifierToolGuarded(vreg *tools.Registry, name string, args map[string]string) tools.Result {
+func (a *Agent) execVerifierToolGuarded(vreg *tools.Registry, name string, args map[string]string, deadline time.Time) tools.Result {
 	if blocked, reason := a.shouldBlockForOutOfScope(name, args); blocked {
 		return tools.Result{Output: "⛔ OUT-OF-SCOPE TARGET BLOCKED — " + reason +
 			"\nYou cannot probe this host during verification. If the finding depends on reaching it, it is not independently verifiable here — submit an 'inconclusive' verdict."}
@@ -240,6 +240,14 @@ func (a *Agent) execVerifierToolGuarded(vreg *tools.Registry, name string, args 
 	}()
 
 	timeout := a.hardTimeoutFor(name)
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return tools.Result{Error: "[verifier deadline reached]"}
+	}
+	if remaining < timeout {
+		timeout = remaining
+	}
+
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 	select {
@@ -247,12 +255,6 @@ func (a *Agent) execVerifierToolGuarded(vreg *tools.Registry, name string, args 
 		a.touchActivity()
 		return res
 	case <-timer.C:
-		switch name {
-		case "terminal_execute", "python_action":
-			a.scanCtx.Terminal.KillAll()
-		case "browser_action":
-			browser.CleanupContext(a.scanCtx.ID)
-		}
 		return tools.Result{Error: fmt.Sprintf("[verifier tool %q TIMEOUT after %s]", name, timeout)}
 	case <-a.ctx.Done():
 		return tools.Result{Error: "agent stopped during verification"}

--- a/internal/tools/agentsgraph/agentsgraph.go
+++ b/internal/tools/agentsgraph/agentsgraph.go
@@ -4,6 +4,7 @@ package agentsgraph
 import (
 	"fmt"
 	"log"
+	"os"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -72,38 +73,38 @@ func Register(r *tools.Registry, agentRunner AgentRunner) {
 		Execute: createAgent,
 	})
 
-	// Asynchronous sub-agent — runs in background
-	r.Register(&tools.Tool{
-		Name:        "spawn_agent",
-		Description: "Spawn a sub-agent asynchronously and return an agent_id immediately. You can continue doing other work and use check_agent or wait_agent later to get results. Max 3 concurrent sub-agents allowed.",
-		Parameters: []tools.Parameter{
-			{Name: "name", Description: "Name for the sub-agent (e.g. 'Directory Brute-forcing')", Required: true},
-			{Name: "task", Description: "Task description for the sub-agent", Required: true},
-			{Name: "target", Description: "Target URL/path for the sub-agent", Required: false},
-		},
-		Execute: spawnAgent,
-	})
+	// Async sub-agent tools are gated behind XALGORIX_ENABLE_ASYNC_AGENTS to prevent zombie goroutines & semaphore leaks
+	if os.Getenv("XALGORIX_ENABLE_ASYNC_AGENTS") == "true" {
+		r.Register(&tools.Tool{
+			Name:        "spawn_agent",
+			Description: "Spawn a sub-agent asynchronously and return an agent_id immediately. You can continue doing other work and use check_agent or wait_agent later to get results. Max 3 concurrent sub-agents allowed.",
+			Parameters: []tools.Parameter{
+				{Name: "name", Description: "Name for the sub-agent (e.g. 'Directory Brute-forcing')", Required: true},
+				{Name: "task", Description: "Task description for the sub-agent", Required: true},
+				{Name: "target", Description: "Target URL/path for the sub-agent", Required: false},
+			},
+			Execute: spawnAgent,
+		})
 
-	// Check status
-	r.Register(&tools.Tool{
-		Name:        "check_agent",
-		Description: "Check the status and partial results of an asynchronously spawned sub-agent.",
-		Parameters: []tools.Parameter{
-			{Name: "agent_id", Description: "The ID returned by spawn_agent", Required: true},
-		},
-		Execute: checkAgent,
-	})
+		r.Register(&tools.Tool{
+			Name:        "check_agent",
+			Description: "Check the status and partial results of an asynchronously spawned sub-agent.",
+			Parameters: []tools.Parameter{
+				{Name: "agent_id", Description: "The ID returned by spawn_agent", Required: true},
+			},
+			Execute: checkAgent,
+		})
 
-	// Wait for completion
-	r.Register(&tools.Tool{
-		Name:        "wait_agent",
-		Description: "Block and wait until a spawned sub-agent completes or fails.",
-		Parameters: []tools.Parameter{
-			{Name: "agent_id", Description: "The ID returned by spawn_agent", Required: true},
-			{Name: "timeout", Description: "Timeout in seconds to wait (default 600)", Required: false},
-		},
-		Execute: waitAgent,
-	})
+		r.Register(&tools.Tool{
+			Name:        "wait_agent",
+			Description: "Block and wait until a spawned sub-agent completes or fails.",
+			Parameters: []tools.Parameter{
+				{Name: "agent_id", Description: "The ID returned by spawn_agent", Required: true},
+				{Name: "timeout", Description: "Timeout in seconds to wait (default 600)", Required: false},
+			},
+			Execute: waitAgent,
+		})
+	}
 }
 
 func createAgent(args map[string]string) (tools.Result, error) {


### PR DESCRIPTION
Fixes #295 (verifier timeout process kill) and #296 (async agent semaphore exhaustion).