### PR TITLE
perf(web): skip non-scan directories in WalkDir & bump version to v4.5.106

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.105
+VERSION=4.5.106
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.105" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.106" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.105"
+var version = "4.5.106"
 
 const defaultWebPort = 9137
 

--- a/internal/web/scan_query.go
+++ b/internal/web/scan_query.go
@@ -121,7 +121,14 @@ type scanEntry struct {
 func (s *Server) findAllScans() []scanEntry {
 	var results []scanEntry
 	_ = filepath.WalkDir(s.dataDir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if name == "scratch" || name == "reports" || name == "logs" || name == "artifacts" || name == "tools" || name == "snapshots" || name == "notes" || name == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 		if d.Name() != "scan.json" {
@@ -179,7 +186,14 @@ func (s *Server) findAllScanSummaries() []scanEntry {
 	seen := make(map[string]struct{})
 
 	_ = filepath.WalkDir(s.dataDir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if name == "scratch" || name == "reports" || name == "logs" || name == "artifacts" || name == "tools" || name == "snapshots" || name == "notes" || name == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 		if d.Name() != "scan.json" {


### PR DESCRIPTION
Optimizes data directory walk performance by skipping non-scan subdirectories.