### PR TITLE
fix(agent): block finish on un-retried report_vulnerability parameter errors & bump to v4.5.107

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.106
+VERSION=4.5.107
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.106" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.107" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.106"
+var version = "4.5.107"
 
 const defaultWebPort = 9137
 

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -53,6 +53,7 @@ type ScanState struct {
 	MaxFinishRejections        int
 	MinIterations              int
 	OASTProbesExecuted         int
+	PendingFailedReportCalls   int
 	DiscoveryMode              bool
 	ReconOnlyMode              bool
 	AllowedPhases              []int
@@ -84,15 +85,15 @@ type ScanState struct {
 	BrowserAuthContext bool // true after browser login/auth detected — justifies browser use
 
 	// Stuck-loop detection
-	StuckDomain        string
-	StuckIterations    int
-	ConsecutiveBrowser int
-	ConsecutiveSearch  int
-	ConsecutiveErrors  int
+	StuckDomain             string
+	StuckIterations         int
+	ConsecutiveBrowser      int
+	ConsecutiveSearch       int
+	ConsecutiveErrors       int
 	ConsecutiveTargetErrors int // consecutive host-unreachable/connection-refused errors
-	EmptyResponseCount int
-	NoToolCount        int
-	RefusalCount       int // consecutive responses that look like a model-side safety refusal
+	EmptyResponseCount      int
+	NoToolCount             int
+	RefusalCount            int // consecutive responses that look like a model-side safety refusal
 
 	// Repeated-call loop detection (orthogonal to the browser/search stuck
 	// tracking above). Catches the agent regenerating the same tool call with
@@ -361,6 +362,7 @@ func RegisterDefaultHooks(reg *HookRegistry) {
 	reg.Register(OnToolResult, hookTargetHealthDetector)
 	reg.Register(OnToolResult, hookTechDetector)
 	reg.Register(OnToolResult, hookResultRepeatTracker)
+	reg.Register(OnToolResult, hookReportVulnerabilityTracker)
 	reg.Register(OnFinishAttempt, hookFinishGatekeeper)
 	reg.Register(OnEmptyResponse, hookEmptyResponseHandler)
 	reg.Register(OnNoToolResponse, hookNoToolHandler)
@@ -1142,6 +1144,14 @@ func hookFinishGatekeeper(state *ScanState, args map[string]string) HookResult {
 		return HookResult{}
 	}
 
+	// Gate: Do not allow finishing if a previous report_vulnerability call failed and hasn't been successfully re-called yet.
+	if state.PendingFailedReportCalls > 0 {
+		return HookResult{
+			Block:       true,
+			BlockReason: "⚠️ UNREPORTED VULNERABILITY DETECTED: You attempted to call report_vulnerability previously, but the tool call failed (e.g. missing required parameters). You MUST successfully re-run report_vulnerability with ALL required fields (title, severity, description, endpoint, exploitation_proof) before finishing, so the vulnerability is saved to the scan report and dashboard.",
+		}
+	}
+
 	// Discovery mode (Phase 1 enumeration): allow finish after minimum work
 	if state.DiscoveryMode {
 		if state.TerminalCalls < 3 {
@@ -1881,6 +1891,26 @@ func extractPaths(blob string) []string {
 	}
 	sort.Strings(paths)
 	return paths
+}
+
+// ── hookReportVulnerabilityTracker ─────────────────────────────────────────
+// Tracks calls to report_vulnerability and maintains PendingFailedReportCalls.
+func hookReportVulnerabilityTracker(state *ScanState, args map[string]string) HookResult {
+	toolName := args["tool"]
+	if toolName != "report_vulnerability" {
+		return HookResult{}
+	}
+	errStr := args["error"]
+	outputStr := args["output"]
+
+	if errStr != "" || strings.Contains(outputStr, "missing required parameter") {
+		state.PendingFailedReportCalls++
+	} else if strings.Contains(outputStr, "Vulnerability reported:") || strings.Contains(outputStr, "RECORDED as EXPLOIT-PROVEN") {
+		if state.PendingFailedReportCalls > 0 {
+			state.PendingFailedReportCalls--
+		}
+	}
+	return HookResult{}
 }
 
 // ── hookResetOnSuccess ───────────────────────────────────────────────────────

--- a/internal/agent/hooks_test.go
+++ b/internal/agent/hooks_test.go
@@ -1093,7 +1093,6 @@ func TestRepeatDetector_CeilingAbortsLoop(t *testing.T) {
 		}
 	}
 
-
 	if finalMessage == "" || !strings.Contains(finalMessage, "Loop limit reached") {
 		t.Fatalf("expected loop limit abort message, got: %q", finalMessage)
 	}
@@ -1127,3 +1126,48 @@ func TestTrivialNoOpCommand_LoopDetector(t *testing.T) {
 	}
 }
 
+func TestHookReportVulnerabilityTracker_BlocksFinishOnPendingFailedCalls(t *testing.T) {
+	state := NewScanState()
+
+	// 1. Initial state: PendingFailedReportCalls is 0, finish allowed (assuming minimums met)
+	state.Iteration = 10
+	state.TerminalCalls = 10
+	state.ReconDone = true
+	state.EndpointInventorySaved = true
+	state.DiscoveryMode = true
+
+	res := hookFinishGatekeeper(state, map[string]string{})
+	if res.Block {
+		t.Fatalf("expected finish allowed, got blocked: %s", res.BlockReason)
+	}
+
+	// 2. Report vulnerability fails due to missing parameters
+	hookReportVulnerabilityTracker(state, map[string]string{
+		"tool":   "report_vulnerability",
+		"output": "missing required parameter 'title' for tool 'report_vulnerability'",
+	})
+	if state.PendingFailedReportCalls != 1 {
+		t.Fatalf("expected PendingFailedReportCalls = 1, got %d", state.PendingFailedReportCalls)
+	}
+
+	// 3. Calling finish now MUST be blocked
+	res = hookFinishGatekeeper(state, map[string]string{})
+	if !res.Block || !strings.Contains(res.BlockReason, "UNREPORTED VULNERABILITY DETECTED") {
+		t.Fatalf("expected finish to be blocked with UNREPORTED VULNERABILITY DETECTED, got: %+v", res)
+	}
+
+	// 4. Report vulnerability succeeds
+	hookReportVulnerabilityTracker(state, map[string]string{
+		"tool":   "report_vulnerability",
+		"output": "✅ Vulnerability reported: [XALG-1] Test (CRITICAL)",
+	})
+	if state.PendingFailedReportCalls != 0 {
+		t.Fatalf("expected PendingFailedReportCalls = 0 after success, got %d", state.PendingFailedReportCalls)
+	}
+
+	// 5. Calling finish now succeeds again
+	res = hookFinishGatekeeper(state, map[string]string{})
+	if res.Block {
+		t.Fatalf("expected finish allowed after successful report, got blocked: %s", res.BlockReason)
+	}
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -305,6 +305,12 @@ func (r *Registry) Execute(name string, args map[string]string) (Result, error) 
 		}
 	}
 	if len(missing) > 0 {
+		if name == "report_vulnerability" {
+			return Result{}, fmt.Errorf(
+				"missing required parameters for tool '%s': %s — ⚠️ CRITICAL: You attempted to report a vulnerability but the call failed. You MUST re-call report_vulnerability IMMEDIATELY with ALL required parameters in a single call so this finding is saved to the dashboard",
+				name, strings.Join(missing, ", "),
+			)
+		}
 		if len(missing) == 1 {
 			return Result{}, fmt.Errorf("missing required parameter '%s' for tool '%s'", missing[0], name)
 		}


### PR DESCRIPTION
Prevents dropped findings by enforcing re-call on report_vulnerability schema failures and blocking finish until all findings are saved.