### PR TITLE
fix(agent): catch Gate 1 rejections in report_vulnerability tracker & bump to v4.5.108

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.107
+VERSION=4.5.108
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.107" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.108" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.107"
+var version = "4.5.108"
 
 const defaultWebPort = 9137
 

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -1903,7 +1903,7 @@ func hookReportVulnerabilityTracker(state *ScanState, args map[string]string) Ho
 	errStr := args["error"]
 	outputStr := args["output"]
 
-	if errStr != "" || strings.Contains(outputStr, "missing required parameter") {
+	if errStr != "" || strings.Contains(outputStr, "missing required parameter") || strings.Contains(outputStr, "❌ REJECTED") {
 		state.PendingFailedReportCalls++
 	} else if strings.Contains(outputStr, "Vulnerability reported:") || strings.Contains(outputStr, "RECORDED as EXPLOIT-PROVEN") {
 		if state.PendingFailedReportCalls > 0 {

--- a/internal/agent/hooks_test.go
+++ b/internal/agent/hooks_test.go
@@ -1150,16 +1150,29 @@ func TestHookReportVulnerabilityTracker_BlocksFinishOnPendingFailedCalls(t *test
 		t.Fatalf("expected PendingFailedReportCalls = 1, got %d", state.PendingFailedReportCalls)
 	}
 
+	// 2b. Report vulnerability fails due to Gate 1 (missing verification_method)
+	hookReportVulnerabilityTracker(state, map[string]string{
+		"tool":   "report_vulnerability",
+		"output": "❌ REJECTED: 'SQL Injection' reported as CRITICAL but has NO verification_method",
+	})
+	if state.PendingFailedReportCalls != 2 {
+		t.Fatalf("expected PendingFailedReportCalls = 2, got %d", state.PendingFailedReportCalls)
+	}
+
 	// 3. Calling finish now MUST be blocked
 	res = hookFinishGatekeeper(state, map[string]string{})
 	if !res.Block || !strings.Contains(res.BlockReason, "UNREPORTED VULNERABILITY DETECTED") {
 		t.Fatalf("expected finish to be blocked with UNREPORTED VULNERABILITY DETECTED, got: %+v", res)
 	}
 
-	// 4. Report vulnerability succeeds
+	// 4. Report vulnerability succeeds (for call 1 and 2)
 	hookReportVulnerabilityTracker(state, map[string]string{
 		"tool":   "report_vulnerability",
 		"output": "✅ Vulnerability reported: [XALG-1] Test (CRITICAL)",
+	})
+	hookReportVulnerabilityTracker(state, map[string]string{
+		"tool":   "report_vulnerability",
+		"output": "✅ Vulnerability reported: [XALG-2] Test 2 (CRITICAL)",
 	})
 	if state.PendingFailedReportCalls != 0 {
 		t.Fatalf("expected PendingFailedReportCalls = 0 after success, got %d", state.PendingFailedReportCalls)

--- a/internal/tools/reporting/reporting.go
+++ b/internal/tools/reporting/reporting.go
@@ -338,7 +338,7 @@ func reportVulnWithContextID(contextID string, args map[string]string) (tools.Re
 	// advisory and may omit it. Any method that IS provided must be valid.
 	if severity != "info" && method == "" {
 		return tools.Result{
-			Output: fmt.Sprintf("❌ REJECTED: '%s' reported as %s but has NO verification_method. Exploit the vulnerability first, then report HOW you verified it (one of: %s). If it is not exploitable, downgrade severity to 'info'.",
+			Output: fmt.Sprintf("❌ REJECTED: '%s' reported as %s but has NO verification_method — ⚠️ CRITICAL: You MUST re-call report_vulnerability IMMEDIATELY with 'verification_method' specified (one of: %s) and ALL other required parameters so this finding is saved to the dashboard. If it is not exploitable, downgrade severity to 'info'.",
 				title, strings.ToUpper(severity), formatValidMethods()),
 		}, nil
 	}


### PR DESCRIPTION
Enhances Gate 1 rejection handling to inject explicit retry guidance and track pending failed report calls.