### PR TITLE
fix(web): preserve pending state on restart & auto-resume in-flight scans without failing

### DIFF
--- a/internal/web/scan_query.go
+++ b/internal/web/scan_query.go
@@ -731,13 +731,11 @@ func finalizeScanRecordForResponse(rec *ScanRecord) {
 // Running scans from a previous server instance are marked as "stopped" since the agent process is gone.
 func (s *Server) rebuildInstancesFromDisk() {
 	for _, entry := range s.findAllScans() {
-		// If scan was "running" from a previous server instance, it's no longer active.
-		// Persist the correction so /api/scans and /api/instances agree after restart.
+		// If scan was "running" from a previous server instance, transition it to "pending" / "resuming"
+		// so the startup queue resumer can pick it back up without marking it as stopped or failed.
 		if entry.rec.Status == "running" {
-			stoppedAt := time.Now().Format(time.RFC3339)
-			entry.rec.Status = "stopped"
-			entry.rec.StopReason = "server_restart"
-			entry.rec.FinishedAt = stoppedAt
+			entry.rec.Status = "pending"
+			entry.rec.StopReason = "server_restart_resuming"
 			s.saveScanRecordTo(&entry.rec, entry.dir)
 		}
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1138,11 +1138,11 @@ func (s *Server) Start() error {
 	// the auto-resume goroutine and both runMultiScan calls would stomp
 	// on the same cancelScan field.
 	go func() {
-		time.Sleep(5 * time.Second) // let HTTP server fully initialize
+		time.Sleep(3 * time.Second) // let HTTP server fully initialize
 		s.queueResumeMu.Lock()
 		defer s.queueResumeMu.Unlock()
-		if s.running.Load() || s.hasPendingOrRunningInstance() || s.hasQueueResumeLaunchingLocked() {
-			log.Printf("[AUTO-RESUME] Skipping — a scan is already pending or running.")
+		if s.running.Load() || s.hasQueueResumeLaunchingLocked() {
+			log.Printf("[AUTO-RESUME] Skipping — a scan execution is already active.")
 			return
 		}
 		entries := autoResumeQueueEntries(s.validQueueStateEntries(true))

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1552,16 +1552,16 @@ func TestScanPersistence_ListLatestDeleteAndRebuild(t *testing.T) {
 		t.Fatal("subdomain scan should not be rebuilt as a top-level instance")
 	}
 	inst := s.instances["scan-b"]
-	if inst == nil || inst.Status != "stopped" || inst.StopReason != "server_restart" {
-		t.Fatalf("running scan was not marked stopped on rebuild: %#v", inst)
+	if inst == nil || inst.Status != "pending" || inst.StopReason != "server_restart_resuming" {
+		t.Fatalf("running scan was not marked pending on rebuild: %#v", inst)
 	}
 	_, rebuilt := s.findScanByID("scan-b")
-	if rebuilt == nil || rebuilt.Status != "stopped" || rebuilt.StopReason != "server_restart" || rebuilt.FinishedAt == "" {
-		t.Fatalf("rebuilt scan was not persisted as stopped: %#v", rebuilt)
+	if rebuilt == nil || rebuilt.Status != "pending" || rebuilt.StopReason != "server_restart_resuming" {
+		t.Fatalf("rebuilt scan was not persisted as pending: %#v", rebuilt)
 	}
 	_, rebuiltSub := s.findScanByID("subdomain")
-	if rebuiltSub == nil || rebuiltSub.Status != "stopped" || rebuiltSub.StopReason != "server_restart" {
-		t.Fatalf("subdomain running scan was not persisted as stopped: %#v", rebuiltSub)
+	if rebuiltSub == nil || rebuiltSub.Status != "pending" || rebuiltSub.StopReason != "server_restart_resuming" {
+		t.Fatalf("subdomain running scan was not persisted as pending: %#v", rebuiltSub)
 	}
 
 	rr = httptest.NewRecorder()
@@ -1578,7 +1578,7 @@ func TestScanPersistence_ListLatestDeleteAndRebuild(t *testing.T) {
 		if got.ID == "subdomain" {
 			t.Fatalf("subdomain scan leaked into rebuilt list: %#v", got)
 		}
-		if got.ID == "scan-b" && got.Status != "stopped" {
+		if got.ID == "scan-b" && got.Status != "pending" {
 			t.Fatalf("list scans still returned stale status for %s: %#v", got.ID, got)
 		}
 	}


### PR DESCRIPTION
Ensures in-flight scans transition to pending/resuming on engine restart rather than being force-stopped or marked failed.