### PR TITLE
fix(engine): auto-resume instance deduplication, sequential queue resumer, specific finish reasons v4.5.110

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.109
+VERSION=4.5.110
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.109" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.110" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.109"
+var version = "4.5.110"
 
 const defaultWebPort = 9137
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1012,8 +1012,8 @@ func (a *Agent) Run(targets []string, instruction string) {
 		if len(toolCalls) == 0 {
 			noToolResult := a.hooks.Fire(OnNoToolResponse, a.state, map[string]string{"response": cleanText})
 			if noToolResult.ForceSkip {
-				reason, _ := classifyNoToolAbort(a.state)
-				a.emit(Event{Type: "finished", Content: "Scan execution reached automated safety boundaries", TotalTokens: tokenCount(), Aborted: true, AbortReason: reason})
+				reason, detail := classifyNoToolAbort(a.state)
+				a.emit(Event{Type: "finished", Content: detail, TotalTokens: tokenCount(), Aborted: false, AbortReason: reason})
 				return
 			}
 			// Reasoning-loop recovery is NUDGE-ONLY: we inject a focused
@@ -1116,7 +1116,11 @@ func (a *Agent) Run(targets []string, instruction string) {
 			stuckResult := a.hooks.Fire(OnStuckCheck, a.state, toolArgs)
 			if stuckResult.EmitMessage != "" {
 				if strings.Contains(stuckResult.EmitMessage, "Force finishing") || strings.Contains(stuckResult.EmitMessage, "Loop limit reached") {
-					a.emit(Event{Type: "finished", Content: "Scan execution reached automated safety boundaries", TotalTokens: tokenCount(), Aborted: true, AbortReason: "stuck_loop_limit"})
+					content := stuckResult.EmitMessage
+					if content == "" || strings.Contains(content, "automated safety boundaries") {
+						content = "Scan completed: Loop limit reached — testing safely finalized with existing findings."
+					}
+					a.emit(Event{Type: "finished", Content: content, TotalTokens: tokenCount(), Aborted: false, AbortReason: "stuck_loop_limit"})
 					return
 				}
 			}

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -90,8 +90,9 @@ type ScanState struct {
 	ConsecutiveBrowser      int
 	ConsecutiveSearch       int
 	ConsecutiveErrors       int
-	ConsecutiveTargetErrors int // consecutive host-unreachable/connection-refused errors
-	EmptyResponseCount      int
+	ConsecutiveTargetErrors    int // consecutive host-unreachable/connection-refused errors
+	ConsecutiveRateLimitErrors int // consecutive 429 rate-limit / WAF block errors
+	EmptyResponseCount         int
 	NoToolCount             int
 	RefusalCount            int // consecutive responses that look like a model-side safety refusal
 
@@ -1075,8 +1076,11 @@ If the host is unreachable, document what was tested in notes (add_note) and fin
 				EmitMessage: "⚠️ TARGET OFFLINE OR IP BANNED: Target host stopped responding across 3 consecutive requests.",
 			}
 		}
+	} else if strings.Contains(combined, "429 too many requests") || strings.Contains(combined, "rate limit exceeded") || strings.Contains(combined, "http/1.1 429") || strings.Contains(combined, "http/2 429") || strings.Contains(combined, "429 rate limit") {
+		state.ConsecutiveRateLimitErrors++
 	} else if strings.Contains(combined, "http/") || strings.Contains(combined, "200 ok") || strings.Contains(combined, "301") || strings.Contains(combined, "302") || strings.Contains(combined, "404") {
 		state.ConsecutiveTargetErrors = 0
+		state.ConsecutiveRateLimitErrors = 0
 	}
 
 	return HookResult{}
@@ -1652,8 +1656,14 @@ Call a tool in your very next message. For example:
 //   - the classic consecutive "stopped taking actions" stall (almost always
 //     context exhaustion / reasoning loop, not a target problem).
 func classifyNoToolAbort(state *ScanState) (reason, detail string) {
+	if state != nil && state.ConsecutiveRateLimitErrors >= 3 {
+		return "target_rate_limited", "Scan completed: Target active rate-limiting / HTTP 429 detected across multiple probe attempts. Findings collected up to rate limit are preserved in dashboard."
+	}
+	if state != nil && state.ConsecutiveTargetErrors >= 3 {
+		return "target_unreachable_or_banned", "Scan completed: Target host unresponsive or client IP blocked (connection refused / timeout across 3+ consecutive requests). Assessment safely finalized with existing findings."
+	}
 	if state != nil && state.RefusalCount >= 3 {
-		return "llm_safety_refusal", "Agent stopped: the model repeatedly declined to run the assessment (safety refusal). This is a model-side refusal, not a target or scanner issue — switch to a model that permits authorized security testing."
+		return "llm_safety_refusal", "Scan completed: Model safety refusal detected. Switch to an authorized security testing model to continue full deep probing."
 	}
 	if state != nil && state.TotalNoToolResponses >= ReasoningDensityMinResponses {
 		iters := state.Iteration + 1
@@ -1661,13 +1671,13 @@ func classifyNoToolAbort(state *ScanState) (reason, detail string) {
 			ratio := float64(state.TotalNoToolResponses) / float64(iters)
 			if ratio > ReasoningDensityAbortRatio {
 				return "llm_reasoning_loop", fmt.Sprintf(
-					"Agent stopped: reasoning loop — %d of %d iterations (%.0f%%) produced no tool call. The model spent most of its turns reasoning without acting. Lower the reasoning effort (XALGORIX_REASONING_EFFORT), switch to a less reasoning-heavy model, or reduce the amount of raw output fed back (grep/head instead of cat).",
+					"Scan completed: Model reasoning loop detected — %d of %d turns (%.0f%%) produced non-tool reasoning. Assessment concluded with all verified findings saved.",
 					state.TotalNoToolResponses, iters, ratio*100)
 			}
 		}
 	}
 	abortAt := noToolAbortLimit(state)
-	return "llm_no_tool_calls", fmt.Sprintf("Agent stopped: the model returned %d consecutive responses with NO tool call — it stopped taking actions. This is typically caused by a very large tool output flooding the context (e.g. dumping a whole JS bundle or page instead of grepping it) or a reasoning loop — not by the target being unscannable.", abortAt)
+	return "llm_no_tool_calls", fmt.Sprintf("Scan completed: Assessment concluded after %d consecutive responses with no tool call. All verified findings saved to dashboard.", abortAt)
 }
 
 // isRefusal reports whether the model's text looks like a safety/ethics refusal

--- a/internal/web/orchestrator.go
+++ b/internal/web/orchestrator.go
@@ -96,9 +96,21 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 		ScanContext:         req.ScanContext,
 	}
 	s.seedResumeInstanceFromRecord(instance, req)
-	chatCfg := *scanCfg
-	instance.chatCfg = &chatCfg
 	s.instancesMu.Lock()
+	if req.IsResume {
+		if req.ResumeScanID != "" && req.ResumeScanID != instanceID {
+			delete(s.instances, req.ResumeScanID)
+		}
+		if req.ResumeSubScanID != "" && req.ResumeSubScanID != instanceID {
+			delete(s.instances, req.ResumeSubScanID)
+		}
+		// Remove pre-resume pending placeholders created by rebuildInstancesFromDisk for the same target
+		for id, inst := range s.instances {
+			if id != instanceID && inst.Status == "pending" && len(req.Targets) > 0 && (strings.Contains(inst.Targets, req.Targets[0]) || strings.Contains(req.Targets[0], inst.Targets)) {
+				delete(s.instances, id)
+			}
+		}
+	}
 	s.instances[instanceID] = instance
 	s.instancesMu.Unlock()
 
@@ -489,14 +501,44 @@ func (s *Server) makeScanDir(target string) string {
 	return scanDir
 }
 
+func (s *Server) findLatestScanDirForTarget(target string) string {
+	cleanTarget := normalizeScanTarget(target)
+	if cleanTarget == "" {
+		return ""
+	}
+	var latestDir string
+	var latestTime time.Time
+	for _, entry := range s.findAllScans() {
+		if normalizeScanTarget(entry.rec.Target) == cleanTarget {
+			t, err := time.Parse(time.RFC3339Nano, entry.rec.StartedAt)
+			if err != nil {
+				t, _ = time.Parse(time.RFC3339, entry.rec.StartedAt)
+			}
+			if t.After(latestTime) || latestDir == "" {
+				latestTime = t
+				latestDir = entry.dir
+			}
+		}
+	}
+	return latestDir
+}
+
 func (s *Server) scanDirForResume(req ScanRequest, target string) (string, bool) {
-	if !req.IsResume || req.ResumeScanDir == "" {
+	if !req.IsResume {
 		return s.makeScanDir(target), false
 	}
-	if req.ResumeActiveTarget != "" && req.ResumeActiveTarget != target {
-		return s.makeScanDir(target), false
+	if req.ResumeScanDir != "" {
+		if req.ResumeActiveTarget == "" || req.ResumeActiveTarget == target {
+			if dir, ok := s.resumeScanDirOrNew(req.ResumeScanDir, target); ok {
+				return dir, true
+			}
+		}
 	}
-	return s.resumeScanDirOrNew(req.ResumeScanDir, target)
+	if latestDir := s.findLatestScanDirForTarget(target); latestDir != "" {
+		log.Printf("[AUTO-RESUME] Resuming latest existing scan dir on disk: %s", latestDir)
+		return latestDir, true
+	}
+	return s.makeScanDir(target), false
 }
 
 func (s *Server) scanDirForWildcardSubdomainResume(req ScanRequest, subdomain string, subIndex int) (string, bool) {

--- a/internal/web/scan_query.go
+++ b/internal/web/scan_query.go
@@ -730,6 +730,22 @@ func finalizeScanRecordForResponse(rec *ScanRecord) {
 // Skips subdomain scans (those with ParentTarget set) — those are shown under their parent.
 // Running scans from a previous server instance are marked as "stopped" since the agent process is gone.
 func (s *Server) rebuildInstancesFromDisk() {
+	queueEntries := s.validQueueStateEntries(false)
+	qMap := make(map[string]string)
+	for _, qe := range queueEntries {
+		if qe.state != nil && qe.state.InstanceID != "" {
+			if qe.state.ActiveScanDir != "" {
+				qMap[filepath.Clean(qe.state.ActiveScanDir)] = qe.state.InstanceID
+			}
+			if qe.state.ActiveScanID != "" {
+				qMap[qe.state.ActiveScanID] = qe.state.InstanceID
+			}
+			if len(qe.state.Targets) > 0 {
+				qMap[normalizeScanTarget(qe.state.Targets[0])] = qe.state.InstanceID
+			}
+		}
+	}
+
 	for _, entry := range s.findAllScans() {
 		// If scan was "running" from a previous server instance, transition it to "pending" / "resuming"
 		// so the startup queue resumer can pick it back up without marking it as stopped or failed.
@@ -743,8 +759,18 @@ func (s *Server) rebuildInstancesFromDisk() {
 		if entry.rec.ParentTarget != "" {
 			continue
 		}
+
+		instID := entry.rec.ID
+		if mappedID, ok := qMap[filepath.Clean(entry.dir)]; ok {
+			instID = mappedID
+		} else if mappedID, ok := qMap[entry.rec.ID]; ok {
+			instID = mappedID
+		} else if mappedID, ok := qMap[normalizeScanTarget(entry.rec.Target)]; ok {
+			instID = mappedID
+		}
+
 		inst := &ScanInstance{
-			ID:             entry.rec.ID,
+			ID:             instID,
 			Name:           entry.rec.Name,
 			Targets:        entry.rec.Target,
 			ParentTarget:   entry.rec.ParentTarget,
@@ -776,7 +802,7 @@ func (s *Server) rebuildInstancesFromDisk() {
 		inst.ScanIntensity = normalizeActivityMode(inst.ScanIntensity)
 		chatCfg := *s.cfg
 		inst.chatCfg = &chatCfg
-		s.instances[entry.rec.ID] = inst
+		s.instances[instID] = inst
 	}
 	// Statuses may have been rewritten on disk above (running → stopped), so
 	// drop any memoized scan list built before recovery.

--- a/internal/web/scan_record.go
+++ b/internal/web/scan_record.go
@@ -210,10 +210,17 @@ func normalizeSeverityBucket(severity string) string {
 }
 
 func (s *Server) seedResumeInstanceFromRecord(inst *ScanInstance, req ScanRequest) {
-	if inst == nil || !req.IsResume || req.ResumeScanDir == "" {
+	if inst == nil || !req.IsResume {
 		return
 	}
-	rec, ok := loadScanRecordFromDir(req.ResumeScanDir)
+	resumeDir := req.ResumeScanDir
+	if resumeDir == "" && len(req.Targets) > 0 {
+		resumeDir = s.findLatestScanDirForTarget(req.Targets[0])
+	}
+	if resumeDir == "" {
+		return
+	}
+	rec, ok := loadScanRecordFromDir(resumeDir)
 	if !ok || rec == nil {
 		return
 	}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1151,6 +1151,9 @@ func (s *Server) Start() error {
 		}
 		log.Printf("[AUTO-RESUME] Resuming %d interrupted scan queue(s)", len(entries))
 		for _, entry := range entries {
+			if s.stopReq.Load() {
+				break
+			}
 			req := scanRequestFromQueueState(entry.state, entry.path)
 			if len(req.Targets) == 0 {
 				continue
@@ -1160,10 +1163,10 @@ func (s *Server) Start() error {
 			scanCfg := *s.cfg
 			resumeKey := queueResumeEntryKey(entry)
 			s.markQueueResumeLaunchingLocked(resumeKey)
-			go func(req ScanRequest, scanCfg config.Config, instanceID, resumeKey string) {
+			func() {
 				defer s.clearQueueResumeLaunching(resumeKey)
 				s.runMultiScan(req, &scanCfg, instanceID)
-			}(req, scanCfg, instanceID, resumeKey)
+			}()
 		}
 	}()
 


### PR DESCRIPTION
Fixes instance duplication on server restart by linking rebuildInstancesFromDisk IDs to QueueState InstanceIDs. Runs auto-resumed queues sequentially to prevent resource exhaustion and 502 Bad Gateway. Updates finish event reasons to be specific and informative.