### PR TITLE
fix(agent): fix report_vulnerability hook tracking key and add explicit report_vulnerability XML instructions to no-tool nudges v4.5.112

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.111
+VERSION=4.5.112
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.111" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.112" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.111"
+var version = "4.5.112"
 
 const defaultWebPort = 9137
 

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -1696,15 +1696,16 @@ func reasoningLoopResumePrompt(state *ScanState, trigger string) string {
 
 STOP planning. STOP reasoning aloud. Your NEXT response MUST contain exactly one tool call. ` + next + `
 
-Do NOT:
-- produce another thinking-only or prose-only response
-- re-summarize what you already know
-- ask whether you should proceed (you are authorized — proceed)
+If you have confirmed vulnerabilities to submit, call report_vulnerability NOW:
+<function=report_vulnerability>
+<parameter=title>Vulnerability Title</parameter>
+<parameter=severity>CRITICAL</parameter>
+<parameter=description>Full technical explanation</parameter>
+<parameter=endpoint>https://TARGET/vulnerable-path</parameter>
+<parameter=exploitation_proof>Proof of Concept payload and output</parameter>
+</function>
 
-Call a tool in your very next message. For example:
-<function=terminal_execute>
-<parameter=command>curl -sk "https://TARGET/api/UNTESTED" -w "\n[%{http_code}]\n"</parameter>
-</function>`
+Otherwise, call a tool in your very next message (e.g. terminal_execute or finish). Do NOT produce another prose-only response.`
 }
 
 // classifyNoToolAbort turns a no-tool force-stop into a machine reason tag plus
@@ -1966,7 +1967,10 @@ func extractPaths(blob string) []string {
 // ── hookReportVulnerabilityTracker ─────────────────────────────────────────
 // Tracks calls to report_vulnerability and maintains PendingFailedReportCalls.
 func hookReportVulnerabilityTracker(state *ScanState, args map[string]string) HookResult {
-	toolName := args["tool"]
+	toolName := args["tool_name"]
+	if toolName == "" {
+		toolName = args["tool"]
+	}
 	if toolName != "report_vulnerability" {
 		return HookResult{}
 	}


### PR DESCRIPTION
Fixes bug in hookReportVulnerabilityTracker args key matching ('tool_name' vs 'tool') which prevented pending failed vulnerability calls from blocking finish. Adds explicit report_vulnerability XML example to no-tool loop recovery nudges.