### PR TITLE
fix(agent): enforce immediate real-time report_vulnerability calls in system and autonomous prompts v4.5.113

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.112
+VERSION=4.5.113
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.112" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.113" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.112"
+var version = "4.5.113"
 
 const defaultWebPort = 9137
 

--- a/internal/agent/agent_prompt.go
+++ b/internal/agent/agent_prompt.go
@@ -202,9 +202,10 @@ If a finding fails any check, fix the evidence or report it as 'info'. The repor
 16. If a parameter seems filtered, try: alternative payloads, encoding, nested injection, polyglot payloads.
 
 ### Vulnerability Reporting Rules (STRICT)
-17. Chain findings for maximum impact: info leak → credential theft → account takeover → RCE.
-18. If you find IDOR, test it on EVERY endpoint — not just one.
-19. If you find an open redirect, chain it with SSRF, OAuth token theft, or phishing.
+17. **REPORT IN REAL-TIME**: Do NOT batch or defer reporting vulnerabilities until the end of the scan or Phase 22! As soon as you confirm a vulnerability via terminal execution or HTTP test, call 'report_vulnerability' IMMEDIATELY in that exact same or next turn. Do NOT just write text notes or message disclaimers about what you found — call 'report_vulnerability' right away so the vulnerability appears on the live dashboard.
+18. Chain findings for maximum impact: info leak → credential theft → account takeover → RCE.
+19. If you find IDOR, test it on EVERY endpoint — not just one.
+20. If you find an open redirect, chain it with SSRF, OAuth token theft, or phishing.
 
 ### CRITICAL: What NOT to Report as Vulnerability
 The following are INFORMATION only - NOT vulnerabilities:

--- a/internal/web/autonomous.go
+++ b/internal/web/autonomous.go
@@ -41,8 +41,9 @@ Your primary target is ` + "`" + `` + target + `` + "`" + `. However, the follow
 
 **Why:** Many applications split auth (login.example.com), API (api.example.com), and web (www.example.com) across subdomains. Testing only www would miss critical attack surface.
 
-## CORE RULE: DETECT → EXPLOIT → REPORT
+## CORE RULE: DETECT → EXPLOIT → REPORT IMMEDIATELY
 
+⚠️ As soon as a vulnerability is exploited and confirmed, call 'report_vulnerability' IMMEDIATELY. Do NOT wait until the end of the scan or batch findings. Real-time reporting feeds the live UI dashboard!
 ⚠️ NEVER report a vulnerability you haven't exploited. The report_vulnerability tool WILL REJECT reports without exploitation proof.
 
 ### Phase 1: RECONNAISSANCE (automated)


### PR DESCRIPTION
Updates system and autonomous pentesting prompts to explicitly forbid deferring/batching report_vulnerability calls. Forces real-time report_vulnerability execution as soon as a finding is exploited and confirmed.