### PR TITLE
fix(agent): default NoToolAbortAt to 0 (never force-finish) and remove finish tool prompt example from resume nudge v4.5.115

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.114
+VERSION=4.5.115
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.114" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.115" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.114"
+var version = "4.5.115"
 
 const defaultWebPort = 9137
 

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -1694,9 +1694,15 @@ func reasoningLoopResumePrompt(state *ScanState, trigger string) string {
 	}
 	return prefix + `
 
-STOP planning. STOP reasoning aloud. Your NEXT response MUST contain exactly one tool call. ` + next + `
+STOP planning, STOP explaining, STOP apologizing, and STOP outputting plain text reasoning. You are an autonomous testing agent and MUST interact with the target using tool calls. ` + next + `
 
-If you have confirmed vulnerabilities to submit, call report_vulnerability NOW:
+Your very NEXT response MUST contain an XML tool call:
+1. To run a probe command, call terminal_execute:
+<function=terminal_execute>
+<parameter=command>your command here</parameter>
+</function>
+
+2. If you have confirmed vulnerabilities to submit, call report_vulnerability:
 <function=report_vulnerability>
 <parameter=title>Vulnerability Title</parameter>
 <parameter=severity>CRITICAL</parameter>
@@ -1705,7 +1711,7 @@ If you have confirmed vulnerabilities to submit, call report_vulnerability NOW:
 <parameter=exploitation_proof>Proof of Concept payload and output</parameter>
 </function>
 
-Otherwise, call a tool in your very next message (e.g. terminal_execute or finish). Do NOT produce another prose-only response.`
+Call ONE tool NOW. Do NOT output any plain text without a tool call.`
 }
 
 // classifyNoToolAbort turns a no-tool force-stop into a machine reason tag plus

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -333,7 +333,7 @@ func load() *Config {
 		DisableBrowser:      envOrBool("XALGORIX_DISABLE_BROWSER", false),
 		MaxIterations:       envOrInt("XALGORIX_MAX_ITERATIONS", 0),
 		MinIterations:       envOrInt("XALGORIX_MIN_ITERATIONS", 50),
-		NoToolAbortAt:       envOrInt("XALGORIX_NO_TOOL_ABORT_AT", 30),
+		NoToolAbortAt:       envOrInt("XALGORIX_NO_TOOL_ABORT_AT", 0),
 		MaxFinishRejections: envOrInt("XALGORIX_MAX_FINISH_REJECTIONS", 15),
 		TargetAuth:          envOr("XALGORIX_TARGET_AUTH", ""),
 		TargetAuthSecondary: envOr("XALGORIX_TARGET_AUTH_B", ""),


### PR DESCRIPTION
Defaults NoToolAbortAt to 0 so the agent never force-finishes scans on no-tool reasoning loops. Removes finish tool XML example from reasoning loop prompt to prevent early finish.