### PR TITLE
fix(agent): restore finish tool option in reasoning loop resume prompt v4.5.116

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.115
+VERSION=4.5.116
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.115" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.116" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.115"
+var version = "4.5.116"
 
 const defaultWebPort = 9137
 

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -1697,12 +1697,17 @@ func reasoningLoopResumePrompt(state *ScanState, trigger string) string {
 STOP planning, STOP explaining, STOP apologizing, and STOP outputting plain text reasoning. You are an autonomous testing agent and MUST interact with the target using tool calls. ` + next + `
 
 Your very NEXT response MUST contain an XML tool call:
-1. To run a probe command, call terminal_execute:
+1. If you wish to finish or conclude the scan, call finish:
+<function=finish>
+<parameter=summary>Detailed final summary of findings</parameter>
+</function>
+
+2. To run a probe command, call terminal_execute:
 <function=terminal_execute>
 <parameter=command>your command here</parameter>
 </function>
 
-2. If you have confirmed vulnerabilities to submit, call report_vulnerability:
+3. If you have confirmed vulnerabilities to submit, call report_vulnerability:
 <function=report_vulnerability>
 <parameter=title>Vulnerability Title</parameter>
 <parameter=severity>CRITICAL</parameter>


### PR DESCRIPTION
Restores option 1 (<function=finish>) in reasoningLoopResumePrompt so the agent has a clear tool pathway to conclude the scan when testing is complete.