### PR TITLE
fix(agent): preserve iteration count and seed LLM resume context briefing on scan restart v4.5.117

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.116
+VERSION=4.5.117
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.116" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.117" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.116"
+var version = "4.5.117"
 
 const defaultWebPort = 9137
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -155,6 +155,11 @@ type Agent struct {
 	// scanContextBriefing is built from scanContext in prepareScanEnvironment
 	// and injected as a high-priority user message at the start of Run.
 	scanContextBriefing string
+
+	// initialIter and resumeBriefing preserve iteration count and previous execution
+	// history when a scan is resumed/restarted across server restarts.
+	initialIter    int
+	resumeBriefing string
 }
 
 // AgentOption configures optional behavior on a *Agent. The
@@ -712,9 +717,13 @@ func (a *Agent) Run(targets []string, instruction string) {
 	if a.scanContextBriefing != "" {
 		a.messages = append(a.messages, llm.Message{Role: "user", Content: a.scanContextBriefing})
 	}
+	if a.resumeBriefing != "" {
+		a.messages = append(a.messages, llm.Message{Role: "user", Content: a.resumeBriefing})
+	}
 
 	// Initialize scan state for hooks (replaces 17+ local tracking variables)
 	a.state = NewScanState()
+	a.state.Iteration = a.initialIter
 	if a.cfg != nil {
 		// Thread the configurable no-tool abort threshold (0 = never give up).
 		a.state.NoToolAbortLimit = a.cfg.NoToolAbortAt
@@ -740,7 +749,7 @@ func (a *Agent) Run(targets []string, instruction string) {
 	// Running total of tool calls, for the optional resource budget.
 	toolCallsTotal := 0
 
-	iter := 0
+	iter := a.initialIter
 	for ; (a.maxIter == 0 || iter < a.maxIter) && !a.stopped.Load() && (a.ctx == nil || a.ctx.Err() == nil); iter++ {
 		// Reset activity watchdog on each iteration — IMMEDIATELY, no delay
 		a.touchActivity()
@@ -1428,6 +1437,18 @@ func (a *Agent) SetSourceRepo(s string) { a.sourceRepo = strings.TrimSpace(s) }
 // SetScanContext sets the per-scan context artifact path (OpenAPI/HAR/Postman
 // file or directory) used to seed the attack surface. Call before Run().
 func (a *Agent) SetScanContext(s string) { a.scanContext = strings.TrimSpace(s) }
+
+// SetInitialIteration sets the starting iteration index for resumed runs. Call before Run().
+func (a *Agent) SetInitialIteration(iter int) {
+	if iter > 0 {
+		a.initialIter = iter
+	}
+}
+
+// SetResumeBriefing sets a briefing summarizing prior state when resuming a scan. Call before Run().
+func (a *Agent) SetResumeBriefing(s string) {
+	a.resumeBriefing = strings.TrimSpace(s)
+}
 
 // prepareScanEnvironment wires per-scan authenticated-session credentials and
 // whitebox source into the shared scan context. Runs at the start of Run()

--- a/internal/web/scan_session.go
+++ b/internal/web/scan_session.go
@@ -174,6 +174,15 @@ func (s *Server) executeScanSession(sess *scanSession) {
 	sess.record = s.scanRecordForSession(sess)
 	s.saveScanRecordTo(sess.record, sess.scanDir)
 
+	if !sess.resetState && sess.record != nil {
+		if sess.record.Iterations > 0 {
+			agnt.SetInitialIteration(sess.record.Iterations)
+		}
+		if briefing := formatResumeBriefing(sess.record, sctx.ID); briefing != "" {
+			agnt.SetResumeBriefing(briefing)
+		}
+	}
+
 	// 5. Event processing goroutine — drains events and broadcasts to WebSocket
 	done := make(chan struct{})
 	go func() {
@@ -805,6 +814,55 @@ func mapValues(values map[string]string) []string {
 		out = append(out, value)
 	}
 	return out
+}
+
+func formatResumeBriefing(rec *ScanRecord, contextID string) string {
+	if rec == nil {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("🔄 SCENARIO RESUME BRIEFING (Continued scan session from Iteration %d):\n", rec.Iterations))
+	sb.WriteString(fmt.Sprintf("Target: %s\n", rec.Target))
+	if len(rec.Vulns) > 0 {
+		sb.WriteString(fmt.Sprintf("Confirmed Vulnerabilities Reported So Far (%d):\n", len(rec.Vulns)))
+		for _, v := range rec.Vulns {
+			sb.WriteString(fmt.Sprintf(" - [%s] %s (%s)\n", strings.ToUpper(v.Severity), v.Title, v.Endpoint))
+		}
+	} else {
+		sb.WriteString("No vulnerabilities reported yet.\n")
+	}
+
+	notesData := notes.FormatForContextID(contextID)
+	if notesData != "" {
+		sb.WriteString("\nDiscovered Endpoints & Target Notes:\n")
+		sb.WriteString(notesData)
+		sb.WriteString("\n")
+	}
+
+	var lastEvents []string
+	if len(rec.Events) > 0 {
+		for i := len(rec.Events) - 1; i >= 0 && len(lastEvents) < 6; i-- {
+			e := rec.Events[i]
+			if e.Type == "tool_call" {
+				lastEvents = append([]string{fmt.Sprintf("Executed tool %s with args: %v", e.ToolName, e.ToolArgs)}, lastEvents...)
+			} else if e.Type == "tool_result" {
+				out := e.Output
+				if len(out) > 300 {
+					out = out[:300] + "... (truncated)"
+				}
+				lastEvents = append([]string{fmt.Sprintf("Tool result (%s): %s", e.ToolName, out)}, lastEvents...)
+			}
+		}
+	}
+	if len(lastEvents) > 0 {
+		sb.WriteString("\nRecent Execution Events Prior To Restart:\n")
+		for _, te := range lastEvents {
+			sb.WriteString(" • " + te + "\n")
+		}
+	}
+
+	sb.WriteString("\nCONTINUE ASSESSMENT: Resume deep penetration testing from where you left off. Do not re-run basic recon steps already documented above. Target new endpoints or unverified attack vectors now.")
+	return sb.String()
 }
 
 func minInt(a, b int) int {


### PR DESCRIPTION
Preserves cumulative iteration count across server restarts/resumes and injects a structured Resume Context Briefing into the LLM context (including previously reported vulns, target notes, discovered endpoints, and recent execution events) so the model remembers its progress and continues testing seamlessly.