### PR TITLE
fix(lint): convert if-else to tagged switch on e.Type in formatResumeBriefing v4.5.118

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.117
+VERSION=4.5.118
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.117" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.118" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.117"
+var version = "4.5.118"
 
 const defaultWebPort = 9137
 

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -85,16 +85,16 @@ type ScanState struct {
 	BrowserAuthContext bool // true after browser login/auth detected — justifies browser use
 
 	// Stuck-loop detection
-	StuckDomain             string
-	StuckIterations         int
-	ConsecutiveBrowser      int
-	ConsecutiveSearch       int
-	ConsecutiveErrors       int
+	StuckDomain                string
+	StuckIterations            int
+	ConsecutiveBrowser         int
+	ConsecutiveSearch          int
+	ConsecutiveErrors          int
 	ConsecutiveTargetErrors    int // consecutive host-unreachable/connection-refused errors
 	ConsecutiveRateLimitErrors int // consecutive 429 rate-limit / WAF block errors
 	EmptyResponseCount         int
-	NoToolCount             int
-	RefusalCount            int // consecutive responses that look like a model-side safety refusal
+	NoToolCount                int
+	RefusalCount               int // consecutive responses that look like a model-side safety refusal
 
 	// Repeated-call loop detection (orthogonal to the browser/search stuck
 	// tracking above). Catches the agent regenerating the same tool call with

--- a/internal/web/scan_session.go
+++ b/internal/web/scan_session.go
@@ -843,9 +843,10 @@ func formatResumeBriefing(rec *ScanRecord, contextID string) string {
 	if len(rec.Events) > 0 {
 		for i := len(rec.Events) - 1; i >= 0 && len(lastEvents) < 6; i-- {
 			e := rec.Events[i]
-			if e.Type == "tool_call" {
+			switch e.Type {
+			case "tool_call":
 				lastEvents = append([]string{fmt.Sprintf("Executed tool %s with args: %v", e.ToolName, e.ToolArgs)}, lastEvents...)
-			} else if e.Type == "tool_result" {
+			case "tool_result":
 				out := e.Output
 				if len(out) > 300 {
 					out = out[:300] + "... (truncated)"


### PR DESCRIPTION
Converts if-else statement on e.Type to a tagged switch in formatResumeBriefing to satisfy staticcheck QF1003.