### PR TITLE
fix(agent): track missing parameter errors in hookResultRepeatTracker to break malformed tool call loops v4.5.119

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.118
+VERSION=4.5.119
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.118" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.119" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.118"
+var version = "4.5.119"
 
 const defaultWebPort = 9137
 

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -871,8 +871,7 @@ func hookResultRepeatTracker(state *ScanState, args map[string]string) HookResul
 
 	output := args["output"]
 	errStr := args["error"]
-	if strings.Contains(output, "missing required parameter") || strings.Contains(errStr, "missing required parameter") ||
-		strings.Contains(output, "unknown tool") || strings.Contains(errStr, "unknown tool") {
+	if strings.Contains(output, "unknown tool") || strings.Contains(errStr, "unknown tool") {
 		return HookResult{}
 	}
 


### PR DESCRIPTION
Removes missing required parameter check exemption from hookResultRepeatTracker so repeated malformed tool calls trigger repeat result nudges and force-skips, breaking token-draining loops.