### PR TITLE
fix(tools): make oob_callback action optional (default generate) and add XML syntax guidance to registry missing parameter errors v4.5.120

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.119
+VERSION=4.5.120
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.119" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.120" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.119"
+var version = "4.5.120"
 
 const defaultWebPort = 9137
 

--- a/internal/tools/oob/oob.go
+++ b/internal/tools/oob/oob.go
@@ -19,7 +19,7 @@ func Register(r *tools.Registry) {
 		Name:        "oob_callback",
 		Description: "Out-of-band (OAST) callback oracle for CONFIRMING blind vulnerabilities (blind SSRF, blind RCE, blind XSS, XXE, blind SQLi, blind CMDi). Captures DNS, HTTP and SMTP callbacks (via interactsh by default — no server setup needed), so even DNS-only sinks that merely resolve your host are proven. Workflow: (1) action=generate → get a unique callback URL/host; (2) plant it in your payload (an SSRF url param, a command like `curl <url>` or `nslookup <host>`, an XXE SYSTEM entity, a blind-XSS script src); (3) action=poll with the token → any recorded interaction is concrete PROOF the target reached your callback.",
 		Parameters: []tools.Parameter{
-			{Name: "action", Description: "'generate' to mint a new callback URL, or 'poll' to check for interactions on a token.", Required: true},
+			{Name: "action", Description: "'generate' to mint a new callback URL (default if omitted), or 'poll' to check for interactions on a token.", Required: false},
 			{Name: "token", Description: "For action=poll: the token returned by generate.", Required: false},
 		},
 		Execute: execute,

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -312,7 +312,7 @@ func (r *Registry) Execute(name string, args map[string]string) (Result, error) 
 			)
 		}
 		if len(missing) == 1 {
-			return Result{}, fmt.Errorf("missing required parameter '%s' for tool '%s'", missing[0], name)
+			return Result{}, fmt.Errorf("missing required parameter '%s' for tool '%s' — you MUST include <parameter=%s>value</parameter> inside <function=%s>...</function>", missing[0], name, missing[0], name)
 		}
 		return Result{}, fmt.Errorf(
 			"missing required parameters for tool '%s': %s — provide ALL of them in a single call (one <parameter=NAME>…</parameter> per field)",

--- a/internal/web/scan_session.go
+++ b/internal/web/scan_session.go
@@ -848,6 +848,10 @@ func formatResumeBriefing(rec *ScanRecord, contextID string) string {
 				lastEvents = append([]string{fmt.Sprintf("Executed tool %s with args: %v", e.ToolName, e.ToolArgs)}, lastEvents...)
 			case "tool_result":
 				out := e.Output
+				errStr := e.Error
+				if strings.Contains(out, "missing required parameter") || strings.Contains(errStr, "missing required parameter") {
+					continue
+				}
 				if len(out) > 300 {
 					out = out[:300] + "... (truncated)"
 				}


### PR DESCRIPTION
Makes oob_callback action parameter optional so calling oob_callback without parameters defaults to generate, adds explicit XML syntax guidance to registry missing parameter errors, and filters out stale missing parameter error events from resume briefings.