### PR TITLE
fix(web): launch auto-resume queue entries asynchronously and wake admission wait loop on pause v4.5.122

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.121
+VERSION=4.5.122
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.121" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.122" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.121"
+var version = "4.5.122"
 
 const defaultWebPort = 9137
 

--- a/internal/web/orchestrator.go
+++ b/internal/web/orchestrator.go
@@ -248,11 +248,7 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 		// again on the safety-net ticker). This wake fires regardless
 		// of whether the scan finished, errored, was stopped, or
 		// panicked, because it lives in the unconditional defer.
-		// (Task 11.2 / R3.2, R3.6 / Property 5.)
-		select {
-		case s.admissionWake <- struct{}{}:
-		default:
-		}
+		s.notifyAdmissionWake()
 		log.Printf("[INFO] runMultiScan instance %s exited (ranScan=%v)", instanceID, ranScan)
 	}()
 
@@ -1653,5 +1649,12 @@ func cleanTmpSubdomainFiles() {
 				log.Printf("[CLEANUP] Removed stale /tmp file: %s", path)
 			}
 		}
+	}
+}
+
+func (s *Server) notifyAdmissionWake() {
+	select {
+	case s.admissionWake <- struct{}{}:
+	default:
 	}
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1163,10 +1163,10 @@ func (s *Server) Start() error {
 			scanCfg := *s.cfg
 			resumeKey := queueResumeEntryKey(entry)
 			s.markQueueResumeLaunchingLocked(resumeKey)
-			func() {
-				defer s.clearQueueResumeLaunching(resumeKey)
-				s.runMultiScan(req, &scanCfg, instanceID)
-			}()
+			go func(e queueStateEntry, r ScanRequest, cfg config.Config, id string, key string) {
+				defer s.clearQueueResumeLaunching(key)
+				s.runMultiScan(r, &cfg, id)
+			}(entry, req, scanCfg, instanceID, resumeKey)
 		}
 	}()
 
@@ -2434,6 +2434,7 @@ func (s *Server) handleInstanceAction(w http.ResponseWriter, r *http.Request) {
 
 		s.broadcastToInstance(instanceID, WSEvent{Type: "paused", Content: "Scan paused by user"})
 		s.broadcastDashboard(WSEvent{Type: "instance_updated", Content: instanceID})
+		s.notifyAdmissionWake()
 		_ = json.NewEncoder(w).Encode(map[string]string{"status": "paused", "instance_id": instanceID})
 		return
 	}


### PR DESCRIPTION
Fixes issue where startup auto-resume executed scan queues synchronously, blocking secondary queued scans from entering the admission wait loop. Also triggers notifyAdmissionWake on pause to instantly admit pending scans.