### PR TITLE
fix: stop LLM retry loops without limiting coverage

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -65,11 +65,26 @@ func init() {
 // tool not explicitly listed in toolHardTimeout.
 const defaultToolHardTimeout = 15 * time.Minute
 
-// maxCumulativeRateLimitWait bounds the total time the agent loop may spend
-// parked in the provider-rate-limit backoff. A persistently 429'd provider
-// would otherwise stall the scan indefinitely because touchActivity() keeps
-// the idle watchdog alive during the wait. Set to 0 to disable the ceiling.
-const maxCumulativeRateLimitWait = 6 * time.Hour
+// maxCumulativeRateLimitWait is the safe fallback when a caller constructs a
+// Config literal instead of loading the environment-backed configuration. A
+// provider usage-window exhaustion is not a normal transient tool failure;
+// waiting for hours while replaying the same context can consume the next
+// window without making progress.
+const maxCumulativeRateLimitWait = 30 * time.Minute
+
+// maxRateLimitWait returns the per-scan ceiling for provider rate-limit waits.
+// A negative configured value disables the ceiling for operators who
+// explicitly need the old behavior; zero means "use the safe default" for
+// programmatic Config literals.
+func (a *Agent) maxRateLimitWait() time.Duration {
+	if a.cfg == nil || a.cfg.MaxRateLimitWaitSec == 0 {
+		return maxCumulativeRateLimitWait
+	}
+	if a.cfg.MaxRateLimitWaitSec < 0 {
+		return 0
+	}
+	return time.Duration(a.cfg.MaxRateLimitWaitSec) * time.Second
+}
 
 // hardTimeoutFor returns the configured hard-timeout ceiling for the given
 // tool name, falling back to defaultToolHardTimeout when the tool is not
@@ -845,9 +860,10 @@ func (a *Agent) Run(targets []string, instruction string) {
 				continue
 			}
 
-			// Rate limit: wait indefinitely with 30-minute intervals until
-			// the LLM recovers. Don't count toward consecutive errors and
-			// don't skip the current target.
+			// Rate limit: wait in a bounded interval for a transient provider
+			// recovery. Do not keep a scan alive for the whole provider usage
+			// window: every retry resends the entire conversation and can make
+			// the next window disappear too.
 			isRateLimited := strings.Contains(errStr, "rate limited") ||
 				strings.Contains(errStr, "429") ||
 				strings.Contains(errStr, "too many requests") ||
@@ -858,25 +874,42 @@ func (a *Agent) Run(targets []string, instruction string) {
 					a.state.ConsecutiveErrors = 0
 				}
 				// Bound the total time the scan may spend parked on provider
-				// rate limits. Without a ceiling a persistently 429'd provider
-				// keeps the scan alive forever (touchActivity defeats the idle
-				// watchdog on purpose during the wait). Once the cumulative
-				// wait exceeds maxCumulativeRateLimitWait, fail the scan cleanly.
-				if maxCumulativeRateLimitWait > 0 && a.state.CumulativeRateLimitWait >= maxCumulativeRateLimitWait {
+				// rate limits. Once the configured ceiling is reached, fail the
+				// scan cleanly instead of issuing another context-sized request.
+				maxWait := a.maxRateLimitWait()
+				if maxWait > 0 && a.state.CumulativeRateLimitWait >= maxWait {
 					a.emit(Event{Type: "error", Content: fmt.Sprintf("⛔ Agent stopped: LLM provider rate limited for a cumulative %s without recovering.", a.state.CumulativeRateLimitWait), TotalTokens: tokenCount()})
 					a.emit(Event{Type: "finished", Content: fmt.Sprintf("Agent stopped: provider rate limited for a cumulative %s without recovering.", a.state.CumulativeRateLimitWait), TotalTokens: tokenCount(), Aborted: true, AbortReason: "llm_rate_limited"})
 					return
 				}
-				a.emit(Event{Type: "error", Content: "⏳ Rate limited by LLM provider — waiting 30 minutes before retrying (will NOT skip this target)", TotalTokens: tokenCount()})
-				// Sleep in 1-minute chunks so we can bail out if the agent is stopped
-				for waited := 0; waited < 30; waited++ {
+				waitFor := 30 * time.Minute
+				if maxWait > 0 && maxWait-a.state.CumulativeRateLimitWait < waitFor {
+					waitFor = maxWait - a.state.CumulativeRateLimitWait
+				}
+				if waitFor <= 0 {
+					a.emit(Event{Type: "finished", Content: "Agent stopped: provider rate-limit wait budget exhausted.", TotalTokens: tokenCount(), Aborted: true, AbortReason: "llm_rate_limited"})
+					return
+				}
+				a.emit(Event{Type: "error", Content: fmt.Sprintf("⏳ Rate limited by LLM provider — waiting up to %s before stopping this scan", waitFor.Round(time.Minute)), TotalTokens: tokenCount()})
+				// Sleep in 1-minute chunks so we can bail out if the agent is stopped.
+				for waited := time.Duration(0); waited < waitFor; {
 					if a.stopped.Load() || (a.ctx != nil && a.ctx.Err() != nil) {
 						break
 					}
-					time.Sleep(1 * time.Minute)
-					a.state.CumulativeRateLimitWait += 1 * time.Minute
+					chunk := time.Minute
+					if waitFor-waited < chunk {
+						chunk = waitFor - waited
+					}
+					time.Sleep(chunk)
+					waited += chunk
+					a.state.CumulativeRateLimitWait += chunk
 				}
 				a.touchActivity() // keep watchdog alive during long wait
+				if maxWait > 0 && a.state.CumulativeRateLimitWait >= maxWait {
+					a.emit(Event{Type: "error", Content: fmt.Sprintf("⛔ Agent stopped: provider rate-limit wait budget exhausted after %s.", a.state.CumulativeRateLimitWait), TotalTokens: tokenCount()})
+					a.emit(Event{Type: "finished", Content: "Agent stopped: provider rate-limit wait budget exhausted; existing findings were preserved.", TotalTokens: tokenCount(), Aborted: true, AbortReason: "llm_rate_limited"})
+					return
+				}
 				continue
 			}
 
@@ -1119,7 +1152,22 @@ func (a *Agent) Run(targets []string, instruction string) {
 			// block loop (no allowed call in between) escalates.
 			a.state.ConsecutiveBlockedCalls = 0
 
-			a.hooks.Fire(OnToolCall, a.state, toolArgs)
+			toolCallHook := a.hooks.Fire(OnToolCall, a.state, toolArgs)
+			if toolCallHook.Nudge != "" {
+				a.msgMu.Lock()
+				a.messages = append(a.messages, llm.Message{Role: "user", Content: toolCallHook.Nudge})
+				a.msgMu.Unlock()
+			}
+			if toolCallHook.EmitMessage != "" {
+				a.emit(Event{Type: "message", Content: toolCallHook.EmitMessage, TotalTokens: tokenCount()})
+				if strings.Contains(toolCallHook.EmitMessage, "Force finishing") || strings.Contains(toolCallHook.EmitMessage, "Loop limit reached") {
+					a.emit(Event{Type: "finished", Content: toolCallHook.EmitMessage, TotalTokens: tokenCount(), Aborted: false, AbortReason: "report_retry_limit"})
+					return
+				}
+			}
+			if toolCallHook.ForceSkip {
+				continue
+			}
 
 			// ── Hook: OnStuckCheck (nudge/force-skip based on stuck counters) ──
 			stuckResult := a.hooks.Fire(OnStuckCheck, a.state, toolArgs)
@@ -1173,6 +1221,11 @@ func (a *Agent) Run(targets []string, instruction string) {
 			toolResultHook := a.hooks.Fire(OnToolResult, a.state, resultArgs)
 			if toolResultHook.EmitMessage != "" {
 				a.emit(Event{Type: "message", Content: toolResultHook.EmitMessage, TotalTokens: tokenCount()})
+			}
+			if toolResultHook.Nudge != "" {
+				a.msgMu.Lock()
+				a.messages = append(a.messages, llm.Message{Role: "user", Content: toolResultHook.Nudge})
+				a.msgMu.Unlock()
 			}
 
 			// ── Hook: OnFinishAttempt ──

--- a/internal/agent/agent_messages.go
+++ b/internal/agent/agent_messages.go
@@ -131,6 +131,13 @@ func alignPruneCutoff(messages []llm.Message, start int) int {
 // discards raw tool-output bytes the agent no longer needs.
 const pruneThresholdBytes = 500 * 1024
 
+// maxMessagesBeforePrune is a second safety boundary independent of byte
+// size. A long run of short tool calls can still make the model resend a very
+// large number of message envelopes on every iteration, especially after a
+// provider rate-limit retry. Keep the old proven message-count guard alongside
+// the window-relative byte ceiling.
+const maxMessagesBeforePrune = 100
+
 // maxRecentMsgBytes caps EACH kept-recent message during pruning. Compaction
 // summarizes OLD messages, but the recent window was kept verbatim — a run of
 // large tool outputs (even after the per-call cap) could still balloon the
@@ -205,6 +212,9 @@ func (a *Agent) shouldPruneBeforeLLM() bool {
 	}
 	a.msgMu.Lock()
 	defer a.msgMu.Unlock()
+	if len(a.messages) > maxMessagesBeforePrune {
+		return true
+	}
 
 	size := 0
 	for i := range a.messages {
@@ -220,14 +230,10 @@ func (a *Agent) pruneMessages() {
 	a.msgMu.Lock()
 	defer a.msgMu.Unlock()
 
-	// Compact only when the serialized buffer has actually grown past the
-	// configured ceiling — a fraction (ContextCompactRatio, ~0.75) of the
-	// model's context window (LLMContextWindow), or an explicit
-	// ContextCompactTokens budget. This replaces the old fixed 100-message
-	// trigger, which compacted far too early on large-context models and
-	// degraded output quality by discarding useful working context. The size
-	// scan mirrors shouldPruneBeforeLLM but is inlined here because msgMu is
-	// already held (shouldPruneBeforeLLM would re-lock and deadlock).
+	// Compact when either the serialized buffer has grown past the configured
+	// ceiling or the message-count safety boundary is reached. The size scan
+	// mirrors shouldPruneBeforeLLM but is inlined here because msgMu is already
+	// held (shouldPruneBeforeLLM would re-lock and deadlock).
 	threshold := a.compactThresholdBytes()
 	if threshold <= 0 {
 		return // auto-compaction disabled
@@ -236,7 +242,7 @@ func (a *Agent) pruneMessages() {
 	for i := range a.messages {
 		size += len(a.messages[i].Content) + perMessageOverheadBytes
 	}
-	if size <= threshold {
+	if size <= threshold && len(a.messages) <= maxMessagesBeforePrune {
 		return
 	}
 

--- a/internal/agent/agent_prompt.go
+++ b/internal/agent/agent_prompt.go
@@ -39,7 +39,7 @@ func (a *Agent) buildSystemPrompt(targets []string, instruction string, ratePoli
 		}
 	}
 
-	return fmt.Sprintf(`You are an elite autonomous AI penetration tester and bug bounty hunter with the mindset of a top-10 HackerOne researcher. You don't just run tools — you THINK like an attacker. You analyze application logic, understand business flows, find edge cases that automated scanners miss, and chain low-severity findings into critical exploits.
+	prompt := fmt.Sprintf(`You are an elite autonomous AI penetration tester and bug bounty hunter with the mindset of a top-10 HackerOne researcher. You don't just run tools — you THINK like an attacker. You analyze application logic, understand business flows, find edge cases that automated scanners miss, and chain low-severity findings into critical exploits.
 
 ## ENGAGEMENT AUTHORIZATION — READ FIRST
 
@@ -368,6 +368,8 @@ You have access to **expert-level vulnerability skills** via the read_skill and 
 		rateInt, rateDelay,
 		rateInt, rateDelay,
 		toolSchema, strings.Join(targets, "\n"), checklist, a.buildClosingInstruction(instruction))
+
+	return prompt + "\n\n## CANONICAL TOOL REFERENCE — FOLLOW EXACTLY\n" + embeddedToolReference
 }
 
 const defaultChecklist = `

--- a/internal/agent/context_compact_test.go
+++ b/internal/agent/context_compact_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/xalgord/xalgorix/v4/internal/config"
 	"github.com/xalgord/xalgorix/v4/internal/llm"
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
 )
 
 func msgsOfSize(totalBytes int) []llm.Message {
@@ -89,5 +90,27 @@ func TestCompactThreshold_RatioClamp(t *testing.T) {
 	want := int(float64(100_000)*0.75) * bytesPerTokenEstimate
 	if got := a.compactThresholdBytes(); got != want {
 		t.Fatalf("threshold = %d, want %d (ratio should clamp to default)", got, want)
+	}
+}
+
+func TestShouldPruneBeforeLLM_MessageCountBoundary(t *testing.T) {
+	a := &Agent{cfg: &config.Config{ContextCompactTokens: 30000}, scanCtx: scanctx.Default()}
+	a.messages = []llm.Message{{Role: "system", Content: "sys"}}
+	for i := 0; i < maxMessagesBeforePrune-1; i++ {
+		a.messages = append(a.messages, llm.Message{Role: "user", Content: "short"})
+	}
+	if a.shouldPruneBeforeLLM() {
+		t.Fatal("message count below the boundary should not trigger pruning")
+	}
+	a.messages = append(a.messages, llm.Message{Role: "assistant", Content: "short"})
+	if !a.shouldPruneBeforeLLM() {
+		t.Fatal("message count above the boundary must trigger pruning even when byte size is small")
+	}
+	a.pruneMessages()
+	if len(a.messages) >= maxMessagesBeforePrune {
+		t.Fatalf("pruned message count = %d, want less than %d", len(a.messages), maxMessagesBeforePrune)
+	}
+	if a.messages[0].Role != "system" {
+		t.Fatal("pruning must preserve the system message")
 	}
 }

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -42,24 +42,30 @@ var notesBlobForContext func(scanContextID string) string
 // ScanState holds all mutable state that hooks can read and write.
 // It replaces the loose local variables previously scattered in Run().
 type ScanState struct {
-	Iteration                  int
-	ScanContextID              string // owning scan-context ID, so hooks can reach shared stores (notes) without an import cycle
-	TerminalCalls              int
-	SkillsLoaded               int
-	UniqueToolsUsed            map[string]bool
-	ReconDone                  bool
-	ScannerUsed                bool
-	FinishAttempts             int
-	MaxFinishRejections        int
-	MinIterations              int
-	OASTProbesExecuted         int
-	PendingFailedReportCalls   int
-	DiscoveryMode              bool
-	ReconOnlyMode              bool
-	AllowedPhases              []int
-	PassiveReconGuardActive    bool
-	PassiveReconPassiveLookups int
-	PassiveReconBlockedActive  int
+	Iteration                int
+	ScanContextID            string // owning scan-context ID, so hooks can reach shared stores (notes) without an import cycle
+	TerminalCalls            int
+	SkillsLoaded             int
+	UniqueToolsUsed          map[string]bool
+	ReconDone                bool
+	ScannerUsed              bool
+	FinishAttempts           int
+	MaxFinishRejections      int
+	MinIterations            int
+	OASTProbesExecuted       int
+	PendingFailedReportCalls int
+	// ReportFailureAttempts counts malformed/failed report submissions for the
+	// current recovery episode. It is deliberately bounded so a bad XML turn
+	// cannot keep the finish gate closed forever.
+	ReportFailureAttempts        int
+	ReportFinishRecoveryAttempts int
+	ReportRetryLimitReached      bool
+	DiscoveryMode                bool
+	ReconOnlyMode                bool
+	AllowedPhases                []int
+	PassiveReconGuardActive      bool
+	PassiveReconPassiveLookups   int
+	PassiveReconBlockedActive    int
 
 	// Coverage counters — track UNIQUE endpoints per test category.
 	// These replace the old boolean flags (InjectionTested, etc.) which
@@ -145,11 +151,10 @@ type ScanState struct {
 	TotalNoToolResponses int
 
 	// NoToolAbortLimit is the consecutive no-tool-call count at which the scan
-	// force-stops (from config XALGORIX_NO_TOOL_ABORT_AT). 0 = never give up:
-	// the agent keeps nudging so the model can fix its own malformed output and
-	// resume. Set from cfg when the agent
-	// initializes ScanState; falls back to NoToolAbortAt when zero-valued only
-	// if the operator did not explicitly disable it (see abortLimit()).
+	// force-stops (from config XALGORIX_NO_TOOL_ABORT_AT). 0 = never give up;
+	// the loaded default is 30, which bounds malformed-output loops while still
+	// allowing normal parser recovery. Set from cfg when the agent initializes
+	// ScanState; see noToolAbortLimit for the explicit-zero behavior.
 	NoToolAbortLimit int
 	// NoToolAbortConfigured records that NoToolAbortLimit was explicitly set
 	// from config (so a value of 0 means "disabled", not "unset default").
@@ -296,8 +301,8 @@ const (
 	//   1. Consecutive: NoToolCount climbs. A gentle reminder fires at
 	//      NoToolSoftNudgeAt, a firm "resume and call a tool" nudge at
 	//      NoToolStrongNudgeAt (and every turn after). In bounded mode the scan
-	//      aborts at NoToolAbortAt; the default is "never give up" (abort
-	//      disabled), so it keeps nudging indefinitely.
+	//      aborts at NoToolAbortAt; the loaded configuration default is 30,
+	//      while an explicit zero still disables the abort.
 	//
 	//   2. Density (non-consecutive): if the model makes an occasional tool
 	//      call — just often enough to reset NoToolCount — the consecutive path
@@ -356,6 +361,7 @@ func floatPtr(f float64) *float64 { return &f }
 // RegisterDefaultHooks registers all built-in behavioral hooks.
 func RegisterDefaultHooks(reg *HookRegistry) {
 	// Order matters: tracking → detection → policy → reset
+	reg.Register(OnToolCall, hookReportRetryGuard)
 	reg.Register(OnToolCall, hookWorkTracker)
 	reg.Register(OnToolCall, hookStuckTracker)
 	reg.Register(OnToolCall, hookCurlPreference)
@@ -372,6 +378,37 @@ func RegisterDefaultHooks(reg *HookRegistry) {
 	reg.Register(OnIterationStart, hookAutoSkillSuggester)
 	reg.Register(OnIterationStart, hookPlanner)
 	reg.Register(OnHealthyResponse, hookResetOnSuccess)
+}
+
+const maxReportRepairAttempts = 3
+
+// hookReportRetryGuard prevents a model from repeatedly invoking a report
+// that has already failed the schema validator three times. The old behavior
+// let malformed report calls continue indefinitely while the finish gate
+// insisted on a successful re-report, creating the post-reset loop seen in
+// the Leather export.
+func hookReportRetryGuard(state *ScanState, args map[string]string) HookResult {
+	if state == nil || args["tool_name"] != "report_vulnerability" || !state.ReportRetryLimitReached {
+		return HookResult{}
+	}
+	// The limit applies to the malformed recovery episode, not to every
+	// finding in the scan. A later complete report is a legitimate new attempt
+	// (or a corrected candidate) and must be allowed through.
+	if strings.TrimSpace(args["title"]) != "" &&
+		strings.TrimSpace(args["severity"]) != "" &&
+		strings.TrimSpace(args["description"]) != "" {
+		state.ReportRetryLimitReached = false
+		state.ReportFailureAttempts = 0
+		state.ReportFinishRecoveryAttempts = 0
+		return HookResult{}
+	}
+
+	msg := "⛔ Loop limit reached: report_vulnerability has already failed its parameter validation three times. Do not call it again for this candidate. Preserve any evidence in add_note if needed. Force finishing to prevent another report/finish usage loop."
+	return HookResult{
+		ForceSkip:   true,
+		Nudge:       msg,
+		EmitMessage: msg,
+	}
 }
 
 // ── hookWorkTracker ──────────────────────────────────────────────────────────
@@ -1196,6 +1233,23 @@ func hookTechDetector(state *ScanState, args map[string]string) HookResult {
 func hookFinishGatekeeper(state *ScanState, args map[string]string) HookResult {
 	state.FinishAttempts++
 
+	// A malformed report must be recoverable, but it must not create a second
+	// infinite loop in which the model calls finish forever and waits for a
+	// success that it cannot produce. Give the model three clear recovery
+	// attempts, then allow a safe finish with the existing findings.
+	if state.PendingFailedReportCalls > 0 && !state.ReportRetryLimitReached {
+		state.ReportFinishRecoveryAttempts++
+		if state.ReportFinishRecoveryAttempts >= maxReportRepairAttempts {
+			state.PendingFailedReportCalls = 0
+			state.ReportRetryLimitReached = true
+			return HookResult{}
+		}
+		return HookResult{
+			Block:       true,
+			BlockReason: "⚠️ REPORT NOT SAVED: the previous report_vulnerability call failed parameter validation. Make one complete corrected call using the canonical XML format with title, severity, and description; exploitation_proof and verification_method are required for actionable severities, while endpoint is optional. If the candidate is not exploitable, do not keep resubmitting it—record a note and finish.",
+		}
+	}
+
 	// Allow finish if the agent has repeatedly attempted to finish (>= MaxFinishRejections + 1 attempts)
 	// to prevent infinite finish-rejection deadlocks when the model refuses or is unable
 	// to execute further commands.
@@ -1205,14 +1259,6 @@ func hookFinishGatekeeper(state *ScanState, args map[string]string) HookResult {
 	}
 	if state.FinishAttempts > maxRejections {
 		return HookResult{}
-	}
-
-	// Gate: Do not allow finishing if a previous report_vulnerability call failed and hasn't been successfully re-called yet.
-	if state.PendingFailedReportCalls > 0 {
-		return HookResult{
-			Block:       true,
-			BlockReason: "⚠️ UNREPORTED VULNERABILITY DETECTED: You attempted to call report_vulnerability previously, but the tool call failed (e.g. missing required parameters). You MUST successfully re-run report_vulnerability with ALL required fields (title, severity, description, endpoint, exploitation_proof) before finishing, so the vulnerability is saved to the scan report and dashboard.",
-		}
 	}
 
 	// Discovery mode (Phase 1 enumeration): allow finish after minimum work
@@ -1552,8 +1598,8 @@ func hookEmptyResponseHandler(state *ScanState, args map[string]string) HookResu
 //  1. Consecutive — NoToolCount climbs. A gentle "use tools" reminder fires at
 //     NoToolSoftNudgeAt (8), a firm "resume and call a tool NOW" nudge at
 //     NoToolStrongNudgeAt (16) and every turn after. In BOUNDED mode the scan
-//     aborts at NoToolAbortAt (30); the default is "never give up" (abort
-//     disabled), so it keeps nudging indefinitely and never force-stops.
+//     aborts at NoToolAbortAt (the loaded default is 30); an explicit zero
+//     keeps nudging indefinitely and disables the force-stop.
 //
 //  2. Density (non-consecutive) — the model makes an occasional tool call,
 //     just often enough to reset the consecutive counter. In BOUNDED mode
@@ -1975,7 +2021,11 @@ func extractPaths(blob string) []string {
 }
 
 // ── hookReportVulnerabilityTracker ─────────────────────────────────────────
-// Tracks calls to report_vulnerability and maintains PendingFailedReportCalls.
+// Tracks calls to report_vulnerability and maintains the bounded recovery
+// state used by hookFinishGatekeeper. Semantic rejections (false positives,
+// unsupported informational claims, verifier rejection) are terminal outcomes
+// for that candidate; they are not schema failures and must not deadlock the
+// scan's finish path.
 func hookReportVulnerabilityTracker(state *ScanState, args map[string]string) HookResult {
 	toolName := args["tool_name"]
 	if toolName == "" {
@@ -1987,11 +2037,41 @@ func hookReportVulnerabilityTracker(state *ScanState, args map[string]string) Ho
 	errStr := args["error"]
 	outputStr := args["output"]
 
-	if errStr != "" || strings.Contains(outputStr, "missing required parameter") || strings.Contains(outputStr, "❌ REJECTED") {
-		state.PendingFailedReportCalls++
-	} else if strings.Contains(outputStr, "Vulnerability reported:") || strings.Contains(outputStr, "RECORDED as EXPLOIT-PROVEN") {
-		if state.PendingFailedReportCalls > 0 {
-			state.PendingFailedReportCalls--
+	isSchemaFailure := errStr != "" ||
+		strings.Contains(outputStr, "missing required parameter") ||
+		strings.Contains(outputStr, "missing required parameters")
+	isSemanticRejection := strings.Contains(outputStr, "❌ REJECTED") ||
+		strings.Contains(outputStr, "REJECTED by independent verifier")
+	isSuccessfulResolution := strings.Contains(outputStr, "Vulnerability reported:") ||
+		strings.Contains(outputStr, "RECORDED as EXPLOIT-PROVEN") ||
+		strings.Contains(outputStr, "DUPLICATE:")
+
+	switch {
+	case isSchemaFailure:
+		state.ReportFailureAttempts++
+		state.ReportFinishRecoveryAttempts = 0
+		state.PendingFailedReportCalls = 1
+		if state.ReportFailureAttempts >= maxReportRepairAttempts {
+			state.PendingFailedReportCalls = 0
+			state.ReportRetryLimitReached = true
+			return HookResult{
+				Nudge: "⛔ REPORT REPAIR STOPPED: report_vulnerability failed three times. Do not call it again for this candidate. Save any useful evidence with add_note and call finish now; already-saved findings are preserved.",
+			}
+		}
+	case isSuccessfulResolution:
+		state.PendingFailedReportCalls = 0
+		state.ReportFailureAttempts = 0
+		state.ReportFinishRecoveryAttempts = 0
+		state.ReportRetryLimitReached = false
+	case isSemanticRejection:
+		// The reporting pipeline deliberately rejected this candidate. Treating
+		// that as an unresolved failed call caused CORS/OAuth false positives to
+		// block finish forever while the model kept resubmitting them.
+		state.PendingFailedReportCalls = 0
+		state.ReportFailureAttempts = 0
+		state.ReportFinishRecoveryAttempts = 0
+		return HookResult{
+			Nudge: "The reporting gate rejected this candidate. Do not resubmit the same claim with the same evidence. If a distinct informational finding is justified, submit one valid info report; otherwise record a note and call finish.",
 		}
 	}
 	return HookResult{}

--- a/internal/agent/hooks_test.go
+++ b/internal/agent/hooks_test.go
@@ -1211,7 +1211,7 @@ func TestHookReportVulnerabilityTracker_CapsMalformedRecovery(t *testing.T) {
 		}
 	}
 	if res := hookReportRetryGuard(state, map[string]string{
-		"tool_name":    "report_vulnerability",
+		"tool_name":   "report_vulnerability",
 		"title":       "A corrected finding",
 		"severity":    "medium",
 		"description": "complete corrected description",

--- a/internal/agent/hooks_test.go
+++ b/internal/agent/hooks_test.go
@@ -1150,22 +1150,23 @@ func TestHookReportVulnerabilityTracker_BlocksFinishOnPendingFailedCalls(t *test
 		t.Fatalf("expected PendingFailedReportCalls = 1, got %d", state.PendingFailedReportCalls)
 	}
 
-	// 2b. Report vulnerability fails due to Gate 1 (missing verification_method)
+	// 2b. A semantic rejection is a resolved candidate, not an unresolved
+	// schema failure. It must not deadlock the finish path.
 	hookReportVulnerabilityTracker(state, map[string]string{
 		"tool":   "report_vulnerability",
 		"output": "❌ REJECTED: 'SQL Injection' reported as CRITICAL but has NO verification_method",
 	})
-	if state.PendingFailedReportCalls != 2 {
-		t.Fatalf("expected PendingFailedReportCalls = 2, got %d", state.PendingFailedReportCalls)
+	if state.PendingFailedReportCalls != 0 {
+		t.Fatalf("semantic rejection must clear PendingFailedReportCalls, got %d", state.PendingFailedReportCalls)
 	}
 
-	// 3. Calling finish now MUST be blocked
+	// 3. Calling finish after the semantic rejection is allowed.
 	res = hookFinishGatekeeper(state, map[string]string{})
-	if !res.Block || !strings.Contains(res.BlockReason, "UNREPORTED VULNERABILITY DETECTED") {
-		t.Fatalf("expected finish to be blocked with UNREPORTED VULNERABILITY DETECTED, got: %+v", res)
+	if res.Block {
+		t.Fatalf("expected finish to be allowed after semantic rejection, got: %+v", res)
 	}
 
-	// 4. Report vulnerability succeeds (for call 1 and 2)
+	// 4. A successful report is also a terminal resolution.
 	hookReportVulnerabilityTracker(state, map[string]string{
 		"tool":   "report_vulnerability",
 		"output": "✅ Vulnerability reported: [XALG-1] Test (CRITICAL)",
@@ -1182,5 +1183,42 @@ func TestHookReportVulnerabilityTracker_BlocksFinishOnPendingFailedCalls(t *test
 	res = hookFinishGatekeeper(state, map[string]string{})
 	if res.Block {
 		t.Fatalf("expected finish allowed after successful report, got blocked: %s", res.BlockReason)
+	}
+}
+
+func TestHookReportVulnerabilityTracker_CapsMalformedRecovery(t *testing.T) {
+	state := NewScanState()
+	state.Iteration = 10
+	state.TerminalCalls = 10
+	state.ReconDone = true
+	state.EndpointInventorySaved = true
+	state.DiscoveryMode = true
+	for i := 0; i < maxReportRepairAttempts; i++ {
+		res := hookReportVulnerabilityTracker(state, map[string]string{
+			"tool":   "report_vulnerability",
+			"output": "missing required parameters for tool 'report_vulnerability': title, severity",
+		})
+		if i < maxReportRepairAttempts-1 && state.PendingFailedReportCalls != 1 {
+			t.Fatalf("attempt %d: pending = %d, want 1", i+1, state.PendingFailedReportCalls)
+		}
+		if i == maxReportRepairAttempts-1 {
+			if state.PendingFailedReportCalls != 0 || !state.ReportRetryLimitReached {
+				t.Fatalf("limit state = pending %d, reached %v; want 0,true", state.PendingFailedReportCalls, state.ReportRetryLimitReached)
+			}
+			if res.Nudge == "" {
+				t.Fatal("expected a final repair nudge")
+			}
+		}
+	}
+	if res := hookReportRetryGuard(state, map[string]string{
+		"tool_name":    "report_vulnerability",
+		"title":       "A corrected finding",
+		"severity":    "medium",
+		"description": "complete corrected description",
+	}); res.ForceSkip {
+		t.Fatal("a later complete report must not be blocked by an earlier malformed-call limit")
+	}
+	if res := hookFinishGatekeeper(state, nil); res.Block {
+		t.Fatalf("finish must be allowed after the repair limit, got: %s", res.BlockReason)
 	}
 }

--- a/internal/agent/reference/TOOL_REFERENCE.md
+++ b/internal/agent/reference/TOOL_REFERENCE.md
@@ -1,0 +1,122 @@
+# Xalgorix canonical tool-call reference
+
+This file is embedded into every agent system prompt. The registry schema is
+the final authority, but these examples are the shortest safe forms to copy.
+
+## XML syntax
+
+Every tool call must be one complete block. Use one `parameter` tag per field:
+
+```xml
+<function=tool_name>
+<parameter=field_name>value</parameter>
+</function>
+```
+
+Rules:
+
+- Use the exact tool and parameter names below; do not use JSON, `command=` prose, or nested parameter tags.
+- Put every field in the same function block. Do not split one call across assistant messages.
+- `terminal_execute` is the only tool that receives a shell command. `report_vulnerability` and `finish` do not have a `command` parameter.
+- If a call is rejected for missing fields, make one complete corrected call. Do not resend the same malformed call.
+
+## Core tools and parameters
+
+### terminal_execute
+
+Required: `command`.
+
+```xml
+<function=terminal_execute>
+<parameter=command>curl -skI https://TARGET</parameter>
+</function>
+```
+
+### http_request
+
+Required: `url`. Optional: `method`, `headers` (JSON object), `body`,
+`follow_redirects`, `timeout`, `max_bytes`.
+
+```xml
+<function=http_request>
+<parameter=url>https://TARGET/api/path</parameter>
+<parameter=method>GET</parameter>
+<parameter=headers>{"Origin":"https://TARGET"}</parameter>
+</function>
+```
+
+### browser_action
+
+Required: `command`. Optional: `url`, `selector`, `text`, `code`, `direction`,
+`tab_id`, `proxy`, `name`, `domain`, `timeout`, `fields`, `session_name`.
+
+```xml
+<function=browser_action>
+<parameter=command>goto</parameter>
+<parameter=url>https://TARGET/login</parameter>
+</function>
+```
+
+### python_action
+
+Required: `code`. Optional: `timeout` (seconds).
+
+```xml
+<function=python_action>
+<parameter=code>print("test")</parameter>
+</function>
+```
+
+### add_note / read_notes
+
+`add_note` requires `key` and `value`. `read_notes` has optional `key` (omit it
+to read all notes).
+
+```xml
+<function=add_note>
+<parameter=key>Endpoint Inventory</parameter>
+<parameter=value>/api/login
+/api/users
+/api/profile</parameter>
+</function>
+```
+
+### report_vulnerability
+
+Registry-required fields: `title`, `severity`, `description`.
+`severity` is one of `critical`, `high`, `medium`, `low`, or `info`.
+
+Policy-required for actionable severities (`critical` through `low`): include
+actual `exploitation_proof` and a valid `verification_method` such as
+`exploited`, `data_extracted`, `callback_received`, `error_based`,
+`time_based`, `reflected`, or `authenticated`. `endpoint`, `target`, `method`,
+CVSS fields, impact, technical analysis, PoC, remediation, and fix are
+optional registry fields.
+
+```xml
+<function=report_vulnerability>
+<parameter=title>Unauthenticated data exposure</parameter>
+<parameter=severity>high</parameter>
+<parameter=description>The endpoint returns customer records without authentication.</parameter>
+<parameter=endpoint>https://TARGET/api/users</parameter>
+<parameter=exploitation_proof>HTTP 200 returned 20 real records including email addresses.</parameter>
+<parameter=verification_method>data_extracted</parameter>
+</function>
+```
+
+If the reporting gate returns `REJECTED`, do not resubmit the same claim with
+the same evidence. Correct the evidence once if it is genuinely exploitable;
+otherwise record the observation with `add_note` and call `finish`.
+
+### finish
+
+Required: `summary`.
+
+```xml
+<function=finish>
+<parameter=summary>Assessment complete. Findings already reported: ...</parameter>
+</function>
+```
+
+After a report is rejected as a false positive or informational-only issue,
+`finish` is the correct next action. Do not loop on report/finish calls.

--- a/internal/agent/tool_reference.go
+++ b/internal/agent/tool_reference.go
@@ -1,0 +1,10 @@
+package agent
+
+import _ "embed"
+
+// embeddedToolReference is kept as a file rather than an inline string so
+// parameter corrections have one reviewable reference that can be updated
+// alongside the registry and prompt examples.
+//
+//go:embed reference/TOOL_REFERENCE.md
+var embeddedToolReference string

--- a/internal/agent/verifier.go
+++ b/internal/agent/verifier.go
@@ -14,7 +14,7 @@
 //   - Restricted tools: read-only re-testing only (terminal/curl, http, browser,
 //     notes, web_search). It CANNOT call report_vulnerability or spawn agents,
 //     so it can never recurse or self-confirm.
-//   - Bounded: a turn cap and an 8-minute wall-clock deadline keep it safely
+//   - Bounded: a turn cap and a 3-minute wall-clock deadline keep it safely
 //     under report_vulnerability's 15-minute tool watchdog (avoiding any race
 //     on the shared LLM client, which the blocked main loop is not using).
 package agent
@@ -36,13 +36,11 @@ import (
 )
 
 const (
-	// Turn/time budget for the independent verifier. Kept comfortably under
-	// report_vulnerability's 15-minute tool watchdog. Bumped from 16/8m because
-	// real re-tests (baseline control + exploit + read the result) were running
-	// out of turns and returning a budget-exhaustion "inconclusive", which then
-	// dropped genuinely-proven findings.
-	verifierMaxTurns = 24
-	verifierDeadline = 10 * time.Minute
+	// Turn/time budget for the independent verifier. A verifier is a bounded
+	// confirmation pass, not a second full scan. The previous 24-turn/10-minute
+	// budget could consume most of a provider window for one report.
+	verifierMaxTurns = 8
+	verifierDeadline = 3 * time.Minute
 )
 
 // verifyFinding is the FindingVerifier installed into the reporting package.
@@ -122,8 +120,10 @@ func (a *Agent) verifyFinding(req reporting.VerificationRequest) reporting.Verif
 
 		resp, err := a.client.Chat(msgs)
 		if err != nil {
-			// Up to 2 retries on temporary network/LLM errors before marking inconclusive.
-			for retry := 0; retry < 2 && err != nil; retry++ {
+			// One retry is enough for a transient transport failure. More retries
+			// multiply provider usage while the main scan is already blocked on
+			// report_vulnerability.
+			for retry := 0; retry < 1 && err != nil; retry++ {
 				time.Sleep(500 * time.Millisecond)
 				resp, err = a.client.Chat(msgs)
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,7 +28,11 @@ type Config struct {
 	OllamaCompatible bool     // XALGORIX_OLLAMA_COMPATIBLE — force Ollama request semantics for a custom endpoint
 	Temperature      *float64 // XALGORIX_TEMPERATURE — LLM temperature (0.0-2.0), default 0.2; pointer to distinguish unset from 0.0
 	LLMMaxRetries    int      // XALGORIX_LLM_MAX_RETRIES
-	MemCompTimeout   int      // XALGORIX_MEMORY_COMPRESSOR_TIMEOUT
+	// MaxRateLimitWaitSec bounds how long a scan waits for a provider rate
+	// limit before stopping cleanly. XALGORIX_MAX_RATE_LIMIT_WAIT, default
+	// 1800 seconds (30 minutes).
+	MaxRateLimitWaitSec int
+	MemCompTimeout      int // XALGORIX_MEMORY_COMPRESSOR_TIMEOUT
 	// MaxOutputTokens caps the model's completion length per call (the
 	// OpenAI-compatible `max_tokens` / Anthropic `max_tokens`). Reasoning
 	// models (e.g. MiniMax-M3) spend part of this budget on hidden thinking
@@ -72,13 +76,15 @@ type Config struct {
 	DisableBrowser bool   // XALGORIX_DISABLE_BROWSER
 	MaxIterations  int    // XALGORIX_MAX_ITERATIONS — 0 = unlimited
 	MinIterations  int    // XALGORIX_MIN_ITERATIONS — minimum testing floor (default 50)
+	// MaxWildcardSubdomains optionally caps the number of full agent sessions
+	// spawned by one wildcard target. XALGORIX_MAX_WILDCARD_SUBDOMAINS,
+	// default -1 (unlimited). Set a positive value only as an explicit
+	// emergency resource cap; coverage is the default priority.
+	MaxWildcardSubdomains int
 
 	// NoToolAbortAt is how many CONSECUTIVE no-tool-call responses force-stop a
-	// scan (the "reasoning loop" abort). XALGORIX_NO_TOOL_ABORT_AT, default 0
-	// (never give up): the agent keeps nudging + periodically compacting
-	// context so the model can fix its own malformed output and resume, bounded
-	// only by the other budgets (iterations/duration/tokens). Set to e.g. 15 to
-	// restore the hard abort after 15 consecutive no-tool responses.
+	// scan (the "reasoning loop" abort). XALGORIX_NO_TOOL_ABORT_AT, default 30.
+	// Set to 0 only when an operator explicitly wants unbounded recovery.
 	NoToolAbortAt int
 
 	// MaxFinishRejections is how many times the agent's finish call will be
@@ -318,6 +324,7 @@ func load() *Config {
 		OllamaCompatible:     envOrBool("XALGORIX_OLLAMA_COMPATIBLE", false),
 		Temperature:          envOrFloatPtr("XALGORIX_TEMPERATURE", 0.2),
 		LLMMaxRetries:        envOrInt("XALGORIX_LLM_MAX_RETRIES", 5),
+		MaxRateLimitWaitSec:  envOrInt("XALGORIX_MAX_RATE_LIMIT_WAIT", 30*60),
 		MaxOutputTokens:      envOrInt("XALGORIX_MAX_OUTPUT_TOKENS", 8192),
 		ContextCompactTokens: envOrInt("XALGORIX_CONTEXT_COMPACT_TOKENS", -1),
 		LLMContextWindow:     envOrInt("XALGORIX_LLM_CONTEXT_WINDOW", 128000),
@@ -325,29 +332,30 @@ func load() *Config {
 		MemCompTimeout:       envOrInt("XALGORIX_MEMORY_COMPRESSOR_TIMEOUT", 30),
 
 		// Runtime
-		RuntimeBackend:      "native", // Always native in Go version
-		Workspace:           workspace,
-		DataDir:             dataDir,
-		WorkspaceRoot:       dataDir,
-		legacyCWD:           cwd,
-		DisableBrowser:      envOrBool("XALGORIX_DISABLE_BROWSER", false),
-		MaxIterations:       envOrInt("XALGORIX_MAX_ITERATIONS", 0),
-		MinIterations:       envOrInt("XALGORIX_MIN_ITERATIONS", 50),
-		NoToolAbortAt:       envOrInt("XALGORIX_NO_TOOL_ABORT_AT", 0),
-		MaxFinishRejections: envOrInt("XALGORIX_MAX_FINISH_REJECTIONS", 15),
-		TargetAuth:          envOr("XALGORIX_TARGET_AUTH", ""),
-		TargetAuthSecondary: envOr("XALGORIX_TARGET_AUTH_B", ""),
-		OOBPublicURL:        envOr("XALGORIX_OOB_PUBLIC_URL", ""),
-		OOBPort:             envOrInt("XALGORIX_OOB_PORT", 0),
-		InteractshServer:    envOr("XALGORIX_INTERACTSH_SERVER", ""),
-		InteractshToken:     envOr("XALGORIX_INTERACTSH_TOKEN", ""),
-		OOBDisable:          envOrBool("XALGORIX_OOB_DISABLE", false),
-		SourceRepo:          envOr("XALGORIX_SOURCE_REPO", ""),
-		ScanContext:         envOr("XALGORIX_SCAN_CONTEXT", ""),
-		ScanHeaders:         loadScanHeaders(),
-		MaxToolCalls:        envOrInt("XALGORIX_MAX_TOOL_CALLS", 0),
-		MaxDurationSec:      envOrInt("XALGORIX_MAX_DURATION", 0),
-		MaxTokens:           envOrInt("XALGORIX_MAX_TOKENS", 0),
+		RuntimeBackend:        "native", // Always native in Go version
+		Workspace:             workspace,
+		DataDir:               dataDir,
+		WorkspaceRoot:         dataDir,
+		legacyCWD:             cwd,
+		DisableBrowser:        envOrBool("XALGORIX_DISABLE_BROWSER", false),
+		MaxIterations:         envOrInt("XALGORIX_MAX_ITERATIONS", 0),
+		MinIterations:         envOrInt("XALGORIX_MIN_ITERATIONS", 50),
+		MaxWildcardSubdomains: envOrInt("XALGORIX_MAX_WILDCARD_SUBDOMAINS", -1),
+		NoToolAbortAt:         envOrInt("XALGORIX_NO_TOOL_ABORT_AT", 30),
+		MaxFinishRejections:   envOrInt("XALGORIX_MAX_FINISH_REJECTIONS", 15),
+		TargetAuth:            envOr("XALGORIX_TARGET_AUTH", ""),
+		TargetAuthSecondary:   envOr("XALGORIX_TARGET_AUTH_B", ""),
+		OOBPublicURL:          envOr("XALGORIX_OOB_PUBLIC_URL", ""),
+		OOBPort:               envOrInt("XALGORIX_OOB_PORT", 0),
+		InteractshServer:      envOr("XALGORIX_INTERACTSH_SERVER", ""),
+		InteractshToken:       envOr("XALGORIX_INTERACTSH_TOKEN", ""),
+		OOBDisable:            envOrBool("XALGORIX_OOB_DISABLE", false),
+		SourceRepo:            envOr("XALGORIX_SOURCE_REPO", ""),
+		ScanContext:           envOr("XALGORIX_SCAN_CONTEXT", ""),
+		ScanHeaders:           loadScanHeaders(),
+		MaxToolCalls:          envOrInt("XALGORIX_MAX_TOOL_CALLS", 0),
+		MaxDurationSec:        envOrInt("XALGORIX_MAX_DURATION", 0),
+		MaxTokens:             envOrInt("XALGORIX_MAX_TOKENS", 0),
 
 		// Scan retention: 0 disables automatic pruning (keep forever).
 		ScanRetentionDays: envOrInt("XALGORIX_SCAN_RETENTION_DAYS", 0),

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -755,7 +755,12 @@ func (c *Client) chatWithRetry(messages []Message) (string, error) {
 		// Track if last error was a rate limit for the post-loop wrapper
 		if isRateLimitError(errStr) {
 			lastErr = fmt.Errorf("rate limited: %w", err)
-			continue
+			// A 429/usage-window response is not made more likely to succeed by
+			// replaying the same full context three to five times immediately.
+			// Return to the agent loop so its bounded, interruptible backoff owns
+			// the retry decision and we issue at most one provider request per
+			// wait interval.
+			return "", fmt.Errorf("rate limited: %w", err)
 		}
 	}
 

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -754,7 +754,6 @@ func (c *Client) chatWithRetry(messages []Message) (string, error) {
 
 		// Track if last error was a rate limit for the post-loop wrapper
 		if isRateLimitError(errStr) {
-			lastErr = fmt.Errorf("rate limited: %w", err)
 			// A 429/usage-window response is not made more likely to succeed by
 			// replaying the same full context three to five times immediately.
 			// Return to the agent loop so its bounded, interruptible backoff owns

--- a/internal/llm/parser.go
+++ b/internal/llm/parser.go
@@ -66,6 +66,15 @@ var (
 	// Normalize quotes around = in tags: <function = "name"> → <function=name>
 	stripQuotesRe = regexp.MustCompile(`<(function|parameter)\s*=\s*["']?([^>"']+?)["']?\s*>`)
 
+	// MiniMax occasionally emits a parameter name as a nested/garbled open
+	// tag, for example `<parameter<parameter>command</parameter>` or
+	// `<parameter<poc_description</parameter>`. These fragments otherwise make
+	// the whole assistant turn look like prose, causing the no-tool recovery
+	// loop. The repair is deliberately limited to identifier-shaped names.
+	malformedNestedParamRe = regexp.MustCompile(`(?s)<parameter<parameter>\s*([A-Za-z_][A-Za-z0-9_-]*)\s*</parameter>`)
+	malformedBareParamRe   = regexp.MustCompile(`(?s)<parameter<([A-Za-z_][A-Za-z0-9_-]*)\s*</parameter>`)
+	malformedBodyParamRe   = regexp.MustCompile(`(?s)(<parameter=[A-Za-z_][A-Za-z0-9_-]*>)\s*<parameter>`)
+
 	// CleanContent regexes — compiled once
 	toolPattern    = regexp.MustCompile(`(?s)<function=[^>]+>.*?</function>`)
 	incompleteFunc = regexp.MustCompile(`(?s)<function=[^>]+>.*$`)
@@ -205,6 +214,9 @@ func normalizeFormat(content string) string {
 	content = repairFnOpenRe.ReplaceAllString(content, "${1}<function=${2}>${3}")
 	// Repair bare-name+quote drops (codeant.ai shape). Same ${1} boundary trick.
 	content = repairBareNameQuotedRe.ReplaceAllString(content, "${1}<function=${2}>${3}")
+	content = malformedNestedParamRe.ReplaceAllString(content, "<parameter=${1}>")
+	content = malformedBareParamRe.ReplaceAllString(content, "<parameter=${1}>")
+	content = malformedBodyParamRe.ReplaceAllString(content, "${1}")
 
 	// Normalize quotes/spaces around = signs: <function = "name"> → <function=name>
 	content = stripQuotesRe.ReplaceAllStringFunc(content, func(s string) string {

--- a/internal/llm/parser_repair_test.go
+++ b/internal/llm/parser_repair_test.go
@@ -88,6 +88,20 @@ func TestParseToolCalls_RepairsMalformedOpenTag(t *testing.T) {
 			wantKey:  "summary",
 			wantVal:  "done",
 		},
+		{
+			name:     "nested parameter tag emitted by MiniMax",
+			input:    "<function=terminal_execute>\n<parameter<parameter>command</parameter>\n<parameter>echo repaired</parameter>\n</function>",
+			wantName: "terminal_execute",
+			wantKey:  "command",
+			wantVal:  "echo repaired",
+		},
+		{
+			name:     "bare malformed parameter name",
+			input:    "<function=finish>\n<parameter<summary</parameter>\n<parameter>done</parameter>\n</function>",
+			wantName: "finish",
+			wantKey:  "summary",
+			wantVal:  "done",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -307,7 +307,7 @@ func (r *Registry) Execute(name string, args map[string]string) (Result, error) 
 	if len(missing) > 0 {
 		if name == "report_vulnerability" {
 			return Result{}, fmt.Errorf(
-				"missing required parameters for tool '%s': %s — ⚠️ CRITICAL: You attempted to report a vulnerability but the call failed. You MUST re-call report_vulnerability IMMEDIATELY with ALL required parameters in a single call so this finding is saved to the dashboard",
+				"missing required parameters for tool '%s': %s — call it once more using the canonical XML shape with title, severity, and description in the same function block; endpoint and exploitation_proof are optional registry fields (proof is enforced by the reporting policy for actionable severities)",
 				name, strings.Join(missing, ", "),
 			)
 		}

--- a/internal/web/orchestrator.go
+++ b/internal/web/orchestrator.go
@@ -883,6 +883,25 @@ func (s *Server) runWildcardTarget(_ context.Context, scanCfg *config.Config, re
 			TotalTargets: total,
 		})
 	}
+
+	// A wildcard target is one user-visible scan, but every discovered live
+	// subdomain is intentionally expanded into a full agent session: coverage
+	// takes priority over an arbitrary fan-out limit. A positive limit remains
+	// available as an explicit emergency control, but the default is unlimited.
+	wildcardLimit := 0
+	if scanCfg != nil {
+		wildcardLimit = scanCfg.MaxWildcardSubdomains
+	}
+	if wildcardLimit > 0 && len(subdomains) > wildcardLimit {
+		skipped := len(subdomains) - wildcardLimit
+		subdomains = subdomains[:wildcardLimit]
+		log.Printf("[wildcard] Explicitly capped full subdomain scans at %d; skipping %d candidates (XALGORIX_MAX_WILDCARD_SUBDOMAINS)", wildcardLimit, skipped)
+		s.broadcastToInstance(req.InstanceID, WSEvent{
+			Type:    "message",
+			Target:  target,
+			Content: fmt.Sprintf("⚠️ Explicit wildcard scan resource cap: scanning %d subdomains; %d additional candidates were discovered but not expanded into full LLM sessions.", wildcardLimit, skipped),
+		})
+	}
 	pendingSubScans := make([]SubScanSummary, 0, len(subdomains))
 	resumeFromSubIndex = clampInt(resumeFromSubIndex, 0, len(subdomains))
 	for i, subdomain := range subdomains {

--- a/internal/web/settings_env.go
+++ b/internal/web/settings_env.go
@@ -128,6 +128,7 @@ func allEnvSettingDefinitions() []envSettingDefinition {
 		{Key: "XALGORIX_REASONING_EFFORT", Label: "Reasoning effort", Category: "LLM", Description: "Reasoning depth for providers that support it.", DefaultValue: "high", InputType: "select", Options: []string{"none", "low", "medium", "high", "xhigh"}},
 		{Key: "XALGORIX_OLLAMA_COMPATIBLE", Label: "Ollama-compatible endpoint", Category: "LLM", Description: "Force Ollama reasoning semantics for a custom endpoint that does not use port 11434.", DefaultValue: "false", InputType: "boolean"},
 		{Key: "XALGORIX_LLM_MAX_RETRIES", Label: "LLM max retries", Category: "LLM", Description: "Retry count for transient LLM provider failures.", DefaultValue: "5", InputType: "number"},
+		{Key: "XALGORIX_MAX_RATE_LIMIT_WAIT", Label: "Provider rate-limit wait (seconds)", Category: "LLM", Description: "Maximum cumulative wait after a provider 429/usage-window error before stopping the scan. Default 1800 seconds; use a negative value only to disable the safety cap.", DefaultValue: "1800", InputType: "number"},
 		{Key: "XALGORIX_MAX_OUTPUT_TOKENS", Label: "Max output tokens", Category: "LLM", Description: "Per-call completion cap (max_tokens). Reasoning models spend part of this on hidden thinking before a tool call, so a small provider default can truncate large calls. Clamped to a 1024 floor.", DefaultValue: "8192", InputType: "number"},
 		{Key: "XALGORIX_LLM_CONTEXT_WINDOW", Label: "LLM context window (tokens)", Category: "LLM", Description: "Total context window of your model, in tokens. Auto-compaction fires at a fraction of this (see compaction ratio) so the running context is only compacted when the window is genuinely filling up. Set to your model's real window (e.g. 1000000 for a 1M-token model). Default 128000.", DefaultValue: "128000", InputType: "number"},
 		{Key: "XALGORIX_CONTEXT_COMPACT_RATIO", Label: "Context compaction ratio", Category: "LLM", Description: "Fraction of the context window at which to auto-compact (0.5–0.9). Default 0.75 = compact at ~75% full. Compacting earlier discards useful working context and hurts output quality; going higher risks hitting the provider's hard limit first.", DefaultValue: "0.75", InputType: "number"},
@@ -135,6 +136,8 @@ func allEnvSettingDefinitions() []envSettingDefinition {
 		{Key: "XALGORIX_MEMORY_COMPRESSOR_TIMEOUT", Label: "Memory compressor timeout", Category: "LLM", Description: "Timeout in seconds for context compression.", DefaultValue: "30", InputType: "number"},
 		{Key: "XALGORIX_MAX_ITERATIONS", Label: "Max iterations", Category: "Runtime", Description: "Maximum agent iterations per scan. 0 means unlimited.", DefaultValue: "0", InputType: "number"},
 		{Key: "XALGORIX_MIN_ITERATIONS", Label: "Min iterations (testing floor)", Category: "Runtime", Description: "Minimum testing floor in iterations before the gatekeeper permits finish. Ensures deep probing (OAST, ReDoS, fuzzing) before concluding.", DefaultValue: "50", InputType: "number"},
+		{Key: "XALGORIX_NO_TOOL_ABORT_AT", Label: "No-tool loop limit", Category: "Runtime", Description: "Consecutive assistant responses without a parsed tool call before cleanly stopping. Default 30; 0 disables this safety limit.", DefaultValue: "30", InputType: "number"},
+		{Key: "XALGORIX_MAX_WILDCARD_SUBDOMAINS", Label: "Wildcard subdomain cap", Category: "Runtime", Description: "Optional maximum full LLM sessions expanded from one wildcard target. Default -1 means unlimited; set a positive value only for an explicit emergency resource cap.", DefaultValue: "-1", InputType: "number"},
 		{Key: "XALGORIX_MAX_FINISH_REJECTIONS", Label: "Max finish rejections", Category: "Runtime", Description: "Number of times the agent's finish call will be rejected by the gatekeeper before allowing a deadlock bypass, enforcing deeper testing coverage.", DefaultValue: "15", InputType: "number"},
 		{Key: "XALGORIX_MAX_TOOL_CALLS", Label: "Max tool calls (budget)", Category: "Runtime", Description: "Per-scan tool-call cap; the scan stops cleanly when reached (findings preserved). 0 = unlimited.", DefaultValue: "0", InputType: "number", RequiresRestart: true},
 		{Key: "XALGORIX_MAX_DURATION", Label: "Max duration seconds (budget)", Category: "Runtime", Description: "Per-scan wall-clock cap in seconds; the scan stops cleanly when reached. 0 = unlimited.", DefaultValue: "0", InputType: "number", RequiresRestart: true},
@@ -746,6 +749,8 @@ func (s *Server) applyEnvironmentToRuntimeConfig(values map[string]string) {
 			s.cfg.OllamaCompatible = parseBoolSetting(value, false)
 		case "XALGORIX_LLM_MAX_RETRIES":
 			s.cfg.LLMMaxRetries = parseIntSetting(value, 5)
+		case "XALGORIX_MAX_RATE_LIMIT_WAIT":
+			s.cfg.MaxRateLimitWaitSec = parseIntSetting(value, 30*60)
 		case "XALGORIX_MAX_OUTPUT_TOKENS":
 			s.cfg.MaxOutputTokens = parseIntSetting(value, 8192)
 		case "XALGORIX_CONTEXT_COMPACT_TOKENS":
@@ -760,6 +765,10 @@ func (s *Server) applyEnvironmentToRuntimeConfig(values map[string]string) {
 			s.cfg.MaxIterations = parseIntSetting(value, 0)
 		case "XALGORIX_MIN_ITERATIONS":
 			s.cfg.MinIterations = parseIntSetting(value, 50)
+		case "XALGORIX_MAX_WILDCARD_SUBDOMAINS":
+			s.cfg.MaxWildcardSubdomains = parseIntSetting(value, -1)
+		case "XALGORIX_NO_TOOL_ABORT_AT":
+			s.cfg.NoToolAbortAt = parseIntSetting(value, 30)
 		case "XALGORIX_MAX_FINISH_REJECTIONS":
 			s.cfg.MaxFinishRejections = parseIntSetting(value, 15)
 		case "XALGORIX_WORKSPACE":
@@ -864,6 +873,8 @@ func (s *Server) envSettingValue(key string) string {
 		return strconv.FormatBool(s.cfg.OllamaCompatible)
 	case "XALGORIX_LLM_MAX_RETRIES":
 		return strconv.Itoa(s.cfg.LLMMaxRetries)
+	case "XALGORIX_MAX_RATE_LIMIT_WAIT":
+		return strconv.Itoa(s.cfg.MaxRateLimitWaitSec)
 	case "XALGORIX_MAX_OUTPUT_TOKENS":
 		return strconv.Itoa(s.cfg.MaxOutputTokens)
 	case "XALGORIX_CONTEXT_COMPACT_TOKENS":
@@ -878,6 +889,10 @@ func (s *Server) envSettingValue(key string) string {
 		return strconv.Itoa(s.cfg.MaxIterations)
 	case "XALGORIX_MIN_ITERATIONS":
 		return strconv.Itoa(s.cfg.MinIterations)
+	case "XALGORIX_MAX_WILDCARD_SUBDOMAINS":
+		return strconv.Itoa(s.cfg.MaxWildcardSubdomains)
+	case "XALGORIX_NO_TOOL_ABORT_AT":
+		return strconv.Itoa(s.cfg.NoToolAbortAt)
 	case "XALGORIX_MAX_FINISH_REJECTIONS":
 		return strconv.Itoa(s.cfg.MaxFinishRejections)
 	case "XALGORIX_WORKSPACE":
@@ -1111,6 +1126,8 @@ func normalizeEnvSettingValue(def envSettingDefinition, value string) (string, e
 		return strconv.Itoa(clampInt(parseIntSetting(value, 60), 10, 3600)), nil
 	case "XALGORIX_LLM_MAX_RETRIES":
 		return strconv.Itoa(clampInt(parseIntSetting(value, 5), 0, 20)), nil
+	case "XALGORIX_MAX_RATE_LIMIT_WAIT":
+		return strconv.Itoa(clampInt(parseIntSetting(value, 30*60), -1, 7*24*60*60)), nil
 	case "XALGORIX_MAX_OUTPUT_TOKENS":
 		return strconv.Itoa(clampInt(parseIntSetting(value, 8192), 1024, 200000)), nil
 	case "XALGORIX_CONTEXT_COMPACT_TOKENS":
@@ -1140,6 +1157,10 @@ func normalizeEnvSettingValue(def envSettingDefinition, value string) (string, e
 		return strconv.Itoa(clampInt(parseIntSetting(value, 0), 0, 1000)), nil
 	case "XALGORIX_MIN_ITERATIONS":
 		return strconv.Itoa(clampInt(parseIntSetting(value, 50), 1, 500)), nil
+	case "XALGORIX_NO_TOOL_ABORT_AT":
+		return strconv.Itoa(clampInt(parseIntSetting(value, 30), 0, 500)), nil
+	case "XALGORIX_MAX_WILDCARD_SUBDOMAINS":
+		return strconv.Itoa(clampInt(parseIntSetting(value, -1), -1, 1000)), nil
 	case "XALGORIX_MAX_FINISH_REJECTIONS":
 		return strconv.Itoa(clampInt(parseIntSetting(value, 15), 1, 100)), nil
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to Xalgorix! Please fill this out so we can review quickly.
`main` is branch-protected — PRs are the only way in. CI runs make lint,
golangci-lint, go vet, and the test suite on every PR.
-->

## What & why

<!-- What does this change and why? Link the issue it addresses. -->

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Refactor / internal
- [ ] Other:

## How was it tested?

<!-- Commands you ran, new tests added, manual verification. -->

- [ ] `make lint` passes
- [ ] `golangci-lint run --config .golangci.yml ./...` passes
- [ ] `go test ./...` passes
- [ ] Added/updated tests for the change

## Checklist

- [ ] I read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md).
- [ ] The tree is `gofmt`-clean.
- [ ] I updated docs (`README`, `docs/`, help text) if behavior changed.
- [ ] This does not weaken a security control (scope guard, verifier, false-positive gate) without explicit discussion.
- [ ] For engine behavior changes: I noted any impact on scan findings/severity.
