### PR TITLE
test(httpclient): fix maxbytes tests failing every April & August

### DIFF
--- a/internal/tools/httpclient/maxbytes_test.go
+++ b/internal/tools/httpclient/maxbytes_test.go
@@ -20,7 +20,17 @@ func sizedServer(t *testing.T, n int) *httptest.Server {
 }
 
 // countBodyAs counts the 'A' payload bytes returned in the tool output.
+//
+// It counts ONLY within the response-body section, not the whole output. The
+// output also prints response headers, and the `Date` header's month
+// abbreviation contains a capital 'A' in April ("Apr") and August ("Aug") — so
+// counting 'A' across the entire output inflated the payload count by one for
+// two months of the year, failing these tests every April and August.
 func countBodyAs(out string) int {
+	const marker = "--- Response Body (text) ---\n"
+	if i := strings.Index(out, marker); i >= 0 {
+		return strings.Count(out[i+len(marker):], "A")
+	}
 	return strings.Count(out, "A")
 }
 


### PR DESCRIPTION
## Problem

`TestMaxBytes_RaisesCapAboveDefault` and `TestMaxBytes_HardCeilingEnforced` fail with an off-by-one:

```
maxbytes_test.go:50: expected full 204800 body bytes, got 204801
maxbytes_test.go:69: body bytes = 524289, want hard cap 524288
```

This is a **time-dependent test bug**, not a product bug — it only triggers in **April and August**.

## Root cause

`countBodyAs(out)` did `strings.Count(out, "A")` over the **entire** tool output. That output includes the printed response headers, and the `Date` header's month abbreviation is `Apr` / `Aug` in those two months — a capital **A** — so the payload count came out exactly one over the cap. The other 10 months have no capital `A` in the `Date` header, so the tests passed.

The body-cap logic in `httpclient.go` is correct (`LimitReader(body, cap+1)`, then slice to `cap` when truncated). Only the test's counting was wrong.

## Fix

Count `A` only within the response-body section (after the `--- Response Body (text) ---` marker), not the header section. Deterministic year-round.

Verified: `go test ./internal/tools/httpclient/` passes; `make lint` clean.

Note: this is unrelated to #378 (license) — that PR's CI was red only because this pre-existing test fails on `main` this month. Merging this unblocks it.
