### PR TITLE
ci: allow CI to be triggered manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ on:
     branches:
       - main
       - master
+  # Allows re-running CI on demand. Needed when push/pull_request events are
+  # dropped or never scheduled — e.g. during an Actions incident, which leaves a
+  # merged commit on main with no coverage and no way to ask for a fresh run.
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds `workflow_dispatch` to `ci.yml`.

## Why
During today's GitHub Actions incident the push events for `cad7f28` (#381) and `268cb3a` (#382) were never scheduled, so `main` currently has **zero CI coverage** for both merged changes. With only `push` and `pull_request` triggers there was no supported way to ask for a fresh run — `gh workflow run` requires `workflow_dispatch`.

A re-run request made during the incident also left run 31125640611 permanently wedged: `run_attempt` stayed at 1 with no job records, and both `/cancel` and `/force-cancel` return HTTP 409 `Cannot cancel a workflow re-run that has not yet queued`.

## Effect
No change to existing behaviour — purely an additional trigger. Direct pushes to `main` are blocked by repository rules, so this PR also doubles as the event that gets CI running against current `main` content again.