### PR TITLE
fix(context): check zip.ReadCloser Close error

### DIFF
--- a/internal/attacksurface/attacksurface.go
+++ b/internal/attacksurface/attacksurface.go
@@ -104,7 +104,7 @@ func LoadFromPath(path string) (*Result, error) {
 		// OOM kill that dropped in-memory dashboard sessions).
 		if isAndroidArchive(p) {
 			if zrc, err := zip.OpenReader(p); err == nil {
-				defer zrc.Close()
+				defer func() { _ = zrc.Close() }()
 				if r := parseAPKZip(&zrc.Reader, 0); r != nil {
 					merged.merge(r)
 				}


### PR DESCRIPTION
Fixes the `golangci-lint` failure on `36baef4`:

```
internal/attacksurface/attacksurface.go:107:20: Error return value of `zrc.Close` is not checked (errcheck)
```

The deferred `zrc.Close()` came in with the streaming APK path. Discarded explicitly via `defer func() { _ = zrc.Close() }()`, consistent with how the package already handles its other archive closers.

Verified locally with the same linter version CI uses (v2.12.2, built against the repo's go1.26 toolchain): **0 issues**. `go build`, `gofmt` and `go test ./internal/attacksurface/...` all pass.

Context: I couldn't catch this before merge because the previously installed golangci-lint was built against go1.25 and refused to run on a go1.26 target. Building the pinned version with the local toolchain works and is now reproducible.