### PR TITLE
build: run golangci-lint from make lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,18 @@ fmt:
 vet:
 	go vet ./...
 
+# Keep in sync with GOLANGCI_LINT_VERSION in .github/workflows/ci.yml.
+GOLANGCI_LINT_VERSION ?= v2.12.2
+
 lint: fmt vet
+	@if command -v golangci-lint >/dev/null 2>&1; then \
+		echo "Running golangci-lint..."; \
+		golangci-lint run ./... || exit 1; \
+	else \
+		echo "golangci-lint not found — skipping (CI enforces it)."; \
+		echo "Install the pinned version with:"; \
+		echo "  go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)"; \
+	fi
 	@echo "Lint passed"
 
 tidy:


### PR DESCRIPTION
`make lint` ran only `go fmt` and `go vet`, so the `errcheck` violation in #385 passed locally and only surfaced in CI. This closes that gap.

- Runs `golangci-lint run ./...` when the binary is on PATH, failing the target on findings.
- Skips with the pinned install command when it is absent, so the target stays usable for anyone without it.
- `GOLANGCI_LINT_VERSION` is documented as needing to stay in sync with `ci.yml`.

Verified both paths locally: with the pinned v2.12.2 on PATH it reports **0 issues** and passes; with it absent it prints the install hint and still passes.

Note CI runs `make lint` and `golangci-lint` as separate steps, so the linter now executes twice there — a modest time cost for keeping local and CI behaviour identical. Happy to drop the standalone CI step instead if you'd rather not pay it.