### PR TITLE
Recommend current frontier models

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -60,7 +60,7 @@ body:
     attributes:
       label: Environment
       description: OS / arch, and LLM provider if relevant.
-      placeholder: Ubuntu 24.04 amd64, MiniMax-M3
+      placeholder: Ubuntu 24.04 amd64, OpenAI GPT-5.6
   - type: checkboxes
     id: checks
     attributes:

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 # Build:  docker build -t xalgorix .
 # Run:    docker run --rm -p 9137:9137 \
 #           --privileged \
-#           -e XALGORIX_LLM=minimax/MiniMax-M3 \
+#           -e XALGORIX_LLM=openai/gpt-5.6 \
 #           -e XALGORIX_API_KEY=your_provider_api_key \
 #           -v xalgorix-data:/data \
 #           ghcr.io/xalgord/xalgorix:latest

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This downloads the prebuilt binary for your platform (Linux amd64/arm64) from th
 xalgorix --setup
 ```
 
-Choose your provider, confirm a model, and enter the API key when prompted. Xalgorix stores it privately in `~/.xalgorix.env` (mode `0600`) and can launch the dashboard for you. Local Ollama needs no API key.
+Choose your provider, confirm a model, and enter the API key when prompted. For best results, use a current frontier model with strong reasoning, long-context performance, and reliable tool calling—such as the latest capable GPT, Claude, or Gemini model available to you. Smaller or local models remain supported, but may require more supervision during long autonomous scans. Xalgorix stores the key privately in `~/.xalgorix.env` (mode `0600`) and can launch the dashboard for you. Local Ollama needs no API key.
 
 If you choose not to launch immediately, start later with `xalgorix --web` and open `http://127.0.0.1:9137`. You can change providers or advanced options at any time under **Settings → LLM**, or rerun `xalgorix --setup`.
 
@@ -224,8 +224,8 @@ The wizard preserves existing settings when rerun, hides API-key input in a term
 ```bash
 docker run --rm -p 9137:9137 \
   --privileged \
-  -e XALGORIX_LLM=minimax/MiniMax-M3 \
-  -e XALGORIX_API_KEY=your_provider_api_key \
+  -e XALGORIX_LLM=openai/gpt-5.6 \
+  -e XALGORIX_API_KEY=your_openai_api_key \
   -v xalgorix-data:/data \
   ghcr.io/xalgord/xalgorix:latest
 ```
@@ -289,9 +289,11 @@ nano ~/.xalgorix.env
 
 ### Minimal Config
 
+For the strongest autonomous scanning results, select a current frontier model. The model ID below is a concrete example; newer compatible model IDs can be entered without waiting for a Xalgorix release.
+
 ```bash
-XALGORIX_LLM=minimax/MiniMax-M3
-XALGORIX_API_KEY=your_provider_api_key
+XALGORIX_LLM=openai/gpt-5.6
+XALGORIX_API_KEY=your_openai_api_key
 ```
 
 ### Provider Examples
@@ -299,7 +301,7 @@ XALGORIX_API_KEY=your_provider_api_key
 OpenAI:
 
 ```bash
-XALGORIX_LLM=openai/gpt-5.4
+XALGORIX_LLM=openai/gpt-5.6
 XALGORIX_API_KEY=sk-...
 ```
 
@@ -322,9 +324,9 @@ Run LiteLLM (example `config.yaml`):
 
 ```yaml
 model_list:
-  - model_name: claude-opus-4-8
+  - model_name: claude-opus-5
     litellm_params:
-      model: github_copilot/claude-opus-4.8   # or openrouter/…, azure/…, ollama/…
+      model: github_copilot/claude-opus-5   # or openrouter/…, azure/…, ollama/…
 general_settings:
   master_key: sk-local-litellm-key
 ```
@@ -333,7 +335,7 @@ Point Xalgorix at it — use the `custom/` prefix so the model name is sent verb
 OpenAI chat-completions protocol is used:
 
 ```bash
-XALGORIX_LLM=custom/claude-opus-4-8            # the LiteLLM model_name
+XALGORIX_LLM=custom/claude-opus-5            # the LiteLLM model_name
 XALGORIX_API_BASE=http://localhost:4000/v1     # your LiteLLM proxy
 XALGORIX_API_KEY=sk-local-litellm-key          # LiteLLM master_key / virtual key
 ```

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -476,7 +476,7 @@ func printUsage() {
 	fmt.Println("  xalgorix --uninstall  Remove xalgorix from system")
 	fmt.Println()
 	fmt.Println("Environment:")
-	fmt.Println("  XALGORIX_LLM              Model name (e.g. minimax/MiniMax-M3)")
+	fmt.Println("  XALGORIX_LLM              Frontier model ID (e.g. openai/gpt-5.6)")
 	fmt.Println("  XALGORIX_API_KEY           API key")
 	fmt.Println("  XALGORIX_API_BASE          API base URL")
 	fmt.Println("  XALGORIX_MAX_ITERATIONS    Max iterations (0 = unlimited)")

--- a/cmd/xalgorix/setup.go
+++ b/cmd/xalgorix/setup.go
@@ -21,10 +21,10 @@ type setupProvider struct {
 }
 
 var setupProviders = []setupProvider{
-	{id: "minimax", name: "MiniMax (recommended)", defaultModel: "MiniMax-M3", needsAPIKey: true},
-	{id: "openai", name: "OpenAI", defaultModel: "gpt-5.4", needsAPIKey: true},
-	{id: "anthropic", name: "Anthropic (Claude)", defaultModel: "claude-sonnet-4-20250514", needsAPIKey: true},
-	{id: "google", name: "Google Gemini", defaultModel: "gemini-3.1-pro-preview", needsAPIKey: true},
+	{id: "openai", name: "OpenAI", defaultModel: "gpt-5.6", needsAPIKey: true},
+	{id: "anthropic", name: "Anthropic (Claude)", defaultModel: "claude-fable-5", needsAPIKey: true},
+	{id: "google", name: "Google Gemini", defaultModel: "gemini-3.5-flash", needsAPIKey: true},
+	{id: "minimax", name: "MiniMax", defaultModel: "MiniMax-M3", needsAPIKey: true},
 	{id: "ollama", name: "Ollama (local, no API key)", defaultModel: "llama3.3"},
 	{id: "custom", name: "Custom OpenAI-compatible endpoint", needsAPIKey: true},
 }
@@ -57,6 +57,9 @@ func runSetup(in io.Reader, out io.Writer) (bool, error) {
 		return false, err
 	}
 	if err := p.println("Configure an LLM in a few steps. You can change advanced options later in Settings."); err != nil {
+		return false, err
+	}
+	if err := p.println("For best results, choose a current frontier model with strong reasoning and reliable tool calling."); err != nil {
 		return false, err
 	}
 	if err := p.printf("Configuration: %s (saved with mode 0600)\n\n", path); err != nil {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     # environment:
     #   XALGORIX_USERNAME: admin
     #   XALGORIX_PASSWORD: change-me-please
-    #   XALGORIX_LLM: minimax/MiniMax-M3
+    #   XALGORIX_LLM: openai/gpt-5.6
     #   XALGORIX_API_KEY: your_provider_api_key
     volumes:
       - xalgorix-data:/data

--- a/docs/TESTING_CHECKLIST.md
+++ b/docs/TESTING_CHECKLIST.md
@@ -51,7 +51,7 @@ This checklist tracks the automated and manual gates for the CLI, web UI, LLM pr
 
 - [ ] Dashboard loads in authenticated and unauthenticated modes.
 - [ ] Model fields allow custom IDs while showing current suggestions.
-- [ ] Gemini suggestions include current text models such as `gemini-3.1-pro-preview` and do not force deprecated models.
+- [ ] Gemini suggestions include current text models such as `gemini-3.5-flash` and do not force deprecated models.
 - [ ] DeepSeek suggestions include `deepseek-v4-pro` and `deepseek-v4-flash`.
 - [ ] Start, stop, queue, resume, chat, report download, and instance detail flows work from the UI.
 - [ ] Empty states, long target names, long logs, upload errors, WebSocket reconnect, and mobile layout render cleanly.

--- a/docs/dockerhub-overview.md
+++ b/docs/dockerhub-overview.md
@@ -18,13 +18,15 @@ This image is **batteries-included**: it's built on Kali Linux with hundreds of 
 
 ```bash
 docker run --rm -p 9137:9137 \
-  -e XALGORIX_LLM=minimax/MiniMax-M3 \
-  -e XALGORIX_API_KEY=your_provider_api_key \
+  -e XALGORIX_LLM=openai/gpt-5.6 \
+  -e XALGORIX_API_KEY=your_openai_api_key \
   -v xalgorix-data:/data \
   xalgord/xalgorix:latest
 ```
 
 Then open **http://127.0.0.1:9137**.
+
+For best autonomous scanning results, choose a current frontier model with strong reasoning and reliable tool calling. The example model can be replaced with any newer compatible provider model ID.
 
 > Use Xalgorix only against systems you own or are explicitly authorized to test.
 
@@ -44,7 +46,7 @@ An extensive toolset ships preinstalled — `nmap`, `nuclei`, `httpx`, `subfinde
 
 | Variable | Required | Description |
 | --- | --- | --- |
-| `XALGORIX_LLM` | ✅ | Model, usually with a provider prefix, e.g. `minimax/MiniMax-M3`, `openai/gpt-5.4`. |
+| `XALGORIX_LLM` | ✅ | Model ID, usually with a provider prefix, e.g. `openai/gpt-5.6`. For best results use a current frontier model; MiniMax and local models remain supported. |
 | `XALGORIX_API_KEY` | ✅ | API key for the configured LLM provider. |
 | `XALGORIX_API_BASE` | — | Custom OpenAI-compatible base URL. |
 | `XALGORIX_USERNAME` / `XALGORIX_PASSWORD` | — | Dashboard auth. **Required** before exposing the dashboard beyond localhost. |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,7 +20,7 @@ import (
 // Config holds all Xalgorix configuration.
 type Config struct {
 	// LLM settings
-	LLM              string   // XALGORIX_LLM — provider-native model ID (for example, "gpt-5.4" or "zai-org/glm-4.5")
+	LLM              string   // XALGORIX_LLM — provider-native model ID (for example, "gpt-5.6" or "zai-org/glm-4.5")
 	LLMProvider      string   // XALGORIX_LLM_PROVIDER — explicit provider ID; keeps provider routing separate from the model name
 	APIBase          string   // XALGORIX_API_BASE — API endpoint
 	APIKey           string   // XALGORIX_API_KEY — API key
@@ -36,9 +36,8 @@ type Config struct {
 	MemCompTimeout      int // XALGORIX_MEMORY_COMPRESSOR_TIMEOUT
 	// MaxOutputTokens caps the model's completion length per call (the
 	// OpenAI-compatible `max_tokens` / Anthropic `max_tokens`). Reasoning
-	// models (e.g. MiniMax-M3) spend part of this budget on hidden thinking
-	// BEFORE emitting a tool call, so a small provider default truncates large
-	// calls like report_vulnerability mid-stream. Set an explicit, generous
+	// models spend part of this budget on hidden thinking BEFORE emitting a
+	// tool call, so a small provider default truncates large calls like report_vulnerability mid-stream. Set an explicit, generous
 	// budget so the full call fits. XALGORIX_MAX_OUTPUT_TOKENS, default 8192.
 	MaxOutputTokens int
 
@@ -494,7 +493,7 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("DataDir is empty — Data_Dir resolution failed; check XALGORIX_DATA_DIR or HOME and verify the binary can create ~/.xalgorix/data with mode 0o700")
 	}
 	if c.LLM == "" {
-		return fmt.Errorf("XALGORIX_LLM is required. Set it to a provider-native model ID such as 'gpt-5.4' or 'claude-sonnet-4-20250514'")
+		return fmt.Errorf("XALGORIX_LLM is required. Set it to a provider-native model ID such as 'gpt-5.6' or 'claude-fable-5'")
 	}
 	if c.APIKey == "" && c.LLMProfile == "" && !c.providerAllowsNoAuth() {
 		return fmt.Errorf("XALGORIX_API_KEY is required for the selected provider. Run 'xalgorix --setup' to configure it")

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -404,7 +404,7 @@ func (c *Client) resolveEndpoint() (string, string) {
 	apiBase := c.cfg.APIBase
 	model := c.apiModel
 
-	// Extract provider prefix if present (e.g., "openai/gpt-5.4" -> provider="openai", model="gpt-5.4")
+	// Extract provider prefix if present (e.g., "openai/gpt-5.6" -> provider="openai", model="gpt-5.6")
 	provider := ""
 	if idx := strings.Index(model, "/"); idx >= 0 {
 		provider = strings.ToLower(model[:idx])

--- a/internal/providers/builtin.go
+++ b/internal/providers/builtin.go
@@ -224,7 +224,6 @@ var builtinList = []Entry{
 		ID:          "minimax",
 		DisplayName: "MiniMax",
 		BaseURL:     "https://api.minimax.io/v1",
-		// Default recommended model.
 		HeaderStyle: "openai",
 		AuthMethods: []string{"api_key"},
 	},

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -269,7 +269,7 @@ type ScanRequest struct {
 	Targets        []string `json:"targets"`
 	Instruction    string   `json:"instruction"`
 	ScanMode       string   `json:"scan_mode"`       // "single" or "wildcard"
-	Model          string   `json:"model"`           // e.g. "minimax/MiniMax-M3"
+	Model          string   `json:"model"`           // e.g. "openai/gpt-5.6"
 	APIKey         string   `json:"api_key"`         // provider API key
 	APIBase        string   `json:"api_base"`        // provider API base URL
 	DiscordWebhook string   `json:"discord_webhook"` // Discord webhook URL

--- a/internal/web/settings_env.go
+++ b/internal/web/settings_env.go
@@ -120,7 +120,7 @@ func allEnvSettingDefinitions() []envSettingDefinition {
 		autoInstallDefault = "true"
 	}
 	return []envSettingDefinition{
-		{Key: "XALGORIX_LLM", Label: "LLM model", Category: "LLM", Description: "Provider-native model ID used by scans and post-scan chat.", Placeholder: "MiniMax-M3", InputType: "text"},
+		{Key: "XALGORIX_LLM", Label: "LLM model", Category: "LLM", Description: "Provider-native model ID used by scans and post-scan chat. For best results, choose a current frontier model with strong reasoning and tool calling.", Placeholder: "gpt-5.6", InputType: "text"},
 		{Key: "XALGORIX_LLM_PROVIDER", Label: "LLM provider", Category: "LLM", Description: "Explicit provider ID used to route the selected model without adding a provider prefix to its model name.", Placeholder: "ollama", InputType: "text"},
 		{Key: "XALGORIX_API_KEY", Label: "LLM API key", Category: "LLM", Description: "Provider API key for the configured model.", Placeholder: "sk-...", InputType: "secret", Sensitive: true},
 		{Key: "XALGORIX_API_BASE", Label: "API base URL", Category: "LLM", Description: "Optional custom provider endpoint. Leave blank to use provider defaults.", Placeholder: "https://api.openai.com/v1", InputType: "url"},

--- a/webui/mock-backend.mjs
+++ b/webui/mock-backend.mjs
@@ -130,8 +130,8 @@ let state = {
 };
 
 const providerCatalog = [
-  { id: "openai", displayName: "OpenAI", baseURL: "https://api.openai.com/v1", headerStyle: "openai", authMethods: ["api_key"], models: ["gpt-5", "gpt-5-mini"] },
-  { id: "google", displayName: "Google Gemini", baseURL: "https://generativelanguage.googleapis.com/v1beta", headerStyle: "gemini", authMethods: ["api_key"], models: ["gemini-2.5-pro", "gemini-2.5-flash"] },
+  { id: "openai", displayName: "OpenAI", baseURL: "https://api.openai.com/v1", headerStyle: "openai", authMethods: ["api_key"], models: ["gpt-5.6", "gpt-5.6-terra", "gpt-5.6-luna"] },
+  { id: "google", displayName: "Google Gemini", baseURL: "https://generativelanguage.googleapis.com/v1beta", headerStyle: "gemini", authMethods: ["api_key"], models: ["gemini-3.5-flash", "gemini-3.6-flash"] },
 ];
 
 const llmSettings = {

--- a/webui/src/pages/settings/provider-keys.tsx
+++ b/webui/src/pages/settings/provider-keys.tsx
@@ -154,9 +154,9 @@ export default function ProviderKeysManager({ className }: ProviderKeysManagerPr
         </CardTitle>
         <CardDescription>
           Configure API keys for multiple providers — xalgorix automatically routes
-          models like <code className="text-xs">gpt-4o</code>,{" "}
-          <code className="text-xs">claude-sonnet-4-20250514</code>, or{" "}
-          <code className="text-xs">gemini-2.5-pro</code> to the correct provider.
+          models like <code className="text-xs">gpt-5.6</code>,{" "}
+          <code className="text-xs">claude-fable-5</code>, or{" "}
+          <code className="text-xs">gemini-3.5-flash</code> to the correct provider.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-5">
@@ -276,7 +276,7 @@ export default function ProviderKeysManager({ className }: ProviderKeysManagerPr
           <div className="flex gap-2">
             <Input
               className="max-w-sm font-mono text-sm"
-              placeholder="e.g., gpt-4o, claude-sonnet-4-20250514, gemini-2.5-pro"
+              placeholder="e.g., gpt-5.6, claude-fable-5, gemini-3.5-flash"
               value={testModel}
               onChange={(e) => setTestModel(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && testRoute()}


### PR DESCRIPTION
## Summary
- make OpenAI the fresh-install default and recommend frontier models based on reasoning and tool-use reliability
- refresh setup suggestions to GPT-5.6, Claude Fable 5, and Gemini 3.5 Flash
- update CLI, dashboard, Docker, README, and provider-routing examples while retaining MiniMax and local-model support
- keep older model identifiers only in backward-compatibility test fixtures

## Validation
- go test ./cmd/xalgorix ./internal/config ./internal/providers ./internal/web ./internal/llm
- npm run build (webui)
- git diff --check
- isolated setup smoke test: OpenAI / gpt-5.6 / config mode 0600