### PR TITLE
fix: stop orphaned restart scans

### DIFF
--- a/internal/web/scan_query.go
+++ b/internal/web/scan_query.go
@@ -746,7 +746,8 @@ func finalizeScanRecordForResponse(rec *ScanRecord) {
 // rebuildInstancesFromDisk populates s.instances from all saved scan.json files on disk.
 // This ensures the dashboard shows historical scans immediately after server restart.
 // Skips subdomain scans (those with ParentTarget set) — those are shown under their parent.
-// Running scans from a previous server instance are marked as "stopped" since the agent process is gone.
+// Interrupted running/pending records are resumable only when a valid queue-state entry
+// still owns them; otherwise they are terminalized so they cannot remain pending forever.
 func (s *Server) rebuildInstancesFromDisk() {
 	queueEntries := s.validQueueStateEntries(false)
 	qMap := make(map[string]string)
@@ -758,33 +759,48 @@ func (s *Server) rebuildInstancesFromDisk() {
 			if qe.state.ActiveScanID != "" {
 				qMap[qe.state.ActiveScanID] = qe.state.InstanceID
 			}
+			if qe.state.WildcardActiveScanDir != "" {
+				qMap[filepath.Clean(qe.state.WildcardActiveScanDir)] = qe.state.InstanceID
+			}
+			if qe.state.WildcardActiveScanID != "" {
+				qMap[qe.state.WildcardActiveScanID] = qe.state.InstanceID
+			}
 			if len(qe.state.Targets) > 0 {
 				qMap[normalizeScanTarget(qe.state.Targets[0])] = qe.state.InstanceID
+			}
+			if qe.state.WildcardActiveTarget != "" {
+				qMap[normalizeScanTarget(qe.state.WildcardActiveTarget)] = qe.state.InstanceID
 			}
 		}
 	}
 
 	for _, entry := range s.findAllScans() {
-		// If scan was "running" from a previous server instance, transition it to "pending" / "resuming"
-		// so the startup queue resumer can pick it back up without marking it as stopped or failed.
-		if entry.rec.Status == "running" {
-			entry.rec.Status = "pending"
-			entry.rec.StopReason = "server_restart_resuming"
+		instID := entry.rec.ID
+		resumable := false
+		if mappedID, ok := qMap[filepath.Clean(entry.dir)]; ok {
+			instID, resumable = mappedID, true
+		} else if mappedID, ok := qMap[entry.rec.ID]; ok {
+			instID, resumable = mappedID, true
+		} else if mappedID, ok := qMap[normalizeScanTarget(entry.rec.Target)]; ok {
+			instID, resumable = mappedID, true
+		}
+
+		if entry.rec.Status == "running" || entry.rec.Status == "pending" {
+			if resumable {
+				entry.rec.Status = "pending"
+				entry.rec.StopReason = "server_restart_resuming"
+				entry.rec.FinishedAt = ""
+			} else {
+				entry.rec.Status = "stopped"
+				entry.rec.StopReason = "server_restart_no_resume_state"
+				entry.rec.FinishedAt = time.Now().Format(time.RFC3339)
+			}
 			s.saveScanRecordTo(&entry.rec, entry.dir)
 		}
 
 		// Skip subdomain scans — they belong to their parent wildcard scan
 		if entry.rec.ParentTarget != "" {
 			continue
-		}
-
-		instID := entry.rec.ID
-		if mappedID, ok := qMap[filepath.Clean(entry.dir)]; ok {
-			instID = mappedID
-		} else if mappedID, ok := qMap[entry.rec.ID]; ok {
-			instID = mappedID
-		} else if mappedID, ok := qMap[normalizeScanTarget(entry.rec.Target)]; ok {
-			instID = mappedID
 		}
 
 		inst := &ScanInstance{

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1552,16 +1552,16 @@ func TestScanPersistence_ListLatestDeleteAndRebuild(t *testing.T) {
 		t.Fatal("subdomain scan should not be rebuilt as a top-level instance")
 	}
 	inst := s.instances["scan-b"]
-	if inst == nil || inst.Status != "pending" || inst.StopReason != "server_restart_resuming" {
-		t.Fatalf("running scan was not marked pending on rebuild: %#v", inst)
+	if inst == nil || inst.Status != "stopped" || inst.StopReason != "server_restart_no_resume_state" {
+		t.Fatalf("orphaned running scan was not stopped on rebuild: %#v", inst)
 	}
 	_, rebuilt := s.findScanByID("scan-b")
-	if rebuilt == nil || rebuilt.Status != "pending" || rebuilt.StopReason != "server_restart_resuming" {
-		t.Fatalf("rebuilt scan was not persisted as pending: %#v", rebuilt)
+	if rebuilt == nil || rebuilt.Status != "stopped" || rebuilt.StopReason != "server_restart_no_resume_state" {
+		t.Fatalf("orphaned rebuilt scan was not persisted as stopped: %#v", rebuilt)
 	}
 	_, rebuiltSub := s.findScanByID("subdomain")
-	if rebuiltSub == nil || rebuiltSub.Status != "pending" || rebuiltSub.StopReason != "server_restart_resuming" {
-		t.Fatalf("subdomain running scan was not persisted as pending: %#v", rebuiltSub)
+	if rebuiltSub == nil || rebuiltSub.Status != "stopped" || rebuiltSub.StopReason != "server_restart_no_resume_state" {
+		t.Fatalf("orphaned subdomain scan was not persisted as stopped: %#v", rebuiltSub)
 	}
 
 	rr = httptest.NewRecorder()
@@ -1578,7 +1578,7 @@ func TestScanPersistence_ListLatestDeleteAndRebuild(t *testing.T) {
 		if got.ID == "subdomain" {
 			t.Fatalf("subdomain scan leaked into rebuilt list: %#v", got)
 		}
-		if got.ID == "scan-b" && got.Status != "pending" {
+		if got.ID == "scan-b" && got.Status != "stopped" {
 			t.Fatalf("list scans still returned stale status for %s: %#v", got.ID, got)
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to Xalgorix! Please fill this out so we can review quickly.
`main` is branch-protected — PRs are the only way in. CI runs make lint,
golangci-lint, go vet, and the test suite on every PR.
-->

## What & why

<!-- What does this change and why? Link the issue it addresses. -->

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Refactor / internal
- [ ] Other:

## How was it tested?

<!-- Commands you ran, new tests added, manual verification. -->

- [ ] `make lint` passes
- [ ] `golangci-lint run --config .golangci.yml ./...` passes
- [ ] `go test ./...` passes
- [ ] Added/updated tests for the change

## Checklist

- [ ] I read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md).
- [ ] The tree is `gofmt`-clean.
- [ ] I updated docs (`README`, `docs/`, help text) if behavior changed.
- [ ] This does not weaken a security control (scope guard, verifier, false-positive gate) without explicit discussion.
- [ ] For engine behavior changes: I noted any impact on scan findings/severity.
