### PR TITLE
Fix scanner-origin SSRF false positives

### DIFF
--- a/internal/agent/agent_prompt.go
+++ b/internal/agent/agent_prompt.go
@@ -168,7 +168,7 @@ This engine tracks a STRUCTURAL task plan, not just your train of thought. A pla
 A finding is only real when the EVIDENCE matches the CLAIM. Detection ≠ proof. Before reporting, it MUST pass all four checks:
 
 1. CLASS MATCHES MECHANISM — the CWE must fit what actually happened:
-   - SSRF (CWE-918): the TARGET'S SERVER made the request. Proof = an out-of-band callback (use the built-in oob_callback tool: generate a URL, plant it, then poll for the hit) or an internal-only resource (e.g. 169.254.169.254) returned BY THE TARGET. A request made by the victim's browser/JS is NOT SSRF.
+   - SSRF (CWE-918): the TARGET'S SERVER made the request. For OOB proof, generate a fresh token, send the injection with redirects explicitly disabled ('curl --max-redirs 0', 'allow_redirects=False', equivalent), and require a non-scanner-origin HTTP interaction. Pass the token as oob_token when reporting. A 30x pointing to the callback, scanner-origin interaction, DNS-only lookup, or victim-browser request is NOT SSRF. Internal-only data returned BY THE TARGET is also valid proof.
    - XSS (CWE-79): the script EXECUTED. Proof = alert(document.domain) firing, an OOB callback, or a screenshot. Reflection alone is NOT XSS.
    - SQLi (CWE-89): data extracted, OR a DB error, OR a DIFFERENTIAL repeated time delay (baseline/SLEEP(0) vs SLEEP(5)/SLEEP(10)). A single slow response is NOT proof.
    - Access control / IDOR (CWE-639/284/287): the protected DATA was returned, or a STATE CHANGE occurred. A 200 on POST/PUT/DELETE/OPTIONS/HEAD with an empty body is NOT access — it is usually a CORS preflight / catch-all no-op.

--- a/internal/agent/verifier.go
+++ b/internal/agent/verifier.go
@@ -287,14 +287,14 @@ Claimed proof (DO NOT TRUST — reproduce it yourself):
 1. Re-run the test yourself with the tools. Reproduce the EXACT observable the claim depends on.
 2. Use a NEGATIVE/BASELINE CONTROL: compare against an un-injected/benign request, an unauthenticated vs authenticated request, baseline vs payload timing, etc. A difference you cannot tie to the control is not proof.
 3. Apply the EVIDENCE STANDARD — the claim is only real if the evidence matches the class:
-   - SSRF (CWE-918): the TARGET'S SERVER made the request (OOB callback or internal-only resource). Browser/client-side URL handling is NOT SSRF.
+   - SSRF (CWE-918): the TARGET'S SERVER made the request. For OOB verification, generate a fresh token, send the injection request with redirects disabled ('curl --max-redirs 0', 'allow_redirects=False', equivalent), and require a non-scanner-origin HTTP interaction. A target 30x pointing to the callback, a scanner-origin hit, or DNS-only activity is NOT SSRF proof. Browser/client-side URL handling is also NOT SSRF.
    - XSS (CWE-79): the script actually EXECUTED (alert(document.domain), OOB callback, screenshot). Reflection alone is NOT XSS.
    - SQLi (CWE-89): extracted data, a DB error, or a DIFFERENTIAL repeated time delay. A single slow response is NOT proof.
    - Access control / IDOR: protected DATA returned or a real STATE CHANGE. A 200 (especially empty body) on POST/PUT/DELETE/OPTIONS is NOT access — usually CORS preflight / no-op.
    - Info disclosure (CWE-200): an actual secret VALUE leaked. Field/parameter NAMES, public OpenAPI/Swagger specs, and by-design data are NOT disclosure.
 4. Sanity-check the narrative: Is this the intended behavior of the technology? Did the "attacker" supply the secret themselves (a token placed in the URL cannot be "stolen" — circular)? Is the CVSS impact (C/I/A) actually demonstrated?
 5. EVIDENCE PROVENANCE — the proof must demonstrate THIS finding's OWN mechanism. If the evidence was actually obtained through a DIFFERENT vulnerability (e.g. "SQLi" proven by dumping the database through an RCE/eval bug instead of through the injection point), it does NOT prove this finding. Re-test the claimed mechanism directly at its own injection point. If only the other vulnerability works, this finding is inconclusive (or rejected if the claimed point is not actually injectable).
-6. BLIND CLASSES (blind XXE / blind SSRF / blind SQLi) — a generic "success"/"OK"/"request made" response is NOT proof. Require an out-of-band callback (interactsh / Burp Collaborator / your own listener) OR actually-retrieved data/file content (e.g. /etc/passwd contents). If you only observe a generic success message with no OOB hit and no returned data, mark inconclusive — do not confirm.
+6. BLIND CLASSES (blind XXE / blind SSRF / blind SQLi) — a generic "success"/"OK"/"request made" response is NOT proof. For SSRF, a DNS-only or scanner-origin OOB hit is also not proof; require a non-scanner-origin HTTP interaction from a fresh token tested with redirects disabled, or actually retrieved internal data. For other blind classes, require class-appropriate OOB provenance or retrieved data/file content. Otherwise mark inconclusive.
 
 ## VERDICT RULES
 - "confirmed" ONLY if YOU independently reproduced real, exploitable impact, ideally with a control.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -127,11 +127,10 @@ type Config struct {
 	InteractshToken  string
 	OOBDisable       bool
 
-	// OOBInteractions restricts which out-of-band interaction PROTOCOLS count as
-	// a callback (proof). Comma-separated subset of dns,http,smtp; empty = all
-	// three (the historical default). Use it to suppress DNS-only false
-	// positives from cloud infra (e.g. AWS resolvers) by allowing only http
-	// (and/or smtp). "http" also matches https. XALGORIX_OOB_INTERACTIONS.
+	// OOBInteractions restricts which out-of-band interaction PROTOCOLS are
+	// returned. Comma-separated subset of dns,http,smtp; empty = all three.
+	// DNS-only activity is retained as a lead but is not sufficient SSRF proof;
+	// the reporting gate requires a non-scanner-origin HTTP interaction.
 	OOBInteractions string
 
 	// SourceRepo enables whitebox / source-assisted assessment: the agent

--- a/internal/oob/interactsh.go
+++ b/internal/oob/interactsh.go
@@ -189,7 +189,9 @@ func ishToInteraction(token string, i *ishserver.Interaction) Interaction {
 			out.Body = truncateRaw(i.RawRequest)
 		}
 	case "dns":
-		// A DNS callback is proof on its own: the target resolved our host.
+		// DNS source addresses normally identify a recursive resolver, not the
+		// process that initiated the lookup. Preserve the lead, but attribution
+		// and SSRF proof require stronger corroboration at the reporting gate.
 		out.Method = "DNS"
 		out.Path = i.QType
 		out.Body = truncateRaw(i.RawRequest)

--- a/internal/oob/server.go
+++ b/internal/oob/server.go
@@ -1,7 +1,7 @@
-// Package oob provides out-of-band (OAST) callback infrastructure so the
-// agent can CONFIRM blind vulnerabilities — blind SSRF, blind RCE, blind
-// XSS, XXE, blind SQLi via HTTP egress — with concrete evidence: the TARGET'S
-// server (or a victim browser) reaching a unique, agent-controlled URL.
+// Package oob provides out-of-band (OAST) callback infrastructure for blind
+// SSRF, RCE, XSS, XXE, and SQLi verification. A callback is concrete evidence
+// that some system reached the unique URL; target attribution remains
+// fail-closed until protocol and scanner-origin provenance are assessed.
 //
 // This is essential under Xalgorix's "no theoretical findings" policy: a blind
 // class that cannot be reproduced by the verifier is dropped, so the agent
@@ -31,17 +31,31 @@ import (
 
 // Interaction is a single recorded out-of-band callback.
 type Interaction struct {
-	Token      string            `json:"token"`
-	Protocol   string            `json:"protocol"` // "http" / "https"
-	Method     string            `json:"method"`
-	Path       string            `json:"path"`
-	Query      string            `json:"query"`
-	RemoteAddr string            `json:"remote_addr"`
-	UserAgent  string            `json:"user_agent"`
-	Headers    map[string]string `json:"headers"`
-	Body       string            `json:"body"`
-	Time       time.Time         `json:"time"`
+	Token          string            `json:"token"`
+	Protocol       string            `json:"protocol"` // "http" / "https"
+	Method         string            `json:"method"`
+	Path           string            `json:"path"`
+	Query          string            `json:"query"`
+	RemoteAddr     string            `json:"remote_addr"`
+	ScannerOrigin  bool              `json:"scanner_origin,omitempty"`
+	OriginAssessed bool              `json:"origin_assessed,omitempty"`
+	UserAgent      string            `json:"user_agent"`
+	Headers        map[string]string `json:"headers"`
+	Body           string            `json:"body"`
+	Time           time.Time         `json:"time"`
 }
+
+// OriginCalibrationState describes whether remote callback provenance can be
+// assessed. Anything except OriginCalibrationCalibrated must be treated as
+// fail-closed for a remote, apparently non-scanner HTTP interaction.
+type OriginCalibrationState string
+
+const (
+	OriginCalibrationNotStarted  OriginCalibrationState = "not_started"
+	OriginCalibrationPending     OriginCalibrationState = "pending"
+	OriginCalibrationCalibrated  OriginCalibrationState = "calibrated"
+	OriginCalibrationUnavailable OriginCalibrationState = "unavailable"
+)
 
 var (
 	mu           sync.Mutex
@@ -49,12 +63,21 @@ var (
 	tokenOrder   []string                     // FIFO of registered tokens for eviction
 	startErr     error
 	startOnce    sync.Once
+
+	scannerOriginMu         sync.RWMutex
+	scannerOriginIPs        = map[string]struct{}{}
+	scannerOriginState      = OriginCalibrationNotStarted
+	scannerOriginRetryAfter time.Time
 )
 
 const (
-	maxOOBBody      = 8 * 1024
-	maxHitsPerToken = 100  // cap interactions kept per token
-	maxTokens       = 4096 // cap registered tokens; oldest evicted beyond this
+	maxOOBBody                     = 8 * 1024
+	maxHitsPerToken                = 100  // cap interactions kept per token
+	maxTokens                      = 4096 // cap registered tokens; oldest evicted beyond this
+	scannerOriginPollWindow        = 7 * time.Second
+	scannerOriginRetryCooldown     = 30 * time.Second
+	scannerOriginRequestTimeout    = 5 * time.Second
+	scannerOriginPollCheckInterval = 200 * time.Millisecond
 )
 
 // selfHosted reports whether the operator configured a self-hosted callback
@@ -70,9 +93,8 @@ func Enabled() bool {
 	return selfHosted() || interactshEnabled()
 }
 
-// Generate mints a callback URL + polling token using whichever backend is
-// active: the self-hosted listener when configured, otherwise interactsh.
-func Generate() (callbackURL, token string, err error) {
+// rawGenerate mints a callback without triggering scanner-origin calibration.
+func rawGenerate() (callbackURL, token string, err error) {
 	if selfHosted() {
 		return selfHostedGenerate()
 	}
@@ -82,23 +104,210 @@ func Generate() (callbackURL, token string, err error) {
 	return interactshGenerate()
 }
 
+func rawPoll(token string) []Interaction {
+	if selfHosted() {
+		return selfHostedPoll(token)
+	}
+	return interactshPoll(token)
+}
+
+func normalizedRemoteIP(remoteAddr string) string {
+	raw := strings.TrimSpace(remoteAddr)
+	if host, _, err := net.SplitHostPort(raw); err == nil {
+		raw = host
+	}
+	raw = strings.Trim(raw, "[]")
+	if ip := net.ParseIP(raw); ip != nil {
+		return ip.String()
+	}
+	return ""
+}
+
+func isDirectScannerOrigin(remoteAddr string) bool {
+	ip := net.ParseIP(normalizedRemoteIP(remoteAddr))
+	if ip == nil {
+		return false
+	}
+	addrs, _ := net.InterfaceAddrs()
+	for _, addr := range addrs {
+		var local net.IP
+		switch value := addr.(type) {
+		case *net.IPNet:
+			local = value.IP
+		case *net.IPAddr:
+			local = value.IP
+		}
+		if local != nil && local.Equal(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// ScannerOriginCalibrationState exposes whether remote callback origin
+// assessments are currently trustworthy.
+func ScannerOriginCalibrationState() OriginCalibrationState {
+	scannerOriginMu.RLock()
+	defer scannerOriginMu.RUnlock()
+	return scannerOriginState
+}
+
+// ScannerOriginCalibrated reports whether external scanner egress calibration
+// succeeded. Callers must fail closed when this is false.
+func ScannerOriginCalibrated() bool {
+	return ScannerOriginCalibrationState() == OriginCalibrationCalibrated
+}
+
+// IsScannerOrigin reports whether an OOB source address matches this scanner's
+// calibrated public/NAT egress or one of its directly assigned interfaces.
+func IsScannerOrigin(remoteAddr string) bool {
+	if isDirectScannerOrigin(remoteAddr) {
+		return true
+	}
+	ip := normalizedRemoteIP(remoteAddr)
+	scannerOriginMu.RLock()
+	_, known := scannerOriginIPs[ip]
+	scannerOriginMu.RUnlock()
+	return ip != "" && known
+}
+
+func assessScannerOrigin(remoteAddr string) (scannerOrigin, assessed bool) {
+	if isDirectScannerOrigin(remoteAddr) {
+		return true, true
+	}
+	ip := normalizedRemoteIP(remoteAddr)
+	scannerOriginMu.RLock()
+	_, known := scannerOriginIPs[ip]
+	calibrated := scannerOriginState == OriginCalibrationCalibrated
+	scannerOriginMu.RUnlock()
+	if !calibrated {
+		return false, false
+	}
+	return ip != "" && known, true
+}
+
+func calibrationHeaderMatches(headers map[string]string, nonce string) bool {
+	for key, value := range headers {
+		if strings.EqualFold(key, "X-Xalgorix-Origin-Calibration") && strings.TrimSpace(value) == nonce {
+			return true
+		}
+	}
+	return false
+}
+
+func finishScannerOriginCalibration(remoteAddr string) {
+	ip := normalizedRemoteIP(remoteAddr)
+	scannerOriginMu.Lock()
+	defer scannerOriginMu.Unlock()
+	if ip != "" {
+		scannerOriginIPs[ip] = struct{}{}
+		scannerOriginState = OriginCalibrationCalibrated
+		scannerOriginRetryAfter = time.Time{}
+		return
+	}
+	scannerOriginState = OriginCalibrationUnavailable
+	scannerOriginRetryAfter = time.Now().Add(scannerOriginRetryCooldown)
+}
+
+// startScannerOriginCalibration starts a retryable background calibration. It
+// never waits for the calibration request or polling window, so Generate can
+// return the caller's independently minted token without calibration latency.
+func startScannerOriginCalibration() {
+	now := time.Now()
+	scannerOriginMu.Lock()
+	if scannerOriginState == OriginCalibrationCalibrated ||
+		scannerOriginState == OriginCalibrationPending ||
+		now.Before(scannerOriginRetryAfter) {
+		scannerOriginMu.Unlock()
+		return
+	}
+	scannerOriginState = OriginCalibrationPending
+	scannerOriginMu.Unlock()
+	go calibrateScannerOrigin()
+}
+
+// calibrateScannerOrigin makes one no-redirect request to a private OOB token
+// and records the source IP observed by the callback service. A nonce header
+// ensures old/shared-token interactions can never poison the calibration.
+func calibrateScannerOrigin() {
+	callbackURL, token, err := rawGenerate()
+	if err != nil {
+		finishScannerOriginCalibration("")
+		return
+	}
+	nonceBytes := make([]byte, 12)
+	if _, err := rand.Read(nonceBytes); err != nil {
+		finishScannerOriginCalibration("")
+		return
+	}
+	nonce := hex.EncodeToString(nonceBytes)
+	req, err := http.NewRequest(http.MethodGet, callbackURL, nil)
+	if err != nil {
+		finishScannerOriginCalibration("")
+		return
+	}
+	req.Header.Set("X-Xalgorix-Origin-Calibration", nonce)
+	req.Header.Set("User-Agent", "xalgorix-origin-calibration/1")
+	client := &http.Client{
+		Timeout: scannerOriginRequestTimeout,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	if response, _ := client.Do(req); response != nil {
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 1024))
+		_ = response.Body.Close()
+	}
+
+	deadline := time.NewTimer(scannerOriginPollWindow)
+	ticker := time.NewTicker(scannerOriginPollCheckInterval)
+	defer deadline.Stop()
+	defer ticker.Stop()
+	for {
+		for _, hit := range rawPoll(token) {
+			protocol := strings.ToLower(strings.TrimSpace(hit.Protocol))
+			if (protocol == "http" || protocol == "https") && calibrationHeaderMatches(hit.Headers, nonce) {
+				finishScannerOriginCalibration(hit.RemoteAddr)
+				return
+			}
+		}
+		select {
+		case <-deadline.C:
+			finishScannerOriginCalibration("")
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// Generate mints a callback URL + polling token using whichever backend is
+// active: the self-hosted listener when configured, otherwise interactsh.
+func Generate() (callbackURL, token string, err error) {
+	startScannerOriginCalibration()
+	return rawGenerate()
+}
+
 // Poll returns interactions for a token from whichever backend is active,
 // filtered to the interaction protocols the operator allows via
-// XALGORIX_OOB_INTERACTIONS (blank = all: dns, http, smtp).
+// XALGORIX_OOB_INTERACTIONS (blank = all: dns, http, smtp). Each returned copy
+// carries a fail-closed origin assessment.
 func Poll(token string) []Interaction {
-	var hits []Interaction
-	if selfHosted() {
-		hits = selfHostedPoll(token)
-	} else {
-		hits = interactshPoll(token)
+	// Polling an existing token is also an opportunity to recover from a
+	// transient calibration failure once the retry cooldown has elapsed.
+	startScannerOriginCalibration()
+	filtered := applyProtocolFilter(rawPoll(token), parseAllowedProtocols(config.Get().OOBInteractions))
+	hits := make([]Interaction, len(filtered))
+	copy(hits, filtered)
+	for index := range hits {
+		hits[index].ScannerOrigin, hits[index].OriginAssessed = assessScannerOrigin(hits[index].RemoteAddr)
 	}
-	return applyProtocolFilter(hits, parseAllowedProtocols(config.Get().OOBInteractions))
+	return hits
 }
 
 // parseAllowedProtocols turns an XALGORIX_OOB_INTERACTIONS value into the set of
 // allowed protocol names. A nil result means "allow everything" (the default),
-// so an unset/blank value preserves the historical behavior of treating any
-// DNS, HTTP or SMTP callback as proof. "https" is folded into "http". A value
+// so an unset/blank value preserves the historical behavior of retaining any
+// DNS, HTTP or SMTP callback. "https" is folded into "http". A value
 // that names no valid protocol also yields nil — an operator typo must never
 // silently drop every callback (use XALGORIX_OOB_DISABLE to turn OOB off).
 func parseAllowedProtocols(raw string) map[string]bool {

--- a/internal/tools/oob/oob.go
+++ b/internal/tools/oob/oob.go
@@ -72,11 +72,11 @@ When polling, HTTP interactions are labeled as scanner-origin, origin-unassessed
 		for i, h := range hits {
 			protocol := strings.ToLower(strings.TrimSpace(h.Protocol))
 			originLabel := "provenance not applicable to this protocol"
-			switch {
-			case protocol == "dns":
+			switch protocol {
+			case "dns":
 				originLabel = "DNS-ONLY — AMBIGUOUS"
 				dnsOnlyCount++
-			case protocol == "http" || protocol == "https":
+			case "http", "https":
 				switch {
 				case !h.OriginAssessed:
 					originLabel = "ORIGIN UNASSESSED — CALIBRATION PENDING/UNAVAILABLE"

--- a/internal/tools/oob/oob.go
+++ b/internal/tools/oob/oob.go
@@ -1,7 +1,7 @@
 // Package oob registers the out-of-band (OAST) callback tool. It lets the
 // agent mint a unique callback URL, plant it in payloads, and poll for
-// interactions — turning blind SSRF/RCE/XSS/XXE into CONFIRMED findings with
-// concrete evidence (the target's server actually reached our URL).
+// interactions. A callback proves that some system reached the URL; protocol
+// and assessed origin must be considered before attributing it to a target.
 package oob
 
 import (
@@ -17,7 +17,7 @@ import (
 func Register(r *tools.Registry) {
 	r.Register(&tools.Tool{
 		Name:        "oob_callback",
-		Description: "Out-of-band (OAST) callback oracle for CONFIRMING blind vulnerabilities (blind SSRF, blind RCE, blind XSS, XXE, blind SQLi, blind CMDi). Captures DNS, HTTP and SMTP callbacks (via interactsh by default — no server setup needed), so even DNS-only sinks that merely resolve your host are proven. Workflow: (1) action=generate → get a unique callback URL/host; (2) plant it in your payload (an SSRF url param, a command like `curl <url>` or `nslookup <host>`, an XXE SYSTEM entity, a blind-XSS script src); (3) action=poll with the token → any recorded interaction is concrete PROOF the target reached your callback.",
+		Description: "Out-of-band (OAST) callback oracle for investigating blind vulnerabilities (blind SSRF, blind RCE, blind XSS, XXE, blind SQLi, blind CMDi). Workflow: (1) action=generate to mint a callback; (2) plant it in the target-side payload; (3) action=poll with the token. IMPORTANT: an interaction proves only that some system contacted the callback. For SSRF, send the injection request with redirects disabled and require an origin-assessed, non-scanner HTTP interaction. DNS-only, scanner-origin, or origin-unassessed hits are leads, not SSRF proof.",
 		Parameters: []tools.Parameter{
 			{Name: "action", Description: "'generate' to mint a new callback URL (default if omitted), or 'poll' to check for interactions on a token.", Required: false},
 			{Name: "token", Description: "For action=poll: the token returned by generate.", Required: false},
@@ -42,11 +42,13 @@ Callback URL: %s
 Token: %s
 
 Plant the URL in your payload, then poll with this token. Examples:
-- SSRF:      set a url/redirect/webhook param to %s
+- SSRF:      set a url/webhook param to %s and send the INJECTION request with redirects disabled (`+"`curl -sk --max-redirs 0 ...`"+`). A 30x Location pointing here is redirect behavior, NOT SSRF.
 - Blind RCE: inject `+"`curl %s`"+` or `+"`wget %s`"+`
 - XXE:       <!ENTITY x SYSTEM "%s">
 - Blind XSS: <script src=%s></script>
-- DNS-only:  a bare host lookup (e.g. `+"`nslookup %s`"+` or a hostname the target resolves) is also captured and counts as proof.`,
+- DNS-only:  a bare lookup such as `+"`nslookup %s`"+` is captured, but DNS alone is ambiguous and does NOT prove SSRF.
+
+When polling, HTTP interactions are labeled as scanner-origin, origin-unassessed, or assessed non-scanner. Only the last category can support callback-based SSRF verification.`,
 				url, token, url, url, url, url, url, host),
 			Metadata: map[string]any{"oob_url": url, "oob_token": token},
 		}, nil
@@ -61,10 +63,34 @@ Plant the URL in your payload, then poll with this token. Examples:
 			return tools.Result{Output: fmt.Sprintf("No OOB interactions for token %s yet. If you just sent the payload, wait a few seconds and poll again. No callback after several tries = the sink is not reaching us (not blind-exploitable via HTTP egress, or egress is filtered).", token)}, nil
 		}
 		var sb strings.Builder
-		sb.WriteString(fmt.Sprintf("✅ %d OOB interaction(s) for token %s — the target REACHED our callback. This is concrete proof of out-of-band exploitation:\n", len(hits), token))
+		scannerOriginHTTPCount := 0
+		dnsOnlyCount := 0
+		originUnassessedHTTPCount := 0
+		nonScannerHTTPCount := 0
+		calibrated := oobsrv.ScannerOriginCalibrated()
+		sb.WriteString(fmt.Sprintf("⚠️ %d OOB interaction(s) observed for token %s. An interaction alone does NOT identify which system initiated it:\n", len(hits), token))
 		for i, h := range hits {
-			sb.WriteString(fmt.Sprintf("\n[%d] %s %s%s\n    from %s at %s\n    User-Agent: %s\n",
-				i+1, h.Method, h.Path, queryStr(h.Query), h.RemoteAddr, h.Time.Format("2006-01-02T15:04:05Z07:00"), h.UserAgent))
+			protocol := strings.ToLower(strings.TrimSpace(h.Protocol))
+			originLabel := "provenance not applicable to this protocol"
+			switch {
+			case protocol == "dns":
+				originLabel = "DNS-ONLY — AMBIGUOUS"
+				dnsOnlyCount++
+			case protocol == "http" || protocol == "https":
+				switch {
+				case !h.OriginAssessed:
+					originLabel = "ORIGIN UNASSESSED — CALIBRATION PENDING/UNAVAILABLE"
+					originUnassessedHTTPCount++
+				case h.ScannerOrigin:
+					originLabel = "SCANNER ORIGIN — NOT TARGET PROOF"
+					scannerOriginHTTPCount++
+				default:
+					originLabel = "ASSESSED NON-SCANNER HTTP"
+					nonScannerHTTPCount++
+				}
+			}
+			sb.WriteString(fmt.Sprintf("\n[%d] %s %s%s\n    from %s at %s\n    provenance: %s\n    User-Agent: %s\n",
+				i+1, h.Method, h.Path, queryStr(h.Query), h.RemoteAddr, h.Time.Format("2006-01-02T15:04:05Z07:00"), originLabel, h.UserAgent))
 			if len(h.Headers) > 0 {
 				keys := make([]string, 0, len(h.Headers))
 				for k := range h.Headers {
@@ -79,8 +105,30 @@ Plant the URL in your payload, then poll with this token. Examples:
 				sb.WriteString(fmt.Sprintf("    body: %s\n", truncate(h.Body, 500)))
 			}
 		}
-		sb.WriteString("\nUse this (method, source IP, timestamp, headers) as the exploitation_proof in report_vulnerability with verification_method=callback_received.")
-		return tools.Result{Output: sb.String(), Metadata: map[string]any{"oob_hits": len(hits)}}, nil
+		if nonScannerHTTPCount > 0 {
+			sb.WriteString("\nFor SSRF, the assessed non-scanner HTTP interaction can support verification only if the injection request used redirects disabled and a baseline did not produce it. Pass this exact token as oob_token to report_vulnerability.")
+		} else {
+			sb.WriteString("\n❌ No assessed non-scanner HTTP interaction is available; do not report callback-confirmed SSRF.")
+		}
+		if originUnassessedHTTPCount > 0 {
+			sb.WriteString(" Origin calibration is pending or unavailable, so remote HTTP interactions are not attributable and must fail closed.")
+		}
+		if scannerOriginHTTPCount > 0 {
+			sb.WriteString(" Scanner-origin HTTP interactions indicate the scanner followed or directly requested its callback and are not SSRF proof.")
+		}
+		if dnsOnlyCount > 0 {
+			sb.WriteString(" DNS-only interactions may come from the scanner or a recursive resolver and are only leads.")
+		}
+		return tools.Result{Output: sb.String(), Metadata: map[string]any{
+			"oob_hits":                         len(hits),
+			"oob_token":                        token,
+			"scanner_origin_http_hits":         scannerOriginHTTPCount,
+			"dns_only_hits":                    dnsOnlyCount,
+			"origin_unassessed_http_hits":      originUnassessedHTTPCount,
+			"non_scanner_http_hits":            nonScannerHTTPCount,
+			"scanner_origin_calibrated":        calibrated,
+			"scanner_origin_calibration_state": oobsrv.ScannerOriginCalibrationState(),
+		}}, nil
 
 	default:
 		return tools.Result{Output: "❌ Unknown action '" + action + "'. Use 'generate' or 'poll'."}, nil

--- a/internal/tools/reporting/reporting.go
+++ b/internal/tools/reporting/reporting.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	oobsrv "github.com/xalgord/xalgorix/v4/internal/oob"
 	"github.com/xalgord/xalgorix/v4/internal/scanctx"
 	"github.com/xalgord/xalgorix/v4/internal/tools"
 )
@@ -280,6 +281,7 @@ func Register(r *tools.Registry) {
 			{Name: "description", Description: "Detailed description of the vulnerability", Required: true},
 			{Name: "exploitation_proof", Description: "REQUIRED for medium+. Concrete evidence of exploitation: extracted data, reflected payload text, command output, timing measurement, callback confirmation. Paste actual output here.", Required: false},
 			{Name: "verification_method", Description: "How you verified: exploited, time_based, data_extracted, callback_received, error_based, blind_confirmed, reflected, authenticated, manual_verified", Required: false},
+			{Name: "oob_token", Description: "For callback-confirmed SSRF: the exact token returned by oob_callback generate. Required so the backend can reject scanner-origin and DNS-only interactions.", Required: false},
 			{Name: "impact", Description: "Real-world impact assessment", Required: false},
 			{Name: "target", Description: "Target URL/host", Required: false},
 			{Name: "endpoint", Description: "Affected endpoint", Required: false},
@@ -404,6 +406,16 @@ Required steps:
 If you cannot exploit it, downgrade severity to 'info' and report as informational.`,
 				title, strings.ToUpper(severity), title),
 		}, nil
+	}
+
+	// ── Gate 2.5: SSRF callback provenance ──
+	// Apply this regardless of the declared method whenever the claim uses OOB
+	// evidence. In-band internal data extraction remains valid without OOB.
+	if isSSRFClaim(title, args["description"], args["cwe_id"]) &&
+		usesSSRFOOBEvidence(args["oob_token"], method, proof, args["description"]) {
+		if rejection := validateSSRFOOBProof(args["oob_token"], proof); rejection != "" {
+			return tools.Result{Output: rejection}, nil
+		}
 	}
 
 	// ── Gate 3: Check for common false positive patterns ──
@@ -681,6 +693,91 @@ func findDuplicateVulnerability(existing []Vulnerability, title, description, ta
 	}
 
 	return Vulnerability{}, "", false
+}
+
+func isSSRFClaim(title, description, cwe string) bool {
+	combined := strings.ToLower(title + " " + description + " " + cwe)
+	return strings.Contains(combined, "ssrf") ||
+		strings.Contains(combined, "server-side request forgery") ||
+		strings.Contains(combined, "server side request forgery") ||
+		strings.Contains(combined, "cwe-918")
+}
+
+func usesSSRFOOBEvidence(token, method, proof, description string) bool {
+	if strings.TrimSpace(token) != "" {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(method)) {
+	case "callback_received", "blind_confirmed":
+		return true
+	}
+	combined := strings.ToLower(proof + " " + description)
+	return anyContains(combined,
+		"callback received", "callback was received", "received callback",
+		"callback observed", "observed callback", "http callback",
+		"https callback", "oob interaction", "oast interaction",
+		"out-of-band", "out of band", "interact.sh", "interactsh",
+		"collaborator", "burpcollaborator", "webhook.site", "requestbin",
+		"canarytoken", "pingback", "http request received",
+		"request received at", "xalgorix-oob-ok", "dns interaction",
+		"dns query received")
+}
+
+func hasExplicitNoRedirectControl(proof string) bool {
+	compact := strings.NewReplacer(" ", "", "\t", "", "\r", "", "\n", "").Replace(strings.ToLower(proof))
+	return anyContains(compact,
+		"--max-redirs0", "--max-redirs=0",
+		"allow_redirects=false", "follow_redirects=false",
+		"max_redirects=0")
+}
+
+func isExactOOBToken(token string) bool {
+	return token != "" && token == strings.TrimSpace(token) && !strings.ContainsAny(token, "/.: \t\r\n")
+}
+
+func validateSSRFOOBProof(token, proof string) string {
+	if !isExactOOBToken(token) {
+		return "❌ REJECTED (SSRF callback provenance): callback-based SSRF requires the exact bare oob_token returned by oob_callback generate. A URL, hostname, missing token, or free-form callback text is not accepted. Re-test with a fresh token and redirects disabled."
+	}
+	if !hasExplicitNoRedirectControl(proof) {
+		return "❌ REJECTED (SSRF redirect control missing): exploitation_proof must include an explicit technical no-redirect control such as `curl --max-redirs 0`, `allow_redirects=False`, or `follow_redirects=False`. Vague prose about redirects is not sufficient."
+	}
+
+	hits := oobsrv.Poll(token)
+	nonScannerHTTP := 0
+	scannerOriginHTTP := 0
+	originUnassessedHTTP := 0
+	dnsOnly := 0
+	for _, hit := range hits {
+		protocol := strings.ToLower(strings.TrimSpace(hit.Protocol))
+		switch {
+		case protocol == "dns":
+			dnsOnly++
+		case protocol == "http" || protocol == "https":
+			switch {
+			case !hit.OriginAssessed:
+				originUnassessedHTTP++
+			case hit.ScannerOrigin:
+				scannerOriginHTTP++
+			default:
+				nonScannerHTTP++
+			}
+		}
+	}
+	if nonScannerHTTP > 0 {
+		return ""
+	}
+	if originUnassessedHTTP > 0 {
+		return fmt.Sprintf("❌ REJECTED (SSRF origin calibration %s): %d HTTP callback(s) have unassessed origin, alongside %d scanner-origin HTTP and %d DNS-only interaction(s). Remote callbacks must fail closed until external scanner-origin calibration succeeds; poll and report again after calibration, or use returned internal-resource data.",
+			oobsrv.ScannerOriginCalibrationState(), originUnassessedHTTP, scannerOriginHTTP, dnsOnly)
+	}
+	if scannerOriginHTTP > 0 {
+		return fmt.Sprintf("❌ REJECTED (scanner-origin SSRF false positive): %d HTTP callback(s) came from Xalgorix's scanner origin; %d DNS-only interaction(s) were also observed. Neither proves that the target server performed SSRF.", scannerOriginHTTP, dnsOnly)
+	}
+	if dnsOnly > 0 {
+		return fmt.Sprintf("❌ REJECTED (DNS-only SSRF evidence): %d DNS interaction(s) were observed, but DNS may originate from the scanner or a recursive resolver. Require an origin-assessed, non-scanner HTTP(S) interaction or returned internal-resource data.", dnsOnly)
+	}
+	return "❌ REJECTED (SSRF callback not attested): the exact oob_token has no origin-assessed, non-scanner HTTP(S) interaction. Re-test with a fresh token, explicit no-redirect controls, and an uninjected baseline."
 }
 
 // anyContains reports whether s contains any of the given substrings.

--- a/internal/tools/reporting/reporting.go
+++ b/internal/tools/reporting/reporting.go
@@ -750,10 +750,10 @@ func validateSSRFOOBProof(token, proof string) string {
 	dnsOnly := 0
 	for _, hit := range hits {
 		protocol := strings.ToLower(strings.TrimSpace(hit.Protocol))
-		switch {
-		case protocol == "dns":
+		switch protocol {
+		case "dns":
 			dnsOnly++
-		case protocol == "http" || protocol == "https":
+		case "http", "https":
 			switch {
 			case !hit.OriginAssessed:
 				originUnassessedHTTP++

--- a/internal/web/autonomous.go
+++ b/internal/web/autonomous.go
@@ -32,7 +32,7 @@ You are an elite penetration tester. YOUR GOAL: Find REAL, EXPLOITABLE vulnerabi
 Your primary target is ` + "`" + `` + target + `` + "`" + `. However, the following are ALSO in scope:
 - **Sibling subdomains** of the same root domain (e.g., if target is www.example.com → login.example.com, api.example.com, app.example.com are ALL in scope)
 - Any subdomain the target **redirects you to** for login, OAuth, SSO, or API calls
-- **HTTP REDIRECT HANDLING (CRITICAL)**: If the target returns an HTTP 301, 302, 307, or 308 redirect (e.g., https://frsi.nationalbank.kz/ -> https://frsi.nationalbank.kz/frsi/), ALWAYS follow the redirect (e.g., use 'curl -L' or 'requests.get(..., allow_redirects=True)') or update your testing path to target the destination path (/frsi/) directly. Do NOT stop probing at the root 301/302 redirect response.
+- **HTTP REDIRECT HANDLING (CRITICAL)**: For normal navigation/recon, if the target returns an HTTP 301, 302, 307, or 308 redirect (e.g., https://frsi.nationalbank.kz/ -> https://frsi.nationalbank.kz/frsi/), follow it or update the testing path to the destination. **SSRF/OOB EXCEPTION:** when testing a URL/redirect/webhook parameter with an OOB callback, NEVER follow redirects ('curl --max-redirs 0', 'allow_redirects=False', equivalent). A 30x Location pointing to your callback is open-redirect/reflection behavior, not proof that the target server fetched it.
 - The root domain itself (e.g., example.com without www)
 
 **Out of scope:** Completely different domains, third-party services (Google, AWS, CDNs), unless they are explicitly part of the target's infrastructure.
@@ -76,10 +76,13 @@ For EVERY potential vulnerability found in Phase 2, you MUST:
 - Severity: reflected (proven) XSS = MEDIUM; stored XSS that fires for other users = HIGH. Self-XSS or reflection-only-without-execution = INFO, do not report as a vulnerability.
 
 **Server-Side Request Forgery (SSRF):**
-- Test with callback: ` + "`" + `curl "URL?param=http://BURP_COLLABORATOR_OR_WEBHOOK"` + "`" + `
-- Test internal access: ` + "`" + `curl "URL?param=http://169.254.169.254/latest/meta-data/"` + "`" + `
-- Proof = received callback or internal metadata in response
-- SSRF means the TARGET'S SERVER makes the request. If the request is made by the victim's BROWSER (client-side JS reading URL params, fetch from a bundle), it is NOT SSRF — do not label it CWE-918. Classify client-side URL control as open redirect / client-side issue instead, and only if a real victim secret is actually exposed.
+- Generate a fresh OOB token, then inject its URL with redirects DISABLED: ` + "`" + `curl -sk --max-redirs 0 -D - "URL?param=http://OOB_CALLBACK"` + "`" + `
+- If the target returns 30x Location: OOB_CALLBACK, that is redirect behavior — do not follow it and do not report SSRF.
+- Test internal access separately: ` + "`" + `curl "URL?param=http://169.254.169.254/latest/meta-data/"` + "`" + `
+- Proof = an origin-assessed, non-scanner HTTP OOB interaction tied to the fresh token, or internal-only data returned by the TARGET. Pass the token as oob_token when reporting callback-confirmed SSRF.
+- DNS-only callbacks are ambiguous (often scanner/resolver activity) and are NOT sufficient SSRF proof.
+- Compare against an uninjected baseline. If the callback source is labeled scanner-origin, discard it as a false positive.
+- SSRF means the TARGET'S SERVER makes the request. If the request is made by the scanner after following a redirect, or by the victim's BROWSER, it is NOT SSRF — classify the actual behavior instead.
 - A credential the attacker places in the crafted URL (e.g. ` + "`" + `?token=...` + "`" + `) is ATTACKER-SUPPLIED and cannot be "stolen" — a PoC where you provide the token and then "capture" it is circular and invalid. Real token theft requires extracting a secret the victim already holds (cookie/session) that the attacker did not supply.
 
 **Remote Code Execution (RCE):**
@@ -283,7 +286,7 @@ You are already inside the target's scan workspace. Save evidence and tool outpu
 
 **SQLi:** Extract actual data with sqlmap --dbs, OR confirm with time-based (SLEEP)
 **XSS:** Prove EXECUTION, not reflection — confirm the payload is reflected RAW (not ` + "`" + `&lt;` + "`" + `-encoded) in a ` + "`" + `text/html` + "`" + ` response AND that it actually runs (browser_action execute_js showing ` + "`" + `alert(document.domain)` + "`" + `, a screenshot, or an out-of-band callback for blind/stored). Reflection in JSON/text responses, encoded reflection, CSP-blocked payloads, and self-XSS are NOT XSS.
-**SSRF:** Get callback or read internal metadata
+**SSRF:** Use a fresh OOB token with redirects explicitly disabled; proof requires an origin-assessed non-scanner HTTP(S) interaction and the exact oob_token, or internal-only data returned in-band by the target.
 **RCE:** Execute id/whoami and show output
 **IDOR:** Log in as User A, access User B's data by changing IDs (authenticated required)
 **Auth Bypass:** Access protected endpoint without any credentials
@@ -417,7 +420,7 @@ If you determine this is a duplicate/parking/redirect subdomain, call finish wit
 For EVERY potential vulnerability:
 - SQLi: Confirm with time-based or extract data
 - XSS: Prove EXECUTION, not reflection — raw (un-encoded) payload in a text/html response that actually runs (browser execute_js alert/document.domain, screenshot, or OOB callback for blind/stored). Encoded reflection, JSON/text responses, and self-XSS are NOT XSS.
-- SSRF: Get callback or read internal metadata
+- SSRF: Use a fresh OOB token with redirects explicitly disabled; require an origin-assessed non-scanner HTTP(S) interaction plus the exact oob_token, or internal-only data returned in-band by the target.
 - RCE: Execute id/whoami and show output
 
 ### Step 5: REPORT (only after exploitation)


### PR DESCRIPTION
## Summary
- calibrate and classify scanner public/NAT callback origins
- reject scanner-origin, DNS-only, and origin-unassessed SSRF callback evidence
- require exact OOB tokens and explicit no-redirect controls
- align autonomous and verifier guidance with the reporting gate

## Validation
- go test ./internal/oob ./internal/tools/oob ./internal/tools/reporting
- go test ./internal/agent ./internal/web ./internal/config
- go build ./cmd/xalgorix
- git diff --check
- diagnostics clean on all eight changed files