### PR TITLE
Return 404 for missing scan records

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -3177,8 +3177,7 @@ func (s *Server) handleGetScan(w http.ResponseWriter, r *http.Request) {
 		_ = dir
 	}
 	if rec == nil {
-		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`null`))
+		http.Error(w, "scan not found", http.StatusNotFound)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- return HTTP 404 from GET /api/scans/{id} when the requested scan cannot be resolved
- replace the ambiguous HTTP 200 null response that prevented clients from recognizing a lost instance after restart

## Validation
- go test ./internal/web/...
- golangci-lint run ./internal/web/...
- editor diagnostics clean
- git diff --check