### PR TITLE
fix: expose exact wildcard instance status

### DIFF
--- a/internal/web/orchestrator.go
+++ b/internal/web/orchestrator.go
@@ -94,6 +94,8 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 		TargetAuthSecondary: req.TargetAuthSecondary,
 		SourceRepo:          req.SourceRepo,
 		ScanContext:         req.ScanContext,
+		SubScans:            make([]SubScanSummary, 0),
+		snapshotFinalizing:  true,
 	}
 	s.seedResumeInstanceFromRecord(instance, req)
 	s.instancesMu.Lock()
@@ -151,6 +153,7 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 			}
 		}
 		instance.FinishedAt = time.Now().Format(time.RFC3339)
+		normalizeTerminalWildcardInstanceLocked(instance)
 		instance.agent = nil
 		instance.cancel = nil
 		instance.sctx = nil
@@ -220,6 +223,12 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 			}
 		}
 		s.broadcastToInstance(instanceID, queueDoneEvt)
+		// The event above is the final exact event snapshot entry. Only now may
+		// the compact endpoint expose a terminal status; SaaS persists this
+		// event/final findings before its terminal status CAS.
+		instance.mu.Lock()
+		instance.snapshotFinalizing = false
+		instance.mu.Unlock()
 		s.broadcastDashboard(WSEvent{Type: "instance_updated", Content: instanceID})
 		time.Sleep(500 * time.Millisecond)
 
@@ -925,6 +934,7 @@ func (s *Server) runWildcardTarget(_ context.Context, scanCfg *config.Config, re
 		parentRecord.SubScanRemaining = len(subdomains) - resumeFromSubIndex
 		parentRecord.Status = "running"
 		s.saveScanRecordTo(parentRecord, scanDir)
+		s.mirrorWildcardProgress(req.InstanceID, parentRecord)
 	}
 	s.saveQueueState(idx, req, queueProgress{
 		ActiveTarget:          target,
@@ -994,6 +1004,7 @@ func (s *Server) runWildcardTarget(_ context.Context, scanCfg *config.Config, re
 			parentRecord.SubScanRemaining = len(subdomains) - completed - running
 			parentRecord.Status = "running"
 			s.saveScanRecordTo(parentRecord, scanDir)
+			s.mirrorWildcardProgress(req.InstanceID, parentRecord)
 		}
 		activeSubScanID := ""
 		if activeSubScanDir != "" {
@@ -1199,7 +1210,9 @@ func (s *Server) runWildcardTarget(_ context.Context, scanCfg *config.Config, re
 			parentRecord.Status = "finished"
 		}
 		parentRecord.FinishedAt = time.Now().Format(time.RFC3339)
+		normalizeTerminalWildcardProgress(parentRecord)
 		s.saveScanRecordTo(parentRecord, scanDir)
+		s.mirrorWildcardProgress(req.InstanceID, parentRecord)
 	}
 
 	log.Printf("[INFO] Wildcard scan complete for %s: scanned %d subdomains", target, len(subdomains))

--- a/internal/web/scan_query.go
+++ b/internal/web/scan_query.go
@@ -333,6 +333,15 @@ func (s *Server) markTelegramConfigured(rec *ScanRecord) {
 	rec.TelegramConfigured = s.telegramConfigured()
 }
 
+func cloneSubScanSummaries(source []SubScanSummary) []SubScanSummary {
+	if source == nil {
+		return nil
+	}
+	cloned := make([]SubScanSummary, len(source))
+	copy(cloned, source)
+	return cloned
+}
+
 func (s *Server) scanRecordFromInstance(inst *ScanInstance) *ScanRecord {
 	if inst == nil {
 		return nil
@@ -346,6 +355,7 @@ func (s *Server) scanRecordFromInstance(inst *ScanInstance) *ScanRecord {
 	copy(vulns, inst.Vulns)
 	phases := append([]int(nil), inst.Phases...)
 	severityFilter := append([]string(nil), inst.SeverityFilter...)
+	subScans := cloneSubScanSummaries(inst.SubScans)
 
 	return &ScanRecord{
 		ID:                       inst.ID,
@@ -374,6 +384,104 @@ func (s *Server) scanRecordFromInstance(inst *ScanInstance) *ScanRecord {
 		LogoPath:                 inst.LogoPath,
 		Phases:                   phases,
 		CurrentPhase:             inst.CurrentPhase,
+		SubScans:                 subScans,
+		SubScanTotal:             inst.SubScanTotal,
+		SubScanCompleted:         inst.SubScanCompleted,
+		SubScanRunning:           inst.SubScanRunning,
+		SubScanRemaining:         inst.SubScanRemaining,
+	}
+}
+
+// mirrorWildcardProgress copies the persisted wildcard parent snapshot into
+// its live instance. The copy keeps /api/instances/{id} lock-only and avoids
+// sharing the mutable parentRecord slice with concurrent HTTP encoders.
+func (s *Server) mirrorWildcardProgress(instanceID string, rec *ScanRecord) {
+	if instanceID == "" || rec == nil {
+		return
+	}
+	children := cloneSubScanSummaries(rec.SubScans)
+
+	s.instancesMu.RLock()
+	inst := s.instances[instanceID]
+	if inst != nil {
+		inst.mu.Lock()
+		inst.SubScans = children
+		inst.SubScanTotal = rec.SubScanTotal
+		inst.SubScanCompleted = rec.SubScanCompleted
+		inst.SubScanRunning = rec.SubScanRunning
+		inst.SubScanRemaining = rec.SubScanRemaining
+		normalizeTerminalWildcardInstanceLocked(inst)
+		inst.mu.Unlock()
+	}
+	s.instancesMu.RUnlock()
+}
+
+// normalizeTerminalSubScans converts unresolved children to a terminal status
+// while preserving whether the scanner ever dispatched them. Never-started
+// pending children remain without lifecycle timestamps; running/started
+// children receive the parent's terminal timestamp.
+func normalizeTerminalSubScans(children []SubScanSummary, parentStatus, finishedAt string) int {
+	fallbackStatus := terminalSubScanStatus(parentStatus)
+	completed := 0
+	for i := range children {
+		status := strings.ToLower(strings.TrimSpace(children[i].Status))
+		started := status == "running" || children[i].StartedAt != "" || children[i].ID != "" ||
+			children[i].VulnCount > 0 || children[i].TotalTokens > 0
+		if isUnresolvedSubScanStatus(status) {
+			children[i].Status = fallbackStatus
+			if started && children[i].FinishedAt == "" {
+				children[i].FinishedAt = finishedAt
+			}
+		}
+		if isFinishedSubScanStatus(children[i].Status) {
+			completed++
+		}
+	}
+	return completed
+}
+
+// normalizeTerminalWildcardProgress prevents a terminal compact snapshot from
+// retaining children as pending/running. This mirrors the historical full
+// response's normalization without its disk walk.
+func normalizeTerminalWildcardProgress(rec *ScanRecord) {
+	if rec == nil || !isTerminalScanStatus(rec.Status) {
+		return
+	}
+	finishedAt := rec.FinishedAt
+	if finishedAt == "" {
+		finishedAt = time.Now().Format(time.RFC3339)
+	}
+	completed := normalizeTerminalSubScans(rec.SubScans, rec.Status, finishedAt)
+	if rec.SubScanTotal < len(rec.SubScans) {
+		rec.SubScanTotal = len(rec.SubScans)
+	}
+	rec.SubScanCompleted = completed
+	rec.SubScanRunning = 0
+	rec.SubScanRemaining = rec.SubScanTotal - completed
+	if rec.SubScanRemaining < 0 {
+		rec.SubScanRemaining = 0
+	}
+}
+
+// normalizeTerminalWildcardInstanceLocked keeps status and wildcard children
+// coherent for exact instance readers. The caller must hold inst.mu.
+func normalizeTerminalWildcardInstanceLocked(inst *ScanInstance) {
+	if inst == nil || inst.ScanMode != "wildcard" || !isTerminalScanStatus(inst.Status) {
+		return
+	}
+	finishedAt := inst.FinishedAt
+	if finishedAt == "" {
+		finishedAt = time.Now().Format(time.RFC3339)
+	}
+	completed := normalizeTerminalSubScans(inst.SubScans, inst.Status, finishedAt)
+	if inst.SubScanTotal < len(inst.SubScans) {
+		inst.SubScanTotal = len(inst.SubScans)
+	}
+	inst.SubScanCompleted = completed
+	inst.SubScanRunning = 0
+	inst.SubScanRemaining = inst.SubScanTotal - completed
+	if inst.SubScanRemaining < 0 {
+		inst.SubScanRemaining = 0
 	}
 }
 
@@ -774,60 +882,90 @@ func (s *Server) rebuildInstancesFromDisk() {
 		}
 	}
 
-	for _, entry := range s.findAllScans() {
+	entries := s.findAllScans()
+	instanceIdentity := func(entry *scanEntry) (string, bool) {
 		instID := entry.rec.ID
-		resumable := false
 		if mappedID, ok := qMap[filepath.Clean(entry.dir)]; ok {
-			instID, resumable = mappedID, true
-		} else if mappedID, ok := qMap[entry.rec.ID]; ok {
-			instID, resumable = mappedID, true
-		} else if mappedID, ok := qMap[normalizeScanTarget(entry.rec.Target)]; ok {
-			instID, resumable = mappedID, true
+			return mappedID, true
 		}
-
-		if entry.rec.Status == "running" || entry.rec.Status == "pending" {
-			if resumable {
-				entry.rec.Status = "pending"
-				entry.rec.StopReason = "server_restart_resuming"
-				entry.rec.FinishedAt = ""
-			} else {
-				entry.rec.Status = "stopped"
-				entry.rec.StopReason = "server_restart_no_resume_state"
-				entry.rec.FinishedAt = time.Now().Format(time.RFC3339)
-			}
-			s.saveScanRecordTo(&entry.rec, entry.dir)
+		if mappedID, ok := qMap[entry.rec.ID]; ok {
+			return mappedID, true
 		}
+		if mappedID, ok := qMap[normalizeScanTarget(entry.rec.Target)]; ok {
+			return mappedID, true
+		}
+		return instID, false
+	}
 
-		// Skip subdomain scans — they belong to their parent wildcard scan
+	// First normalize every interrupted record so wildcard parent aggregation
+	// below observes the recovered child statuses rather than stale running
+	// values captured before the restart.
+	for i := range entries {
+		entry := &entries[i]
+		_, resumable := instanceIdentity(entry)
+		if entry.rec.Status != "running" && entry.rec.Status != "pending" {
+			continue
+		}
+		if resumable {
+			entry.rec.Status = "pending"
+			entry.rec.StopReason = "server_restart_resuming"
+			entry.rec.FinishedAt = ""
+		} else {
+			entry.rec.Status = "stopped"
+			entry.rec.StopReason = "server_restart_no_resume_state"
+			entry.rec.FinishedAt = time.Now().Format(time.RFC3339)
+		}
+		normalizeTerminalWildcardProgress(&entry.rec)
+		s.saveScanRecordTo(&entry.rec, entry.dir)
+	}
+
+	for i := range entries {
+		entry := &entries[i]
+		// Skip subdomain scans — they belong to their parent wildcard scan.
 		if entry.rec.ParentTarget != "" {
 			continue
 		}
 
+		instID, _ := instanceIdentity(entry)
+		if entry.rec.ScanMode == "wildcard" || entry.rec.SubScans != nil || entry.rec.SubScanTotal > 0 {
+			// Rebuild the exact parent snapshot from the now-normalized child
+			// records. This restores findings and physical provenance as well as
+			// authoritative child counters without requiring request-time I/O.
+			s.attachWildcardSubScansFrom(&entry.rec, entries)
+			normalizeTerminalWildcardProgress(&entry.rec)
+			s.saveScanRecordTo(&entry.rec, entry.dir)
+		}
+
 		inst := &ScanInstance{
-			ID:             instID,
-			Name:           entry.rec.Name,
-			Targets:        entry.rec.Target,
-			ParentTarget:   entry.rec.ParentTarget,
-			Status:         entry.rec.Status,
-			StartedAt:      entry.rec.StartedAt,
-			FinishedAt:     entry.rec.FinishedAt,
-			StopReason:     entry.rec.StopReason,
-			Iterations:     entry.rec.Iterations,
-			ToolCalls:      entry.rec.ToolCalls,
-			VulnCount:      len(entry.rec.Vulns),
-			TotalTokens:    entry.rec.TotalTokens,
-			ScanMode:       entry.rec.ScanMode,
-			Instruction:    entry.rec.Instruction,
-			SeverityFilter: entry.rec.SeverityFilter,
-			Phases:         entry.rec.Phases,
-			ReconMode:      entry.rec.ReconMode,
-			ScanIntensity:  entry.rec.ScanIntensity,
-			CompanyName:    entry.rec.CompanyName,
-			LogoPath:       entry.rec.LogoPath,
-			DiscordWebhook: entry.rec.DiscordWebhook,
-			Vulns:          entry.rec.Vulns,
-			CurrentPhase:   entry.rec.CurrentPhase,
-			events:         append([]WSEvent(nil), entry.rec.Events...),
+			ID:               instID,
+			Name:             entry.rec.Name,
+			Targets:          entry.rec.Target,
+			ParentTarget:     entry.rec.ParentTarget,
+			Status:           entry.rec.Status,
+			StartedAt:        entry.rec.StartedAt,
+			FinishedAt:       entry.rec.FinishedAt,
+			StopReason:       entry.rec.StopReason,
+			Iterations:       entry.rec.Iterations,
+			ToolCalls:        entry.rec.ToolCalls,
+			VulnCount:        len(entry.rec.Vulns),
+			TotalTokens:      entry.rec.TotalTokens,
+			ScanMode:         entry.rec.ScanMode,
+			Instruction:      entry.rec.Instruction,
+			SeverityFilter:   entry.rec.SeverityFilter,
+			Phases:           entry.rec.Phases,
+			ReconMode:        entry.rec.ReconMode,
+			ScanIntensity:    entry.rec.ScanIntensity,
+			CompanyName:      entry.rec.CompanyName,
+			LogoPath:         entry.rec.LogoPath,
+			DiscordWebhook:   entry.rec.DiscordWebhook,
+			Vulns:            entry.rec.Vulns,
+			CurrentPhase:     entry.rec.CurrentPhase,
+			SubScans:         cloneSubScanSummaries(entry.rec.SubScans),
+			SubScanTotal:     entry.rec.SubScanTotal,
+			SubScanCompleted: entry.rec.SubScanCompleted,
+			SubScanRunning:   entry.rec.SubScanRunning,
+			SubScanRemaining: entry.rec.SubScanRemaining,
+			events:           append([]WSEvent(nil), entry.rec.Events...),
 		}
 		if inst.CurrentPhase == 0 {
 			inst.CurrentPhase = firstSelectedPhase(inst.Phases)

--- a/internal/web/scan_record.go
+++ b/internal/web/scan_record.go
@@ -121,6 +121,28 @@ func mergeReportedVulnerabilitiesIntoRecord(rec *ScanRecord, reported []reportin
 	}
 }
 
+// mirrorPersistedSessionVulnerabilities copies the session findings that have
+// already been saved to scan.json into the exact parent instance snapshot.
+// Wildcard children use the shared parent instance ID, so this also builds the
+// complete parent finding set without a disk walk. The copy happens before a
+// terminal instance can become observable.
+func (s *Server) mirrorPersistedSessionVulnerabilities(instanceID string, vulns []VulnSummary) {
+	if instanceID == "" || len(vulns) == 0 {
+		return
+	}
+	s.instancesMu.RLock()
+	inst := s.instances[instanceID]
+	if inst != nil {
+		inst.mu.Lock()
+		for _, vuln := range vulns {
+			appendVulnSummaryUnique(&inst.Vulns, vuln)
+		}
+		inst.VulnCount = len(inst.Vulns)
+		inst.mu.Unlock()
+	}
+	s.instancesMu.RUnlock()
+}
+
 // effectiveVulnCount returns the most stable counter source for an instance.
 // Strategy: prefer in-memory while running (live), fall back to on-disk
 // VulnCount once the scan is finished or torn down (stable across teardown).
@@ -266,6 +288,13 @@ func (s *Server) seedResumeInstanceFromRecord(inst *ScanInstance, req ScanReques
 	inst.ToolCalls = rec.ToolCalls
 	inst.TotalTokens = rec.TotalTokens
 	inst.Vulns = append([]VulnSummary(nil), rec.Vulns...)
+	if rec.SubScans != nil {
+		inst.SubScans = cloneSubScanSummaries(rec.SubScans)
+	}
+	inst.SubScanTotal = rec.SubScanTotal
+	inst.SubScanCompleted = rec.SubScanCompleted
+	inst.SubScanRunning = rec.SubScanRunning
+	inst.SubScanRemaining = rec.SubScanRemaining
 	// Resume path: scan is being seeded from on-disk record, no live session
 	// exists yet, so effectiveVulnCount falls back to len(inst.Vulns).
 	inst.VulnCount = s.effectiveVulnCount(inst, nil)

--- a/internal/web/scan_session.go
+++ b/internal/web/scan_session.go
@@ -281,6 +281,7 @@ func (s *Server) executeScanSession(sess *scanSession) {
 						inst.Status = "failed"
 						inst.StopReason = sess.abortReason
 						inst.FinishedAt = finishedAt
+						normalizeTerminalWildcardInstanceLocked(inst)
 					}
 					inst.mu.Unlock()
 				}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -499,15 +499,26 @@ type ScanInstance struct {
 	ScanContext         string        `json:"-"`
 	Vulns               []VulnSummary `json:"vulns,omitempty"`
 	CurrentPhase        int           `json:"current_phase,omitempty"`
-	agent               *agent.Agent
-	cancel              context.CancelFunc
-	scanDir             string
-	sctx                *scanctx.ScanContext // per-instance session state (vulns, notes, terminal, browser)
-	events              []WSEvent            // buffered events for replay
-	chatCfg             *config.Config       // provider settings for post-scan chat (not exposed)
-	chatMessages        []llm.Message        // lightweight post-scan chat history (not exposed)
-	mu                  sync.RWMutex
-	lastSessionTokens   int // tracks token count from current session for delta calculation
+	// Wildcard progress is mirrored from the persisted parent record so the
+	// exact instance endpoint can serve a complete snapshot without a data-dir
+	// walk. SubScans intentionally omits `omitempty`: an empty array is the
+	// capability marker SaaS uses to distinguish upgraded scanners from older
+	// versions that cannot safely finalize wildcard scans from this endpoint.
+	SubScans           []SubScanSummary `json:"sub_scans"`
+	SubScanTotal       int              `json:"sub_scan_total"`
+	SubScanCompleted   int              `json:"sub_scan_completed"`
+	SubScanRunning     int              `json:"sub_scan_running"`
+	SubScanRemaining   int              `json:"sub_scan_remaining"`
+	agent              *agent.Agent
+	cancel             context.CancelFunc
+	scanDir            string
+	sctx               *scanctx.ScanContext // per-instance session state (vulns, notes, terminal, browser)
+	events             []WSEvent            // buffered events for replay
+	chatCfg            *config.Config       // provider settings for post-scan chat (not exposed)
+	chatMessages       []llm.Message        // lightweight post-scan chat history (not exposed)
+	mu                 sync.RWMutex
+	lastSessionTokens  int  // tracks token count from current session for delta calculation
+	snapshotFinalizing bool // terminal status is not externally coherent until the final queue event is buffered
 }
 
 // maxConcurrentInstances removed — replaced by dynamic resource-aware
@@ -1219,6 +1230,7 @@ func (s *Server) Start() error {
 				inst.Status = "stopped"
 				inst.StopReason = "signal_" + sig.String()
 				inst.FinishedAt = time.Now().Format(time.RFC3339)
+				normalizeTerminalWildcardInstanceLocked(inst)
 				if inst.agent != nil {
 					inst.agent.Stop()
 				}
@@ -1652,6 +1664,7 @@ func (s *Server) handleStop(w http.ResponseWriter, r *http.Request) {
 			inst.Status = "stopped"
 			inst.StopReason = "user_stopped"
 			inst.FinishedAt = time.Now().Format(time.RFC3339Nano)
+			normalizeTerminalWildcardInstanceLocked(inst)
 			if inst.cancel != nil {
 				inst.cancel()
 			}
@@ -2063,25 +2076,30 @@ func (s *Server) handleInstances(w http.ResponseWriter, r *http.Request) {
 	for _, inst := range s.instances {
 		inst.mu.RLock()
 		instances = append(instances, &ScanInstance{
-			ID:             inst.ID,
-			Name:           inst.Name,
-			Targets:        inst.Targets,
-			Status:         inst.Status,
-			StartedAt:      inst.StartedAt,
-			FinishedAt:     inst.FinishedAt,
-			Iterations:     inst.Iterations,
-			ToolCalls:      inst.ToolCalls,
-			VulnCount:      inst.VulnCount,
-			TotalTokens:    inst.TotalTokens,
-			ScanMode:       inst.ScanMode,
-			Instruction:    inst.Instruction,
-			SeverityFilter: append([]string(nil), inst.SeverityFilter...),
-			Phases:         inst.Phases,
-			ReconMode:      inst.ReconMode,
-			ScanIntensity:  inst.ScanIntensity,
-			CompanyName:    inst.CompanyName,
-			LogoPath:       inst.LogoPath,
-			CurrentPhase:   inst.CurrentPhase,
+			ID:               inst.ID,
+			Name:             inst.Name,
+			Targets:          inst.Targets,
+			Status:           inst.Status,
+			StartedAt:        inst.StartedAt,
+			FinishedAt:       inst.FinishedAt,
+			Iterations:       inst.Iterations,
+			ToolCalls:        inst.ToolCalls,
+			VulnCount:        inst.VulnCount,
+			TotalTokens:      inst.TotalTokens,
+			ScanMode:         inst.ScanMode,
+			Instruction:      inst.Instruction,
+			SeverityFilter:   append([]string(nil), inst.SeverityFilter...),
+			Phases:           inst.Phases,
+			ReconMode:        inst.ReconMode,
+			ScanIntensity:    inst.ScanIntensity,
+			CompanyName:      inst.CompanyName,
+			LogoPath:         inst.LogoPath,
+			CurrentPhase:     inst.CurrentPhase,
+			SubScans:         cloneSubScanSummaries(inst.SubScans),
+			SubScanTotal:     inst.SubScanTotal,
+			SubScanCompleted: inst.SubScanCompleted,
+			SubScanRunning:   inst.SubScanRunning,
+			SubScanRemaining: inst.SubScanRemaining,
 		})
 		inst.mu.RUnlock()
 	}
@@ -2257,9 +2275,18 @@ func (s *Server) handleInstanceAction(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// GET /api/instances/{id} — return instance details
+	// GET /api/instances/{id} — return instance details. A stop/failure path
+	// can mark the instance terminal before the active session has drained and
+	// persisted its final events/findings. Do not expose that partial terminal
+	// snapshot; callers retry and receive the coherent snapshot after the
+	// runMultiScan defer clears the live session pointers.
 	if r.Method == http.MethodGet && (len(parts) == 1 || parts[1] == "") {
 		inst.mu.RLock()
+		if isTerminalScanStatus(inst.Status) && inst.snapshotFinalizing {
+			inst.mu.RUnlock()
+			http.Error(w, "terminal instance snapshot is still finalizing", http.StatusConflict)
+			return
+		}
 		_ = json.NewEncoder(w).Encode(inst)
 		inst.mu.RUnlock()
 		return
@@ -2273,6 +2300,7 @@ func (s *Server) handleInstanceAction(w http.ResponseWriter, r *http.Request) {
 			inst.Status = "stopped"
 			inst.StopReason = "user_stopped"
 			inst.FinishedAt = time.Now().Format(time.RFC3339Nano)
+			normalizeTerminalWildcardInstanceLocked(inst)
 			if inst.cancel != nil {
 				inst.cancel()
 			}
@@ -2597,6 +2625,10 @@ func (sess *scanSession) cleanup() {
 				log.Printf("[cleanup] Persisted %d in-memory vulns into scan.json for session %s", added, sess.sctx.ID)
 			}
 			sess.server.saveScanRecordTo(sess.record, sess.scanDir)
+			// The exact instance endpoint must carry every persisted finding,
+			// including findings hidden from live broadcasts by severity filters.
+			// This runs before runMultiScan publishes its terminal snapshot.
+			sess.server.mirrorPersistedSessionVulnerabilities(sess.instanceID, sess.record.Vulns)
 		}()
 
 		// Wildcard vuln accumulation: merge this session's vulns into
@@ -3121,6 +3153,7 @@ func (s *Server) handleGetScan(w http.ResponseWriter, r *http.Request) {
 					inst.Status = "stopped"
 					inst.StopReason = "user_deleted"
 					inst.FinishedAt = time.Now().Format(time.RFC3339Nano)
+					normalizeTerminalWildcardInstanceLocked(inst)
 				}
 				if inst.cancel != nil {
 					inst.cancel()


### PR DESCRIPTION
## Summary
- expose authoritative wildcard child state and counters on exact instance snapshots
- mirror persisted findings into live parent instances and rebuild wildcard state after restarts
- normalize terminal child state while preserving whether each child was actually dispatched
- hold terminal snapshots until final findings and queue events are coherent

## Validation
- `go test ./internal/web/...`
- `golangci-lint run ./...` (0 issues)
- `git diff --check`

## Rollout
Deploy/release this scanner change before the SaaS coordinator and before enabling its Supabase cron migration.