### PR TITLE
release: v4.5.137

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.136
+VERSION=4.5.137
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.136" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.137" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.136"
+var version = "4.5.137"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
### Changes

- 578fd8f fix: serve persisted record for GET /api/instances/{id} after restart (#416)
- a4cbddf release: v4.5.136 (#415)