### PR TITLE
fix: make exact scan state durable

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -705,6 +705,12 @@ func (a *Agent) executeToolAsync(toolName string, toolArgs map[string]string) (r
 
 // Run starts the agent loop with the given targets and instructions.
 func (a *Agent) Run(targets []string, instruction string) {
+	// Stop-before-Run is a valid lifecycle outcome when exact cancellation wins
+	// the session admission race. Do not clone source, initialize browsers, or
+	// touch the target after that stop has become authoritative.
+	if a.stopped.Load() {
+		return
+	}
 	a.scanStart = time.Now()
 	// Wire per-scan auth + whitebox source here (in the scan goroutine) so a
 	// slow git clone never blocks scan creation or the HTTP handler.

--- a/internal/web/dispatch_state.go
+++ b/internal/web/dispatch_state.go
@@ -1,0 +1,477 @@
+package web
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+var errDispatchSnapshotNotFound = errors.New("dispatch snapshot not found")
+
+func (s *Server) dispatchSnapshotPath(instanceID string) string {
+	return filepath.Join(s.dataDir, ".dispatches", instanceID+".json")
+}
+
+func (s *Server) loadExactDispatchSnapshot(instanceID string) (*ScanRecord, error) {
+	instanceID = strings.TrimSpace(instanceID)
+	if !validDispatchID(instanceID) {
+		return nil, errDispatchSnapshotNotFound
+	}
+	data, err := os.ReadFile(s.dispatchSnapshotPath(instanceID))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, errDispatchSnapshotNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	var rec ScanRecord
+	if err := json.Unmarshal(data, &rec); err != nil {
+		return nil, err
+	}
+	if rec.InstanceID != instanceID || rec.ID != instanceID {
+		return nil, fmt.Errorf("dispatch snapshot identity mismatch for %q", instanceID)
+	}
+	return &rec, nil
+}
+
+func (s *Server) saveExactDispatchSnapshot(rec *ScanRecord) error {
+	if rec == nil || !validDispatchID(strings.TrimSpace(rec.InstanceID)) || rec.ID != rec.InstanceID {
+		return errors.New("invalid exact dispatch snapshot")
+	}
+	// Webhook URLs are credentials. Exact coordinator snapshots carry status,
+	// findings, events, and dispatch evidence only; they never duplicate secrets.
+	copyRec := *rec
+	copyRec.DiscordWebhook = ""
+	copyRec.DiscordWebhookConfigured = rec.DiscordWebhookConfigured
+	copyRec.Events = append([]WSEvent(nil), rec.Events...)
+	copyRec.Vulns = append([]VulnSummary(nil), rec.Vulns...)
+	copyRec.SubScans = cloneSubScanSummaries(rec.SubScans)
+
+	data, err := json.MarshalIndent(&copyRec, "", "  ")
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(s.dispatchSnapshotPath(rec.InstanceID))
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".dispatch-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		if removeErr := os.Remove(tmpPath); removeErr != nil && !os.IsNotExist(removeErr) {
+			// The rename normally removes tmpPath. A leftover is non-fatal but
+			// should remain diagnosable instead of being silently ignored.
+			fmt.Fprintf(os.Stderr, "warning: remove dispatch temp file %s: %v\n", tmpPath, removeErr)
+		}
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, s.dispatchSnapshotPath(rec.InstanceID)); err != nil {
+		return err
+	}
+	if err := fsyncParentDir(s.dispatchSnapshotPath(rec.InstanceID)); err != nil {
+		return fmt.Errorf("commit exact dispatch snapshot rename: %w", err)
+	}
+	return nil
+}
+
+// persistPendingDispatchSnapshot makes HTTP acceptance durable before the scan
+// goroutine can register. A prior exact-stop tombstone always wins.
+func (s *Server) persistPendingDispatchSnapshot(req ScanRequest, instanceID string) (string, bool, error) {
+	s.dispatchMu.Lock()
+	defer s.dispatchMu.Unlock()
+	if existing, err := s.loadExactDispatchSnapshot(instanceID); err == nil {
+		delete(s.dispatchReservations, instanceID)
+		return existing.Status, false, nil
+	} else if !errors.Is(err, errDispatchSnapshotNotFound) {
+		delete(s.dispatchReservations, instanceID)
+		return "", false, err
+	}
+	now := time.Now().Format(time.RFC3339Nano)
+	rec := &ScanRecord{
+		ID: instanceID, InstanceID: instanceID, Name: req.Name,
+		Target: strings.Join(req.Targets, ", "), StartedAt: now,
+		Status: "pending", ScanMode: req.ScanMode, Instruction: req.Instruction,
+		SeverityFilter:           append([]string(nil), req.SeverityFilter...),
+		DiscordWebhookConfigured: req.DiscordWebhook != "" || s.discordWebhook != "",
+		ReconMode:                req.ReconMode, ScanIntensity: req.ScanIntensity,
+		Events: []WSEvent{}, Vulns: []VulnSummary{}, SubScans: []SubScanSummary{},
+		CompanyName: req.CompanyName, LogoPath: req.LogoPath,
+		Phases: append([]int(nil), req.Phases...), CurrentPhase: firstSelectedPhase(req.Phases),
+	}
+	if err := s.saveExactDispatchSnapshot(rec); err != nil {
+		delete(s.dispatchReservations, instanceID)
+		return "", false, err
+	}
+	return "pending", true, nil
+}
+
+// persistExactInstanceSnapshot serializes the in-memory snapshot with exact
+// cancellation. Taking dispatchMu before reading the instance prevents a stale
+// running copy captured before stop from overwriting a durable tombstone.
+func (s *Server) persistExactInstanceSnapshot(inst *ScanInstance) error {
+	s.dispatchMu.Lock()
+	defer s.dispatchMu.Unlock()
+	return s.persistExactInstanceSnapshotLocked(inst)
+}
+
+// persistExactInstanceSnapshotLocked persists one coherent instance snapshot.
+// The caller must hold dispatchMu; the lock order is dispatchMu -> instance.mu.
+func (s *Server) persistExactInstanceSnapshotLocked(inst *ScanInstance) error {
+	rec := s.scanRecordFromInstance(inst)
+	if rec == nil {
+		return errors.New("missing exact instance")
+	}
+	return s.saveExactDispatchSnapshot(rec)
+}
+
+// retryReadyExactSnapshot lets an authoritative GET complete a terminal
+// snapshot whose background persistence exhausted its transient retries.
+func (s *Server) retryReadyExactSnapshot(inst *ScanInstance) error {
+	if inst == nil {
+		return errors.New("missing exact instance")
+	}
+	inst.mu.RLock()
+	ready := inst.snapshotReady && inst.snapshotFinalizing && isTerminalScanStatus(inst.Status)
+	inst.mu.RUnlock()
+	if !ready {
+		return errors.New("exact instance snapshot is not ready")
+	}
+	if err := s.persistExactInstanceSnapshot(inst); err != nil {
+		return err
+	}
+	inst.mu.Lock()
+	if inst.snapshotReady && isTerminalScanStatus(inst.Status) {
+		inst.snapshotFinalizing = false
+	}
+	status, stopReason := inst.Status, inst.StopReason
+	inst.mu.Unlock()
+	if !shouldPreserveQueueStateOnExit(status, stopReason, false) {
+		if err := s.clearQueueStateDurable(inst.ID); err != nil {
+			// The terminal tombstone is already durable and prevents resurrection;
+			// retain visibility while making deletion durability diagnosable.
+			fmt.Fprintf(os.Stderr, "warning: exact snapshot durable but queue cleanup failed for %s: %v\n", inst.ID, err)
+		}
+	}
+	return nil
+}
+
+// abortPendingDispatchSnapshot records a concrete local rejection when HTTP
+// acceptance cannot also persist a resumable queue request. A retry therefore
+// sees a terminal rejection instead of an orphaned pending acknowledgement.
+func (s *Server) abortPendingDispatchSnapshot(instanceID, reason string) error {
+	s.dispatchMu.Lock()
+	defer s.dispatchMu.Unlock()
+	rec, err := s.loadExactDispatchSnapshot(instanceID)
+	if err != nil {
+		return err
+	}
+	if !isTerminalScanStatus(rec.Status) {
+		rec.Status = "failed"
+		rec.StopReason = reason
+		rec.FinishedAt = time.Now().Format(time.RFC3339Nano)
+		normalizeTerminalWildcardProgress(rec)
+	}
+	delete(s.dispatchReservations, instanceID)
+	return s.saveExactDispatchSnapshot(rec)
+}
+
+const exactStopEventContent = "Instance stopped by user"
+
+func exactStopEvent(instanceID string) WSEvent {
+	return withEventTimestamp(WSEvent{
+		Type:       "stopped",
+		Content:    exactStopEventContent,
+		InstanceID: instanceID,
+	})
+}
+
+func ensureExactStopEvent(events *[]WSEvent, instanceID string) bool {
+	for i := range *events {
+		if (*events)[i].Type == "stopped" && (*events)[i].Content == exactStopEventContent {
+			if (*events)[i].InstanceID == "" {
+				(*events)[i].InstanceID = instanceID
+			}
+			return false
+		}
+	}
+	*events = append(*events, exactStopEvent(instanceID))
+	return true
+}
+
+func instanceHasExactStopEvent(inst *ScanInstance) bool {
+	if inst == nil {
+		return false
+	}
+	inst.mu.RLock()
+	defer inst.mu.RUnlock()
+	for _, event := range inst.events {
+		if event.Type == "stopped" && event.Content == exactStopEventContent {
+			return true
+		}
+	}
+	return false
+}
+
+func serverInstanceHasExactStopEvent(s *Server, instanceID string) bool {
+	s.instancesMu.RLock()
+	inst := s.instances[instanceID]
+	s.instancesMu.RUnlock()
+	return instanceHasExactStopEvent(inst)
+}
+
+func stableEventKey(event WSEvent) string {
+	data, _ := json.Marshal(event)
+	return string(data)
+}
+
+func stableDedupeAndSortEvents(groups ...[]WSEvent) []WSEvent {
+	seen := make(map[string]struct{})
+	var events []WSEvent
+	for _, group := range groups {
+		for _, event := range group {
+			key := stableEventKey(event)
+			if _, duplicate := seen[key]; duplicate {
+				continue
+			}
+			seen[key] = struct{}{}
+			events = append(events, event)
+		}
+	}
+	sort.SliceStable(events, func(i, j int) bool {
+		left, right := events[i].Timestamp, events[j].Timestamp
+		if left != right {
+			if left == "" {
+				return false
+			}
+			if right == "" {
+				return true
+			}
+			return left < right
+		}
+		return stableEventKey(events[i]) < stableEventKey(events[j])
+	})
+	return events
+}
+
+func mergeDispatchSubScan(children *[]SubScanSummary, candidate SubScanSummary) {
+	for i := range *children {
+		if ((*children)[i].ID != "" && (*children)[i].ID == candidate.ID) ||
+			(normalizeScanTarget((*children)[i].Target) != "" && normalizeScanTarget((*children)[i].Target) == normalizeScanTarget(candidate.Target)) {
+			if candidate.ID != "" {
+				(*children)[i].ID = candidate.ID
+			}
+			if candidate.Target != "" {
+				(*children)[i].Target = candidate.Target
+			}
+			if candidate.StartedAt != "" {
+				(*children)[i].StartedAt = candidate.StartedAt
+			}
+			if candidate.FinishedAt != "" {
+				(*children)[i].FinishedAt = candidate.FinishedAt
+			}
+			if candidate.Status != "" {
+				(*children)[i].Status = candidate.Status
+			}
+			if candidate.VulnCount > (*children)[i].VulnCount {
+				(*children)[i].VulnCount = candidate.VulnCount
+			}
+			if candidate.TotalTokens > (*children)[i].TotalTokens {
+				(*children)[i].TotalTokens = candidate.TotalTokens
+			}
+			return
+		}
+	}
+	*children = append(*children, candidate)
+}
+
+// mergePersistedDispatchStopSnapshot reconstructs the strongest durable exact
+// snapshot available after a process restart interrupted live-stop draining.
+// It never infers identity: every merged physical record must carry the exact
+// immutable external instance ID.
+func mergePersistedDispatchStopSnapshot(rec *ScanRecord, entries []scanEntry) bool {
+	if rec == nil {
+		return false
+	}
+	eventGroups := make([][]WSEvent, 0, len(entries)+1)
+	eventGroups = append(eventGroups, rec.Events)
+	vulns := append([]VulnSummary(nil), rec.Vulns...)
+	children := cloneSubScanSummaries(rec.SubScans)
+	matched := false
+	for i := range entries {
+		candidate := &entries[i].rec
+		if candidate.InstanceID != rec.InstanceID {
+			continue
+		}
+		matched = true
+		eventGroups = append(eventGroups, candidate.Events)
+		for _, vuln := range candidate.Vulns {
+			if vuln.SourceScanID == "" {
+				vuln.SourceScanID = candidate.ID
+			}
+			appendVulnSummaryUnique(&vulns, vuln)
+		}
+		rec.WorkStarted = rec.WorkStarted || candidate.WorkStarted || candidate.ToolCalls > 0 || candidate.Iterations > 0
+		if candidate.CurrentPhase > rec.CurrentPhase {
+			rec.CurrentPhase = candidate.CurrentPhase
+		}
+		if candidate.ParentTarget != "" {
+			mergeDispatchSubScan(&children, SubScanSummary{
+				ID: candidate.ID, Target: candidate.Target, StartedAt: candidate.StartedAt,
+				FinishedAt: candidate.FinishedAt, Status: candidate.Status,
+				VulnCount: len(candidate.Vulns), TotalTokens: candidate.TotalTokens,
+			})
+		}
+		for _, child := range candidate.SubScans {
+			mergeDispatchSubScan(&children, child)
+		}
+	}
+	rec.Events = stableDedupeAndSortEvents(eventGroups...)
+	rec.Vulns = vulns
+	rec.SubScans = children
+	rec.Status = "stopped"
+	rec.FinishedAt = time.Now().Format(time.RFC3339Nano)
+	normalizeTerminalWildcardProgress(rec)
+	return matched
+}
+
+func (s *Server) claimExactStopNotificationLocked(instanceID string) bool {
+	if s.exactStopNotifications == nil {
+		s.exactStopNotifications = make(map[string]bool)
+	}
+	if s.exactStopNotifications[instanceID] {
+		return false
+	}
+	s.exactStopNotifications[instanceID] = true
+	return true
+}
+
+func (s *Server) stopLiveExactDispatchLocked(instanceID string, inst *ScanInstance) (*ScanRecord, bool, error) {
+	inst.mu.Lock()
+	if inst.Status == "running" || inst.Status == "pending" || inst.Status == "paused" {
+		inst.Status = "stopped"
+		inst.StopReason = "user_stopped"
+		inst.FinishedAt = time.Now().Format(time.RFC3339Nano)
+		normalizeTerminalWildcardInstanceLocked(inst)
+		if inst.cancel != nil {
+			inst.cancel()
+		}
+		if inst.agent != nil {
+			inst.agent.Stop()
+		}
+	}
+	ensureExactStopEvent(&inst.events, instanceID)
+	finalizing := inst.snapshotFinalizing
+	ready := inst.snapshotReady
+	inst.mu.Unlock()
+
+	rec := s.scanRecordFromInstance(inst)
+	if rec == nil {
+		return nil, false, errors.New("missing live exact instance snapshot")
+	}
+	if finalizing && !ready {
+		// Durable cancellation intent blocks duplicate dispatch and survives a
+		// crash, but remains non-terminal until final findings/events drain.
+		rec.Status = "stopping"
+		rec.FinishedAt = ""
+	}
+	delete(s.dispatchReservations, instanceID)
+	if err := s.saveExactDispatchSnapshot(rec); err != nil {
+		return nil, false, err
+	}
+	if finalizing && ready {
+		inst.mu.Lock()
+		inst.snapshotFinalizing = false
+		inst.mu.Unlock()
+	}
+	return rec, s.claimExactStopNotificationLocked(instanceID), nil
+}
+
+// cancelExactDispatch is the single serialization point for exact stop versus
+// delayed POST registration and session admission. A live stop is persisted as
+// non-terminal `stopping` until its event processor and cleanup have drained;
+// only the coherent final aggregate is exposed as terminal.
+func (s *Server) cancelExactDispatch(instanceID string) (*ScanRecord, bool, error) {
+	if !validDispatchID(instanceID) {
+		return nil, false, errDispatchSnapshotNotFound
+	}
+
+	// The common live path must not wait for a data-directory walk: stopping an
+	// active agent has a bounded control-plane deadline. Check under dispatchMu
+	// first, then perform legacy/restart reconstruction only when no live owner
+	// exists, and recheck after reacquiring the lock.
+	s.dispatchMu.Lock()
+	s.instancesMu.RLock()
+	inst := s.instances[instanceID]
+	s.instancesMu.RUnlock()
+	if inst != nil {
+		rec, notifyListeners, err := s.stopLiveExactDispatchLocked(instanceID, inst)
+		s.dispatchMu.Unlock()
+		return rec, notifyListeners, err
+	}
+	s.dispatchMu.Unlock()
+
+	_, aliasRecord := s.findScanByID(instanceID)
+	persistedEntries := s.findAllScans()
+
+	s.dispatchMu.Lock()
+	defer s.dispatchMu.Unlock()
+	s.instancesMu.RLock()
+	inst = s.instances[instanceID]
+	s.instancesMu.RUnlock()
+	if inst != nil {
+		return s.stopLiveExactDispatchLocked(instanceID, inst)
+	}
+
+	// A dashboard record ID is provenance, not external run ownership. Never
+	// turn a known canonical alias into a tombstone for some other instance.
+	if aliasRecord != nil && aliasRecord.InstanceID != "" && aliasRecord.InstanceID != instanceID {
+		return nil, false, errDispatchSnapshotNotFound
+	}
+
+	rec, err := s.loadExactDispatchSnapshot(instanceID)
+	if err != nil && !errors.Is(err, errDispatchSnapshotNotFound) {
+		return nil, false, err
+	}
+	if rec == nil {
+		now := time.Now().Format(time.RFC3339Nano)
+		rec = &ScanRecord{
+			ID: instanceID, InstanceID: instanceID, StartedAt: now,
+			FinishedAt: now, Status: "stopped", StopReason: "exact_stop_tombstone",
+			Events: []WSEvent{}, Vulns: []VulnSummary{}, SubScans: []SubScanSummary{},
+		}
+	} else if !isTerminalScanStatus(rec.Status) {
+		if mergePersistedDispatchStopSnapshot(rec, persistedEntries) {
+			rec.StopReason = "exact_stop_recovered_after_restart"
+		} else {
+			rec.StopReason = "exact_stop_before_registration"
+		}
+	}
+	ensureExactStopEvent(&rec.Events, instanceID)
+	delete(s.dispatchReservations, instanceID)
+	if err := s.saveExactDispatchSnapshot(rec); err != nil {
+		return nil, false, err
+	}
+	return rec, s.claimExactStopNotificationLocked(instanceID), nil
+}

--- a/internal/web/dispatch_state_test.go
+++ b/internal/web/dispatch_state_test.go
@@ -1,0 +1,344 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/xalgord/xalgorix/v4/internal/agent"
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+	"github.com/xalgord/xalgorix/v4/internal/scopeguard"
+)
+
+func TestExactStopTombstonePreventsDelayedDispatch(t *testing.T) {
+	s := newTestServer(t, nil)
+	id := "550e8400-e29b-41d4-a716-446655440000"
+
+	stopReq := httptest.NewRequest(http.MethodPost, "/api/instances/"+id+"/stop", nil)
+	stopReq.Header.Set("X-Xalgorix-Exact-Instance", "1")
+	stopRR := httptest.NewRecorder()
+	s.handleInstanceAction(stopRR, stopReq)
+	if stopRR.Code != http.StatusOK {
+		t.Fatalf("pre-dispatch exact stop code=%d body=%s", stopRR.Code, stopRR.Body.String())
+	}
+	var stopSnapshot struct {
+		InstanceID  string `json:"instance_id"`
+		Status      string `json:"status"`
+		WorkStarted bool   `json:"work_started"`
+	}
+	if err := json.Unmarshal(stopRR.Body.Bytes(), &stopSnapshot); err != nil {
+		t.Fatalf("decode pre-dispatch stop snapshot: %v", err)
+	}
+	if stopSnapshot.InstanceID != id || stopSnapshot.Status != "stopped" || stopSnapshot.WorkStarted {
+		t.Fatalf("pre-dispatch stop returned invalid work evidence: %#v", stopSnapshot)
+	}
+
+	body := strings.NewReader(`{"targets":["https://example.test"],"scan_mode":"single","dispatch_id":"` + id + `"}`)
+	startRR := httptest.NewRecorder()
+	s.handleScan(startRR, httptest.NewRequest(http.MethodPost, "/api/scan", body))
+	var ack map[string]string
+	if err := json.Unmarshal(startRR.Body.Bytes(), &ack); err != nil {
+		t.Fatalf("decode delayed dispatch ack: %v", err)
+	}
+	if ack["instance_id"] != id || ack["status"] != "stopped" {
+		t.Fatalf("delayed dispatch bypassed tombstone: %#v", ack)
+	}
+	if s.instances[id] != nil {
+		t.Fatal("delayed dispatch registered an instance after exact stop")
+	}
+}
+
+func TestDurableExactSnapshotOwnsMultiTargetDispatch(t *testing.T) {
+	s := newTestServer(t, nil)
+	id := "550e8400-e29b-41d4-a716-446655440001"
+	for _, item := range []struct{ path, recordID, target string }{
+		{"one/2026-08-12/record-one", "record-one", "https://one.test"},
+		{"two/2026-08-12/record-two", "record-two", "https://two.test"},
+	} {
+		writeScanRecord(t, s.dataDir, item.path, ScanRecord{
+			ID: item.recordID, InstanceID: id, Target: item.target,
+			StartedAt: "2026-08-12T10:00:00Z", FinishedAt: "2026-08-12T10:10:00Z", Status: "finished",
+		})
+	}
+	inst := &ScanInstance{
+		ID: id, Targets: "https://one.test, https://two.test", Status: "finished",
+		StartedAt: "2026-08-12T10:00:00Z", FinishedAt: "2026-08-12T10:10:00Z",
+		WorkStarted: true, SubScans: []SubScanSummary{},
+		events: []WSEvent{{Type: "queue_finished", Content: "both targets complete"}},
+	}
+	if err := s.persistExactInstanceSnapshot(inst); err != nil {
+		t.Fatalf("persist exact aggregate: %v", err)
+	}
+
+	_, rec := s.findScanByInstanceID(id)
+	if rec == nil || rec.ID != id || rec.Target != inst.Targets || !rec.WorkStarted {
+		t.Fatalf("exact aggregate did not own duplicated target records: %#v", rec)
+	}
+	rr := httptest.NewRecorder()
+	s.handleInstanceAction(rr, httptest.NewRequest(http.MethodGet, "/api/instances/"+id+"/snapshot", nil))
+	if rr.Code != http.StatusOK || !strings.Contains(rr.Body.String(), "both targets complete") {
+		t.Fatalf("exact aggregate snapshot code=%d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestDuplicateDispatchDuringFinalizationIsNonterminal(t *testing.T) {
+	s := newTestServer(t, nil)
+	id := "550e8400-e29b-41d4-a716-446655440002"
+	s.instances[id] = &ScanInstance{ID: id, Status: "finished", snapshotFinalizing: true}
+	if status, reserved := s.reserveDispatchID(id); reserved || status != "pending" {
+		t.Fatalf("finalizing duplicate = (%q,%v), want pending acknowledgement", status, reserved)
+	}
+}
+
+func TestSessionAdmissionSerializesWithExactStop(t *testing.T) {
+	s := newTestServer(t, nil)
+	id := "550e8400-e29b-41d4-a716-446655440003"
+	inst := &ScanInstance{ID: id, Status: "running", SubScans: []SubScanSummary{}}
+	s.instances[id] = inst
+
+	newSessionAgent := func(name string) (*scanSession, *scanctx.ScanContext, *agent.Agent) {
+		t.Helper()
+		sctx := scanctx.New(name, t.TempDir())
+		agnt := agent.NewAgent(s.cfg, name, make(chan agent.Event, 1), scopeguard.Config{}, sctx)
+		sess := &scanSession{id: name, instanceID: id, scanDir: t.TempDir(), parentCtx: context.Background()}
+		t.Cleanup(func() { agnt.Stop(); sctx.Close() })
+		return sess, sctx, agnt
+	}
+
+	sess, sctx, agnt := newSessionAgent("admitted")
+	if !s.registerSessionAgent(sess, sctx, agnt) || !inst.WorkStarted {
+		t.Fatal("running session was not atomically admitted")
+	}
+	persisted, err := s.loadExactDispatchSnapshot(id)
+	if err != nil || persisted.Status != "running" || !persisted.WorkStarted {
+		t.Fatalf("work admission was not durable before Agent.Run: rec=%#v err=%v", persisted, err)
+	}
+	stopReq := httptest.NewRequest(http.MethodPost, "/api/instances/"+id+"/stop", nil)
+	stopReq.Header.Set("X-Xalgorix-Exact-Instance", "1")
+	stopRR := httptest.NewRecorder()
+	s.handleInstanceAction(stopRR, stopReq)
+	if stopRR.Code != http.StatusOK {
+		t.Fatalf("exact stop code=%d body=%s", stopRR.Code, stopRR.Body.String())
+	}
+	var stopSnapshot struct {
+		Status      string `json:"status"`
+		WorkStarted bool   `json:"work_started"`
+	}
+	if err := json.Unmarshal(stopRR.Body.Bytes(), &stopSnapshot); err != nil {
+		t.Fatalf("decode admitted stop snapshot: %v", err)
+	}
+	if stopSnapshot.Status != "stopped" || !stopSnapshot.WorkStarted {
+		t.Fatalf("admitted stop lost positive work evidence: %#v", stopSnapshot)
+	}
+	if _, err := agnt.SendMessage("must be stopped"); err == nil {
+		t.Fatal("admitted agent remained startable after exact stop")
+	}
+
+	lateSess, lateCtx, lateAgent := newSessionAgent("late")
+	if s.registerSessionAgent(lateSess, lateCtx, lateAgent) {
+		t.Fatal("session registered after exact stop")
+	}
+}
+
+func TestWildcardChildStopRejectsLaterSessionAdmission(t *testing.T) {
+	s := newTestServer(t, nil)
+	id := "550e8400-e29b-41d4-a716-446655440004"
+	inst := &ScanInstance{
+		ID: id, Status: "running", ScanMode: "wildcard",
+		SubScans:     []SubScanSummary{{Target: "child.example", Status: "pending"}},
+		SubScanTotal: 1, SubScanRemaining: 1,
+	}
+	s.instances[id] = inst
+
+	if !s.beginWildcardSubScan(id, 0, "child.example", "child-session") {
+		t.Fatal("wildcard child was not admitted before stop")
+	}
+
+	stopReq := httptest.NewRequest(http.MethodPost, "/api/instances/"+id+"/stop", nil)
+	stopReq.Header.Set("X-Xalgorix-Exact-Instance", "1")
+	stopRR := httptest.NewRecorder()
+	s.handleInstanceAction(stopRR, stopReq)
+	if stopRR.Code != http.StatusOK {
+		t.Fatalf("exact wildcard stop code=%d body=%s", stopRR.Code, stopRR.Body.String())
+	}
+
+	sctx := scanctx.New("child-session", t.TempDir())
+	agnt := agent.NewAgent(s.cfg, "child-session", make(chan agent.Event, 1), scopeguard.Config{}, sctx)
+	sess := &scanSession{
+		id: "child-session", instanceID: id, scanDir: t.TempDir(), parentCtx: context.Background(),
+	}
+	t.Cleanup(func() { agnt.Stop(); sctx.Close() })
+	if s.registerSessionAgent(sess, sctx, agnt) {
+		t.Fatal("wildcard child session registered after exact stop")
+	}
+
+	inst.mu.RLock()
+	defer inst.mu.RUnlock()
+	if inst.Status != "stopped" || inst.WorkStarted {
+		t.Fatalf("stopped wildcard gained false work evidence: status=%q work_started=%v", inst.Status, inst.WorkStarted)
+	}
+	if got := inst.SubScans[0].Status; got != "stopped" {
+		t.Fatalf("dispatched wildcard child status=%q, want stopped", got)
+	}
+}
+
+func TestExactStopWaitsForDurableFinalSnapshot(t *testing.T) {
+	s := newTestServer(t, nil)
+	id := "550e8400-e29b-41d4-a716-446655440005"
+	inst := &ScanInstance{
+		ID: id, Targets: "https://example.test", Status: "running", ScanMode: "single",
+		WorkStarted: true, snapshotFinalizing: true,
+		events: []WSEvent{{Type: "tool_result", Content: "final evidence"}},
+	}
+	s.instances[id] = inst
+
+	stop := func() *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPost, "/api/instances/"+id+"/stop", nil)
+		req.Header.Set("X-Xalgorix-Exact-Instance", "1")
+		rr := httptest.NewRecorder()
+		s.handleInstanceAction(rr, req)
+		return rr
+	}
+	if rr := stop(); rr.Code != http.StatusConflict {
+		t.Fatalf("finalizing exact stop code=%d body=%s", rr.Code, rr.Body.String())
+	}
+	stopping, err := s.loadExactDispatchSnapshot(id)
+	if err != nil || stopping.Status != "stopping" || !stopping.WorkStarted {
+		t.Fatalf("durable stop intent missing: rec=%#v err=%v", stopping, err)
+	}
+
+	inst.mu.Lock()
+	inst.events = append(inst.events, WSEvent{Type: "queue_finished", Content: "Scan queue stopped"})
+	inst.Vulns = append(inst.Vulns, VulnSummary{ID: "v-final", Title: "Final finding", Severity: "high"})
+	inst.mu.Unlock()
+	if err := s.persistExactInstanceSnapshot(inst); err != nil {
+		t.Fatalf("persist coherent stopped snapshot: %v", err)
+	}
+	inst.mu.Lock()
+	inst.snapshotFinalizing = false
+	inst.mu.Unlock()
+
+	rr := stop()
+	if rr.Code != http.StatusOK {
+		t.Fatalf("coherent exact stop code=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var got ScanRecord
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode coherent stop: %v", err)
+	}
+	if got.Status != "stopped" || len(got.Events) < 2 || len(got.Vulns) != 1 || !got.WorkStarted {
+		t.Fatalf("exact stop omitted final durable data: %#v", got)
+	}
+}
+
+func TestExactStopReconstructsStoppingSnapshotAfterRestart(t *testing.T) {
+	s := newTestServer(t, nil)
+	id := "550e8400-e29b-41d4-a716-446655440006"
+	if err := s.saveExactDispatchSnapshot(&ScanRecord{
+		ID: id, InstanceID: id, Target: "https://example.test", Status: "stopping",
+		Events: []WSEvent{}, Vulns: []VulnSummary{}, SubScans: []SubScanSummary{},
+	}); err != nil {
+		t.Fatalf("persist stopping intent: %v", err)
+	}
+	writeScanRecord(t, s.dataDir, "example/2026-08-12/physical-record", ScanRecord{
+		ID: "physical-record", InstanceID: id, Target: "https://example.test", Status: "stopped",
+		ToolCalls: 1, Events: []WSEvent{{Type: "tool_result", Content: "persisted before crash"}},
+		Vulns: []VulnSummary{{ID: "v-crash", Title: "Crash-safe finding", Severity: "high"}},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/instances/"+id+"/stop", nil)
+	req.Header.Set("X-Xalgorix-Exact-Instance", "1")
+	rr := httptest.NewRecorder()
+	s.handleInstanceAction(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("restart recovery stop code=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var got ScanRecord
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode restart recovery: %v", err)
+	}
+	if got.Status != "stopped" || got.StopReason != "exact_stop_recovered_after_restart" ||
+		len(got.Events) != 2 || got.Events[0].Content != "persisted before crash" ||
+		got.Events[1].Content != exactStopEventContent || len(got.Vulns) != 1 || !got.WorkStarted {
+		t.Fatalf("restart stop did not reconstruct exact durable records: %#v", got)
+	}
+}
+
+func TestQueuePersistenceFailureTerminalizesPendingDispatch(t *testing.T) {
+	s := newTestServer(t, nil)
+	id := "550e8400-e29b-41d4-a716-446655440007"
+	req := ScanRequest{Targets: []string{"https://example.test"}, ScanMode: "single", InstanceID: id}
+	if _, accepted, err := s.persistPendingDispatchSnapshot(req, id); err != nil || !accepted {
+		t.Fatalf("persist pending dispatch: accepted=%v err=%v", accepted, err)
+	}
+	if err := s.abortPendingDispatchSnapshot(id, "queue_state_persist_failed"); err != nil {
+		t.Fatalf("abort orphanable pending dispatch: %v", err)
+	}
+	rec, err := s.loadExactDispatchSnapshot(id)
+	if err != nil || rec.Status != "failed" || rec.StopReason != "queue_state_persist_failed" {
+		t.Fatalf("pending dispatch remained retryable without queue state: rec=%#v err=%v", rec, err)
+	}
+}
+
+func TestResumeReplacementRequiresExactInertPlaceholder(t *testing.T) {
+	placeholder := &ScanInstance{Status: "pending", StopReason: "server_restart_resuming"}
+	if !isReplaceableResumePlaceholder(placeholder) {
+		t.Fatal("exact inert restart placeholder was not replaceable")
+	}
+	for name, inst := range map[string]*ScanInstance{
+		"new reservation": {Status: "pending"},
+		"live generation": {Status: "running", StopReason: "server_restart_resuming"},
+		"active placeholder": {
+			Status: "pending", StopReason: "server_restart_resuming", cancel: func() {},
+		},
+	} {
+		if isReplaceableResumePlaceholder(inst) {
+			t.Fatalf("resume could overwrite %s: %#v", name, inst)
+		}
+	}
+}
+
+func TestSnapshotGETRetriesReadyTerminalPersistence(t *testing.T) {
+	s := newTestServer(t, nil)
+	id := "550e8400-e29b-41d4-a716-446655440008"
+	req := ScanRequest{
+		InstanceID: id,
+		Targets:    []string{"https://example.test"},
+		ScanMode:   "single",
+	}
+	if err := s.saveQueueStateDurable(0, req); err != nil {
+		t.Fatalf("save resumable queue state: %v", err)
+	}
+	inst := &ScanInstance{
+		ID: id, Targets: "https://example.test", Status: "finished", ScanMode: "single",
+		FinishedAt: time.Now().Format(time.RFC3339Nano), WorkStarted: true,
+		snapshotFinalizing: true, snapshotReady: true,
+		events: []WSEvent{{Type: "queue_finished", Content: "Scan queue ended"}},
+	}
+	s.instances[id] = inst
+
+	rr := httptest.NewRecorder()
+	s.handleInstanceAction(rr, httptest.NewRequest(http.MethodGet, "/api/instances/"+id+"/snapshot", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("ready terminal snapshot GET code=%d body=%s", rr.Code, rr.Body.String())
+	}
+	inst.mu.RLock()
+	finalizing := inst.snapshotFinalizing
+	inst.mu.RUnlock()
+	if finalizing {
+		t.Fatal("GET did not clear finalization after durable exact snapshot retry")
+	}
+	persisted, err := s.loadExactDispatchSnapshot(id)
+	if err != nil || persisted.Status != "finished" || len(persisted.Events) != 1 {
+		t.Fatalf("GET did not persist coherent terminal snapshot: rec=%#v err=%v", persisted, err)
+	}
+	if _, err := os.Stat(s.queueStatePathForInstance(id)); !os.IsNotExist(err) {
+		t.Fatalf("queue state remained after durable terminal retry: %v", err)
+	}
+}

--- a/internal/web/durability.go
+++ b/internal/web/durability.go
@@ -1,0 +1,22 @@
+package web
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// fsyncParentDir makes a successful rename or unlink durable across a Linux
+// crash. Syncing the file alone does not commit the parent directory entry.
+func fsyncParentDir(path string) error {
+	dir := filepath.Dir(path)
+	f, err := os.Open(dir)
+	if err != nil {
+		return fmt.Errorf("open parent directory %s: %w", dir, err)
+	}
+	defer f.Close()
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("sync parent directory %s: %w", dir, err)
+	}
+	return nil
+}

--- a/internal/web/instance_action_resolve_test.go
+++ b/internal/web/instance_action_resolve_test.go
@@ -1,11 +1,15 @@
 package web
 
-import "testing"
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
 
-// The per-instance action endpoints (stop/pause/restart/start) must resolve not
-// just the live instance id but also a scan RECORD id / short alias, because the
-// scan-detail page routes by those. Previously a record id 404'd, so Stop/Delete
-// did nothing on the scan-detail page while working on the Instances page.
+// Per-instance actions may resolve either a live instance id or an exact,
+// persisted scan record id used by dashboard navigation. They must never infer
+// an unrelated run from a recent short alias.
 func TestResolveInstanceForAction(t *testing.T) {
 	s := newTestServer(t, nil)
 
@@ -49,4 +53,172 @@ func TestResolveInstanceForAction(t *testing.T) {
 			t.Fatal("empty id should not resolve")
 		}
 	})
+}
+
+func TestRestartRebuildPreservesExactInstanceSnapshot(t *testing.T) {
+	s := newTestServer(t, nil)
+	writeScanRecord(t, s.dataDir, "example/2026-08-12/canonical-record", ScanRecord{
+		ID: "canonical-record", InstanceID: "a52be226", Target: "https://example.test",
+		StartedAt: "2026-08-12T10:00:00Z", FinishedAt: "2026-08-12T10:10:00Z", Status: "finished",
+		Events: []WSEvent{{Type: "message", Content: "final event"}},
+	})
+
+	s.rebuildInstancesFromDisk()
+	if s.instances["a52be226"] == nil {
+		t.Fatal("persisted external instance id was not reconstructed")
+	}
+	if s.instances["canonical-record"] != nil {
+		t.Fatal("canonical record id replaced persisted external instance ownership")
+	}
+
+	assertSnapshot := func(wantID string) {
+		t.Helper()
+		rr := httptest.NewRecorder()
+		s.handleInstanceAction(rr, httptest.NewRequest(http.MethodGet, "/api/instances/a52be226/snapshot", nil))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("snapshot code=%d body=%s", rr.Code, rr.Body.String())
+		}
+		var got ScanRecord
+		if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode snapshot: %v", err)
+		}
+		if got.ID != wantID || got.InstanceID != "a52be226" || len(got.Events) != 1 {
+			t.Fatalf("snapshot identity/events mismatch: %#v", got)
+		}
+	}
+	assertSnapshot("a52be226")
+
+	// Simulate terminal instance eviction: the exact persisted fallback keeps
+	// the canonical record provenance and external run identity independently.
+	s.instancesMu.Lock()
+	delete(s.instances, "a52be226")
+	s.instancesMu.Unlock()
+	assertSnapshot("canonical-record")
+}
+
+func TestUnknownShortIDCannotReadOrMutateAnotherScan(t *testing.T) {
+	s := newTestServer(t, nil)
+	writeScanRecord(t, s.dataDir, "example/2026-08-12/owned-record", ScanRecord{
+		ID: "owned-record", InstanceID: "a52be226", Target: "https://example.test",
+		StartedAt: "2026-08-12T10:00:00Z", Status: "finished",
+		Vulns: []VulnSummary{{ID: "v1", Title: "kept"}},
+	})
+	s.rebuildInstancesFromDisk()
+
+	for _, tc := range []struct{ method, path string }{
+		{http.MethodGet, "/api/instances/deadbeef"},
+		{http.MethodGet, "/api/instances/deadbeef/snapshot"},
+		{http.MethodPost, "/api/instances/deadbeef/stop"},
+		{http.MethodPost, "/api/instances/deadbeef/restart"},
+	} {
+		rr := httptest.NewRecorder()
+		s.handleInstanceAction(rr, httptest.NewRequest(tc.method, tc.path, nil))
+		if rr.Code != http.StatusNotFound {
+			t.Fatalf("%s %s code=%d body=%s", tc.method, tc.path, rr.Code, rr.Body.String())
+		}
+	}
+
+	rr := httptest.NewRecorder()
+	s.handleDeleteVuln(rr, httptest.NewRequest(http.MethodDelete, "/api/scans/deadbeef/vulns/v1", nil))
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("unknown alias deleted vulnerability: code=%d body=%s", rr.Code, rr.Body.String())
+	}
+	_, rec := s.findScanByInstanceID("a52be226")
+	if rec == nil || len(rec.Vulns) != 1 {
+		t.Fatalf("owned record was mutated through unknown alias: %#v", rec)
+	}
+}
+
+func TestExactSnapshotWaitsForFinalEventPublication(t *testing.T) {
+	s := newTestServer(t, nil)
+	inst := &ScanInstance{
+		ID:                 "exact-run",
+		Targets:            "https://example.test",
+		Status:             "finished",
+		FinishedAt:         "2026-08-12T10:10:00Z",
+		snapshotFinalizing: true,
+		events:             []WSEvent{{Type: "message", Content: "persisted finding"}},
+	}
+	s.instancesMu.Lock()
+	s.instances[inst.ID] = inst
+	s.instancesMu.Unlock()
+
+	requestSnapshot := func() *httptest.ResponseRecorder {
+		t.Helper()
+		rr := httptest.NewRecorder()
+		s.handleInstanceAction(rr, httptest.NewRequest(http.MethodGet, "/api/instances/exact-run/snapshot", nil))
+		return rr
+	}
+	if rr := requestSnapshot(); rr.Code != http.StatusConflict {
+		t.Fatalf("finalizing snapshot code=%d body=%s", rr.Code, rr.Body.String())
+	}
+
+	inst.mu.Lock()
+	inst.events = append(inst.events, WSEvent{Type: "queue_finished", Content: "Scan queue ended"})
+	inst.snapshotFinalizing = false
+	inst.mu.Unlock()
+
+	rr := requestSnapshot()
+	if rr.Code != http.StatusOK {
+		t.Fatalf("published snapshot code=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var got struct {
+		InstanceID string    `json:"instance_id"`
+		Events     []WSEvent `json:"events"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode snapshot: %v", err)
+	}
+	if got.InstanceID != "exact-run" || len(got.Events) != 2 || got.Events[1].Type != "queue_finished" {
+		t.Fatalf("snapshot published without exact final event: %#v", got)
+	}
+}
+
+func TestDuplicatePersistedInstanceIDIsNeverAuthoritative(t *testing.T) {
+	s := newTestServer(t, nil)
+	for _, item := range []struct{ path, id, target string }{
+		{"one/2026-08-12/record-one", "record-one", "https://one.test"},
+		{"two/2026-08-12/record-two", "record-two", "https://two.test"},
+	} {
+		writeScanRecord(t, s.dataDir, item.path, ScanRecord{
+			ID: item.id, InstanceID: "duplicate-run", Target: item.target,
+			StartedAt: "2026-08-12T10:00:00Z", FinishedAt: "2026-08-12T10:10:00Z", Status: "finished",
+		})
+	}
+
+	s.rebuildInstancesFromDisk()
+	if s.instances["duplicate-run"] != nil {
+		t.Fatal("ambiguous persisted ownership was rebuilt as a live exact instance")
+	}
+	if _, rec := s.findScanByInstanceID("duplicate-run"); rec != nil {
+		t.Fatalf("ambiguous persisted ownership resolved to %#v", rec)
+	}
+	if status, reserved := s.reserveDispatchID("duplicate-run"); reserved || status != "conflict" {
+		t.Fatalf("ambiguous persisted ID was reusable: status=%q reserved=%v", status, reserved)
+	}
+	rr := httptest.NewRecorder()
+	s.handleInstanceAction(rr, httptest.NewRequest(http.MethodGet, "/api/instances/duplicate-run/snapshot", nil))
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("ambiguous exact snapshot code=%d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestExactStopHeaderNeverResolvesCanonicalRecordAlias(t *testing.T) {
+	s := newTestServer(t, nil)
+	writeScanRecord(t, s.dataDir, "example/2026-08-12/canonical-record", ScanRecord{
+		ID: "canonical-record", InstanceID: "exact-external-instance", Target: "https://example.test", Status: "running",
+	})
+	inst := &ScanInstance{ID: "exact-external-instance", Status: "running", Targets: "https://example.test"}
+	s.instances[inst.ID] = inst
+
+	req := httptest.NewRequest(http.MethodPost, "/api/instances/canonical-record/stop", nil)
+	req.Header.Set("X-Xalgorix-Exact-Instance", "1")
+	rr := httptest.NewRecorder()
+	s.handleInstanceAction(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("exact stop accepted canonical alias: code=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if inst.Status != "running" {
+		t.Fatalf("exact stop mutated aliased instance: status=%q", inst.Status)
+	}
 }

--- a/internal/web/notify.go
+++ b/internal/web/notify.go
@@ -29,20 +29,37 @@ var (
 	tgBoldRe       = regexp.MustCompile(`\*\*([^*]+?)\*\*`)
 )
 
-// sendDiscord sends a rich embed message to the configured Discord webhook.
-func (s *Server) sendDiscord(color int, title, description string) {
-	s.sendDiscordWithFile(color, title, description, "")
+func (s *Server) discordWebhookForScan(webhook string) string {
+	if webhook = strings.TrimSpace(webhook); webhook != "" {
+		return webhook
+	}
+	return s.discordWebhook
 }
 
-// sendDiscordWithFile sends a rich embed message with an optional file attachment to Discord.
+// sendDiscord sends a rich embed message to the configured Discord webhook.
+func (s *Server) sendDiscord(color int, title, description string) {
+	s.sendDiscordTo(s.discordWebhook, color, title, description)
+}
+
+func (s *Server) sendDiscordTo(webhook string, color int, title, description string) {
+	s.sendDiscordWithFileTo(webhook, color, title, description, "")
+}
+
+// sendDiscordWithFile sends to the global endpoint for legacy callers.
 func (s *Server) sendDiscordWithFile(color int, title, description, filePath string) {
-	if s.discordWebhook == "" {
+	s.sendDiscordWithFileTo(s.discordWebhook, color, title, description, filePath)
+}
+
+// sendDiscordWithFileTo captures an immutable per-scan endpoint before the
+// asynchronous send. Concurrent scans can never overwrite each other's URL.
+func (s *Server) sendDiscordWithFileTo(webhook string, color int, title, description, filePath string) {
+	if webhook == "" {
 		return
 	}
 
 	// If no file, send simple embed
 	if filePath == "" {
-		s.sendSimpleEmbed(color, title, description)
+		s.sendSimpleEmbedTo(webhook, color, title, description)
 		return
 	}
 
@@ -51,7 +68,7 @@ func (s *Server) sendDiscordWithFile(color int, title, description, filePath str
 	if err != nil {
 		log.Printf("Failed to read PDF for Discord: %v", err)
 		// Send embed without file
-		s.sendSimpleEmbed(color, title, description+" (PDF generation failed)")
+		s.sendSimpleEmbedTo(webhook, color, title, description+" (PDF generation failed)")
 		return
 	}
 
@@ -103,7 +120,7 @@ func (s *Server) sendDiscordWithFile(color int, title, description, filePath str
 	// Send request
 	go func() {
 		client := &http.Client{Timeout: 30 * time.Second}
-		resp, err := client.Post(s.discordWebhook, contentType, &b)
+		resp, err := client.Post(webhook, contentType, &b)
 		if err != nil {
 			log.Printf("Discord webhook file upload error: %v", err)
 			return
@@ -119,8 +136,10 @@ func (s *Server) sendDiscordWithFile(color int, title, description, filePath str
 	}()
 }
 
-// sendSimpleEmbed sends a simple embed without file attachment
-func (s *Server) sendSimpleEmbed(color int, title, description string) {
+func (s *Server) sendSimpleEmbedTo(webhook string, color int, title, description string) {
+	if webhook == "" {
+		return
+	}
 	payload := map[string]any{
 		"username":   "Xalgorix",
 		"avatar_url": "https://raw.githubusercontent.com/xalgord/xalgord/main/assets/logo.png",
@@ -143,7 +162,9 @@ func (s *Server) sendSimpleEmbed(color int, title, description string) {
 	}
 
 	go func() {
-		resp, err := http.Post(s.discordWebhook, "application/json", bytes.NewReader(body))
+		// #nosec G107 -- webhook is an operator/customer-configured outbound
+		// notification endpoint; the call is intentionally made to that URL.
+		resp, err := http.Post(webhook, "application/json", bytes.NewReader(body))
 		if err != nil {
 			log.Printf("Discord webhook error: %v", err)
 			return

--- a/internal/web/orchestrator.go
+++ b/internal/web/orchestrator.go
@@ -3,6 +3,7 @@ package web
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log"
@@ -27,6 +28,18 @@ import (
 )
 
 // ────────────────────────────────────────────────────────
+
+// isReplaceableResumePlaceholder accepts only the inert marker created by
+// restart reconstruction. Auto-resume must never overwrite a newly reserved,
+// queued, or live exact generation that happens to use the same ID.
+func isReplaceableResumePlaceholder(inst *ScanInstance) bool {
+	if inst == nil {
+		return false
+	}
+	inst.mu.RLock()
+	defer inst.mu.RUnlock()
+	return inst.Status == "pending" && inst.agent == nil && inst.cancel == nil && inst.StopReason == "server_restart_resuming"
+}
 
 // runMultiScan processes targets sequentially, one at a time.
 // Each target is scanned in a fully isolated scanSession.
@@ -73,6 +86,26 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 		instanceID = randomSlug()
 	}
 
+	// Hold a stable advisory lock for the entire registration/resume/run
+	// lifetime. The lockfile inode is never renamed, so another scanner process
+	// sharing dataDir cannot execute the same queue instance concurrently.
+	ownership := req.queueOwnership
+	req.queueOwnership = nil
+	if ownership == nil {
+		var owned bool
+		var err error
+		ownership, owned, err = s.acquireQueueOwnership(instanceID)
+		if err != nil {
+			log.Printf("[queue] refusing instance %s: could not acquire ownership: %v", instanceID, err)
+			return
+		}
+		if !owned {
+			log.Printf("[queue] refusing instance %s: queue is owned by another process", instanceID)
+			return
+		}
+	}
+	defer ownership.release()
+
 	// Register instance as pending initially
 	instance := &ScanInstance{
 		ID:                  instanceID,
@@ -98,23 +131,50 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 		snapshotFinalizing:  true,
 	}
 	s.seedResumeInstanceFromRecord(instance, req)
-	s.instancesMu.Lock()
-	if req.IsResume {
-		if req.ResumeScanID != "" && req.ResumeScanID != instanceID {
-			delete(s.instances, req.ResumeScanID)
-		}
-		if req.ResumeSubScanID != "" && req.ResumeSubScanID != instanceID {
-			delete(s.instances, req.ResumeSubScanID)
-		}
-		// Remove pre-resume pending placeholders created by rebuildInstancesFromDisk for the same target
-		for id, inst := range s.instances {
-			if id != instanceID && inst.Status == "pending" && len(req.Targets) > 0 && (strings.Contains(inst.Targets, req.Targets[0]) || strings.Contains(req.Targets[0], inst.Targets)) {
-				delete(s.instances, id)
-			}
+	// Disk discovery is intentionally outside the global instance-map lock.
+	// The dispatch mutex below is the serialization point that revalidates the
+	// durable tombstone before any map entry can be installed.
+	legacyClaimed := false
+	if !req.IsResume {
+		if _, err := s.loadExactDispatchSnapshot(instanceID); errors.Is(err, errDispatchSnapshotNotFound) {
+			_, legacyClaimed = s.persistedInstanceIDClaim(instanceID)
 		}
 	}
+	s.dispatchMu.Lock()
+	if durable, err := s.loadExactDispatchSnapshot(instanceID); err == nil &&
+		(isTerminalScanStatus(durable.Status) || strings.EqualFold(durable.Status, "stopping")) {
+		delete(s.dispatchReservations, instanceID)
+		s.dispatchMu.Unlock()
+		log.Printf("[scan] refusing dispatch %q after durable exact stop/status %q", instanceID, durable.Status)
+		return
+	} else if err != nil && !errors.Is(err, errDispatchSnapshotNotFound) {
+		delete(s.dispatchReservations, instanceID)
+		s.dispatchMu.Unlock()
+		log.Printf("[scan] refusing dispatch %q with unreadable durable state: %v", instanceID, err)
+		return
+	}
+	s.instancesMu.Lock()
+	if existing := s.instances[instanceID]; existing != nil {
+		replaceableResumePlaceholder := req.IsResume && isReplaceableResumePlaceholder(existing)
+		if !replaceableResumePlaceholder {
+			s.instancesMu.Unlock()
+			delete(s.dispatchReservations, instanceID)
+			s.dispatchMu.Unlock()
+			log.Printf("[scan] refusing live instance id collision for %q", instanceID)
+			return
+		}
+	}
+	if !req.IsResume && legacyClaimed {
+		s.instancesMu.Unlock()
+		delete(s.dispatchReservations, instanceID)
+		s.dispatchMu.Unlock()
+		log.Printf("[scan] refusing legacy persisted instance id collision for %q", instanceID)
+		return
+	}
 	s.instances[instanceID] = instance
+	delete(s.dispatchReservations, instanceID)
 	s.instancesMu.Unlock()
+	s.dispatchMu.Unlock()
 
 	// Persist the queue state immediately, BEFORE the admission wait loop.
 	// Previously the first saveQueueState ran only after admission (well past
@@ -159,37 +219,19 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 		instance.sctx = nil
 		instance.mu.Unlock()
 
-		// Full post-scan cleanup only when the scan actually ran.
-		// Pending→stopped instances skip queue/agent teardown since
-		// they never acquired resources.
-		if ranScan {
-			// Only clear queue state when the scan really finished. Paused,
-			// panicked, and signal-stopped scans keep it for resume.
-			preserveQueue := false
-			instance.mu.RLock()
-			preserveQueue = shouldPreserveQueueStateOnExit(instance.Status, instance.StopReason, panicRecovered)
-			instance.mu.RUnlock()
-			if !preserveQueue {
-				s.clearQueueState(instanceID)
-			} else {
-				log.Printf("[AUTO-RESUME] Preserving queue state after interrupted scan")
-			}
-		} else {
-			// The instance exited pending WITHOUT ever running. A queue_state
-			// file was written at creation so the scan could survive a restart;
-			// decide its fate here.
-			//   - server_shutdown: preserve → the auto-resume goroutine re-queues
-			//     it after restart (the whole point of persisting pending scans).
-			//   - user_stopped / any other reason: clear → a canceled scan must
-			//     NOT be resurrected on the next boot.
-			instance.mu.RLock()
-			reason := instance.StopReason
-			instance.mu.RUnlock()
-			if reason == "server_shutdown" {
-				log.Printf("[AUTO-RESUME] Preserving pending queue state (server_shutdown) for %s", instanceID)
-			} else {
-				s.clearQueueState(instanceID)
-			}
+		// Decide queue retention now, but do not unlink anything until the exact
+		// terminal aggregate has been durably committed below. A failed snapshot
+		// must leave enough state for a later GET retry or process restart.
+		instance.mu.RLock()
+		finalStatus := instance.Status
+		finalStopReason := instance.StopReason
+		instance.mu.RUnlock()
+		preserveQueue := shouldPreserveQueueStateOnExit(finalStatus, finalStopReason, panicRecovered)
+		if !ranScan {
+			preserveQueue = finalStopReason == "server_shutdown" || panicRecovered
+		}
+		if preserveQueue {
+			log.Printf("[AUTO-RESUME] Preserving queue state after interrupted scan %s", instanceID)
 		}
 
 		// Always clean up server references (safe even if never set)
@@ -200,10 +242,6 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 		}
 		s.mu.Unlock()
 
-		instance.mu.RLock()
-		finalStatus := instance.Status
-		finalStopReason := instance.StopReason
-		instance.mu.RUnlock()
 		if finalStatus == "paused" {
 			s.markQueueStatePaused(instanceID)
 		}
@@ -222,13 +260,39 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 				queueDoneEvt.CurrentPhase = 22
 			}
 		}
-		s.broadcastToInstance(instanceID, queueDoneEvt)
-		// The event above is the final exact event snapshot entry. Only now may
-		// the compact endpoint expose a terminal status; SaaS persists this
-		// event/final findings before its terminal status CAS.
+		if finalStatus != "stopped" || !instanceHasExactStopEvent(instance) {
+			s.broadcastToInstance(instanceID, queueDoneEvt)
+		}
+		// The final event is buffered and every session cleanup has run, so a
+		// later exact-stop request may safely retry terminal persistence if the
+		// writes below encounter a transient disk failure.
 		instance.mu.Lock()
-		instance.snapshotFinalizing = false
+		instance.snapshotReady = true
 		instance.mu.Unlock()
+		// Persist the coherent terminal aggregate before exposing it through the live API.
+		// A transient disk error keeps snapshotFinalizing true and is retried;
+		// terminal visibility never outruns durable findings/events.
+		var snapshotErr error
+		for attempt := 0; attempt < 3; attempt++ {
+			snapshotErr = s.persistExactInstanceSnapshot(instance)
+			if snapshotErr == nil {
+				break
+			}
+			log.Printf("[scan] failed to persist exact terminal snapshot for %s (attempt %d/3): %v", instanceID, attempt+1, snapshotErr)
+			time.Sleep(time.Duration(attempt+1) * 50 * time.Millisecond)
+		}
+		if snapshotErr == nil {
+			instance.mu.Lock()
+			instance.snapshotFinalizing = false
+			instance.mu.Unlock()
+			if !preserveQueue {
+				if err := s.clearQueueStateDurable(instanceID); err != nil {
+					log.Printf("[queue] exact snapshot for %s is durable but queue deletion failed: %v", instanceID, err)
+				}
+			}
+		} else {
+			log.Printf("[queue] preserving queue state for %s because exact terminal persistence failed", instanceID)
+		}
 		s.broadcastDashboard(WSEvent{Type: "instance_updated", Content: instanceID})
 		time.Sleep(500 * time.Millisecond)
 
@@ -306,12 +370,14 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 			inst.mu.RUnlock()
 		}
 		canAdmit, reason := resources.CanAdmitScan(runningCount)
+		instance.mu.Lock()
 		if canAdmit && instance.Status == "pending" {
 			instance.Status = "running"
 			instance.StartedAt = time.Now().Format(time.RFC3339)
 			gotSlot = true
 			log.Printf("[ADMIT] Scan %s started (running: %d) — %s", instanceID, runningCount+1, reason)
 		}
+		instance.mu.Unlock()
 		s.instancesMu.Unlock()
 
 		if gotSlot {
@@ -361,8 +427,9 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 	// process exits during admission/startup.
 	req.InstanceID = instanceID // (re)thread instance ID; also set before the admission wait
 	s.running.Store(true)
-	if req.DiscordWebhook != "" {
-		s.discordWebhook = req.DiscordWebhook
+	scanDiscordWebhook := strings.TrimSpace(req.DiscordWebhook)
+	if scanDiscordWebhook == "" {
+		scanDiscordWebhook = s.discordWebhook
 	}
 
 	if req.IsResume {
@@ -396,7 +463,7 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 	})
 
 	// Discord: scan started
-	s.sendDiscord(0x00ff88, "🚀 Scan Started", fmt.Sprintf("**Targets:** %s\n**Mode:** %s\n**Total:** %d target(s)", strings.Join(req.Targets, ", "), req.ScanMode, totalTargets))
+	s.sendDiscordTo(scanDiscordWebhook, 0x00ff88, "🚀 Scan Started", fmt.Sprintf("**Targets:** %s\n**Mode:** %s\n**Total:** %d target(s)", strings.Join(req.Targets, ", "), req.ScanMode, totalTargets))
 	// Telegram: scan started
 	if s.telegramConfigured() {
 		s.sendTelegram(0x00ff88, "🚀 Scan Started", fmt.Sprintf("**Targets:** %s\n**Mode:** %s\n**Total:** %d target(s)", strings.Join(req.Targets, ", "), req.ScanMode, totalTargets))
@@ -414,7 +481,7 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 			interruptedQueue = true
 			if instStatus == "paused" {
 				s.broadcastToInstance(instanceID, WSEvent{Type: "paused", Content: "Scan queue paused"})
-			} else {
+			} else if !instanceHasExactStopEvent(instance) {
 				s.broadcastToInstance(instanceID, WSEvent{Type: "stopped", Content: "Scan queue stopped by user"})
 			}
 			break
@@ -477,12 +544,12 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 	s.instancesMu.RUnlock()
 	if vulnCount > 0 {
 		desc := fmt.Sprintf("**Targets:** %d completed\n**Vulnerabilities:** %d found\n**Completed at:** %s", totalTargets, vulnCount, time.Now().Format("15:04:05 MST"))
-		s.sendDiscord(0x3b82f6, "✅ Scan Finished - Vulnerabilities Found", desc)
+		s.sendDiscordTo(scanDiscordWebhook, 0x3b82f6, "✅ Scan Finished - Vulnerabilities Found", desc)
 		if s.telegramConfigured() {
 			s.sendTelegram(0x3b82f6, "✅ Scan Finished - Vulnerabilities Found", desc)
 		}
 	} else {
-		s.sendDiscord(0x3b82f6, "✅ Scan Finished", fmt.Sprintf("**Targets:** %d completed\n**Vulnerabilities:** 0 found\n**Completed at:** %s", totalTargets, time.Now().Format("15:04:05 MST")))
+		s.sendDiscordTo(scanDiscordWebhook, 0x3b82f6, "✅ Scan Finished", fmt.Sprintf("**Targets:** %d completed\n**Vulnerabilities:** 0 found\n**Completed at:** %s", totalTargets, time.Now().Format("15:04:05 MST")))
 		if s.telegramConfigured() {
 			s.sendTelegram(0x3b82f6, "✅ Scan Finished", fmt.Sprintf("**Targets:** %d completed\n**Vulnerabilities:** 0 found\n**Completed at:** %s", totalTargets, time.Now().Format("15:04:05 MST")))
 		}
@@ -607,7 +674,7 @@ func subdomainTargetsFromRecord(rec *ScanRecord) []string {
 }
 
 // runSingleTarget handles a single-site mode scan for one target.
-func (s *Server) runSingleTarget(_ context.Context, scanCfg *config.Config, req ScanRequest, target string, idx, total int) {
+func (s *Server) runSingleTarget(ctx context.Context, scanCfg *config.Config, req ScanRequest, target string, idx, total int) {
 	scanDir, resumed := s.scanDirForResume(req, target)
 	s.saveQueueState(idx, req, queueProgress{
 		ActiveTarget:  target,
@@ -651,6 +718,7 @@ func (s *Server) runSingleTarget(_ context.Context, scanCfg *config.Config, req 
 		genReport:          true,
 		resetState:         !resumed,
 		instanceID:         req.InstanceID,
+		parentCtx:          ctx,
 		scanMode:           "single",
 		companyName:        req.CompanyName,
 		logoPath:           req.LogoPath,
@@ -678,7 +746,7 @@ func (s *Server) runSingleTarget(_ context.Context, scanCfg *config.Config, req 
 }
 
 // runDASTTarget handles a DAST mode scan for one target URL.
-func (s *Server) runDASTTarget(_ context.Context, scanCfg *config.Config, req ScanRequest, target string, idx, total int) {
+func (s *Server) runDASTTarget(ctx context.Context, scanCfg *config.Config, req ScanRequest, target string, idx, total int) {
 	scanDir, resumed := s.scanDirForResume(req, target)
 	s.saveQueueState(idx, req, queueProgress{
 		ActiveTarget:  target,
@@ -723,6 +791,7 @@ func (s *Server) runDASTTarget(_ context.Context, scanCfg *config.Config, req Sc
 		genReport:          true,
 		resetState:         !resumed,
 		instanceID:         req.InstanceID,
+		parentCtx:          ctx,
 		scanMode:           "dast",
 		companyName:        req.CompanyName,
 		logoPath:           req.LogoPath,
@@ -749,8 +818,41 @@ func (s *Server) runDASTTarget(_ context.Context, scanCfg *config.Config, req Sc
 	})
 }
 
+// beginWildcardSubScan is the serialization point between per-host dispatch
+// and an exact stop. If dispatch wins, the stop snapshot includes immutable
+// positive evidence (ID + started_at). If stop wins, no new child can start.
+func (s *Server) beginWildcardSubScan(instanceID string, index int, target, childID string) bool {
+	s.instancesMu.RLock()
+	inst := s.instances[instanceID]
+	s.instancesMu.RUnlock()
+	if inst == nil {
+		return false
+	}
+
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+	if inst.Status != "running" || index < 0 || index >= len(inst.SubScans) {
+		return false
+	}
+	child := inst.SubScans[index]
+	child.Target = target
+	child.Status = "running"
+	child.ID = childID
+	if child.StartedAt == "" {
+		child.StartedAt = time.Now().Format(time.RFC3339Nano)
+	}
+	inst.SubScans[index] = child
+	inst.SubScanRunning = 1
+	remaining := inst.SubScanTotal - inst.SubScanCompleted - 1
+	if remaining < 0 {
+		remaining = 0
+	}
+	inst.SubScanRemaining = remaining
+	return true
+}
+
 // runWildcardTarget handles wildcard mode: Phase 1 subdomain discovery, then Phase 2 per-subdomain scanning.
-func (s *Server) runWildcardTarget(_ context.Context, scanCfg *config.Config, req ScanRequest, target string, idx, total int) {
+func (s *Server) runWildcardTarget(ctx context.Context, scanCfg *config.Config, req ScanRequest, target string, idx, total int) {
 	// ── Stable parent reporting context for vuln accumulation ──
 	// All subdomain sessions merge their vulns into this context.
 	// It persists across the entire wildcard scan and is cleaned up at the end.
@@ -834,6 +936,7 @@ func (s *Server) runWildcardTarget(_ context.Context, scanCfg *config.Config, re
 			genReport:          false,
 			resetState:         true,
 			instanceID:         req.InstanceID,
+			parentCtx:          ctx,
 			scanMode:           "wildcard",
 			skipNotesCleanup:   true, // preserve notes for subdomain collection
 			companyName:        req.CompanyName,
@@ -1031,7 +1134,9 @@ func (s *Server) runWildcardTarget(_ context.Context, scanCfg *config.Config, re
 		// flip the instance status, which instanceInterrupted observes).
 		if s.instanceInterrupted(req.InstanceID) {
 			log.Printf("[INFO] Subdomain loop stopped by user at %d/%d for %s", j+1, len(subdomains), target)
-			s.broadcastToInstance(req.InstanceID, WSEvent{Type: "stopped", Content: "Scan queue stopped by user"})
+			if !serverInstanceHasExactStopEvent(s, req.InstanceID) {
+				s.broadcastToInstance(req.InstanceID, WSEvent{Type: "stopped", Content: "Scan queue stopped by user"})
+			}
 			wildcardStopped = true
 			break
 		}
@@ -1049,6 +1154,11 @@ func (s *Server) runWildcardTarget(_ context.Context, scanCfg *config.Config, re
 		subScanDir, subResumed := s.scanDirForWildcardSubdomainResume(req, subdomain, j)
 		if subResumed {
 			log.Printf("[AUTO-RESUME] Reusing interrupted subdomain scan dir for %s: %s", subdomain, subScanDir)
+		}
+		if !s.beginWildcardSubScan(req.InstanceID, j, subdomain, filepath.Base(subScanDir)) {
+			log.Printf("[INFO] Subdomain dispatch stopped before %d/%d for %s", j+1, len(subdomains), target)
+			wildcardStopped = true
+			break
 		}
 		log.Printf("[INFO] Starting subdomain %d/%d: %s (parent: %s)", j+1, len(subdomains), subdomain, target)
 		saveWildcardProgress(j, j, subdomain, subScanDir)
@@ -1103,6 +1213,7 @@ func (s *Server) runWildcardTarget(_ context.Context, scanCfg *config.Config, re
 				genReport:            false,
 				resetState:           false, // accumulate vulns across subdomains
 				instanceID:           req.InstanceID,
+				parentCtx:            ctx,
 				scanMode:             "wildcard",
 				parentReportingCtxID: parentReportingCtxID, // merge vulns into parent on cleanup
 				companyName:          req.CompanyName,

--- a/internal/web/queue_state.go
+++ b/internal/web/queue_state.go
@@ -1,18 +1,33 @@
 package web
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+	"syscall"
 	"time"
 )
 
-// saveQueueState saves the current queue state to disk.
+// saveQueueState records best-effort progress updates after acceptance. The
+// acceptance path uses saveQueueStateDurable directly and rejects the request
+// if the initial resumable state cannot be committed.
 func (s *Server) saveQueueState(idx int, req ScanRequest, progress ...queueProgress) {
+	if err := s.saveQueueStateDurable(idx, req, progress...); err != nil {
+		log.Printf("Error: failed to save queue state: %v", err)
+	}
+}
+
+// saveQueueStateDurable atomically saves the current queue state to disk.
+// Callers on the HTTP acceptance path must check the error: an accepted
+// dispatch without this request would be stranded after a process crash.
+func (s *Server) saveQueueStateDurable(idx int, req ScanRequest, progress ...queueProgress) error {
 	normalizeScanRequestActivity(&req)
 	state := QueueState{
 		InstanceID:     req.InstanceID,
@@ -55,13 +70,45 @@ func (s *Server) saveQueueState(idx int, req ScanRequest, progress ...queueProgr
 	}
 	data, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
-		log.Printf("Error: failed to marshal queue state: %v", err)
-		return
+		return fmt.Errorf("marshal queue state: %w", err)
 	}
 	path := s.queueStatePathForInstance(req.InstanceID)
-	if err := os.WriteFile(path, data, 0600); err != nil {
-		log.Printf("Error: failed to save queue state: %v", err)
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create queue state directory: %w", err)
 	}
+	tmp, err := os.CreateTemp(dir, ".queue-state-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create queue state temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		if removeErr := os.Remove(tmpPath); removeErr != nil && !os.IsNotExist(removeErr) {
+			log.Printf("Warning: failed to remove queue state temp file %s: %v", tmpPath, removeErr)
+		}
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("secure queue state temp file: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write queue state: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync queue state: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close queue state: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("publish queue state: %w", err)
+	}
+	if err := fsyncParentDir(path); err != nil {
+		return fmt.Errorf("commit queue state rename: %w", err)
+	}
+	return nil
 }
 
 func (s *Server) queueStatePath() string {
@@ -431,26 +478,94 @@ func (s *Server) markQueueStatePaused(instanceID string) {
 // clearQueueState removes queue state. With an instance ID it clears only that
 // scan's resume file; with no ID it clears every resumable queue.
 func (s *Server) clearQueueState(instanceIDs ...string) {
-	if len(instanceIDs) > 0 {
-		for _, instanceID := range instanceIDs {
-			if strings.TrimSpace(instanceID) == "" {
-				s.clearQueueStatePath(s.queueStatePath())
-				continue
-			}
-			s.clearQueueStatePath(s.queueStatePathForInstance(instanceID))
-		}
-		return
-	}
-	for _, path := range s.queueStatePaths() {
-		s.clearQueueStatePath(path)
+	if err := s.clearQueueStateDurable(instanceIDs...); err != nil {
+		log.Printf("Warning: failed to durably clear queue state: %v", err)
 	}
 }
 
+func (s *Server) clearQueueStateDurable(instanceIDs ...string) error {
+	var paths []string
+	if len(instanceIDs) > 0 {
+		for _, instanceID := range instanceIDs {
+			if strings.TrimSpace(instanceID) == "" {
+				paths = append(paths, s.queueStatePath())
+			} else {
+				paths = append(paths, s.queueStatePathForInstance(instanceID))
+			}
+		}
+	} else {
+		paths = s.queueStatePaths()
+	}
+	var errs []error
+	for _, path := range paths {
+		if err := s.clearQueueStatePathDurable(path); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
 func (s *Server) clearQueueStatePath(path string) {
+	if err := s.clearQueueStatePathDurable(path); err != nil {
+		log.Printf("Warning: failed to durably remove queue state file %s: %v", path, err)
+	}
+}
+
+func (s *Server) clearQueueStatePathDurable(path string) error {
 	if path == "" {
+		return nil
+	}
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("remove queue state %s: %w", path, err)
+	}
+	if err := fsyncParentDir(path); err != nil {
+		return fmt.Errorf("commit queue state deletion %s: %w", path, err)
+	}
+	return nil
+}
+
+type queueOwnership struct {
+	file *os.File
+	path string
+}
+
+func (s *Server) acquireQueueOwnership(instanceID string) (*queueOwnership, bool, error) {
+	instanceID = strings.TrimSpace(instanceID)
+	if instanceID == "" {
+		instanceID = "legacy"
+	}
+	sum := sha256.Sum256([]byte(instanceID))
+	dir := filepath.Join(s.dataDir, ".queue-locks")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, false, fmt.Errorf("create queue lock directory: %w", err)
+	}
+	path := filepath.Join(dir, hex.EncodeToString(sum[:])+".lock")
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, false, fmt.Errorf("open queue ownership lock: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("lock queue ownership: %w", err)
+	}
+	return &queueOwnership{file: f, path: path}, true, nil
+}
+
+func (ownership *queueOwnership) release() {
+	if ownership == nil || ownership.file == nil {
 		return
 	}
-	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-		log.Printf("Warning: failed to remove queue state file %s: %v", path, err)
+	if err := syscall.Flock(int(ownership.file.Fd()), syscall.LOCK_UN); err != nil {
+		log.Printf("Warning: failed to unlock queue ownership %s: %v", ownership.path, err)
 	}
+	if err := ownership.file.Close(); err != nil {
+		log.Printf("Warning: failed to close queue ownership %s: %v", ownership.path, err)
+	}
+	ownership.file = nil
 }

--- a/internal/web/scan_query.go
+++ b/internal/web/scan_query.go
@@ -2,11 +2,11 @@ package web
 
 import (
 	"encoding/json"
+	"errors"
 	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -253,26 +253,35 @@ func (s *Server) findScanByID(scanID string) (string, *ScanRecord) {
 		return "", nil
 	}
 
-	// First: prefer top-level scans. Multiple wildcard child records share the
-	// same instance id; returning a child here makes the UI route land on one
-	// subdomain instead of the parent wildcard scan.
 	entries := s.findAllScans()
-	for _, entry := range entries {
-		if entry.rec.ParentTarget != "" {
-			continue
+	resolveUnique := func(topLevelOnly bool) (string, *ScanRecord, bool) {
+		var matchedDir string
+		var matched *ScanRecord
+		for _, entry := range entries {
+			if topLevelOnly && entry.rec.ParentTarget != "" {
+				continue
+			}
+			if entry.rec.ID != scanID && entry.rec.InstanceID != scanID && filepath.Base(entry.dir) != scanID {
+				continue
+			}
+			if matched != nil {
+				log.Printf("[scan] refusing ambiguous scan id %q: records %q and %q both match", scanID, matched.ID, entry.rec.ID)
+				return "", nil, true
+			}
+			rec := entry.rec
+			matchedDir = entry.dir
+			matched = &rec
 		}
-		if entry.rec.ID == scanID || entry.rec.InstanceID == scanID || filepath.Base(entry.dir) == scanID {
-			return entry.dir, &entry.rec
-		}
+		return matchedDir, matched, matched != nil
 	}
-	// Second: allow direct child lookup when the caller explicitly uses a child
-	// scan id, for report generation and historical compatibility.
-	for _, entry := range entries {
-		if entry.rec.ID == scanID || entry.rec.InstanceID == scanID || filepath.Base(entry.dir) == scanID {
-			return entry.dir, &entry.rec
-		}
+	if dir, rec, found := resolveUnique(true); found {
+		return dir, rec
 	}
-	// Second: try legacy flat path as fallback (dataDir/scanID/scan.json)
+	if dir, rec, found := resolveUnique(false); found {
+		return dir, rec
+	}
+
+	// Legacy flat path fallback (dataDir/scanID/scan.json).
 	direct := filepath.Join(s.dataDir, scanID, "scan.json")
 	if data, err := os.ReadFile(direct); err == nil {
 		var rec ScanRecord
@@ -283,33 +292,65 @@ func (s *Server) findScanByID(scanID string) (string, *ScanRecord) {
 	return "", nil
 }
 
-var shortHexIDPattern = regexp.MustCompile(`^[a-f0-9]{8}$`)
+// persistedInstanceIDClaim reports whether any top-level persisted record
+// claims an external instance ID. Ambiguous duplicate claims are still a hard
+// reservation conflict even though they are intentionally non-authoritative
+// for reads.
+func (s *Server) persistedInstanceIDClaim(instanceID string) (string, bool) {
+	instanceID = strings.TrimSpace(instanceID)
+	if instanceID == "" {
+		return "", false
+	}
+	if rec, err := s.loadExactDispatchSnapshot(instanceID); err == nil {
+		return rec.Status, true
+	} else if !errors.Is(err, errDispatchSnapshotNotFound) {
+		return "conflict", true
+	}
+	status := ""
+	claims := 0
+	for _, entry := range s.findAllScans() {
+		if entry.rec.ParentTarget == "" && entry.rec.InstanceID == instanceID {
+			claims++
+			status = entry.rec.Status
+		}
+	}
+	if claims > 1 {
+		return "conflict", true
+	}
+	return status, claims == 1
+}
 
-func (s *Server) findRecentScanForShortAlias(scanID string) (string, *ScanRecord) {
-	if !shortHexIDPattern.MatchString(scanID) {
+// findScanByInstanceID resolves only the immutable external instance identity
+// persisted on a top-level scan record. It deliberately does not accept record
+// IDs, directory names, target similarity, or short aliases: authoritative
+// status snapshots must either prove the requested run identity or return no
+// news.
+func (s *Server) findScanByInstanceID(instanceID string) (string, *ScanRecord) {
+	instanceID = strings.TrimSpace(instanceID)
+	if instanceID == "" {
 		return "", nil
 	}
-
-	entries := s.findAllScans()
-	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].rec.StartedAt > entries[j].rec.StartedAt
-	})
-
-	for _, entry := range entries {
-		if entry.rec.ParentTarget != "" {
-			continue
-		}
-		startedAt, err := time.Parse(time.RFC3339Nano, entry.rec.StartedAt)
-		if err != nil {
-			continue
-		}
-		if time.Since(startedAt) > 24*time.Hour {
-			continue
-		}
-		log.Printf("[web] Resolving short scan route %s to recent scan %s", scanID, entry.rec.ID)
-		return entry.dir, &entry.rec
+	if rec, err := s.loadExactDispatchSnapshot(instanceID); err == nil {
+		return filepath.Dir(s.dispatchSnapshotPath(instanceID)), rec
+	} else if !errors.Is(err, errDispatchSnapshotNotFound) {
+		log.Printf("[scan] refusing unreadable exact dispatch snapshot %q: %v", instanceID, err)
+		return "", nil
 	}
-	return "", nil
+	var matchedDir string
+	var matched *ScanRecord
+	for _, entry := range s.findAllScans() {
+		if entry.rec.ParentTarget != "" || entry.rec.InstanceID != instanceID {
+			continue
+		}
+		if matched != nil {
+			log.Printf("[scan] refusing ambiguous external instance id %q: records %q and %q both claim it", instanceID, matched.ID, entry.rec.ID)
+			return "", nil
+		}
+		rec := entry.rec
+		matchedDir = entry.dir
+		matched = &rec
+	}
+	return matchedDir, matched
 }
 
 func (s *Server) markDiscordWebhookConfigured(rec *ScanRecord) {
@@ -389,6 +430,7 @@ func (s *Server) scanRecordFromInstance(inst *ScanInstance) *ScanRecord {
 		SubScanCompleted:         inst.SubScanCompleted,
 		SubScanRunning:           inst.SubScanRunning,
 		SubScanRemaining:         inst.SubScanRemaining,
+		WorkStarted:              inst.WorkStarted,
 	}
 }
 
@@ -618,6 +660,7 @@ func (s *Server) applyInstanceSnapshot(rec *ScanRecord, includeEvents bool) {
 	if snapshot.TotalTokens > rec.TotalTokens {
 		rec.TotalTokens = snapshot.TotalTokens
 	}
+	rec.WorkStarted = rec.WorkStarted || snapshot.WorkStarted
 	for _, vuln := range snapshot.Vulns {
 		appendVulnSummaryUnique(&rec.Vulns, vuln)
 	}
@@ -883,18 +926,45 @@ func (s *Server) rebuildInstancesFromDisk() {
 	}
 
 	entries := s.findAllScans()
+	externalIdentityCounts := make(map[string]int)
+	for i := range entries {
+		entry := &entries[i]
+		if entry.rec.ParentTarget == "" {
+			if persistedID := strings.TrimSpace(entry.rec.InstanceID); persistedID != "" {
+				externalIdentityCounts[persistedID]++
+			}
+		}
+	}
 	instanceIdentity := func(entry *scanEntry) (string, bool) {
-		instID := entry.rec.ID
-		if mappedID, ok := qMap[filepath.Clean(entry.dir)]; ok {
-			return mappedID, true
+		// ScanRecord.InstanceID is immutable run ownership metadata. Once it
+		// exists, queue recovery may prove that same run resumable but must never
+		// replace it with an identity inferred from a target, directory, or
+		// canonical record ID.
+		persistedID := strings.TrimSpace(entry.rec.InstanceID)
+		candidates := []string{
+			qMap[filepath.Clean(entry.dir)],
+			qMap[entry.rec.ID],
+			qMap[normalizeScanTarget(entry.rec.Target)],
 		}
-		if mappedID, ok := qMap[entry.rec.ID]; ok {
-			return mappedID, true
+		if persistedID != "" {
+			for _, mappedID := range candidates {
+				if mappedID == persistedID {
+					return persistedID, true
+				}
+			}
+			return persistedID, false
 		}
-		if mappedID, ok := qMap[normalizeScanTarget(entry.rec.Target)]; ok {
-			return mappedID, true
+
+		// Legacy records without ownership metadata can only inherit an active
+		// instance ID from an exact queue-state relationship. Historical terminal
+		// records are keyed by their canonical record ID; no short-alias guess is
+		// permitted.
+		for _, mappedID := range candidates {
+			if mappedID != "" {
+				return mappedID, true
+			}
 		}
-		return instID, false
+		return entry.rec.ID, false
 	}
 
 	// First normalize every interrupted record so wildcard parent aggregation
@@ -927,6 +997,10 @@ func (s *Server) rebuildInstancesFromDisk() {
 		}
 
 		instID, _ := instanceIdentity(entry)
+		if externalIdentityCounts[instID] > 1 {
+			log.Printf("[scan] refusing to rebuild ambiguous external instance id %q claimed by %d top-level records", instID, externalIdentityCounts[instID])
+			continue
+		}
 		if entry.rec.ScanMode == "wildcard" || entry.rec.SubScans != nil || entry.rec.SubScanTotal > 0 {
 			// Rebuild the exact parent snapshot from the now-normalized child
 			// records. This restores findings and physical provenance as well as
@@ -965,6 +1039,7 @@ func (s *Server) rebuildInstancesFromDisk() {
 			SubScanCompleted: entry.rec.SubScanCompleted,
 			SubScanRunning:   entry.rec.SubScanRunning,
 			SubScanRemaining: entry.rec.SubScanRemaining,
+			WorkStarted:      entry.rec.WorkStarted,
 			events:           append([]WSEvent(nil), entry.rec.Events...),
 		}
 		if inst.CurrentPhase == 0 {

--- a/internal/web/scan_record.go
+++ b/internal/web/scan_record.go
@@ -55,6 +55,7 @@ func (s *Server) freshScanRecordForSession(sess *scanSession, startedAt string) 
 		LogoPath:                 sess.logoPath,
 		Phases:                   append([]int(nil), sess.phases...),
 		CurrentPhase:             firstSelectedPhase(sess.phases),
+		WorkStarted:              true,
 	}
 }
 
@@ -82,6 +83,7 @@ func (s *Server) refreshResumedScanRecord(rec *ScanRecord, sess *scanSession, fa
 		rec.StartedAt = fallbackStartedAt
 	}
 	rec.Status = "running"
+	rec.WorkStarted = true
 	rec.FinishedAt = ""
 	rec.StopReason = ""
 	if rec.Events == nil {

--- a/internal/web/scan_session.go
+++ b/internal/web/scan_session.go
@@ -40,6 +40,72 @@ func shouldFailInstanceOnAbort(scanMode, parentTarget string, discoveryMode bool
 	return true
 }
 
+// registerSessionAgent is the single admission transition shared with exact
+// stop. If registration wins, stop sees and stops this agent. If stop wins,
+// status is already terminal and no session can be published or run afterward.
+func (s *Server) registerSessionAgent(sess *scanSession, sctx *scanctx.ScanContext, agnt *agent.Agent) bool {
+	if sess.instanceID != "" {
+		// Exact stop and work admission share dispatchMu. If admission wins, its
+		// positive evidence is durable before any target work starts. If stop
+		// wins, the terminal status is visible before this session can publish.
+		s.dispatchMu.Lock()
+		s.instancesMu.RLock()
+		inst := s.instances[sess.instanceID]
+		if inst == nil {
+			s.instancesMu.RUnlock()
+			s.dispatchMu.Unlock()
+			return false
+		}
+		inst.mu.Lock()
+		canceled := false
+		if sess.parentCtx != nil {
+			select {
+			case <-sess.parentCtx.Done():
+				canceled = true
+			default:
+			}
+		}
+		if inst.Status != "running" || canceled {
+			inst.mu.Unlock()
+			s.instancesMu.RUnlock()
+			s.dispatchMu.Unlock()
+			return false
+		}
+		inst.sctx = sctx
+		inst.agent = agnt
+		inst.scanDir = sess.scanDir
+		inst.lastSessionTokens = 0
+		inst.WorkStarted = true
+		inst.mu.Unlock()
+		s.instancesMu.RUnlock()
+
+		// Positive work admission must survive a process restart before any
+		// source preparation or target activity begins. dispatchMu remains held,
+		// so exact stop cannot be overwritten by this running snapshot.
+		if err := s.persistExactInstanceSnapshotLocked(inst); err != nil {
+			inst.mu.Lock()
+			if inst.Status == "running" {
+				inst.Status = "failed"
+				inst.StopReason = "dispatch_evidence_persist_failed"
+				inst.FinishedAt = time.Now().Format(time.RFC3339Nano)
+				inst.WorkStarted = false
+			}
+			inst.mu.Unlock()
+			s.dispatchMu.Unlock()
+			log.Printf("[scan] refusing session %s: could not persist work admission: %v", sess.id, err)
+			return false
+		}
+		s.dispatchMu.Unlock()
+	}
+
+	s.mu.Lock()
+	s.currentScanDir = sess.scanDir
+	s.currentScanID = sess.id
+	s.currentAgents[sess.id] = agnt
+	s.mu.Unlock()
+	return true
+}
+
 // executeScanSession runs a single scan in complete isolation.
 // It NEVER panics upward — all panics are caught and logged.
 func (s *Server) executeScanSession(sess *scanSession) {
@@ -71,16 +137,8 @@ func (s *Server) executeScanSession(sess *scanSession) {
 		reporting.SetParentContext(sctx.ID, sess.parentReportingCtxID)
 	}
 
-	// Propagate ScanContext to parent instance (if multi-instance mode)
-	if sess.instanceID != "" {
-		s.instancesMu.RLock()
-		if inst, ok := s.instances[sess.instanceID]; ok {
-			inst.mu.Lock()
-			inst.sctx = sctx
-			inst.mu.Unlock()
-		}
-		s.instancesMu.RUnlock()
-	}
+	// Parent instance publication happens atomically with agent admission below;
+	// publishing the context earlier would reopen a stop-before-agent race.
 
 	// 1. Reset per-context state if requested (context-aware)
 	if sess.resetState {
@@ -148,25 +206,12 @@ func (s *Server) executeScanSession(sess *scanSession) {
 		agnt.SetCodeScanMode(sess.codeScanMode)
 	}
 	sess.agent = agnt
-
-	// Store agent ref on server for handleStop/handleChat (under lock)
-	s.mu.Lock()
-	s.currentScanDir = sess.scanDir
-	s.currentScanID = sess.id
-	s.currentAgents[sess.id] = agnt
-	s.mu.Unlock()
-
-	// Register agent with parent instance if applicable
-	if sess.instanceID != "" {
-		s.instancesMu.RLock()
-		if inst, ok := s.instances[sess.instanceID]; ok {
-			inst.mu.Lock()
-			inst.agent = agnt
-			inst.scanDir = sess.scanDir
-			inst.lastSessionTokens = 0 // reset token delta for this new session/phase
-			inst.mu.Unlock()
-		}
-		s.instancesMu.RUnlock()
+	if !s.registerSessionAgent(sess, sctx, agnt) {
+		// Exact stop, deletion, or parent cancellation won before admission.
+		// Stop-before-Run is safe because Agent.Run checks the stopped flag before
+		// preparing source or touching the target.
+		agnt.Stop()
+		return
 	}
 
 	// 4. Initialize scan record. Resume paths preserve previously persisted
@@ -203,7 +248,12 @@ func (s *Server) executeScanSession(sess *scanSession) {
 		instruction = buildSeverityPrefix(sess.severityFilter) + "\n\n" + instruction
 	}
 
-	// 7. Run agent (blocks until finished or stopped)
+	// 7. Run agent (blocks until finished or stopped). Recheck the parent after
+	// record setup; a stop racing this point either makes this check fail or
+	// observes the registered agent and sets its stopped flag before Run works.
+	if status, _ := s.instanceRunStatus(sess.instanceID); sess.instanceID != "" && status != "running" {
+		agnt.Stop()
+	}
 	agnt.Run([]string{sess.target}, instruction)
 
 	// 8. Close events channel and wait for event processor to drain
@@ -314,14 +364,12 @@ func (s *Server) executeScanSession(sess *scanSession) {
 			if vulnCount > 0 {
 				desc := fmt.Sprintf("**Target:** %s\n**Vulnerabilities:** %d found\n**Completed at:** %s",
 					sess.target, vulnCount, time.Now().Format("15:04:05 MST"))
-				s.sendDiscordWithFile(0x3b82f6, "✅ Scan Finished - Report Ready", desc, p)
 				if s.telegramConfigured() {
 					s.sendTelegramWithFile(0x3b82f6, "✅ Scan Finished - Report Ready", desc, p)
 				}
 			} else {
 				desc := fmt.Sprintf("**Target:** %s\n**Result:** No vulnerabilities found (clean scan)\n**Completed at:** %s",
 					sess.target, time.Now().Format("15:04:05 MST"))
-				s.sendDiscordWithFile(0x2dd4bf, "✅ Scan Finished - Clean Report", desc, p)
 				if s.telegramConfigured() {
 					s.sendTelegramWithFile(0x2dd4bf, "✅ Scan Finished - Clean Report", desc, p)
 				}
@@ -446,7 +494,7 @@ func (s *Server) processEvent(evt agent.Event, sess *scanSession) {
 							}
 							// Apply Discord minimum severity filter
 							if severityMeetsThreshold(vs.Severity, s.discordMinSeverity) {
-								s.sendDiscord(sevColor, fmt.Sprintf("🐛 %s Vulnerability Found", strings.ToUpper(vs.Severity)), details.String())
+								s.sendDiscordTo(s.discordWebhookForScan(sess.discordWebhook), sevColor, fmt.Sprintf("🐛 %s Vulnerability Found", strings.ToUpper(vs.Severity)), details.String())
 							} else {
 								log.Printf("[DISCORD] Skipping %s vuln notification (min severity: %s)", vs.Severity, s.discordMinSeverity)
 							}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -239,6 +239,63 @@ func setWebUICacheHeaders(w http.ResponseWriter) {
 	w.Header().Set("Expires", "0")
 }
 
+func validDispatchID(id string) bool {
+	if len(id) < 16 || len(id) > 128 {
+		return false
+	}
+	for _, r := range id {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') || r == '-' || r == '_' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// reserveDispatchID serializes duplicate HTTP submissions before runMultiScan
+// registers the instance. Existing/reserved IDs are idempotent acknowledgments,
+// never permission to overwrite another live run.
+func (s *Server) reserveDispatchID(id string) (string, bool) {
+	s.dispatchMu.Lock()
+	defer s.dispatchMu.Unlock()
+	if s.dispatchReservations == nil {
+		s.dispatchReservations = make(map[string]bool)
+	}
+	if s.dispatchReservations[id] {
+		return "pending", false
+	}
+	s.instancesMu.RLock()
+	inst := s.instances[id]
+	s.instancesMu.RUnlock()
+	if inst != nil {
+		inst.mu.RLock()
+		status := inst.Status
+		if isTerminalScanStatus(status) && inst.snapshotFinalizing {
+			status = "pending"
+		}
+		inst.mu.RUnlock()
+		return status, false
+	}
+	if rec, err := s.loadExactDispatchSnapshot(id); err == nil {
+		return rec.Status, false
+	} else if !errors.Is(err, errDispatchSnapshotNotFound) {
+		log.Printf("[scan] refusing dispatch id %q because its durable snapshot is unreadable: %v", id, err)
+		return "conflict", false
+	}
+	if status, claimed := s.persistedInstanceIDClaim(id); claimed {
+		return status, false
+	}
+	s.dispatchReservations[id] = true
+	return "", true
+}
+
+func (s *Server) releaseDispatchID(id string) {
+	s.dispatchMu.Lock()
+	delete(s.dispatchReservations, id)
+	s.dispatchMu.Unlock()
+}
+
 func canStartInstanceStatus(status string) bool {
 	switch strings.ToLower(strings.TrimSpace(status)) {
 	case "saved", "stopped", "failed", "finished":
@@ -315,6 +372,10 @@ type ScanRequest struct {
 	// per Requirement 11.4.
 	// Validates: Requirements 11.1, 11.2, 11.5.
 	ProviderProfile string `json:"provider_profile,omitempty"`
+	// DispatchID is an optional caller-owned idempotency key for control-plane
+	// dispatch. It is validated and reserved before the goroutine starts; the
+	// internal InstanceID remains wire-inaccessible for resume safety.
+	DispatchID string `json:"dispatch_id,omitempty"`
 	// Internal fields — `json:"-"` makes them un-settable from the wire.
 	// Critical: a client must not be able to set InstanceID to spoof
 	// broadcasts to another scan, or set IsResume to bypass the resume
@@ -332,6 +393,7 @@ type ScanRequest struct {
 	ResumeSubIndex       int      `json:"-"`
 	ResumeDiscoveryDone  bool     `json:"-"`
 	ResumeOriginalTarget int      `json:"-"`
+	queueOwnership       *queueOwnership
 
 	// Code-scan internals, resolved server-side from CodeScan in handleScan.
 	// codeScanMode drives the agent's methodology; allowLoopbackPorts is the
@@ -433,6 +495,7 @@ type ScanRecord struct {
 	SubScanCompleted         int              `json:"sub_scan_completed,omitempty"`
 	SubScanRunning           int              `json:"sub_scan_running,omitempty"`
 	SubScanRemaining         int              `json:"sub_scan_remaining,omitempty"`
+	WorkStarted              bool             `json:"work_started,omitempty"` // positive proof that an agent session was admitted
 }
 
 // QueueState persists scan queue state for recovery after restart
@@ -509,6 +572,7 @@ type ScanInstance struct {
 	SubScanCompleted   int              `json:"sub_scan_completed"`
 	SubScanRunning     int              `json:"sub_scan_running"`
 	SubScanRemaining   int              `json:"sub_scan_remaining"`
+	WorkStarted        bool             `json:"work_started"` // true once any agent session is admitted
 	agent              *agent.Agent
 	cancel             context.CancelFunc
 	scanDir            string
@@ -518,7 +582,8 @@ type ScanInstance struct {
 	chatMessages       []llm.Message        // lightweight post-scan chat history (not exposed)
 	mu                 sync.RWMutex
 	lastSessionTokens  int  // tracks token count from current session for delta calculation
-	snapshotFinalizing bool // terminal status is not externally coherent until the final queue event is buffered
+	snapshotReady      bool // final queue event and session cleanup are complete; persistence may be retried safely
+	snapshotFinalizing bool // terminal status is not externally coherent until the final queue event is durably snapshotted
 }
 
 // maxConcurrentInstances removed — replaced by dynamic resource-aware
@@ -621,25 +686,28 @@ type Server struct {
 	// forceRestartFn performs an immediate restart for POST /api/restart?force=true.
 	// nil in production (the handler re-execs via restartNow); tests set it to a
 	// stub so the force path can be exercised without exec'ing the process.
-	forceRestartFn       func()
-	dataDir              string
-	currentScanDir       string
-	currentScanID        string
-	discordWebhook       string
-	discordMinSeverity   string // minimum severity to send to Discord ("info", "low", "medium", "high", "critical")
-	telegramBotToken     string // XALGORIX_TELEGRAM_BOT_TOKEN (secret, never exposed via API)
-	telegramChatID       string // XALGORIX_TELEGRAM_CHAT_ID (numeric ID or @channelusername)
-	telegramMinSeverity  string // minimum severity to send to Telegram ("info", "low", "medium", "high", "critical")
-	rateLimiter          *RateLimiter
-	settingsMu           sync.Mutex
-	instances            map[string]*ScanInstance // concurrent scan instances
-	instancesMu          sync.RWMutex
-	queueResumeMu        sync.Mutex
-	queueResumeLaunching map[string]bool
-	postScanChatFn       func(*config.Config, []llm.Message) (string, error)
-	schedulesMu          sync.RWMutex
-	schedules            map[string]*ScanSchedule
-	shutdownChan         chan struct{}
+	forceRestartFn         func()
+	dataDir                string
+	currentScanDir         string
+	currentScanID          string
+	discordWebhook         string
+	discordMinSeverity     string // minimum severity to send to Discord ("info", "low", "medium", "high", "critical")
+	telegramBotToken       string // XALGORIX_TELEGRAM_BOT_TOKEN (secret, never exposed via API)
+	telegramChatID         string // XALGORIX_TELEGRAM_CHAT_ID (numeric ID or @channelusername)
+	telegramMinSeverity    string // minimum severity to send to Telegram ("info", "low", "medium", "high", "critical")
+	rateLimiter            *RateLimiter
+	settingsMu             sync.Mutex
+	instances              map[string]*ScanInstance // concurrent scan instances
+	instancesMu            sync.RWMutex
+	dispatchMu             sync.Mutex
+	dispatchReservations   map[string]bool
+	exactStopNotifications map[string]bool
+	queueResumeMu          sync.Mutex
+	queueResumeLaunching   map[string]bool
+	postScanChatFn         func(*config.Config, []llm.Message) (string, error)
+	schedulesMu            sync.RWMutex
+	schedules              map[string]*ScanSchedule
+	shutdownChan           chan struct{}
 	// scanListCache memoizes the built GET /api/scans list for a few seconds
 	// so paging/filtering/polling don't each re-walk the whole data dir.
 	scanListCacheMu sync.Mutex
@@ -728,19 +796,21 @@ func NewServer(cfg *config.Config, port int) *Server {
 	rl := NewRateLimiter(cfg.RateLimitRequests, time.Duration(cfg.RateLimitWindow)*time.Second)
 
 	srv := &Server{
-		cfg:                  cfg,
-		port:                 port,
-		clients:              make(map[*wsClient]bool),
-		currentAgents:        make(map[string]*agent.Agent),
-		dataDir:              dataDir,
-		discordWebhook:       cfg.DiscordWebhook,
-		discordMinSeverity:   strings.ToLower(strings.TrimSpace(cfg.DiscordMinSeverity)),
-		telegramBotToken:     cfg.TelegramBotToken,
-		telegramChatID:       cfg.TelegramChatID,
-		telegramMinSeverity:  strings.ToLower(strings.TrimSpace(cfg.TelegramMinSeverity)),
-		rateLimiter:          rl,
-		instances:            make(map[string]*ScanInstance),
-		queueResumeLaunching: make(map[string]bool),
+		cfg:                    cfg,
+		port:                   port,
+		clients:                make(map[*wsClient]bool),
+		currentAgents:          make(map[string]*agent.Agent),
+		dataDir:                dataDir,
+		discordWebhook:         cfg.DiscordWebhook,
+		discordMinSeverity:     strings.ToLower(strings.TrimSpace(cfg.DiscordMinSeverity)),
+		telegramBotToken:       cfg.TelegramBotToken,
+		telegramChatID:         cfg.TelegramChatID,
+		telegramMinSeverity:    strings.ToLower(strings.TrimSpace(cfg.TelegramMinSeverity)),
+		rateLimiter:            rl,
+		instances:              make(map[string]*ScanInstance),
+		dispatchReservations:   make(map[string]bool),
+		exactStopNotifications: make(map[string]bool),
+		queueResumeLaunching:   make(map[string]bool),
 		// postScanChatFn is set BELOW, after srv has been
 		// allocated, so the closure can capture *srv and read
 		// srv.catalog / srv.profiles at call time. Those fields
@@ -1619,9 +1689,70 @@ func (s *Server) handleScan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	instanceID := randomSlug()
+	instanceID := strings.TrimSpace(req.DispatchID)
+	callerDispatchID := instanceID != ""
+	if callerDispatchID {
+		if !validDispatchID(instanceID) {
+			http.Error(w, "dispatch_id must be 16-128 URL-safe characters", http.StatusBadRequest)
+			return
+		}
+	} else {
+		for {
+			instanceID = randomSlug()
+			if _, reserved := s.reserveDispatchID(instanceID); reserved {
+				break
+			}
+		}
+	}
+	if callerDispatchID {
+		if status, reserved := s.reserveDispatchID(instanceID); !reserved {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": status, "instance_id": instanceID})
+			return
+		}
+	}
+	ownership, owned, err := s.acquireQueueOwnership(instanceID)
+	if err != nil {
+		s.releaseDispatchID(instanceID)
+		http.Error(w, "could not acquire dispatch queue ownership", http.StatusInternalServerError)
+		return
+	}
+	if !owned {
+		s.releaseDispatchID(instanceID)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "pending", "instance_id": instanceID})
+		return
+	}
+	req.queueOwnership = ownership
+	status, accepted, err := s.persistPendingDispatchSnapshot(req, instanceID)
+	if err != nil {
+		ownership.release()
+		s.releaseDispatchID(instanceID)
+		http.Error(w, "could not durably reserve dispatch identity", http.StatusInternalServerError)
+		return
+	}
+	if !accepted {
+		ownership.release()
+		s.releaseDispatchID(instanceID)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": status, "instance_id": instanceID})
+		return
+	}
 	req.Name = strings.TrimSpace(req.Name) // propagate name to running scans too
-	go s.runMultiScan(req, &scanCfg, instanceID)
+	req.InstanceID = instanceID
+	if err := s.saveQueueStateDurable(0, req); err != nil {
+		if abortErr := s.abortPendingDispatchSnapshot(instanceID, "queue_state_persist_failed"); abortErr != nil {
+			log.Printf("[scan] failed to terminalize dispatch %s after queue-state error: %v", instanceID, abortErr)
+		}
+		ownership.release()
+		s.releaseDispatchID(instanceID)
+		http.Error(w, "could not durably persist resumable dispatch", http.StatusInternalServerError)
+		return
+	}
+	go func() {
+		defer s.releaseDispatchID(instanceID)
+		s.runMultiScan(req, &scanCfg, instanceID)
+	}()
 
 	// The ack reflects the scan's actual local state: it is QUEUED as
 	// "pending" (orchestrator.go registers it pending, then the admission
@@ -2245,12 +2376,11 @@ func (s *Server) resolveInstanceForAction(id string) (*ScanInstance, bool) {
 	if ok {
 		return inst, true
 	}
-	// Not a live instance id — try to resolve it as a scan record id, then as a
-	// recent short alias, and map the resolved record back to its instance.
+	// Not a live instance id — resolve only a provable persisted record
+	// relationship and map that record back to its instance. Record IDs remain
+	// supported for dashboard navigation, but recency/target/short-alias guesses
+	// are forbidden for reads and mutations.
 	_, rec := s.findScanByID(id)
-	if rec == nil {
-		_, rec = s.findRecentScanForShortAlias(id)
-	}
 	if rec != nil {
 		if inst := s.instanceForRecord(rec); inst != nil {
 			return inst, true
@@ -2268,6 +2398,97 @@ func (s *Server) handleInstanceAction(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	instanceID := parts[0]
+
+	// GET /api/instances/{id}/snapshot is the authoritative coordinator API.
+	// It resolves only the exact external instance ID and returns status,
+	// findings, wildcard counters, and events under one lock / one persisted
+	// record read. This gives callers independent identity proof and prevents a
+	// terminal summary from being paired with another run's bare event array.
+	if r.Method == http.MethodGet && len(parts) >= 2 && parts[1] == "snapshot" {
+		s.instancesMu.RLock()
+		exact := s.instances[instanceID]
+		s.instancesMu.RUnlock()
+		if exact != nil {
+			exact.mu.RLock()
+			terminalFinalizing := isTerminalScanStatus(exact.Status) && exact.snapshotFinalizing
+			ready := exact.snapshotReady
+			exact.mu.RUnlock()
+			if terminalFinalizing {
+				if !ready {
+					http.Error(w, "terminal instance snapshot is still finalizing", http.StatusConflict)
+					return
+				}
+				if err := s.retryReadyExactSnapshot(exact); err != nil {
+					log.Printf("[scan] GET exact snapshot retry failed for %s: %v", instanceID, err)
+					http.Error(w, "terminal instance snapshot is still finalizing", http.StatusConflict)
+					return
+				}
+			}
+			exact.mu.RLock()
+			events := append([]WSEvent(nil), exact.events...)
+			response := struct {
+				*ScanInstance
+				InstanceID string    `json:"instance_id"`
+				Events     []WSEvent `json:"events"`
+			}{ScanInstance: exact, InstanceID: exact.ID, Events: events}
+			_ = json.NewEncoder(w).Encode(response)
+			exact.mu.RUnlock()
+			return
+		}
+
+		// An evicted or post-restart terminal run remains readable only when its
+		// persisted immutable InstanceID exactly equals the requested value.
+		// Active persisted records without a live instance are uncertainty.
+		_, rec := s.findScanByInstanceID(instanceID)
+		if rec == nil || !isTerminalScanStatus(rec.Status) {
+			http.Error(w, "instance not found", http.StatusNotFound)
+			return
+		}
+		s.attachWildcardSubScans(rec)
+		finalizeScanRecordForResponse(rec)
+		_ = json.NewEncoder(w).Encode(rec)
+		return
+	}
+
+	// Exact control-plane stop must resolve under the same dispatch lock used by
+	// delayed POST registration and work admission. A map lookup performed
+	// before that lock can go stale and tombstone an ID while its live instance
+	// continues running.
+	if r.Header.Get("X-Xalgorix-Exact-Instance") == "1" &&
+		len(parts) >= 2 && parts[1] == "stop" && r.Method == http.MethodPost {
+		rec, notifyListeners, err := s.cancelExactDispatch(instanceID)
+		if err != nil {
+			if errors.Is(err, errDispatchSnapshotNotFound) {
+				http.Error(w, "instance not found", http.StatusNotFound)
+			} else {
+				http.Error(w, "could not durably stop exact instance", http.StatusInternalServerError)
+			}
+			return
+		}
+		if notifyListeners {
+			for _, event := range rec.Events {
+				if event.Type == "stopped" && event.Content == exactStopEventContent {
+					s.notifyInstanceListeners(instanceID, event)
+					break
+				}
+			}
+		}
+		s.broadcastDashboard(WSEvent{Type: "instance_updated", Content: instanceID})
+		if strings.EqualFold(rec.Status, "stopping") {
+			http.Error(w, "instance stop is still finalizing", http.StatusConflict)
+			return
+		}
+		if err := s.clearQueueStateDurable(instanceID); err != nil {
+			log.Printf("[queue] exact stop persisted for %s but queue deletion failed: %v", instanceID, err)
+			http.Error(w, "instance stopped but queue cleanup was not durable", http.StatusInternalServerError)
+			return
+		}
+		// A successful exact stop is the same coherent durable aggregate served
+		// by the snapshot endpoint, including final events and findings.
+		finalizeScanRecordForResponse(rec)
+		_ = json.NewEncoder(w).Encode(rec)
+		return
+	}
 
 	inst, ok := s.resolveInstanceForAction(instanceID)
 
@@ -2290,20 +2511,10 @@ func (s *Server) handleInstanceAction(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// No live in-memory instance — serve the persisted scan record for
-		// finished/stopped scans so the SaaS coordinator can read terminal
-		// status after a scanner restart without waiting for the five-minute
-		// reaper. Inject `instance_id` equal to the requested alias so that
-		// the SaaS identity guard (which checks both `id` and `instance_id`
-		// against the stored external_instance_id) accepts the response even
-		// when the persisted canonical `id` uses a different slug format.
-		//
-		// IMPORTANT: only use findScanByID (exact canonical-ID match) — never
-		// findRecentScanForShortAlias, which searches persisted records by
-		// 4-byte hex alias and can collide with a completely different scan
-		// that happened to receive the same alias in a previous session. A
-		// colliding record would carry a stale terminal status and cause the
-		// SaaS to incorrectly finalize a scan that is still running.
+		// No live in-memory instance — serve only an exact persisted terminal
+		// record. The payload keeps its immutable IDs unchanged so callers can
+		// verify either the canonical record ID or external instance ID; unknown
+		// short aliases remain 404/no-news.
 		_, rec := s.findScanByID(instanceID)
 		if rec == nil {
 			http.Error(w, "instance not found", http.StatusNotFound)
@@ -2319,12 +2530,6 @@ func (s *Server) handleInstanceAction(w http.ResponseWriter, r *http.Request) {
 		s.applyInstanceSnapshot(rec, false)
 		s.attachWildcardSubScans(rec)
 		finalizeScanRecordForResponse(rec)
-		// Mirror the requested alias into instance_id so callers that store
-		// a short-hex external_instance_id can verify identity even when the
-		// on-disk canonical id uses a different format (e.g. target_hash).
-		if rec.InstanceID == "" || rec.InstanceID != instanceID {
-			rec.InstanceID = instanceID
-		}
 		_ = json.NewEncoder(w).Encode(rec)
 		return
 	}
@@ -2363,7 +2568,20 @@ func (s *Server) handleInstanceAction(w http.ResponseWriter, r *http.Request) {
 		// Broadcast update to dashboard clients
 		s.broadcastDashboard(WSEvent{Type: "instance_updated", Content: instanceID})
 
-		_ = json.NewEncoder(w).Encode(map[string]string{"status": "stopped", "instance_id": instanceID})
+		inst.mu.RLock()
+		stopResponse := struct {
+			InstanceID  string           `json:"instance_id"`
+			Status      string           `json:"status"`
+			SubScans    []SubScanSummary `json:"sub_scans"`
+			WorkStarted bool             `json:"work_started"`
+		}{
+			InstanceID:  inst.ID,
+			Status:      inst.Status,
+			SubScans:    cloneSubScanSummaries(inst.SubScans),
+			WorkStarted: inst.WorkStarted,
+		}
+		inst.mu.RUnlock()
+		_ = json.NewEncoder(w).Encode(stopResponse)
 		return
 	}
 
@@ -2587,6 +2805,7 @@ type scanSession struct {
 	genReport          bool
 	resetState         bool
 	instanceID         string               // parent instance ID for multi-instance tracking
+	parentCtx          context.Context      // parent target context; canceled by exact stop
 	scanMode           string               // single, wildcard, dast — persisted so dashboard shows correct mode
 	sctx               *scanctx.ScanContext // per-session isolated state
 	companyName        string               // report branding: company name
@@ -2760,14 +2979,19 @@ func (sess *scanSession) cleanup() {
 	sess.server.mu.Unlock()
 }
 
-// randomSlug generates a short random hex string for scan IDs.
+var fallbackSlugCounter atomic.Uint64
+
+// randomSlug generates a 128-bit hex identifier. The fallback preserves the
+// same width and process-local uniqueness if the kernel CSPRNG is unavailable.
 func randomSlug() string {
-	b := make([]byte, 4)
+	b := make([]byte, 16)
 	if _, err := cryptorand.Read(b); err != nil {
-		log.Printf("Warning: crypto/rand failed, falling back to time-based slug: %v", err)
-		return fmt.Sprintf("%x", time.Now().UnixNano())
+		counter := fallbackSlugCounter.Add(1)
+		log.Printf("Warning: crypto/rand failed, falling back to hashed process identity: %v", err)
+		sum := sha256.Sum256([]byte(fmt.Sprintf("%d:%d:%d", os.Getpid(), time.Now().UnixNano(), counter)))
+		return hex.EncodeToString(sum[:16])
 	}
-	return fmt.Sprintf("%x", b)
+	return hex.EncodeToString(b)
 }
 
 // sanitizeTarget creates a safe directory name from a target URL/domain.
@@ -3248,10 +3472,6 @@ func (s *Server) handleGetScan(w http.ResponseWriter, r *http.Request) {
 	dir, rec := s.findScanByID(scanID)
 	_ = dir
 	if rec == nil {
-		dir, rec = s.findRecentScanForShortAlias(scanID)
-		_ = dir
-	}
-	if rec == nil {
 		http.Error(w, "scan not found", http.StatusNotFound)
 		return
 	}
@@ -3288,9 +3508,6 @@ func (s *Server) handleDeleteVuln(w http.ResponseWriter, r *http.Request) {
 	}
 
 	dir, rec := s.findScanByID(scanID)
-	if rec == nil {
-		dir, rec = s.findRecentScanForShortAlias(scanID)
-	}
 	if rec == nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1609,7 +1609,7 @@ func TestFindScanByID_ResolvesParentInstanceAlias(t *testing.T) {
 	}
 }
 
-func TestHandleGetScan_FallsBackFromRecentShortInstanceRoute(t *testing.T) {
+func TestHandleGetScan_RejectsUnknownShortInstanceRoute(t *testing.T) {
 	s := newTestServer(t, nil)
 	writeScanRecord(t, s.dataDir, "target-a/2026-05-01/scan-a", ScanRecord{
 		ID:        "scan-a",
@@ -1620,8 +1620,8 @@ func TestHandleGetScan_FallsBackFromRecentShortInstanceRoute(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	s.handleGetScan(rr, httptest.NewRequest(http.MethodGet, "/api/scans/deadbeef", nil))
-	if rr.Code != http.StatusOK || !strings.Contains(rr.Body.String(), `"id":"scan-a"`) {
-		t.Fatalf("recent short route did not resolve to latest scan: code=%d body=%s", rr.Code, rr.Body.String())
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("unknown short route resolved another scan: code=%d body=%s", rr.Code, rr.Body.String())
 	}
 }
 
@@ -2290,8 +2290,13 @@ func TestInstanceAction_GetAndStopSpecificInstance(t *testing.T) {
 		ID:        "inst-1",
 		Targets:   "https://a.test",
 		Status:    "running",
+		ScanMode:  "wildcard",
 		StartedAt: "2026-05-02T10:00:00Z",
-		cancel:    cancel,
+		SubScans: []SubScanSummary{
+			{ID: "child-1", Target: "a.example.test", Status: "running", StartedAt: "2026-05-02T10:01:00Z"},
+			{Target: "b.example.test", Status: "pending"},
+		},
+		cancel: cancel,
 	}
 
 	rr := httptest.NewRecorder()
@@ -2312,6 +2317,23 @@ func TestInstanceAction_GetAndStopSpecificInstance(t *testing.T) {
 	}
 	if got := s.instances["inst-1"].Status; got != "stopped" {
 		t.Fatalf("instance status = %q, want stopped", got)
+	}
+	var stopped struct {
+		InstanceID string           `json:"instance_id"`
+		Status     string           `json:"status"`
+		SubScans   []SubScanSummary `json:"sub_scans"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &stopped); err != nil {
+		t.Fatalf("decode stop response: %v", err)
+	}
+	if stopped.InstanceID != "inst-1" || stopped.Status != "stopped" {
+		t.Fatalf("stop response identity/status = %#v", stopped)
+	}
+	if len(stopped.SubScans) != 2 || stopped.SubScans[0].Status != "stopped" || stopped.SubScans[0].ID != "child-1" {
+		t.Fatalf("stop response did not freeze exact dispatched children: %#v", stopped.SubScans)
+	}
+	if stopped.SubScans[1].Status != "stopped" || stopped.SubScans[1].ID != "" || stopped.SubScans[1].StartedAt != "" {
+		t.Fatalf("never-dispatched child gained evidence: %#v", stopped.SubScans[1])
 	}
 }
 
@@ -3315,5 +3337,76 @@ func TestHandleRestart_DefaultSchedulesWhenBusy(t *testing.T) {
 	}
 	if got := rr.Body.String(); strings.Contains(got, `"idle":true`) {
 		t.Fatalf("scanner should report busy (idle=false), got: %s", got)
+	}
+}
+
+func TestDispatchIDValidationAndReservation(t *testing.T) {
+	s := newTestServer(t, nil)
+	if validDispatchID("short") || validDispatchID(strings.Repeat("a", 129)) {
+		t.Fatal("invalid dispatch id length was accepted")
+	}
+	if validDispatchID("123456789012345!") || !validDispatchID("550e8400-e29b-41d4-a716-446655440000") {
+		t.Fatal("dispatch id URL-safe validation mismatch")
+	}
+
+	id := "550e8400-e29b-41d4-a716-446655440000"
+	if status, ok := s.reserveDispatchID(id); !ok || status != "" {
+		t.Fatalf("first reservation = (%q, %v), want reserved", status, ok)
+	}
+	if status, ok := s.reserveDispatchID(id); ok || status != "pending" {
+		t.Fatalf("duplicate reservation = (%q, %v), want pending acknowledgement", status, ok)
+	}
+	s.releaseDispatchID(id)
+
+	s.instances[id] = &ScanInstance{ID: id, Status: "running"}
+	if status, ok := s.reserveDispatchID(id); ok || status != "running" {
+		t.Fatalf("live collision = (%q, %v), want running acknowledgement", status, ok)
+	}
+	delete(s.instances, id)
+
+	writeScanRecord(t, s.dataDir, "example/2026-08-12/persisted", ScanRecord{
+		ID: "persisted", InstanceID: id, Target: "https://example.test", Status: "finished",
+	})
+	if status, ok := s.reserveDispatchID(id); ok || status != "finished" {
+		t.Fatalf("persisted collision = (%q, %v), want finished acknowledgement", status, ok)
+	}
+}
+
+func TestRandomSlugHas128BitsAndNoImmediateCollisions(t *testing.T) {
+	seen := make(map[string]bool)
+	for i := 0; i < 256; i++ {
+		id := randomSlug()
+		if len(id) != 32 || !validDispatchID(id) {
+			t.Fatalf("random slug %q is not a 128-bit URL-safe id", id)
+		}
+		if seen[id] {
+			t.Fatalf("random slug collision: %q", id)
+		}
+		seen[id] = true
+	}
+}
+
+func TestBeginWildcardSubScanSerializesWithStop(t *testing.T) {
+	s := newTestServer(t, nil)
+	inst := &ScanInstance{
+		ID: "wildcard-instance", Status: "running", SubScanTotal: 2,
+		SubScans: []SubScanSummary{{Target: "a.example"}, {Target: "b.example"}},
+	}
+	s.instances[inst.ID] = inst
+	if !s.beginWildcardSubScan(inst.ID, 0, "a.example", "child-a") {
+		t.Fatal("running child dispatch was rejected")
+	}
+	if child := inst.SubScans[0]; child.ID != "child-a" || child.StartedAt == "" || child.Status != "running" {
+		t.Fatalf("positive dispatch evidence missing: %#v", child)
+	}
+	inst.mu.Lock()
+	inst.Status = "stopped"
+	normalizeTerminalWildcardInstanceLocked(inst)
+	inst.mu.Unlock()
+	if s.beginWildcardSubScan(inst.ID, 1, "b.example", "child-b") {
+		t.Fatal("child dispatch started after terminal stop")
+	}
+	if child := inst.SubScans[1]; child.ID != "" || child.StartedAt != "" {
+		t.Fatalf("stopped child gained dispatch evidence: %#v", child)
 	}
 }

--- a/internal/web/ws_hub.go
+++ b/internal/web/ws_hub.go
@@ -308,6 +308,34 @@ func (s *Server) broadcastToInstance(instanceID string, evt WSEvent) {
 	}
 }
 
+// notifyInstanceListeners delivers an event that is already present in the
+// coherent instance snapshot. Unlike broadcastToInstance it never buffers the
+// event again, preventing exact-stop retries from duplicating replay history.
+func (s *Server) notifyInstanceListeners(instanceID string, evt WSEvent) {
+	evt = withEventTimestamp(evt)
+	if evt.InstanceID == "" {
+		evt.InstanceID = instanceID
+	}
+	data, err := json.Marshal(evt)
+	if err != nil {
+		return
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for client := range s.clients {
+		if client.instanceID == "" || client.instanceID == instanceID {
+			select {
+			case client.send <- data:
+			default:
+				go func(c *wsClient) {
+					s.removeClient(c)
+					c.conn.Close()
+				}(client)
+			}
+		}
+	}
+}
+
 // broadcastDashboard sends an event only to dashboard clients (no instance subscription).
 func (s *Server) broadcastDashboard(evt WSEvent) {
 	evt = withEventTimestamp(evt)


### PR DESCRIPTION
## Summary
- bind every scanner run to an immutable caller-owned dispatch ID
- persist exact pending, running, stopping, and terminal snapshots atomically
- keep resumable queue state until terminal events and findings are durable
- reconstruct exact terminal state after restart without alias or recency guesses
- serialize admission, cancellation, wildcard dispatch, and multi-process resume ownership

## State synchronization impact
- completed/stopped scans no longer remain indefinitely pending or running after snapshot write failures
- GET snapshot retries a ready terminal snapshot that previously failed to persist
- exact stop responses include coherent final events, findings, wildcard state, and work evidence
- scanner restart recovery preserves queue-level and physical scan events

## Validation
- go test ./internal/web/... ./internal/agent/... -count=1
- focused exact-state tests with -race
- golangci-lint run ./... (0 issues)
- git diff --check origin/main...HEAD

Full browser integration was intentionally not run because the active scanner owns 127.0.0.1:38401.