### PR TITLE
feat: add opt-in loopback pprof debug server (XALGORIX_PPROF_ADDR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,7 @@ Some settings require a restart because they affect process startup or server bi
 | `XALGORIX_LLM_MAX_RETRIES`           | `5`              | Retry count for transient LLM failures.                |
 | `XALGORIX_MEMORY_COMPRESSOR_TIMEOUT` | `30`             | Timeout in seconds for context compression.            |
 | `XALGORIX_MAX_ITERATIONS`            | `0`              | Agent iteration cap. `0` means unlimited.              |
+| `XALGORIX_PPROF_ADDR`                | none             | Opt-in Go profiler. When set (e.g. `127.0.0.1:6060`), starts a standalone pprof server at `/debug/pprof/` on that address for CPU/heap diagnosis. Disabled by default. Exposes process internals — bind loopback and reach it via an SSH tunnel; never expose publicly. |
 | `GEMINI_API_KEY`                     | none             | Optional Gemini key for web-search enrichment.         |
 
 ### 🔒 Web and Security

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -261,6 +261,10 @@ func main() {
 		printServiceAccessInfo(cfg, port)
 		fmt.Println()
 
+		// Opt-in profiling: starts a loopback pprof listener only when
+		// XALGORIX_PPROF_ADDR is set (disabled by default). See pprof.go.
+		web.StartDebugServerFromEnv()
+
 		srv := web.NewServer(cfg, port)
 		if err := srv.Start(); err != nil {
 			fmt.Fprintf(os.Stderr, "Server error: %v\n", err)

--- a/internal/web/pprof.go
+++ b/internal/web/pprof.go
@@ -1,0 +1,72 @@
+package web
+
+import (
+	"log"
+	"net/http"
+	"net/http/pprof"
+	"os"
+	"strings"
+	"time"
+)
+
+// StartDebugServerFromEnv starts a standalone pprof/debug HTTP server when
+// XALGORIX_PPROF_ADDR is set (e.g. "127.0.0.1:6060"). It is DISABLED by
+// default — profiling is opt-in.
+//
+// SECURITY: pprof exposes process internals (heap contents, goroutine stacks,
+// command line). It is deliberately served on its OWN listener, separate from
+// the authenticated dashboard mux, and should only ever be bound to a trusted
+// interface. Prefer loopback (127.0.0.1) and reach it through an SSH tunnel:
+//
+//	ssh -L 6060:127.0.0.1:6060 user@host
+//	go tool pprof http://127.0.0.1:6060/debug/pprof/profile?seconds=30
+//	go tool pprof http://127.0.0.1:6060/debug/pprof/heap
+//
+// A non-loopback bind logs a loud warning but is still honored (operators
+// behind a firewall may want it); it never binds automatically.
+func StartDebugServerFromEnv() {
+	addr := strings.TrimSpace(os.Getenv("XALGORIX_PPROF_ADDR"))
+	if addr == "" {
+		return
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	if !isLoopbackAddr(addr) {
+		log.Printf("[pprof] WARNING: XALGORIX_PPROF_ADDR=%q is not loopback — pprof exposes process "+
+			"internals (heap/goroutines). Bind 127.0.0.1 and use an SSH tunnel instead.", addr)
+	}
+
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() {
+		log.Printf("[pprof] debug server listening on %s (/debug/pprof/)", addr)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Printf("[pprof] debug server stopped: %v", err)
+		}
+	}()
+}
+
+// isLoopbackAddr reports whether a "host:port" listen address targets the
+// loopback interface (or an unspecified host, which is treated as local).
+func isLoopbackAddr(addr string) bool {
+	host := addr
+	if i := strings.LastIndex(addr, ":"); i >= 0 {
+		host = addr[:i]
+	}
+	host = strings.Trim(host, "[]")
+	switch host {
+	case "", "127.0.0.1", "localhost", "::1":
+		return true
+	default:
+		return strings.HasPrefix(host, "127.")
+	}
+}

--- a/internal/web/pprof_test.go
+++ b/internal/web/pprof_test.go
@@ -1,0 +1,21 @@
+package web
+
+import "testing"
+
+func TestIsLoopbackAddr(t *testing.T) {
+	cases := map[string]bool{
+		"127.0.0.1:6060":             true,
+		"localhost:6060":             true,
+		"[::1]:6060":                 true,
+		":6060":                      true,
+		"127.5.0.1:6060":             true,
+		"0.0.0.0:6060":               false,
+		"192.168.1.10:6060":          false,
+		"scanner2.xalgorix.com:6060": false,
+	}
+	for addr, want := range cases {
+		if got := isLoopbackAddr(addr); got != want {
+			t.Errorf("isLoopbackAddr(%q) = %v, want %v", addr, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Adds a standalone Go profiler endpoint to diagnose CPU/heap on running instances (e.g. investigating why the `xalgorix` process itself consumes multiple cores under load).

## Behavior
- **Disabled by default.** Only starts when `XALGORIX_PPROF_ADDR` is set (e.g. `127.0.0.1:6060`).
- Runs on its **own listener**, separate from the authenticated dashboard mux — never wired into normal request routing.
- Serves `/debug/pprof/` (profile, heap, goroutine, allocs, trace, cmdline, symbol).
- Logs a loud warning if bound to a non-loopback address.

## Usage
```bash
# on the host (systemd env / launch env), set and restart:
XALGORIX_PPROF_ADDR=127.0.0.1:6060

# from your laptop:
ssh -L 6060:127.0.0.1:6060 user@host
go tool pprof http://127.0.0.1:6060/debug/pprof/profile\?seconds\=30   # CPU
go tool pprof http://127.0.0.1:6060/debug/pprof/heap                 # memory
```

## Security
pprof exposes process internals (heap contents, goroutine stacks, cmdline). It's intentionally opt-in, bound to whatever address you specify (intended: loopback + SSH tunnel), and kept off the public/authenticated surface. Documented in the README with the loopback warning.

## Tests
`go build`, `go vet`, `golangci-lint run` (0 issues), and a unit test for the loopback-address classifier all pass.
