### PR TITLE
chore: gitignore .env to keep secrets out of release commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,13 @@ build/
 xalgorix-data/
 *_assessment/
 
+# Secrets / local env (never commit — contains tokens like DOCKERHUB_TOKEN).
+# release.sh does `git add -A`, so an un-ignored .env would be swept into the
+# release commit and blocked by push protection (or worse, leaked).
+.env
+.env.*
+!.env.example
+
 # AI agent config (local only)
 .agent/
 CLAUDE.md


### PR DESCRIPTION
release.sh runs `git add -A` to build the release commit. An un-ignored `.env` in the repo root (holding `DOCKERHUB_TOKEN`) was swept into the v4.5.141 release commit and correctly rejected by GitHub push protection. This ignores `.env`/`.env.*` (keeping `.env.example`) so it can't recur. Required before cutting v4.5.141.