### PR TITLE
release: v4.5.141

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.140
+VERSION=4.5.141
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.140" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.141" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.140"
+var version = "4.5.141"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
### Changes

- dcfeba6 chore: gitignore .env to keep secrets out of release commits (#426)
- 69e3b4e feat: add opt-in loopback pprof debug server (XALGORIX_PPROF_ADDR) (#425)
- fd43c7b fix: point GitHub repo URLs at xalgorix/xalgorix (fix updater 404) (#424)
- 2afed3a release: v4.5.140 (#423)