### PR TITLE
fix: auto-resume scans interrupted by a graceful restart

### DIFF
--- a/internal/web/resume_recover_test.go
+++ b/internal/web/resume_recover_test.go
@@ -1,0 +1,34 @@
+package web
+
+import "testing"
+
+func TestIsInterruptedRecoverableRecord(t *testing.T) {
+	cases := []struct {
+		status     string
+		stopReason string
+		want       bool
+		note       string
+	}{
+		{"running", "", true, "crash/SIGKILL mid-run"},
+		{"pending", "", true, "queued when process died"},
+		{"stopped", "signal_terminated", true, "graceful SIGTERM restart"},
+		{"stopped", "signal_interrupt", true, "graceful SIGINT restart"},
+		{"stopped", "panic_recovered", true, "recovered panic"},
+		{"stopped", "server_restart_resuming", true, "already flagged for resume"},
+		{"stopped", "user_stopped", false, "explicit user stop must NOT resume"},
+		{"stopped", "", false, "plain stop with no resume reason"},
+		{"stopped", "server_restart_no_resume_state", false, "already terminalized, no resume"},
+		{"finished", "", false, "completed scans never resume"},
+		{"completed", "", false, "completed scans never resume"},
+		{"failed", "", false, "failed scans never resume"},
+		{"paused", "user_paused", false, "paused handled by its own path"},
+		{"RUNNING", "", true, "case-insensitive status"},
+		{"Stopped", "SIGNAL_terminated", true, "case-insensitive prefix"},
+	}
+	for _, c := range cases {
+		if got := isInterruptedRecoverableRecord(c.status, c.stopReason); got != c.want {
+			t.Errorf("isInterruptedRecoverableRecord(%q,%q)=%v want %v (%s)",
+				c.status, c.stopReason, got, c.want, c.note)
+		}
+	}
+}

--- a/internal/web/scan_query.go
+++ b/internal/web/scan_query.go
@@ -571,6 +571,38 @@ func isTerminalScanStatus(status string) bool {
 	}
 }
 
+// isInterruptedRecoverableRecord reports whether an on-disk scan record was
+// interrupted by something the operator did NOT intend as a final stop, and is
+// therefore a candidate for auto-resume on the next startup.
+//
+// Two cases qualify:
+//   - running/pending: the process died before the scan reached a terminal
+//     state (crash / SIGKILL). scan.json still says running/pending.
+//   - stopped with a signal_/panic_ reason: a graceful SIGTERM/SIGINT (or a
+//     recovered panic) persisted the scan as "stopped" but PRESERVED its
+//     queue_state on purpose (shouldPreserveQueueStateOnExit). Without this
+//     case those scans stayed "stopped" forever and only a fresh "Start" was
+//     offered — the bug this closes.
+//
+// A user-initiated stop is deliberately NOT recoverable: handleStop clears the
+// queue_state, so even when such a record reaches this function the downstream
+// resumability check (valid queue_state ownership) fails and it stays stopped.
+// Gating resume on queue_state ownership — not on this predicate alone — is
+// what keeps user-stopped/finished scans from being revived.
+func isInterruptedRecoverableRecord(status, stopReason string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "running", "pending":
+		return true
+	case "stopped":
+		reason := strings.ToLower(strings.TrimSpace(stopReason))
+		return strings.HasPrefix(reason, "signal_") ||
+			reason == "panic_recovered" ||
+			reason == "server_restart_resuming"
+	default:
+		return false
+	}
+}
+
 func isUnresolvedSubScanStatus(status string) bool {
 	switch strings.ToLower(strings.TrimSpace(status)) {
 	case "", "pending", "running":
@@ -973,14 +1005,18 @@ func (s *Server) rebuildInstancesFromDisk() {
 	for i := range entries {
 		entry := &entries[i]
 		_, resumable := instanceIdentity(entry)
-		if entry.rec.Status != "running" && entry.rec.Status != "pending" {
+		if !isInterruptedRecoverableRecord(entry.rec.Status, entry.rec.StopReason) {
 			continue
 		}
 		if resumable {
 			entry.rec.Status = "pending"
 			entry.rec.StopReason = "server_restart_resuming"
 			entry.rec.FinishedAt = ""
-		} else {
+		} else if entry.rec.Status != "stopped" {
+			// Only terminalize records that were mid-flight (running/pending)
+			// and have no resume state. A signal-stopped record with no valid
+			// queue_state is already correctly "stopped"; leave its reason
+			// intact rather than rewriting it every boot.
 			entry.rec.Status = "stopped"
 			entry.rec.StopReason = "server_restart_no_resume_state"
 			entry.rec.FinishedAt = time.Now().Format(time.RFC3339)


### PR DESCRIPTION
## Problem
Restarting the server (including a graceful `systemctl restart`) leaves in-progress scans **STOPPED**, and the only UI option is a fresh **Start** that re-runs from scratch — losing all findings/progress. This is despite the shutdown path explicitly promising "Interrupted scans will auto-resume."

## Root cause
Graceful shutdown (SIGTERM/SIGINT) persists in-flight scans as `stopped` + `signal_<sig>` and **preserves** their `queue_state` on purpose (`shouldPreserveQueueStateOnExit`). But `rebuildInstancesFromDisk` only reconciled records whose status was `running`/`pending`, so `signal_`-stopped records were skipped on boot — never flagged for resume, never picked up by the existing queue-state auto-resume goroutine.

## Fix
- Add `isInterruptedRecoverableRecord(status, stopReason)`: `running`/`pending`, or `stopped` with a `signal_` / `panic_recovered` / `server_restart_resuming` reason.
- `rebuildInstancesFromDisk` now considers those records for resume (marking them `pending` + `server_restart_resuming` when a valid `queue_state` owns them, so the existing boot auto-resume re-dispatches with `IsResume=true`).

## Safety (why this can't revive user-stopped/finished scans)
Resume stays **gated on valid `queue_state` ownership**, not on this predicate alone. A **user stop clears `queue_state`**, so such records fail the ownership check and remain stopped. `finished`/`completed`/`failed` and plain `stopped` (no signal reason) are excluded outright. A signal-stopped record with no valid queue_state keeps its original reason instead of being rewritten each boot.

## Tests
Unit test `TestIsInterruptedRecoverableRecord` covers the recoverable/non-recoverable matrix (signal/panic/pending/running resume; user-stopped/finished/failed/plain-stopped do not). `go build`, `go vet`, `golangci-lint` (0 issues), and the full `internal/web` suite pass.

## Verification note
I validated the reconciliation decision logic and the full package build/tests, but the end-to-end live flow (restart a box mid-scan and watch it resume) should be smoke-tested on a real deployment, since it depends on runtime `queue_state` validity/timing that unit tests don't exercise. If a case still doesn't resume after this, the next suspect is `queue_state` `Active`/timing on shutdown.
