### PR TITLE
feat: configurable Gemini safety threshold (XALGORIX_GEMINI_SAFETY) for authorized security testing

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,22 @@ type Config struct {
 	// budget so the full call fits. XALGORIX_MAX_OUTPUT_TOKENS, default 8192.
 	MaxOutputTokens int
 
+	// GeminiSafetyThreshold sets the HarmBlockThreshold applied to every
+	// adjustable safety category (harassment, hate speech, sexually explicit,
+	// dangerous content) on the NATIVE Gemini API path
+	// (generativelanguage.googleapis.com). Xalgorix is an authorized
+	// security-testing tool: Gemini's default filter classifies legitimate
+	// exploit payloads and offensive-security methodology as
+	// HARM_CATEGORY_DANGEROUS_CONTENT and blocks the response, which surfaces
+	// as an empty candidate (finishReason SAFETY) and a failed agent turn.
+	// XALGORIX_GEMINI_SAFETY. Accepted values (case-insensitive): BLOCK_NONE
+	// (default), OFF, BLOCK_ONLY_HIGH, BLOCK_MEDIUM_AND_ABOVE,
+	// BLOCK_LOW_AND_ABOVE, or DEFAULT/"" to send no safetySettings and use
+	// Google's server-side defaults. This ONLY affects Gemini content
+	// filtering — it does not touch scope enforcement, target authorization,
+	// the destructive-command guard, logging, or audit trails.
+	GeminiSafetyThreshold string
+
 	// ContextCompactTokens is an OPTIONAL absolute override for the compaction
 	// trigger. When > 0, the agent auto-compacts older turns into a structured
 	// digest (+ saved notes) once the running message history is estimated to
@@ -344,6 +360,11 @@ func load() *Config {
 		LLMContextWindow:     envOrInt("XALGORIX_LLM_CONTEXT_WINDOW", 128000),
 		ContextCompactRatio:  envOrFloat("XALGORIX_CONTEXT_COMPACT_RATIO", 0.75),
 		MemCompTimeout:       envOrInt("XALGORIX_MEMORY_COMPRESSOR_TIMEOUT", 30),
+
+		// Gemini content-filter posture (native Gemini API path only). Default
+		// BLOCK_NONE so authorized security-testing output is not refused;
+		// DEFAULT / "" restores Google's server-side defaults.
+		GeminiSafetyThreshold: envOr("XALGORIX_GEMINI_SAFETY", "BLOCK_NONE"),
 
 		// Runtime
 		RuntimeBackend:        "native", // Always native in Go version

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -199,21 +199,45 @@ type geminiGenerationConfig struct {
 	Temperature     *float64 `json:"temperature,omitempty"`
 }
 
+// geminiSafetySetting is one entry of Gemini's "safetySettings" array: an
+// adjustable harm category paired with the HarmBlockThreshold to apply. Xalgorix
+// is an authorized security-testing tool, so by default it sends BLOCK_NONE for
+// every category to stop Gemini's content filter from refusing legitimate
+// exploit payloads / offensive-security methodology (classified under
+// HARM_CATEGORY_DANGEROUS_CONTENT). Operator-configurable via
+// XALGORIX_GEMINI_SAFETY — see config.Config.GeminiSafetyThreshold.
+type geminiSafetySetting struct {
+	Category  string `json:"category"`
+	Threshold string `json:"threshold"`
+}
+
 type geminiRequest struct {
 	Contents          []geminiContent         `json:"contents,omitempty"`
 	SystemInstruction *geminiContent          `json:"system_instruction,omitempty"`
 	GenerationConfig  *geminiGenerationConfig `json:"generationConfig,omitempty"`
+	SafetySettings    []geminiSafetySetting   `json:"safetySettings,omitempty"`
 }
 
 type geminiCandidate struct {
 	Content struct {
 		Parts []geminiPart `json:"parts"`
 	} `json:"content"`
+	// FinishReason is captured so a safety block (finishReason "SAFETY") is
+	// diagnosable instead of surfacing as an opaque "no content" error.
+	FinishReason string `json:"finishReason,omitempty"`
+}
+
+// geminiPromptFeedback carries prompt-level safety verdicts. BlockReason is
+// non-empty (e.g. "SAFETY", "PROHIBITED_CONTENT") when Gemini refused the whole
+// prompt before generating any candidate.
+type geminiPromptFeedback struct {
+	BlockReason string `json:"blockReason,omitempty"`
 }
 
 type geminiResponse struct {
-	Candidates    []geminiCandidate    `json:"candidates"`
-	UsageMetadata *geminiUsageMetadata `json:"usageMetadata,omitempty"`
+	Candidates     []geminiCandidate     `json:"candidates"`
+	UsageMetadata  *geminiUsageMetadata  `json:"usageMetadata,omitempty"`
+	PromptFeedback *geminiPromptFeedback `json:"promptFeedback,omitempty"`
 }
 
 // geminiUsageMetadata carries token counts returned by the Gemini
@@ -641,6 +665,94 @@ func (c *Client) maxOutputTokens() int {
 	return n
 }
 
+// geminiHarmCategories are the adjustable Gemini safety categories Xalgorix sets
+// a threshold on. All four get the same operator-configured threshold so an
+// authorized assessment is not blocked mid-scan when the model reasons about
+// exploit payloads or offensive-security methodology (Gemini files these under
+// HARM_CATEGORY_DANGEROUS_CONTENT). HARM_CATEGORY_CIVIC_INTEGRITY is
+// intentionally omitted — it is unrelated to security testing.
+var geminiHarmCategories = []string{
+	"HARM_CATEGORY_HARASSMENT",
+	"HARM_CATEGORY_HATE_SPEECH",
+	"HARM_CATEGORY_SEXUALLY_EXPLICIT",
+	"HARM_CATEGORY_DANGEROUS_CONTENT",
+}
+
+// unknownGeminiSafetyOnce guards a single warning line for an unrecognized
+// XALGORIX_GEMINI_SAFETY value so a typo produces one breadcrumb, not log spam.
+var unknownGeminiSafetyOnce sync.Once
+
+// normalizeGeminiSafetyThreshold maps the operator-facing XALGORIX_GEMINI_SAFETY
+// value to a canonical Gemini HarmBlockThreshold. It returns ("", false) when no
+// safetySettings should be sent — empty / "default" / "unspecified" — so Gemini
+// applies its own server-side defaults (preserving the pre-change behavior for
+// operators who explicitly opt back into it). Unknown values fall back to
+// BLOCK_NONE (the tool's default posture for authorized security testing) with a
+// one-time warning rather than sending an invalid value that Gemini would 400.
+func normalizeGeminiSafetyThreshold(raw string) (string, bool) {
+	switch strings.ToUpper(strings.TrimSpace(raw)) {
+	case "", "DEFAULT", "UNSPECIFIED", "HARM_BLOCK_THRESHOLD_UNSPECIFIED":
+		return "", false
+	case "OFF":
+		return "OFF", true
+	case "BLOCK_NONE", "NONE":
+		return "BLOCK_NONE", true
+	case "BLOCK_ONLY_HIGH", "ONLY_HIGH":
+		return "BLOCK_ONLY_HIGH", true
+	case "BLOCK_MEDIUM_AND_ABOVE", "MEDIUM":
+		return "BLOCK_MEDIUM_AND_ABOVE", true
+	case "BLOCK_LOW_AND_ABOVE", "LOW":
+		return "BLOCK_LOW_AND_ABOVE", true
+	default:
+		unknownGeminiSafetyOnce.Do(func() {
+			log.Printf("[llm] unknown XALGORIX_GEMINI_SAFETY=%q; using BLOCK_NONE (authorized-security-testing default)", raw)
+		})
+		return "BLOCK_NONE", true
+	}
+}
+
+// geminiSafetySettings builds the per-request safetySettings array from the
+// operator's configured threshold. Returns nil (the field is omitted, so Gemini
+// uses its server-side defaults) when the operator opted into DEFAULT/"".
+func (c *Client) geminiSafetySettings() []geminiSafetySetting {
+	raw := ""
+	if c.cfg != nil {
+		raw = c.cfg.GeminiSafetyThreshold
+	}
+	threshold, ok := normalizeGeminiSafetyThreshold(raw)
+	if !ok {
+		return nil
+	}
+	settings := make([]geminiSafetySetting, 0, len(geminiHarmCategories))
+	for _, cat := range geminiHarmCategories {
+		settings = append(settings, geminiSafetySetting{Category: cat, Threshold: threshold})
+	}
+	return settings
+}
+
+// geminiBlockDetail returns a human-readable suffix explaining WHY a Gemini
+// response carried no usable content, so a safety block is diagnosable instead
+// of surfacing as an opaque "no content" error. Empty when no signal is present.
+func geminiBlockDetail(resp geminiResponse) string {
+	var finishReason, blockReason string
+	if len(resp.Candidates) > 0 {
+		finishReason = resp.Candidates[0].FinishReason
+	}
+	if resp.PromptFeedback != nil {
+		blockReason = resp.PromptFeedback.BlockReason
+	}
+	if finishReason == "" && blockReason == "" {
+		return ""
+	}
+	detail := fmt.Sprintf(" (finishReason=%q promptFeedback.blockReason=%q", finishReason, blockReason)
+	if strings.EqualFold(finishReason, "SAFETY") ||
+		strings.EqualFold(blockReason, "SAFETY") ||
+		strings.EqualFold(blockReason, "PROHIBITED_CONTENT") {
+		detail += "; Gemini's safety filter blocked this response — set XALGORIX_GEMINI_SAFETY=BLOCK_NONE (or OFF) to allow authorized security-testing content"
+	}
+	return detail + ")"
+}
+
 // usesMaxCompletionTokens reports whether an OpenAI model requires the
 // `max_completion_tokens` parameter and rejects the legacy `max_tokens` with a
 // 400 ("Unsupported parameter: 'max_tokens' is not supported with this model.
@@ -838,6 +950,7 @@ func (c *Client) ChatStream(messages []Message) <-chan StreamChunk {
 				MaxOutputTokens: c.maxOutputTokens(),
 				Temperature:     c.effectiveTemperature(),
 			}
+			gemReq.SafetySettings = c.geminiSafetySettings()
 			body, _ = json.Marshal(gemReq)
 		} else if isAnthropic {
 			var systemPrompt string
@@ -1075,6 +1188,7 @@ func (c *Client) doChat(messages []Message) (out string, err error) {
 			MaxOutputTokens: c.maxOutputTokens(),
 			Temperature:     c.effectiveTemperature(),
 		}
+		gemReq.SafetySettings = c.geminiSafetySettings()
 		body, err = json.Marshal(gemReq)
 		if err != nil {
 			return "", fmt.Errorf("failed to marshal Gemini request: %w", err)
@@ -1139,7 +1253,7 @@ func (c *Client) doChat(messages []Message) (out string, err error) {
 			return "", fmt.Errorf("failed to parse Gemini response: %w", err)
 		}
 		if len(gemResp.Candidates) == 0 || len(gemResp.Candidates[0].Content.Parts) == 0 {
-			return "", fmt.Errorf("no content in Gemini response")
+			return "", fmt.Errorf("no content in Gemini response%s", geminiBlockDetail(gemResp))
 		}
 		if gemResp.UsageMetadata != nil {
 			c.mu.Lock()

--- a/internal/llm/gemini_safety_test.go
+++ b/internal/llm/gemini_safety_test.go
@@ -1,0 +1,151 @@
+package llm
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/config"
+)
+
+// newGeminiCapturingServer returns an httptest server that records the request
+// body and replies with a minimal successful Gemini response so Chat returns on
+// the first attempt (no retry/backoff).
+func newGeminiCapturingServer(t *testing.T, gotBody *[]byte) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"ok"}]}}]}`))
+	}))
+}
+
+// TestGeminiRequestSendsSafetySettings proves that with the default
+// XALGORIX_GEMINI_SAFETY posture (BLOCK_NONE), a native Gemini request carries a
+// safetySettings array covering HARM_CATEGORY_DANGEROUS_CONTENT so Gemini's
+// content filter cannot refuse legitimate authorized-security-testing output.
+func TestGeminiRequestSendsSafetySettings(t *testing.T) {
+	var gotBody []byte
+	srv := newGeminiCapturingServer(t, &gotBody)
+	defer srv.Close()
+
+	cfg := &config.Config{
+		LLM:                   "gemini-2.5-flash",
+		APIBase:               srv.URL,
+		APIKey:                "test",
+		GeminiSafetyThreshold: "BLOCK_NONE",
+	}
+	c := NewClient(cfg)
+	c.provider = "google"
+
+	if _, err := c.Chat([]Message{{Role: "user", Content: "ping"}}); err != nil {
+		t.Fatalf("Chat returned error: %v", err)
+	}
+
+	var req geminiRequest
+	if err := json.Unmarshal(gotBody, &req); err != nil {
+		t.Fatalf("request body is not valid geminiRequest JSON: %v\nbody=%s", err, gotBody)
+	}
+	if len(req.SafetySettings) != len(geminiHarmCategories) {
+		t.Fatalf("safetySettings has %d entries; want %d; body=%s", len(req.SafetySettings), len(geminiHarmCategories), gotBody)
+	}
+	got := make(map[string]string, len(req.SafetySettings))
+	for _, s := range req.SafetySettings {
+		got[s.Category] = s.Threshold
+	}
+	if got["HARM_CATEGORY_DANGEROUS_CONTENT"] != "BLOCK_NONE" {
+		t.Errorf("dangerous-content threshold = %q; want BLOCK_NONE; body=%s", got["HARM_CATEGORY_DANGEROUS_CONTENT"], gotBody)
+	}
+	for _, cat := range geminiHarmCategories {
+		if got[cat] != "BLOCK_NONE" {
+			t.Errorf("category %s threshold = %q; want BLOCK_NONE", cat, got[cat])
+		}
+	}
+}
+
+// TestGeminiRequestOmitsSafetySettingsForDefault proves the opt-out path: when
+// the operator sets XALGORIX_GEMINI_SAFETY=default (or leaves it empty), Xalgorix
+// sends NO safetySettings and Gemini applies its own server-side defaults —
+// preserving the pre-change behavior byte-for-byte.
+func TestGeminiRequestOmitsSafetySettingsForDefault(t *testing.T) {
+	for _, raw := range []string{"", "default", "DEFAULT", "unspecified"} {
+		var gotBody []byte
+		srv := newGeminiCapturingServer(t, &gotBody)
+
+		cfg := &config.Config{
+			LLM:                   "gemini-2.5-flash",
+			APIBase:               srv.URL,
+			APIKey:                "test",
+			GeminiSafetyThreshold: raw,
+		}
+		c := NewClient(cfg)
+		c.provider = "google"
+
+		if _, err := c.Chat([]Message{{Role: "user", Content: "ping"}}); err != nil {
+			srv.Close()
+			t.Fatalf("Chat returned error for %q: %v", raw, err)
+		}
+		srv.Close()
+
+		var req geminiRequest
+		if err := json.Unmarshal(gotBody, &req); err != nil {
+			t.Fatalf("request body is not valid geminiRequest JSON: %v\nbody=%s", err, gotBody)
+		}
+		if len(req.SafetySettings) != 0 {
+			t.Errorf("XALGORIX_GEMINI_SAFETY=%q sent %d safetySettings; want 0 (server-side defaults)", raw, len(req.SafetySettings))
+		}
+	}
+}
+
+func TestNormalizeGeminiSafetyThreshold(t *testing.T) {
+	cases := []struct {
+		in       string
+		want     string
+		wantSend bool
+	}{
+		{"", "", false},
+		{"default", "", false},
+		{"UNSPECIFIED", "", false},
+		{"block_none", "BLOCK_NONE", true},
+		{"BLOCK_NONE", "BLOCK_NONE", true},
+		{"none", "BLOCK_NONE", true},
+		{"off", "OFF", true},
+		{"block_only_high", "BLOCK_ONLY_HIGH", true},
+		{"block_medium_and_above", "BLOCK_MEDIUM_AND_ABOVE", true},
+		{"block_low_and_above", "BLOCK_LOW_AND_ABOVE", true},
+		{"  BLOCK_NONE  ", "BLOCK_NONE", true},
+		{"totally-bogus", "BLOCK_NONE", true}, // unknown falls back to BLOCK_NONE
+	}
+	for _, tc := range cases {
+		gotThreshold, gotSend := normalizeGeminiSafetyThreshold(tc.in)
+		if gotThreshold != tc.want || gotSend != tc.wantSend {
+			t.Errorf("normalizeGeminiSafetyThreshold(%q) = (%q, %v); want (%q, %v)", tc.in, gotThreshold, gotSend, tc.want, tc.wantSend)
+		}
+	}
+}
+
+// TestGeminiBlockDetailSurfacesSafety proves that a safety-blocked Gemini
+// response (empty candidate, finishReason SAFETY) produces a diagnosable detail
+// string with an actionable remediation hint, instead of an opaque "no content"
+// error.
+func TestGeminiBlockDetailSurfacesSafety(t *testing.T) {
+	resp := geminiResponse{
+		Candidates:     []geminiCandidate{{FinishReason: "SAFETY"}},
+		PromptFeedback: &geminiPromptFeedback{BlockReason: "SAFETY"},
+	}
+	detail := geminiBlockDetail(resp)
+	if !strings.Contains(detail, "SAFETY") {
+		t.Errorf("detail %q does not mention the SAFETY finish/block reason", detail)
+	}
+	if !strings.Contains(detail, "XALGORIX_GEMINI_SAFETY") {
+		t.Errorf("detail %q does not surface the remediation env var", detail)
+	}
+
+	// A benign empty response (no finish/block reason) must not fabricate a hint.
+	if got := geminiBlockDetail(geminiResponse{}); got != "" {
+		t.Errorf("geminiBlockDetail(empty) = %q; want empty", got)
+	}
+}


### PR DESCRIPTION
Closes #430.

## Problem

On the native Gemini API path, Xalgorix sends **no `safetySettings`**, so Gemini applies its **default** thresholds and blocks `HARM_CATEGORY_DANGEROUS_CONTENT` (exploit payloads, offensive-security methodology) mid-scan on **authorized** engagements. The blocked candidate comes back empty (`finishReason: "SAFETY"`) and the agent turn fails with the opaque error `no content in Gemini response` — so operators can't even tell that **Gemini** (not Xalgorix) is the blocker.

Traced end-to-end, the refusal is **only** the Gemini filter: the system prompt already declares the engagement authorized, the tool layer first-classes `nmap/nuclei/httpx/ffuf/curl/sqlmap` (blocking only destructive commands), and `scopeguard` blocks only the operator's own host (it deliberately allows RFC1918 + `169.254.169.254`). Google documents adjusting these thresholds for exactly this use case: https://ai.google.dev/gemini-api/docs/safety-settings

## Change (3 files)

- **`internal/llm/client.go`**
  - Add a `safetySettings` field to `geminiRequest` and populate it in **both** `doChat` (scan loop) and `ChatStream` (chat) for the four adjustable categories: harassment, hate-speech, sexually-explicit, dangerous-content.
  - Capture `finishReason` (candidate) and `promptFeedback.blockReason` (response); the empty-content error now appends them plus a remediation hint, so a safety block is diagnosable instead of opaque.
- **`internal/config/config.go`**
  - New `GeminiSafetyThreshold` field driven by `XALGORIX_GEMINI_SAFETY`.
- **`internal/llm/gemini_safety_test.go`** — new tests.

### `XALGORIX_GEMINI_SAFETY` values (case-insensitive)

| Value | Effect |
|---|---|
| `BLOCK_NONE` | **Default.** Send `BLOCK_NONE` for all four categories (never block). |
| `OFF` | Send `OFF` (fully disable the filter) for all four. |
| `BLOCK_ONLY_HIGH` / `BLOCK_MEDIUM_AND_ABOVE` / `BLOCK_LOW_AND_ABOVE` | Send that threshold. |
| `DEFAULT` / empty | Send **no** `safetySettings` — keep Google's server-side defaults (pre-change behavior, byte-for-byte). |

Unknown values fall back to `BLOCK_NONE` with a one-time warning (never an invalid value that Gemini would 400).

## Safeguards preserved

This touches **only** Gemini content filtering. Scope enforcement (`scopeguard`), target authorization, the destructive-command guard, the `report_vulnerability` evidence gate, logging, and audit trails are all unchanged. The default is chosen because Xalgorix is a dedicated authorized-security-testing tool; operators who want Google's stock behavior set `XALGORIX_GEMINI_SAFETY=DEFAULT`.

## Test plan

- `gofmt -l` clean; `go vet ./internal/llm/... ./internal/config/...` OK.
- `go test ./internal/llm/... ./internal/config/...` passes (new tests: request carries `safetySettings` with `BLOCK_NONE` incl. dangerous-content; `DEFAULT`/empty omits the field; threshold normalizer table; block-detail surfaces `SAFETY` + the env-var hint). Verified on `golang:1.26-bookworm`.
- Deployed and verified on a live self-hosted instance: rebuilt binary contains the new code, dashboard healthy, authorized scans proceed with `safetySettings` on every Gemini request.

Reference: **https://ai.google.dev/gemini-api/docs/safety-settings**