### PR TITLE
Docker: always ship the latest nuclei engine + templates

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -92,5 +92,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # TOOLS_REFRESH busts the dedicated nuclei engine+template layer on
+          # every run, so each published image ships the latest nuclei + latest
+          # templates (matters if a build-cache backend is added here later).
           build-args: |
             VERSION=${{ steps.meta.outputs.version || github.ref_name }}
+            TOOLS_REFRESH=${{ github.run_id }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,10 +74,13 @@ RUN CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=${VERSION}" \
 # Latest versions of the Go tools the engine knows how to auto-install
 # (packageMap → goTools), into /go/bin. Best-effort per tool so one flaky
 # module never fails the image; anything missing stays runtime-installable.
+# NOTE: nuclei is deliberately NOT in this loop. It's the security-critical,
+# fast-moving scanner, so it's installed + template-synced in a dedicated,
+# cache-bustable layer in the runtime stage (see NUCLEI_VERSION/TOOLS_REFRESH
+# below) to guarantee a fresh engine + latest templates on every refreshed build.
 ENV GOBIN=/go/bin
 RUN set -eux; \
     for pkg in \
-      github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest \
       github.com/projectdiscovery/httpx/cmd/httpx@latest \
       github.com/projectdiscovery/dnsx/cmd/dnsx@latest \
       github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest \
@@ -213,8 +216,32 @@ RUN git clone --depth 1 https://github.com/Dionach/CMSmap /opt/CMSmap \
     && chmod +x /usr/local/bin/cmsmap \
     || echo "WARN: cmsmap prefetch failed (installable at runtime)"
 
-# Bake nuclei templates so first-run scans don't stall on a template fetch.
-RUN /root/go/bin/nuclei -update-templates >/dev/null 2>&1 || echo "WARN: nuclei template prefetch skipped"
+# ── nuclei engine + templates: always-latest, dedicated cache-bustable layer ──
+# nuclei is the security-critical, fast-moving scanner — a stale engine or stale
+# vuln templates directly means missed findings. Installing it HERE (instead of
+# the bulk go-tool loop in the builder) isolates it after every other expensive
+# apt/tool/pipx layer, so a cache-bust re-pulls the latest engine AND templates
+# cheaply, without re-running the layers above:
+#
+#   * default build ................ uses Docker's layer cache (fast, unchanged)
+#   * --build-arg TOOLS_REFRESH=<changing value> .. forces a fresh engine +
+#         templates. redeploy.sh and the release CI pass this on every build, so
+#         shipped images always carry the latest nuclei + latest templates.
+#   * --build-arg NUCLEI_VERSION=vX.Y.Z ........... pin the engine for repro builds.
+#
+# The runtime Go toolchain (copied above) builds it; the module/build caches are
+# pruned afterwards so the layer stays lean. Best-effort: a network blip leaves
+# nuclei runtime-installable, consistent with the rest of this image.
+ARG NUCLEI_VERSION=latest
+ARG TOOLS_REFRESH=
+# echo references TOOLS_REFRESH so a changing value invalidates this layer's
+# cache; go clean runs in the SAME RUN so the module/build caches are never
+# committed to the image.
+RUN echo "nuclei refresh token: ${TOOLS_REFRESH:-none}"; \
+    { GOBIN=/root/go/bin go install -v "github.com/projectdiscovery/nuclei/v3/cmd/nuclei@${NUCLEI_VERSION}" \
+      && /root/go/bin/nuclei -update-templates >/dev/null 2>&1 ; } \
+      || echo "WARN: nuclei engine/template refresh failed (installable at runtime)"; \
+    go clean -cache -modcache 2>/dev/null || true
 
 # Make `httpx` resolve to ProjectDiscovery's scanner. Kali/pip ship a Python
 # `httpx` CLI (the HTTP client) at /usr/bin/httpx that otherwise answers `httpx`
@@ -223,6 +250,14 @@ RUN /root/go/bin/nuclei -update-templates >/dev/null 2>&1 || echo "WARN: nuclei 
 # binary so nothing falls back to the Python client.
 RUN if [ -x /root/go/bin/httpx ]; then ln -sf /root/go/bin/httpx /usr/bin/httpx; \
     else echo "WARN: ProjectDiscovery httpx not baked into /root/go/bin"; fi
+
+# Same story for nuclei: Kali's kali-tools-vulnerability metapackage installs an
+# (often older) nuclei at /usr/bin/nuclei. /root/go/bin is already ahead of
+# /usr/bin on PATH, but pin the absolute path to the freshly-installed PD engine
+# so login shells and any hard-coded /usr/bin/nuclei can't fall back to the apt
+# build.
+RUN if [ -x /root/go/bin/nuclei ]; then ln -sf /root/go/bin/nuclei /usr/bin/nuclei; \
+    else echo "WARN: ProjectDiscovery nuclei not present in /root/go/bin"; fi
 
 ENV XALGORIX_BIND=0.0.0.0 \
     XALGORIX_BROWSER_PATH=/usr/bin/chromium \

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ The image is **batteries-included**: an extensive offensive-security toolset is 
 
 The container runs as root by design (the engine only enables runtime auto-install for uid 0, and apt/go/cargo installs need system write access). Treat it as a disposable, network-isolated scanning sandbox. It's published for `amd64`; use the one-line installer for arm64 hosts.
 
-On first run, if you don't set dashboard auth the container **generates a random admin password and prints it to the logs** (the image binds `0.0.0.0`, which the engine won't do without auth). Set `XALGORIX_USERNAME` + `XALGORIX_PASSWORD` (or `XALGORIX_PASSWORD_HASH`) to use your own. The binary never self-updates inside the container (`XALGORIX_NO_AUTO_UPDATE=1`) — pull a new image tag to upgrade.
+On first run, if you don't set dashboard auth the container **generates a random admin password and prints it to the logs** (the image binds `0.0.0.0`, which the engine won't do without auth). Set `XALGORIX_USERNAME` + `XALGORIX_PASSWORD` (or `XALGORIX_PASSWORD_HASH`) to use your own. The binary never self-updates inside the container (`XALGORIX_NO_AUTO_UPDATE=1`) — pull a new image tag to upgrade. The **nuclei** engine and its vuln templates are refreshed to the latest on every image build (the release CI and `redeploy.sh` force this); pass `--build-arg NUCLEI_VERSION=vX.Y.Z` to pin the engine, or `NUCLEI_REFRESH=0 ./redeploy.sh` to reuse Docker's cache.
 
 ### 📋 Requirements (build from source)
 

--- a/redeploy.sh
+++ b/redeploy.sh
@@ -35,6 +35,10 @@
 #           dashboard on loopback only (recommended behind a reverse proxy).
 #   VERSION=<from cmd/xalgorix/main.go, else `git describe`>   # stamps the
 #           dashboard version so a --build image reports vX.Y.Z, not "vdocker".
+#   NUCLEI_REFRESH=1     # on `build`, re-pull the LATEST nuclei engine + vuln
+#           templates (cache-bust). Set NUCLEI_REFRESH=0 to reuse Docker's cache.
+#   NUCLEI_VERSION=<tag> # pin a specific nuclei engine (e.g. v3.11.1) for repro
+#           builds; default `latest`. Only applied when NUCLEI_REFRESH != 0.
 #
 set -euo pipefail
 
@@ -144,7 +148,17 @@ case "$MODE" in
     VERSION="${VERSION:-$(sed -n 's/^var version = "\(.*\)"$/\1/p' "$BUILD_CONTEXT/cmd/xalgorix/main.go" 2>/dev/null | head -1)}"
     [ -z "$VERSION" ] && VERSION="$(git -C "$BUILD_CONTEXT" describe --tags 2>/dev/null | sed 's/^v//')"
     info "Building $IMAGE from $BUILD_CONTEXT (version=${VERSION:-docker}) ..."
-    docker build ${VERSION:+--build-arg VERSION="$VERSION"} -t "$IMAGE" "$BUILD_CONTEXT"
+    # Refresh nuclei (engine + templates) to the latest on every build unless
+    # NUCLEI_REFRESH=0. The Dockerfile gates nuclei behind TOOLS_REFRESH, so a
+    # changing value re-pulls the latest engine + vuln templates WITHOUT
+    # re-running the heavy apt/tool layers. Pin with NUCLEI_VERSION=vX.Y.Z.
+    REFRESH_ARG=""
+    if [ "${NUCLEI_REFRESH:-1}" != "0" ]; then
+      REFRESH_ARG="--build-arg TOOLS_REFRESH=$(date +%s)"
+      [ -n "${NUCLEI_VERSION:-}" ] && REFRESH_ARG="$REFRESH_ARG --build-arg NUCLEI_VERSION=$NUCLEI_VERSION"
+      info "nuclei: forcing latest engine + templates${NUCLEI_VERSION:+ (pinned $NUCLEI_VERSION)} — set NUCLEI_REFRESH=0 to reuse cache."
+    fi
+    docker build ${VERSION:+--build-arg VERSION="$VERSION"} $REFRESH_ARG -t "$IMAGE" "$BUILD_CONTEXT"
     ;;
   pull)
     info "Pulling $IMAGE ..."


### PR DESCRIPTION
## Problem

The nuclei binary and its vuln templates are pinned to whatever `@latest` resolved to when the image layer was first built, then **frozen by Docker's build cache**:

- `nuclei/v3/cmd/nuclei@latest` sits in the bulk `go install` loop. On a cached rebuild (unchanged tree, or a coincidental BuildKit cache hit) that layer is reused, so the engine can be **months old**.
- `nuclei -update-templates` bakes templates once; same cache story.
- The published `:latest` tag is only rebuilt on version tags (`docker.yml` triggers on `v*`), so between releases it's frozen too.
- Kali's `kali-tools-vulnerability` metapackage also installs an **older** `nuclei` at `/usr/bin/nuclei`. `/root/go/bin` is ahead on PATH so the engine normally wins, but — unlike `httpx`, which is force-symlinked — nuclei has no such guard, so a login shell or a hard-coded `/usr/bin/nuclei` silently falls back to the apt build.

Net effect: a scanner that looks current can quietly run a stale engine and stale templates, missing findings the current templates would catch.

Observed on a running deployment: the engine binary happened to be current (`v3.11.1`) only because it had been manually `go install`-ed inside the live container — a fix that's lost on the next rebuild.

## Changes

- **Dedicated, cache-bustable nuclei layer.** Move nuclei out of the bulk go-install loop into its own runtime-stage layer gated by `ARG TOOLS_REFRESH`, placed **after** every other expensive apt/tool/pipx layer. A changing `TOOLS_REFRESH` re-pulls the latest engine **and** re-syncs templates cheaply, without re-running the layers above. `ARG NUCLEI_VERSION=latest` lets you pin a specific engine for reproducible builds. Module/build caches are pruned in the **same** `RUN` so the image stays lean.
- **Symlink `/usr/bin/nuclei` → `/root/go/bin/nuclei`**, mirroring the existing `httpx` handling, so Kali's older apt nuclei can't shadow the ProjectDiscovery engine.
- **`redeploy.sh`** passes `TOOLS_REFRESH` on every `build` by default (`NUCLEI_REFRESH=0` to reuse the cache, `NUCLEI_VERSION=vX.Y.Z` to pin).
- **Release CI** (`docker.yml`) passes `TOOLS_REFRESH=${{ github.run_id }}` so every published image ships fresh nuclei + templates (and stays correct if a build-cache backend is added later).
- **README** documents the new knobs.

## Design notes

- This is a **build-time** refresh only — it does **not** introduce runtime self-updating, so it stays consistent with `XALGORIX_NO_AUTO_UPDATE=1` and the "pull/build a new image to upgrade" model.
- Default `docker build` behavior is unchanged (still cache-friendly); the refresh only kicks in when `TOOLS_REFRESH` is passed, which the two supported build paths (redeploy.sh, release CI) now do.
- Best-effort, consistent with the rest of the image: a network blip during the nuclei layer leaves it runtime-installable rather than failing the build.

## Test plan

- [ ] `docker build -t xalgorix .` (default) succeeds; `docker run --rm xalgorix nuclei -version` reports a current engine and `nuclei -templates-version` a current template set.
- [ ] `docker build --build-arg TOOLS_REFRESH=$(date +%s) -t xalgorix .` re-runs only the nuclei layer (not the apt/tool layers) and pulls the newest engine + templates.
- [ ] `docker build --build-arg NUCLEI_VERSION=v3.11.1 --build-arg TOOLS_REFRESH=$(date +%s) .` installs exactly that engine.
- [ ] `readlink -f $(command -v nuclei)` inside the image resolves to `/root/go/bin/nuclei`, and a login shell (`sh -lc 'nuclei -version'`) reports the same engine (no apt fallback).
- [ ] `NUCLEI_REFRESH=0 ./redeploy.sh` reuses the cache; a plain `./redeploy.sh` forces the refresh.
- [ ] Final image size is unchanged (module/build caches pruned in-layer).
