### PR TITLE
perf: stop re-parsing every scan.json (with events) on GET /api/scans/{id}

### DIFF
--- a/internal/web/scan_query.go
+++ b/internal/web/scan_query.go
@@ -253,10 +253,17 @@ func (s *Server) findScanByID(scanID string) (string, *ScanRecord) {
 		return "", nil
 	}
 
-	entries := s.findAllScans()
-	resolveUnique := func(topLevelOnly bool) (string, *ScanRecord, bool) {
+	// Locate the matching scan DIRECTORY using the cached, events-free
+	// summaries instead of re-walking the data dir and fully parsing every
+	// scan.json (including each scan's large event log) on every request.
+	// Only the single matched record is then loaded in full (with events).
+	// This keeps GET /api/scans/{id} at O(1) full parse instead of
+	// O(all scans on disk) — the hot-path blowup seen in CPU/heap profiles
+	// (findScanByID → findAllScans → json.Unmarshal dominating CPU and RSS).
+	entries := s.findAllScanSummaries()
+	resolveUniqueDir := func(topLevelOnly bool) (string, bool, bool) {
 		var matchedDir string
-		var matched *ScanRecord
+		found := false
 		for _, entry := range entries {
 			if topLevelOnly && entry.rec.ParentTarget != "" {
 				continue
@@ -264,21 +271,30 @@ func (s *Server) findScanByID(scanID string) (string, *ScanRecord) {
 			if entry.rec.ID != scanID && entry.rec.InstanceID != scanID && filepath.Base(entry.dir) != scanID {
 				continue
 			}
-			if matched != nil {
-				log.Printf("[scan] refusing ambiguous scan id %q: records %q and %q both match", scanID, matched.ID, entry.rec.ID)
-				return "", nil, true
+			if found {
+				log.Printf("[scan] refusing ambiguous scan id %q: multiple records match", scanID)
+				return "", false, true // ambiguous → resolved, no match
 			}
-			rec := entry.rec
 			matchedDir = entry.dir
-			matched = &rec
+			found = true
 		}
-		return matchedDir, matched, matched != nil
+		return matchedDir, found, false
 	}
-	if dir, rec, found := resolveUnique(true); found {
-		return dir, rec
+	loadFull := func(dir string) (string, *ScanRecord) {
+		if rec, ok := loadScanRecordFromDir(dir); ok {
+			return dir, rec
+		}
+		return "", nil
 	}
-	if dir, rec, found := resolveUnique(false); found {
-		return dir, rec
+	if dir, found, ambiguous := resolveUniqueDir(true); ambiguous {
+		return "", nil
+	} else if found {
+		return loadFull(dir)
+	}
+	if dir, found, ambiguous := resolveUniqueDir(false); ambiguous {
+		return "", nil
+	} else if found {
+		return loadFull(dir)
 	}
 
 	// Legacy flat path fallback (dataDir/scanID/scan.json).
@@ -714,7 +730,11 @@ func (s *Server) attachWildcardSubScans(rec *ScanRecord) {
 	if rec == nil || rec.ParentTarget != "" {
 		return
 	}
-	s.attachWildcardSubScansFrom(rec, s.findAllScans())
+	// Use the cached, events-free summaries: sub-scan attachment only reads
+	// child target/status/counts/vulns, never the event log. Calling the
+	// full findAllScans() here (per parent, on every GET) was a primary
+	// driver of the JSON-decode CPU and multi-GB transient allocations.
+	s.attachWildcardSubScansFrom(rec, s.findAllScanSummaries())
 }
 
 // attachWildcardSubScansFrom is the same as attachWildcardSubScans but reuses


### PR DESCRIPTION
## Diagnosis (from production pprof)
CPU + heap profiles of a busy prod instance (`XALGORIX_PPROF_ADDR`) showed the `xalgorix` process itself as the CPU/RSS consumer — not the scan tools:

- **CPU (30s ≈ 7 cores):** ~39% in `encoding/json.(*decodeState).object` + `checkValid`/`unquoteBytes`/`literalStore`, ~14% `os.readdir`/syscalls.
- **Heap (6.5 GB in-use):** ~98% under this chain:
  ```
  handleGetScan → findScanByID → findAllScans → json.Unmarshal
  ```

## Root cause
`findScanByID` (hit on every scan-detail poll) and `attachWildcardSubScans` call `findAllScans()`, which **walks the entire data dir and fully parses every `scan.json` — including each scan's large `events` array — on every request**, only to locate one scan by ID / attach child sub-scans. Cost scales with the number of historical scans on disk, so a long-lived instance re-parses gigabytes of JSON per request. This is the CPU spikes and the multi-GB RSS growth (transient `literalStore`/`growslice` allocations), and why a busy prod box pegs while an idle/low-scan box doesn't.

## Fix
Reuse the existing events-free, stat-cached walker `findAllScanSummaries()` on the hot paths:
- **`findScanByID`** locates the matching scan *directory* via cached summaries, then loads only that **one** record in full (with events). `O(all scans, full parse)` → `O(all scans, cached stat)` + `O(1)` parse.
- **`attachWildcardSubScans`** uses summaries (child attachment only reads target/status/counts/vulns, never the event log).

Ambiguity detection and the legacy flat-path fallback are preserved. `rebuildInstancesFromDisk` (startup, needs events) intentionally keeps the full walker.

## Expected impact
GET `/api/scans/{id}` and dashboard polling no longer re-parse the whole scan history per request. On the profiled box (many historical scans) this should drop the `xalgorix` process from multiple cores to near-idle between LLM turns, and eliminate the multi-GB transient allocations driving RSS.

## Tests
`go build`, `go vet`, `golangci-lint` (0 issues), full `internal/web` suite pass. After deploy, recommend re-capturing a CPU profile under load to confirm `findAllScans` is gone from the hot path.
