### PR TITLE
fix: let auto-resume proceed past the durable stopped exact-snapshot

### DIFF
--- a/internal/web/orchestrator.go
+++ b/internal/web/orchestrator.go
@@ -141,16 +141,35 @@ func (s *Server) runMultiScan(req ScanRequest, scanCfg *config.Config, instanceI
 		}
 	}
 	s.dispatchMu.Lock()
-	if durable, err := s.loadExactDispatchSnapshot(instanceID); err == nil &&
+	durable, durErr := s.loadExactDispatchSnapshot(instanceID)
+	if durErr == nil &&
 		(isTerminalScanStatus(durable.Status) || strings.EqualFold(durable.Status, "stopping")) {
+		// A durable terminal snapshot normally tombstones this id so a stale
+		// dispatch can't resurrect a stopped scan. BUT a graceful shutdown
+		// persists interrupted scans as "stopped" + "signal_..." while
+		// deliberately PRESERVING their queue_state for resume. Those must be
+		// allowed to auto-resume — otherwise the exact-snapshot tombstone
+		// silently blocks every restart resume and the scans sit at "pending"
+		// forever (they were dispatched but refused here).
+		//
+		// Only an auto-resume (req.IsResume, set exclusively by the boot
+		// queue-state resumer) of a RECOVERABLE interruption may pass. A
+		// user/terminal stop clears queue_state (so it's never auto-resumed)
+		// and its stop reason is not signal_/panic_/restart, so it stays
+		// refused on both counts.
+		if req.IsResume && isInterruptedRecoverableRecord(durable.Status, durable.StopReason) {
+			log.Printf("[scan] resume dispatch %q proceeding past durable %q/%q (recoverable interruption)",
+				instanceID, durable.Status, durable.StopReason)
+		} else {
+			delete(s.dispatchReservations, instanceID)
+			s.dispatchMu.Unlock()
+			log.Printf("[scan] refusing dispatch %q after durable exact stop/status %q", instanceID, durable.Status)
+			return
+		}
+	} else if durErr != nil && !errors.Is(durErr, errDispatchSnapshotNotFound) {
 		delete(s.dispatchReservations, instanceID)
 		s.dispatchMu.Unlock()
-		log.Printf("[scan] refusing dispatch %q after durable exact stop/status %q", instanceID, durable.Status)
-		return
-	} else if err != nil && !errors.Is(err, errDispatchSnapshotNotFound) {
-		delete(s.dispatchReservations, instanceID)
-		s.dispatchMu.Unlock()
-		log.Printf("[scan] refusing dispatch %q with unreadable durable state: %v", instanceID, err)
+		log.Printf("[scan] refusing dispatch %q with unreadable durable state: %v", instanceID, durErr)
 		return
 	}
 	s.instancesMu.Lock()


### PR DESCRIPTION
Follow-up to #428. On a production restart, interrupted scans got stuck at **`pending`** and never ran (11 pending, 0 running, 6 free slots, idle CPU).

## Root cause (from prod logs)
```
[AUTO-RESUME] Resuming 14 interrupted scan queue(s)
[scan] refusing dispatch "<id>" after durable exact stop/status "stopped"
```
The boot resumer dispatched all 14, but `runMultiScan` refused each one. Graceful shutdown writes **two** durable records per scan:
1. `queue_state` — preserved for resume (signal reason).
2. `.dispatches/<id>.json` exact snapshot — written as **`stopped`**.

On restart, `runMultiScan`'s tombstone guard sees the exact snapshot's terminal `stopped` and refuses — treating a *signal-interrupted* stop exactly like a *user* stop. #428 correctly marked these scans `pending`/resumable, but this older guard still blocked the actual dispatch, so the rebuilt placeholder sat at `pending` forever.

## Fix
Allow the dispatch past a durable terminal snapshot **only** when it's an auto-resume (`req.IsResume`, set solely by the boot queue-state resumer) of a recoverable interruption (`isInterruptedRecoverableRecord`: `signal_`/`panic_`/`server_restart_resuming`).

## Why user-stopped scans still can't be revived (two independent guards)
- A **user stop clears `queue_state`**, so the boot resumer never dispatches it (`req.IsResume` is never set for it).
- Even if it were, its stop reason isn't `signal_`/`panic_`/`restart`, so `isInterruptedRecoverableRecord` returns false and it stays refused.

Unreadable-snapshot handling is unchanged.

## Tests
`go build`, `go vet`, `golangci-lint` (0 issues), full `internal/web` suite pass. The pure predicate is covered by `TestIsInterruptedRecoverableRecord` (from #428). 

## Verification note
The end-to-end restart→resume flow depends on runtime state (durable snapshot + queue_state) that unit tests don't fully exercise, so please smoke-test on the box: restart mid-scan and confirm the pending scans promote to `running` within a few seconds (up to `MAX_INSTANCES`), instead of sticking at `pending`.
