### PR TITLE
perf(web): gzip-compress API responses

### DIFF
--- a/internal/web/compression.go
+++ b/internal/web/compression.go
@@ -1,0 +1,152 @@
+package web
+
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// gzipWriterPool recycles gzip.Writer instances so the compression middleware
+// does not allocate a fresh writer (and its ~64KB window) on every request.
+var gzipWriterPool = sync.Pool{
+	New: func() any { return gzip.NewWriter(io.Discard) },
+}
+
+// gzipMiddleware transparently compresses responses with gzip when the client
+// advertises support via Accept-Encoding. The dashboard's JSON payloads —
+// especially GET /api/scans/{id}, whose body embeds the full event log — are
+// highly compressible (typically ~8-10x), so this cuts transfer time for large
+// scans without any handler changes.
+//
+// The WebSocket endpoint (/ws) is never wrapped: it hijacks the raw connection
+// and must not have its ResponseWriter replaced. Responses are only compressed
+// when the Content-Type is text-like and the handler did not already set a
+// Content-Encoding.
+func gzipMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/ws" || !clientAcceptsGzip(r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		gw := &gzipResponseWriter{ResponseWriter: w}
+		defer gw.close()
+		next.ServeHTTP(gw, r)
+	})
+}
+
+func clientAcceptsGzip(r *http.Request) bool {
+	for _, part := range strings.Split(r.Header.Get("Accept-Encoding"), ",") {
+		if strings.EqualFold(strings.TrimSpace(strings.SplitN(part, ";", 2)[0]), "gzip") {
+			return true
+		}
+	}
+	return false
+}
+
+// gzipResponseWriter defers the compress/passthrough decision until the
+// response headers are known, so it can honor the handler's Content-Type and
+// avoid double-compressing already-encoded or binary payloads.
+type gzipResponseWriter struct {
+	http.ResponseWriter
+	gz          *gzip.Writer
+	wroteHeader bool
+	compress    bool
+}
+
+func (w *gzipResponseWriter) WriteHeader(status int) {
+	if w.wroteHeader {
+		return
+	}
+	w.wroteHeader = true
+
+	h := w.ResponseWriter.Header()
+	// Only compress a normal body: skip informational/no-content/not-modified
+	// responses, anything already encoded, and non-text content types.
+	if status >= 200 && status != http.StatusNoContent && status != http.StatusNotModified &&
+		h.Get("Content-Encoding") == "" && isCompressibleContentType(h.Get("Content-Type")) {
+		w.compress = true
+		// Length changes after compression; let net/http stream it chunked.
+		h.Del("Content-Length")
+		h.Set("Content-Encoding", "gzip")
+		addVaryAcceptEncoding(h)
+		gz := gzipWriterPool.Get().(*gzip.Writer)
+		gz.Reset(w.ResponseWriter)
+		w.gz = gz
+	}
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *gzipResponseWriter) Write(b []byte) (int, error) {
+	if !w.wroteHeader {
+		// Handlers that Write without an explicit WriteHeader: pin the
+		// Content-Type from the first chunk (mirroring net/http's own
+		// sniffing) so the compress decision is stable, then default to 200.
+		if w.ResponseWriter.Header().Get("Content-Type") == "" {
+			w.ResponseWriter.Header().Set("Content-Type", http.DetectContentType(b))
+		}
+		w.WriteHeader(http.StatusOK)
+	}
+	if w.compress {
+		return w.gz.Write(b)
+	}
+	return w.ResponseWriter.Write(b)
+}
+
+// Flush supports streaming handlers (Server-Sent-Events style progress). It
+// flushes the gzip buffer first so bytes actually reach the client.
+func (w *gzipResponseWriter) Flush() {
+	if w.compress && w.gz != nil {
+		_ = w.gz.Flush()
+	}
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (w *gzipResponseWriter) close() {
+	if w.gz != nil {
+		_ = w.gz.Close()
+		gzipWriterPool.Put(w.gz)
+		w.gz = nil
+	}
+}
+
+func addVaryAcceptEncoding(h http.Header) {
+	for _, v := range h.Values("Vary") {
+		if strings.EqualFold(strings.TrimSpace(v), "Accept-Encoding") {
+			return
+		}
+	}
+	h.Add("Vary", "Accept-Encoding")
+}
+
+// isCompressibleContentType reports whether a Content-Type is worth gzipping.
+// Text formats compress well; images/video/archives/fonts are already
+// compressed and would only waste CPU (and can grow slightly).
+func isCompressibleContentType(ct string) bool {
+	if ct == "" {
+		return false
+	}
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = ct[:i]
+	}
+	ct = strings.TrimSpace(strings.ToLower(ct))
+	if strings.HasPrefix(ct, "text/") {
+		return true
+	}
+	switch ct {
+	case "application/json",
+		"application/javascript",
+		"application/xml",
+		"application/rss+xml",
+		"application/atom+xml",
+		"application/manifest+json",
+		"application/wasm",
+		"image/svg+xml":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/web/compression_test.go
+++ b/internal/web/compression_test.go
@@ -1,0 +1,127 @@
+package web
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func jsonHandler(body string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	})
+}
+
+func TestGzipMiddleware_CompressesJSONWhenAccepted(t *testing.T) {
+	body := `{"events":[` + strings.Repeat(`{"k":"vvvvvvvvvv"},`, 200) + `null]}`
+	h := gzipMiddleware(jsonHandler(body))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/scans/x", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if got := rr.Header().Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("Content-Encoding = %q, want gzip", got)
+	}
+	if !strings.Contains(rr.Header().Get("Vary"), "Accept-Encoding") {
+		t.Fatalf("Vary header missing Accept-Encoding: %q", rr.Header().Get("Vary"))
+	}
+	if rr.Header().Get("Content-Length") != "" {
+		t.Fatalf("Content-Length must be dropped for compressed responses, got %q", rr.Header().Get("Content-Length"))
+	}
+
+	zr, err := gzip.NewReader(bytes.NewReader(rr.Body.Bytes()))
+	if err != nil {
+		t.Fatalf("gzip.NewReader: %v", err)
+	}
+	got, err := io.ReadAll(zr)
+	if err != nil {
+		t.Fatalf("read gzip body: %v", err)
+	}
+	if string(got) != body {
+		t.Fatalf("decompressed body mismatch")
+	}
+	if rr.Body.Len() >= len(body) {
+		t.Fatalf("compressed size %d not smaller than original %d", rr.Body.Len(), len(body))
+	}
+}
+
+func TestGzipMiddleware_SkipsWhenClientDoesNotAccept(t *testing.T) {
+	body := `{"ok":true}`
+	h := gzipMiddleware(jsonHandler(body))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/scans/x", nil)
+	// no Accept-Encoding header
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Header().Get("Content-Encoding") != "" {
+		t.Fatalf("must not set Content-Encoding without client support")
+	}
+	if rr.Body.String() != body {
+		t.Fatalf("body = %q, want %q", rr.Body.String(), body)
+	}
+}
+
+func TestGzipMiddleware_SkipsWebSocketPath(t *testing.T) {
+	called := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		// The real /ws handler hijacks the connection; assert we handed it the
+		// raw ResponseWriter, not our wrapper (which is not a Hijacker).
+		if _, ok := w.(*gzipResponseWriter); ok {
+			t.Fatalf("/ws must not be wrapped by gzipResponseWriter")
+		}
+	})
+	h := gzipMiddleware(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	h.ServeHTTP(httptest.NewRecorder(), req)
+	if !called {
+		t.Fatal("inner handler was not invoked for /ws")
+	}
+}
+
+func TestGzipMiddleware_SkipsNonCompressibleContentType(t *testing.T) {
+	png := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(bytes.Repeat([]byte{0x89, 0x50, 0x4e, 0x47}, 100))
+	})
+	h := gzipMiddleware(png)
+
+	req := httptest.NewRequest(http.MethodGet, "/logo.png", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Header().Get("Content-Encoding") == "gzip" {
+		t.Fatal("image/png must not be gzip-compressed")
+	}
+}
+
+func TestIsCompressibleContentType(t *testing.T) {
+	cases := map[string]bool{
+		"application/json":                true,
+		"application/json; charset=utf-8": true,
+		"text/html; charset=utf-8":        true,
+		"text/plain":                      true,
+		"image/svg+xml":                   true,
+		"application/javascript":          true,
+		"image/png":                       false,
+		"application/zip":                 false,
+		"font/woff2":                      false,
+		"":                                false,
+	}
+	for ct, want := range cases {
+		if got := isCompressibleContentType(ct); got != want {
+			t.Errorf("isCompressibleContentType(%q) = %v, want %v", ct, got, want)
+		}
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1257,10 +1257,12 @@ func (s *Server) Start() error {
 	httpServer := &http.Server{
 		Addr: addr,
 		// safe.HTTPMiddleware MUST be the outermost wrapper so it catches
-		// panics from every layer below it (auth, rate-limit, mux,
+		// panics from every layer below it (auth, rate-limit, gzip, mux,
 		// individual handlers). On panic it increments PanicsRecovered,
 		// emits a structured log line with stack trace, and returns 500.
-		Handler: safe.HTTPMiddleware(authMw(rlMiddleware(mux))),
+		// gzip sits innermost (closest to the mux) so it compresses handler
+		// output after auth + rate limiting have run; it skips /ws.
+		Handler: safe.HTTPMiddleware(authMw(rlMiddleware(gzipMiddleware(mux)))),
 		// Bound the time spent reading request headers so a slow client
 		// cannot hold a connection open indefinitely (Slowloris). The
 		// dashboard serves interactive traffic, so keep this generous.


### PR DESCRIPTION
## Problem

The scan detail page is slow to load for large scans. `GET /api/scans/{id}` (`handleGetScan`) marshals the full `ScanRecord`, whose body embeds the entire event log (`Events []WSEvent` — every LLM message and raw tool stdout). For high-token / wildcard scans that's a multi-MB JSON payload, and it was being sent **uncompressed** (no compression middleware existed on the API).

## Change

Add a gzip middleware wired innermost in the chain (`safe → auth → rate-limit → **gzip** → mux`), so it compresses handler output after auth and rate limiting run:

- Compresses only when the client sends `Accept-Encoding: gzip`.
- Compresses only text-like content types (JSON, HTML, JS, SVG, XML, wasm…); skips already-encoded/binary payloads (images, archives, fonts) to avoid wasting CPU.
- Never wraps `/ws` — the WebSocket handler hijacks the raw connection.
- Drops `Content-Length` and adds `Vary: Accept-Encoding` on compressed responses; supports `Flush()` for streaming handlers.
- Pools `gzip.Writer` instances to avoid per-request allocation.

JSON like the scan event log typically compresses ~8-10x, so this substantially cuts transfer time for the scan detail (and list) endpoints with no handler changes.

## Tests

New `compression_test.go`:
- Compresses JSON when accepted; body round-trips; `Content-Length` dropped; `Vary` set; smaller than original.
- Skips when client doesn't advertise gzip.
- Skips `/ws` (asserts the handler receives the raw, non-wrapped writer).
- Skips `image/png`.
- Content-type table test.

`go build ./...` and the full `internal/web` package test suite pass.

## Follow-up

The structural fix (paginate/lazy-load the event log out of the detail response) is still worth doing; this is the low-risk, high-ratio quick win.