### PR TITLE
perf(web): stream past events in the scan summary walk

### DIFF
--- a/internal/web/scan_detail_load.go
+++ b/internal/web/scan_detail_load.go
@@ -61,19 +61,41 @@ func walkScanJSON(path string, onEvent func(idx int, raw json.RawMessage)) (map[
 				return nil, 0, err
 			}
 			if d, ok := t.(json.Delim); ok && d == '[' {
-				for dec.More() {
-					var raw json.RawMessage
-					if err := dec.Decode(&raw); err != nil {
+				if onEvent == nil {
+					// Summary mode: skip the events array by token depth without
+					// materializing any element. Critically this avoids copying a
+					// multi-hundred-MB events blob into memory (the old
+					// ReadFile + scanRecordLite path did exactly that on every
+					// cache-cold walk, thrashing GC near GOMEMLIMIT). Element
+					// strings are tokenized transiently and GC'd one at a time.
+					depth := 1
+					for depth > 0 {
+						tok, err := dec.Token()
+						if err != nil {
+							return nil, 0, err
+						}
+						if delim, ok := tok.(json.Delim); ok {
+							switch delim {
+							case '[', '{':
+								depth++
+							case ']', '}':
+								depth--
+							}
+						}
+					}
+				} else {
+					for dec.More() {
+						var raw json.RawMessage
+						if err := dec.Decode(&raw); err != nil {
+							return nil, 0, err
+						}
+						onEvent(total, raw)
+						total++
+					}
+					// Closing ']'.
+					if _, err := dec.Token(); err != nil {
 						return nil, 0, err
 					}
-					if onEvent != nil {
-						onEvent(total, raw)
-					}
-					total++
-				}
-				// Closing ']'.
-				if _, err := dec.Token(); err != nil {
-					return nil, 0, err
 				}
 			}
 			// else: null (or unexpected) → no events.
@@ -110,6 +132,24 @@ func decodeEvents(raws []json.RawMessage) []WSEvent {
 		}
 	}
 	return events
+}
+
+// readScanSummary parses a scan.json into a ScanRecord WITHOUT its event log,
+// streaming past the events array so a huge log is never read into memory. This
+// is the events-free parse behind the summary cache; it replaces the old
+// os.ReadFile + Unmarshal(scanRecordLite) path that copied the entire events
+// blob into a RawMessage only to discard it.
+func readScanSummary(path string) (*ScanRecord, bool) {
+	meta, _, err := walkScanJSON(path, nil)
+	if err != nil {
+		return nil, false
+	}
+	rec, err := recordFromMeta(meta)
+	if err != nil {
+		return nil, false
+	}
+	rec.Events = nil
+	return rec, true
 }
 
 // loadScanRecordForDetail loads a scan record for the detail response with only

--- a/internal/web/scan_detail_load_test.go
+++ b/internal/web/scan_detail_load_test.go
@@ -167,6 +167,34 @@ func TestHandleScanEvents_Endpoint(t *testing.T) {
 	}
 }
 
+func TestReadScanSummary_SkipsEventsKeepsMetadata(t *testing.T) {
+	s := newTestServer(t, nil)
+	writeScanRecord(t, s.dataDir, "sum.com/2026-08-15/sum.com_s", ScanRecord{
+		ID:          "sum.com_s",
+		Target:      "sum.com",
+		Status:      "finished",
+		TotalTokens: 4242,
+		Iterations:  7,
+		Vulns:       []VulnSummary{{ID: "v1", Title: "x", Severity: "high"}},
+		Events:      makeEvents(400),
+	})
+	dir, _ := s.resolveScanDirByID("sum.com_s")
+
+	rec, ok := readScanSummary(dir + "/scan.json")
+	if !ok {
+		t.Fatal("readScanSummary failed")
+	}
+	if rec.Events != nil {
+		t.Fatalf("summary must not carry events, got %d", len(rec.Events))
+	}
+	if rec.Target != "sum.com" || rec.TotalTokens != 4242 || rec.Iterations != 7 {
+		t.Fatalf("metadata not preserved: %+v", rec)
+	}
+	if len(rec.Vulns) != 1 || rec.Vulns[0].ID != "v1" {
+		t.Fatalf("vulns (a field AFTER events in the JSON) not preserved: %+v", rec.Vulns)
+	}
+}
+
 func TestHandleGetScan_ReturnsTailAndTruncatedFlag(t *testing.T) {
 	s := newTestServer(t, nil)
 	total := 700

--- a/internal/web/scan_query.go
+++ b/internal/web/scan_query.go
@@ -217,16 +217,11 @@ func (s *Server) findAllScanSummaries() []scanEntry {
 			results = append(results, scanEntry{dir: filepath.Dir(path), rec: c.rec})
 			return nil
 		}
-		data, rerr := os.ReadFile(path)
-		if rerr != nil {
+		recPtr, ok := readScanSummary(path)
+		if !ok {
 			return nil
 		}
-		var lite scanRecordLite
-		if json.Unmarshal(data, &lite) != nil {
-			return nil
-		}
-		rec := lite.ScanRecord
-		rec.Events = nil
+		rec := *recPtr
 		s.scanSummaryCache[path] = scanSummaryCacheEntry{modNano: modNano, size: size, rec: rec}
 		results = append(results, scanEntry{dir: filepath.Dir(path), rec: rec})
 		return nil


### PR DESCRIPTION
## Problem (follow-up to #441)

The detail payload is now small, but opening even a *small* scan on an instance that also holds huge scans still took ~7s, and the huge scans intermittently failed to resolve (404) / appeared to restart the server.

Root cause: `findAllScanSummaries` — the events-free cache behind the scan list, `resolveScanDirByID`, and wildcard child attachment — still did `os.ReadFile`(whole file) + `json.Unmarshal` into `scanRecordLite`, which copies each `scan.json`'s **entire events array** into a `json.RawMessage` only to immediately discard it (`rec.Events = nil`). For multi-hundred-MB event logs that allocates the whole blob on every cache-cold walk, pushing the heap toward the 4 GB `GOMEMLIMIT` and thrashing GC. That GC pressure is what made a small scan's detail (which triggers a summary resolve) take ~7s and made huge scans flaky under load.

## Fix

Replace that path with `readScanSummary`, which streams `scan.json` and **skips the events array by token depth** — no per-element allocation, no giant RawMessage copy — keeping only the small metadata fields. Reuses `walkScanJSON` with a nil event callback. Memory during a cold summary build is now bounded regardless of event-log size.

## Tests

- `TestReadScanSummary_SkipsEventsKeepsMetadata`: events dropped, metadata preserved including `vulns` (a field that appears *after* `events` in the JSON, so it proves the skip resumes parsing correctly).
- Full `internal/web` suite passes; `golangci-lint` 0 issues.