### PR TITLE
perf(web): scan.meta.json sidecar for instant scan-detail loads

### DIFF
--- a/internal/web/scan_detail_load.go
+++ b/internal/web/scan_detail_load.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // detailEventTail is how many of the most recent events GET /api/scans/{id}
@@ -134,6 +135,95 @@ func decodeEvents(raws []json.RawMessage) []WSEvent {
 	return events
 }
 
+// scanMetaFile is a small sidecar next to scan.json holding exactly what the
+// detail view needs: the scan metadata plus only the last detailEventTail
+// events and the true event count. Reading it is O(tail) instead of streaming
+// the whole (possibly hundreds-of-MB) scan.json, which is what makes opening a
+// large scan instant — the same shape the SaaS gets for free from Postgres.
+// scan.json remains the full source of truth (reports, full-event consumers).
+const scanMetaFile = "scan.meta.json"
+
+// buildDetailMeta returns a light copy of rec carrying only the tail of events
+// plus the total/truncation hints — the exact payload the detail view needs.
+func buildDetailMeta(rec *ScanRecord) *ScanRecord {
+	light := *rec
+	total := len(rec.Events)
+	if total > detailEventTail {
+		light.Events = append([]WSEvent(nil), rec.Events[total-detailEventTail:]...)
+	} else {
+		light.Events = append([]WSEvent(nil), rec.Events...)
+	}
+	light.EventsTotal = total
+	light.EventsTruncated = total > len(light.Events)
+	return &light
+}
+
+// writeScanDetailMeta persists the detail sidecar for a full record. Best-effort:
+// a failure just means the next detail read falls back to streaming scan.json.
+func writeScanDetailMeta(dir string, rec *ScanRecord) {
+	if dir == "" || rec == nil {
+		return
+	}
+	writeScanDetailMetaLight(dir, buildDetailMeta(rec))
+}
+
+// writeScanDetailMetaLight writes an already-trimmed light record atomically.
+func writeScanDetailMetaLight(dir string, light *ScanRecord) {
+	if dir == "" || light == nil {
+		return
+	}
+	data, err := json.Marshal(light)
+	if err != nil {
+		return
+	}
+	tmp, err := os.CreateTemp(dir, ".scanmeta-*.tmp")
+	if err != nil {
+		return
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		_ = os.Remove(tmpPath)
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return
+	}
+	// Atomic replace so a concurrent reader never sees a half-written sidecar.
+	if err := os.Rename(tmpPath, filepath.Join(dir, scanMetaFile)); err != nil {
+		_ = os.Remove(tmpPath)
+	}
+}
+
+// readScanDetailMeta loads the detail sidecar if present and current. It is
+// considered stale (and ignored) when scan.json is newer, so a scan.json
+// written by a path that didn't refresh the sidecar can't serve stale data.
+func readScanDetailMeta(dir string) (*ScanRecord, bool) {
+	if dir == "" {
+		return nil, false
+	}
+	metaPath := filepath.Join(dir, scanMetaFile)
+	metaInfo, err := os.Stat(metaPath)
+	if err != nil {
+		return nil, false
+	}
+	if srcInfo, err := os.Stat(filepath.Join(dir, "scan.json")); err == nil {
+		if srcInfo.ModTime().After(metaInfo.ModTime()) {
+			return nil, false // sidecar predates the latest scan.json → rebuild
+		}
+	}
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		return nil, false
+	}
+	var rec ScanRecord
+	if err := json.Unmarshal(data, &rec); err != nil {
+		return nil, false
+	}
+	return &rec, true
+}
+
 // readScanSummary parses a scan.json into a ScanRecord WITHOUT its event log,
 // streaming past the events array so a huge log is never read into memory. This
 // is the events-free parse behind the summary cache; it replaces the old
@@ -163,6 +253,13 @@ func (s *Server) loadScanRecordForDetail(dir string, tail int) (*ScanRecord, boo
 	if tail < 0 {
 		tail = 0
 	}
+
+	// Fast path: a current sidecar already holds metadata + the event tail, so
+	// serve it without touching the (possibly huge) scan.json at all.
+	if meta, ok := readScanDetailMeta(dir); ok {
+		return meta, true
+	}
+
 	path := filepath.Join(dir, "scan.json")
 
 	// Ring buffer keeping only the last `tail` raw events.
@@ -189,7 +286,25 @@ func (s *Server) loadScanRecordForDetail(dir string, tail int) (*ScanRecord, boo
 	rec.Events = decodeEvents(ring)
 	rec.EventsTotal = total
 	rec.EventsTruncated = total > len(rec.Events)
+
+	// Lazily persist the sidecar so the next open of this (immutable, terminal)
+	// scan is instant. Running scans get a fresh sidecar from saveScanRecordTo
+	// on every save, so only backfill terminal ones here.
+	if isTerminalDetailStatus(rec.Status) {
+		writeScanDetailMetaLight(dir, rec)
+	}
 	return rec, true
+}
+
+// isTerminalDetailStatus reports whether a scan will no longer change on disk,
+// making its detail sidecar safe to cache indefinitely.
+func isTerminalDetailStatus(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "finished", "completed", "stopped", "failed":
+		return true
+	default:
+		return false
+	}
 }
 
 // loadScanEventsWindow returns the events in [offset, offset+limit) in original

--- a/internal/web/scan_detail_load_test.go
+++ b/internal/web/scan_detail_load_test.go
@@ -4,7 +4,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 )
 
 func makeEvents(n int) []WSEvent {
@@ -192,6 +195,85 @@ func TestReadScanSummary_SkipsEventsKeepsMetadata(t *testing.T) {
 	}
 	if len(rec.Vulns) != 1 || rec.Vulns[0].ID != "v1" {
 		t.Fatalf("vulns (a field AFTER events in the JSON) not preserved: %+v", rec.Vulns)
+	}
+}
+
+func TestSaveScanRecordTo_WritesDetailSidecar(t *testing.T) {
+	s := newTestServer(t, nil)
+	dir := filepath.Join(s.dataDir, "side.com", "2026-08-16", "side.com_a")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := &ScanRecord{ID: "side.com_a", Target: "side.com", Status: "finished", Events: makeEvents(800)}
+	s.saveScanRecordTo(rec, dir)
+
+	if _, err := os.Stat(filepath.Join(dir, scanMetaFile)); err != nil {
+		t.Fatalf("sidecar not written: %v", err)
+	}
+	meta, ok := readScanDetailMeta(dir)
+	if !ok {
+		t.Fatal("readScanDetailMeta failed")
+	}
+	if meta.EventsTotal != 800 || !meta.EventsTruncated || len(meta.Events) != detailEventTail {
+		t.Fatalf("sidecar contents wrong: total=%d trunc=%v inline=%d", meta.EventsTotal, meta.EventsTruncated, len(meta.Events))
+	}
+	// scan.json remains the full source of truth.
+	full, ok := loadScanRecordFromDir(dir)
+	if !ok || len(full.Events) != 800 {
+		t.Fatalf("scan.json must keep all events, got ok=%v n=%d", ok, len(full.Events))
+	}
+}
+
+func TestLoadScanRecordForDetail_UsesSidecarFastPath(t *testing.T) {
+	s := newTestServer(t, nil)
+	dir := filepath.Join(s.dataDir, "fp.com", "2026-08-16", "fp.com_a")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// scan.json says 10 events; a sidecar (fresher) says something different so
+	// we can prove the reader served the sidecar, not scan.json.
+	writeScanRecord(t, dir, ".", ScanRecord{ID: "fp.com_a", Target: "fp.com", Status: "finished", Events: makeEvents(10)})
+	// Rename the written file into place (writeScanRecord wrote scan.json here).
+	sentinel := &ScanRecord{ID: "fp.com_a", Target: "fp.com", Status: "finished", Events: makeEvents(3)}
+	sentinel.EventsTotal = 999
+	sentinel.EventsTruncated = true
+	writeScanDetailMetaLight(dir, sentinel)
+	// Make the sidecar newer than scan.json.
+	now := time.Now().Add(2 * time.Second)
+	_ = os.Chtimes(filepath.Join(dir, scanMetaFile), now, now)
+
+	rec, ok := s.loadScanRecordForDetail(dir, detailEventTail)
+	if !ok {
+		t.Fatal("load failed")
+	}
+	if rec.EventsTotal != 999 {
+		t.Fatalf("expected sidecar to be served (total=999), got %d", rec.EventsTotal)
+	}
+}
+
+func TestReadScanDetailMeta_IgnoresStaleSidecar(t *testing.T) {
+	s := newTestServer(t, nil)
+	dir := filepath.Join(s.dataDir, "stale.com", "2026-08-16", "stale.com_a")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Old sidecar first.
+	writeScanDetailMetaLight(dir, &ScanRecord{ID: "stale.com_a", EventsTotal: 5})
+	old := time.Now().Add(-1 * time.Hour)
+	_ = os.Chtimes(filepath.Join(dir, scanMetaFile), old, old)
+	// Newer scan.json (as if a later write skipped the sidecar).
+	writeScanRecord(t, dir, ".", ScanRecord{ID: "stale.com_a", Target: "stale.com", Status: "finished", Events: makeEvents(50)})
+
+	if _, ok := readScanDetailMeta(dir); ok {
+		t.Fatal("stale sidecar (older than scan.json) must be ignored")
+	}
+	// The detail loader should then rebuild from scan.json and refresh the sidecar.
+	rec, ok := s.loadScanRecordForDetail(dir, detailEventTail)
+	if !ok || rec.EventsTotal != 50 {
+		t.Fatalf("rebuild from scan.json failed: ok=%v total=%d", ok, rec.EventsTotal)
+	}
+	if meta, ok := readScanDetailMeta(dir); !ok || meta.EventsTotal != 50 {
+		t.Fatalf("sidecar not refreshed after rebuild: ok=%v", ok)
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -3045,7 +3045,13 @@ func (s *Server) saveScanRecordTo(rec *ScanRecord, scanDir string) {
 	if err := os.WriteFile(filepath.Join(scanDir, "scan.json"), data, 0600); err != nil {
 		log.Printf("Error: failed to save scan record to %s: %v", scanDir, err)
 		s.broadcast(WSEvent{Type: "error", Content: fmt.Sprintf("⚠️ Failed to save scan data: %v", err)})
+		return
 	}
+	// Refresh the detail sidecar (metadata + event tail) so GET /api/scans/{id}
+	// stays instant regardless of how large the event log grows. Best-effort and
+	// written after scan.json so a reader never sees a sidecar newer than its
+	// source (readScanDetailMeta treats a stale sidecar as absent).
+	writeScanDetailMeta(scanDir, rec)
 }
 
 // diskAvailable returns available bytes on the filesystem containing path, or 0 on error.


### PR DESCRIPTION
## Problem

Even after the streaming loader (#441, v4.5.146) and the summary-walk fix (#443, v4.5.147), opening a large scan still took **~6.8s every time** (measured on the 15.2M-token scan, warm cache). `GET /api/scans/{id}` still had to stream the entire `scan.json` — hundreds of MB of inlined events — to reach the metadata fields stored *after* the events array and to tail/count them.

That's the architectural gap with the SaaS: the SaaS stores scans as **indexed Postgres rows** (bounded reads), while the scanner stores each scan as **one monolithic JSON file** with the whole event transcript inlined.

## Fix

Add a small **`scan.meta.json`** sidecar next to `scan.json` holding exactly what the detail view needs: metadata + the last `detailEventTail` (300) events + the true event count. `GET /api/scans/{id}` reads that sidecar (O(tail)) instead of the full file → **instant regardless of event-log size**.

- `saveScanRecordTo` refreshes the sidecar after every `scan.json` write → new/running scans are always fast.
- `loadScanRecordForDetail` serves the sidecar when present + current; otherwise streams `scan.json` (as before) and **lazily backfills** the sidecar for terminal scans, so existing scans become instant after their first open.
- `readScanDetailMeta` treats a sidecar older than `scan.json` as absent (mtime check), so any path that rewrites `scan.json` without refreshing the sidecar self-heals instead of serving stale data.

`scan.json` stays the **full source of truth** — reports and every full-event consumer are unchanged. The sidecar is ignored by the `scan.json` dir walks and removed with the scan dir on delete. The `/events` pagination endpoint still streams `scan.json` on demand.

## Tests

- Sidecar written on save; `scan.json` keeps all events.
- Detail loader serves the sidecar fast-path (proven with a sentinel value that differs from `scan.json`).
- Stale sidecar (older than `scan.json`) is ignored and rebuilt+refreshed.
- Existing tail/window/endpoint tests still pass.

Full `internal/web` suite passes; `golangci-lint` 0 issues.