### PR TITLE
perf(web): stop walking artifact subtrees when listing/resolving scans

### DIFF
--- a/internal/web/scan_detail_load_test.go
+++ b/internal/web/scan_detail_load_test.go
@@ -170,6 +170,37 @@ func TestHandleScanEvents_Endpoint(t *testing.T) {
 	}
 }
 
+func TestWalkScanDirs_PrunesArtifactSubtree(t *testing.T) {
+	root := t.TempDir()
+	// Canonical scan dir: target/date/slug/scan.json
+	slug := filepath.Join(root, "example.com", "2026-08-16", "example.com_a")
+	if err := os.MkdirAll(slug, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(slug, "scan.json"), []byte(`{"id":"a"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Artifact subtree UNDER the slug dir, including a decoy scan.json that a
+	// scanned site might have produced. The walker must NOT descend here.
+	decoy := filepath.Join(slug, "js", "assets")
+	if err := os.MkdirAll(decoy, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(decoy, "scan.json"), []byte(`{"id":"decoy"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var found []string
+	walkScanDirs(root, func(p string) { found = append(found, p) })
+
+	if len(found) != 1 {
+		t.Fatalf("expected exactly 1 scan.json (artifact subtree pruned), got %d: %v", len(found), found)
+	}
+	if filepath.Dir(found[0]) != slug {
+		t.Fatalf("found wrong scan dir: %s", found[0])
+	}
+}
+
 func TestReadScanSummary_SkipsEventsKeepsMetadata(t *testing.T) {
 	s := newTestServer(t, nil)
 	writeScanRecord(t, s.dataDir, "sum.com/2026-08-15/sum.com_s", ScanRecord{

--- a/internal/web/scan_query.go
+++ b/internal/web/scan_query.go
@@ -3,7 +3,6 @@ package web
 import (
 	"encoding/json"
 	"errors"
-	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
@@ -123,34 +122,52 @@ type scanEntry struct {
 	rec ScanRecord // parsed record
 }
 
-// findAllScans recursively walks dataDir to find all scan.json files.
-// Structure: dataDir/target/date/slug/scan.json
+// walkScanDirs invokes fn with the path to every scan.json under root WITHOUT
+// descending into a scan directory's artifact subtree. A directory that
+// contains a scan.json IS a scan directory; its subdirectories (tool output,
+// downloaded site assets, caches — collectively tens of GB and, on a busy
+// install, ~millions of filesystem entries) are never traversed. This keeps a
+// full walk proportional to the number of SCANS (a few thousand directory
+// listings) instead of the total data size.
+//
+// Before this, both walkers used filepath.WalkDir over the entire data dir, so
+// every scan-list / scan-resolve request statted the whole artifact tree
+// (~1.9M entries for 401 scans here). That, not any single scan.json's size,
+// was what made the scan pages slow.
+func walkScanDirs(root string, fn func(scanJSONPath string)) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if !e.IsDir() && e.Name() == "scan.json" {
+			fn(filepath.Join(root, "scan.json"))
+			return // this is a scan dir; do not descend into its artifacts
+		}
+	}
+	for _, e := range entries {
+		// e.IsDir() is false for symlinks, so symlinked dirs are not followed
+		// (no traversal loops).
+		if e.IsDir() {
+			walkScanDirs(filepath.Join(root, e.Name()), fn)
+		}
+	}
+}
+
+// findAllScans finds all scan.json files under dataDir and fully parses each
+// (event log included). Structure: dataDir/target/date/slug/scan.json.
 func (s *Server) findAllScans() []scanEntry {
 	var results []scanEntry
-	_ = filepath.WalkDir(s.dataDir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return nil
-		}
-		if d.IsDir() {
-			name := d.Name()
-			if name == "scratch" || name == "reports" || name == "logs" || name == "artifacts" || name == "tools" || name == "snapshots" || name == "notes" || name == ".git" {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if d.Name() != "scan.json" {
-			return nil
-		}
+	walkScanDirs(s.dataDir, func(path string) {
 		data, err := os.ReadFile(path)
 		if err != nil {
-			return nil
+			return
 		}
 		var rec ScanRecord
 		if json.Unmarshal(data, &rec) != nil {
-			return nil
+			return
 		}
 		results = append(results, scanEntry{dir: filepath.Dir(path), rec: rec})
-		return nil
 	})
 	return results
 }
@@ -177,11 +194,11 @@ type scanRecordLite struct {
 }
 
 // findAllScanSummaries is the events-free, cached counterpart to findAllScans.
-// It walks the data dir, parses each scan.json without decoding its event log,
-// and memoizes the result per file keyed by (modtime, size). Subsequent walks
-// only stat each file and re-parse the few that changed, so warm rebuilds are
-// effectively free. Callers that need the event log (report generation,
-// scan-detail) must use findAllScans instead.
+// It walks the data dir (pruning artifact subtrees via walkScanDirs), parses
+// each scan.json without decoding its event log, and memoizes the result per
+// file keyed by (modtime, size). Subsequent walks only stat each scan.json and
+// re-parse the few that changed. Callers that need the event log (report
+// generation) must use findAllScans instead.
 func (s *Server) findAllScanSummaries() []scanEntry {
 	var results []scanEntry
 
@@ -192,39 +209,25 @@ func (s *Server) findAllScanSummaries() []scanEntry {
 	}
 	seen := make(map[string]struct{})
 
-	_ = filepath.WalkDir(s.dataDir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return nil
-		}
-		if d.IsDir() {
-			name := d.Name()
-			if name == "scratch" || name == "reports" || name == "logs" || name == "artifacts" || name == "tools" || name == "snapshots" || name == "notes" || name == ".git" {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if d.Name() != "scan.json" {
-			return nil
-		}
-		info, ierr := d.Info()
+	walkScanDirs(s.dataDir, func(path string) {
+		info, ierr := os.Stat(path)
 		if ierr != nil {
-			return nil
+			return
 		}
 		seen[path] = struct{}{}
 		modNano := info.ModTime().UnixNano()
 		size := info.Size()
 		if c, ok := s.scanSummaryCache[path]; ok && c.modNano == modNano && c.size == size {
 			results = append(results, scanEntry{dir: filepath.Dir(path), rec: c.rec})
-			return nil
+			return
 		}
 		recPtr, ok := readScanSummary(path)
 		if !ok {
-			return nil
+			return
 		}
 		rec := *recPtr
 		s.scanSummaryCache[path] = scanSummaryCacheEntry{modNano: modNano, size: size, rec: rec}
 		results = append(results, scanEntry{dir: filepath.Dir(path), rec: rec})
-		return nil
 	})
 
 	// Drop cache entries for files that no longer exist so deleted scans


### PR DESCRIPTION
## The actual root cause

Profiling on the live instance showed my earlier premise (huge `scan.json`) was wrong: the largest `scan.json` is ~1 MB and there are only 401 scans — but the data dir holds **22 GB / ~1.9M filesystem entries** of per-scan *artifacts* (tool output, downloaded site assets, caches).

`findAllScans` and `findAllScanSummaries` used `filepath.WalkDir` over the whole data dir, so **every** scan-list and scan-resolve request traversed all ~1.9M entries just to find 401 `scan.json` files. Cold after a restart + under active-scan CPU/IO load that was ~22s for the list and ~50s for a detail open. The summary cache didn't help because it only skips re-*parsing* `scan.json`, not the traversal.

## Fix

Add `walkScanDirs`: a directory that contains `scan.json` **is** a scan directory, so its subdirectories (the artifacts) are never descended into. A full walk is now proportional to the number of scans (a few thousand directory listings) instead of total data size. Used by both `findAllScans` and `findAllScanSummaries`.

Symlinked dirs aren't followed (`DirEntry.IsDir()` is false for symlinks), so there are no traversal loops.

## Tests

- `TestWalkScanDirs_PrunesArtifactSubtree`: a decoy `scan.json` inside an artifact subtree (`slug/js/assets/scan.json`) is NOT discovered — the walker stops at the real scan dir.
- All existing list/summary/detail/resolve tests pass; `golangci-lint` 0 issues.

## Note

This supersedes the wrong diagnosis behind #441/#443/#445 (which assumed huge JSON). Those changes still help (small detail payload, sidecar, memory-bounded parse), but **this** is the one that addresses the observed slowness.