### PR TITLE
fix(scan): auto-resume scans left pending at graceful shutdown

### DIFF
--- a/internal/web/resume_recover_test.go
+++ b/internal/web/resume_recover_test.go
@@ -15,6 +15,8 @@ func TestIsInterruptedRecoverableRecord(t *testing.T) {
 		{"stopped", "signal_interrupt", true, "graceful SIGINT restart"},
 		{"stopped", "panic_recovered", true, "recovered panic"},
 		{"stopped", "server_restart_resuming", true, "already flagged for resume"},
+		{"stopped", "server_shutdown", true, "queued (pending) at graceful shutdown must resume"},
+		{"Stopped", "SERVER_SHUTDOWN", true, "case-insensitive server_shutdown"},
 		{"stopped", "user_stopped", false, "explicit user stop must NOT resume"},
 		{"stopped", "", false, "plain stop with no resume reason"},
 		{"stopped", "server_restart_no_resume_state", false, "already terminalized, no resume"},

--- a/internal/web/scan_query.go
+++ b/internal/web/scan_query.go
@@ -595,11 +595,21 @@ func isTerminalScanStatus(status string) bool {
 // Two cases qualify:
 //   - running/pending: the process died before the scan reached a terminal
 //     state (crash / SIGKILL). scan.json still says running/pending.
-//   - stopped with a signal_/panic_ reason: a graceful SIGTERM/SIGINT (or a
-//     recovered panic) persisted the scan as "stopped" but PRESERVED its
-//     queue_state on purpose (shouldPreserveQueueStateOnExit). Without this
-//     case those scans stayed "stopped" forever and only a fresh "Start" was
-//     offered — the bug this closes.
+//   - stopped with a signal_/panic_/server_shutdown reason: a graceful
+//     SIGTERM/SIGINT, a recovered panic, or a scan that was still QUEUED
+//     (pending, waiting for an admission slot) when the server shut down.
+//     All persist the scan as "stopped" but PRESERVE its queue_state on
+//     purpose (shouldPreserveQueueStateOnExit / the admission-loop shutdown
+//     branch). Without this case those scans stayed "stopped"/"pending"
+//     forever and only a fresh "Start" was offered — the bug this closes.
+//
+// The "server_shutdown" reason specifically is set for a scan that never got a
+// slot before shutdown (orchestrator admission loop). Its queue_state is kept
+// (preserveQueue), so it MUST also be recognized here — otherwise auto-resume
+// keeps the queue_state but the exact-stop tombstone refuses dispatch, and the
+// scan is stranded as an orphaned "pending" record with no driver goroutine
+// that nothing ever promotes (observed: queued wildcard scans never starting
+// after a restart even with free slots).
 //
 // A user-initiated stop is deliberately NOT recoverable: handleStop clears the
 // queue_state, so even when such a record reaches this function the downstream
@@ -614,7 +624,8 @@ func isInterruptedRecoverableRecord(status, stopReason string) bool {
 		reason := strings.ToLower(strings.TrimSpace(stopReason))
 		return strings.HasPrefix(reason, "signal_") ||
 			reason == "panic_recovered" ||
-			reason == "server_restart_resuming"
+			reason == "server_restart_resuming" ||
+			reason == "server_shutdown"
 	default:
 		return false
 	}


### PR DESCRIPTION
## Symptom

Queued (pending) scans don't auto-run after a running scan completes — even with free slots — but a brand-new scan starts immediately.

## Root cause

A scan still **pending** (waiting for an admission slot) when the server shuts down is persisted by the admission loop as `stopped` / `server_shutdown`, and its `queue_state` is preserved (the orchestrator exit defer force-preserves it for `server_shutdown` when the scan never ran).

On restart, auto-resume finds that `queue_state` and dispatches — but `runMultiScan`'s durable exact-stop tombstone guard calls `isInterruptedRecoverableRecord`, which did **not** list `server_shutdown` as recoverable (only `signal_*`, `panic_recovered`, `server_restart_resuming`). So dispatch is refused:

```
[scan] refusing dispatch "83dd446d..." after durable exact stop/status "stopped"
```

The scan is left stranded as an orphaned `pending` record with **no driver goroutine** — nothing ever promotes it, even when slots free. A new scan gets a fresh id with no tombstone, so it runs. Confirmed on the live instance: two queued wildcard scans (`server_shutdown`) never started after a restart despite only 3/5 slots used.

## Fix

Add `server_shutdown` to the recoverable stop reasons in `isInterruptedRecoverableRecord`, consistent with the queue-state preservation that already targets these scans. User-initiated stops stay non-recoverable (`handleStop` clears `queue_state`).

Currently-stranded pending scans will resume on the next restart after this ships.

## Tests

- New table cases: `stopped`/`server_shutdown` → recoverable (+ case-insensitive). Full `internal/web` suite passes; `golangci-lint` 0 issues.