### PR TITLE
fix(notify): include exploitation evidence in Telegram/Discord vuln alerts

### DIFF
--- a/internal/web/scan_session.go
+++ b/internal/web/scan_session.go
@@ -7,6 +7,7 @@ import (
 	"runtime/debug"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/xalgord/xalgorix/v4/internal/agent"
 	"github.com/xalgord/xalgorix/v4/internal/scanctx"
@@ -14,6 +15,75 @@ import (
 	"github.com/xalgord/xalgorix/v4/internal/tools/notes"
 	"github.com/xalgord/xalgorix/v4/internal/tools/reporting"
 )
+
+// vulnNotificationDetails renders the Markdown body pushed to Telegram/Discord
+// for a reported vulnerability. It includes the concrete exploitation evidence
+// (proof + verification method + verified/manual-review status) that
+// report_vulnerability's gates guarantee for actionable findings — without it
+// every alert reads like an unsubstantiated claim and gets treated as a false
+// positive (issue #429). Fields are written only when present, mirroring the
+// PDF report's evidence section.
+func vulnNotificationDetails(vs VulnSummary) string {
+	var details strings.Builder
+	details.WriteString(fmt.Sprintf("**%s**\n\n", vs.Title))
+	if vs.Description != "" {
+		details.WriteString(fmt.Sprintf("📝 **Description:**\n%s\n\n", vs.Description))
+	}
+	if vs.Endpoint != "" {
+		details.WriteString(fmt.Sprintf("🔗 **Endpoint:** `%s`\n", vs.Endpoint))
+	}
+	if vs.Method != "" {
+		details.WriteString(fmt.Sprintf("📡 **Method:** `%s`\n", vs.Method))
+	}
+	if vs.CVE != "" {
+		details.WriteString(fmt.Sprintf("🏷️ **CVE:** `%s`\n", vs.CVE))
+	}
+	details.WriteString(fmt.Sprintf("📊 **CVSS:** `%.1f` | **Severity:** `%s`\n\n", vs.CVSS, strings.ToUpper(vs.Severity)))
+	if vs.Impact != "" {
+		details.WriteString(fmt.Sprintf("💥 **Impact:**\n%s\n\n", vs.Impact))
+	}
+	if vs.TechnicalAnalysis != "" {
+		details.WriteString(fmt.Sprintf("🔬 **Technical Analysis:**\n%s\n\n", vs.TechnicalAnalysis))
+	}
+	if vs.PoCDescription != "" {
+		details.WriteString(fmt.Sprintf("🧪 **PoC:**\n%s\n", vs.PoCDescription))
+	}
+	if vs.PoCScript != "" {
+		details.WriteString(fmt.Sprintf("```\n%s\n```\n\n", truncateForNotification(vs.PoCScript, 800)))
+	}
+	// Exploitation evidence — the concrete proof (extracted data, command
+	// output like `uid=0(root)`, reflected payload) that distinguishes a real
+	// finding from an unsubstantiated claim. This is the fix for issue #429.
+	if vs.ExploitationProof != "" {
+		details.WriteString(fmt.Sprintf("🔓 **Exploitation Proof:**\n```\n%s\n```\n\n", truncateForNotification(vs.ExploitationProof, 800)))
+	}
+	if vs.VerificationMethod != "" {
+		status := "unverified — needs manual review"
+		if vs.Verified {
+			status = "verified — independently reproduced"
+		}
+		details.WriteString(fmt.Sprintf("✅ **Verified via:** `%s` (%s)\n\n", vs.VerificationMethod, status))
+	}
+	if vs.Remediation != "" {
+		details.WriteString(fmt.Sprintf("🛡️ **Remediation:**\n%s", vs.Remediation))
+	}
+	return details.String()
+}
+
+// truncateForNotification caps a code/proof block at maxBytes without splitting
+// a multi-byte UTF-8 rune (so the notification never carries invalid bytes),
+// appending a truncation marker when it trims.
+func truncateForNotification(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	cut := maxBytes
+	// Back up to a rune boundary.
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + "\n... (truncated)"
+}
 
 // shouldFailInstanceOnAbort reports whether an LLM-abort (no-tool / empty /
 // repeated-error / rate-limit) in THIS session may mark the whole scan
@@ -458,49 +528,16 @@ func (s *Server) processEvent(evt agent.Event, sess *scanSession) {
 							case "low", "info":
 								sevColor = 0x3b82f6
 							}
-							var details strings.Builder
-							details.WriteString(fmt.Sprintf("**%s**\n\n", vs.Title))
-							if vs.Description != "" {
-								details.WriteString(fmt.Sprintf("📝 **Description:**\n%s\n\n", vs.Description))
-							}
-							if vs.Endpoint != "" {
-								details.WriteString(fmt.Sprintf("🔗 **Endpoint:** `%s`\n", vs.Endpoint))
-							}
-							if vs.Method != "" {
-								details.WriteString(fmt.Sprintf("📡 **Method:** `%s`\n", vs.Method))
-							}
-							if vs.CVE != "" {
-								details.WriteString(fmt.Sprintf("🏷️ **CVE:** `%s`\n", vs.CVE))
-							}
-							details.WriteString(fmt.Sprintf("📊 **CVSS:** `%.1f` | **Severity:** `%s`\n\n", vs.CVSS, strings.ToUpper(vs.Severity)))
-							if vs.Impact != "" {
-								details.WriteString(fmt.Sprintf("💥 **Impact:**\n%s\n\n", vs.Impact))
-							}
-							if vs.TechnicalAnalysis != "" {
-								details.WriteString(fmt.Sprintf("🔬 **Technical Analysis:**\n%s\n\n", vs.TechnicalAnalysis))
-							}
-							if vs.PoCDescription != "" {
-								details.WriteString(fmt.Sprintf("🧪 **PoC:**\n%s\n", vs.PoCDescription))
-							}
-							if vs.PoCScript != "" {
-								poc := vs.PoCScript
-								if len(poc) > 800 {
-									poc = poc[:800] + "\n... (truncated)"
-								}
-								details.WriteString(fmt.Sprintf("```\n%s\n```\n\n", poc))
-							}
-							if vs.Remediation != "" {
-								details.WriteString(fmt.Sprintf("🛡️ **Remediation:**\n%s", vs.Remediation))
-							}
+							details := vulnNotificationDetails(vs)
 							// Apply Discord minimum severity filter
 							if severityMeetsThreshold(vs.Severity, s.discordMinSeverity) {
-								s.sendDiscordTo(s.discordWebhookForScan(sess.discordWebhook), sevColor, fmt.Sprintf("🐛 %s Vulnerability Found", strings.ToUpper(vs.Severity)), details.String())
+								s.sendDiscordTo(s.discordWebhookForScan(sess.discordWebhook), sevColor, fmt.Sprintf("🐛 %s Vulnerability Found", strings.ToUpper(vs.Severity)), details)
 							} else {
 								log.Printf("[DISCORD] Skipping %s vuln notification (min severity: %s)", vs.Severity, s.discordMinSeverity)
 							}
 							// Apply Telegram minimum severity filter (independent of Discord)
 							if s.telegramConfigured() && severityMeetsThreshold(vs.Severity, s.telegramMinSeverity) {
-								s.sendTelegram(sevColor, fmt.Sprintf("🐛 %s Vulnerability Found", strings.ToUpper(vs.Severity)), details.String())
+								s.sendTelegram(sevColor, fmt.Sprintf("🐛 %s Vulnerability Found", strings.ToUpper(vs.Severity)), details)
 							} else if s.telegramConfigured() {
 								log.Printf("[TELEGRAM] Skipping %s vuln notification (min severity: %s)", vs.Severity, s.telegramMinSeverity)
 							}

--- a/internal/web/vuln_notification_test.go
+++ b/internal/web/vuln_notification_test.go
@@ -1,0 +1,90 @@
+package web
+
+import (
+	"strings"
+	"testing"
+)
+
+// Regression for issue #429: vulnerability notifications must carry the
+// concrete exploitation evidence (proof + verification method + verified
+// status), not just the descriptive fields — otherwise every alert reads like
+// an unsubstantiated claim.
+func TestVulnNotificationDetails_IncludesExploitationEvidence(t *testing.T) {
+	vs := VulnSummary{
+		Title:              "SQLi in /login",
+		Severity:           "high",
+		CVSS:               8.6,
+		Endpoint:           "/login",
+		Method:             "POST",
+		Description:        "Boolean-based blind SQL injection.",
+		Impact:             "Full DB read.",
+		TechnicalAnalysis:  "Payload breaks out of the WHERE clause.",
+		PoCDescription:     "Inject ' OR 1=1--",
+		PoCScript:          "curl -d \"u=' OR 1=1--\" https://t/login",
+		ExploitationProof:  "uid=0(root) gid=0(root)\nextracted: admin@site.com",
+		VerificationMethod: "data_extracted",
+		Verified:           true,
+		Remediation:        "Use parameterized queries.",
+	}
+
+	out := vulnNotificationDetails(vs)
+
+	if !strings.Contains(out, "Exploitation Proof") {
+		t.Error("notification must include an Exploitation Proof section")
+	}
+	if !strings.Contains(out, "uid=0(root)") {
+		t.Error("notification must include the actual exploitation proof output")
+	}
+	if !strings.Contains(out, "Verified via") || !strings.Contains(out, "data_extracted") {
+		t.Error("notification must include the verification method")
+	}
+	if !strings.Contains(out, "verified — independently reproduced") {
+		t.Errorf("verified finding must show verified status; got:\n%s", out)
+	}
+}
+
+func TestVulnNotificationDetails_UnverifiedStatus(t *testing.T) {
+	vs := VulnSummary{
+		Title:              "Reflected XSS",
+		Severity:           "medium",
+		VerificationMethod: "reflected",
+		Verified:           false,
+	}
+	out := vulnNotificationDetails(vs)
+	if !strings.Contains(out, "unverified — needs manual review") {
+		t.Errorf("unverified finding must show manual-review status; got:\n%s", out)
+	}
+}
+
+// Fields that are absent must not render empty/placeholder sections.
+func TestVulnNotificationDetails_OmitsEmptyEvidence(t *testing.T) {
+	vs := VulnSummary{Title: "Info finding", Severity: "info", CVSS: 0}
+	out := vulnNotificationDetails(vs)
+	if strings.Contains(out, "Exploitation Proof") {
+		t.Error("must not render an Exploitation Proof section when proof is empty")
+	}
+	if strings.Contains(out, "Verified via") {
+		t.Error("must not render a verification section when method is empty")
+	}
+}
+
+func TestTruncateForNotification_RuneSafe(t *testing.T) {
+	// A run of multi-byte runes; truncating at a byte cap must not split a rune
+	// (the result must remain valid UTF-8).
+	s := strings.Repeat("é", 1000) // 2 bytes each → 2000 bytes
+	out := truncateForNotification(s, 801)
+	if !strings.HasSuffix(out, "... (truncated)") {
+		t.Fatal("expected truncation marker")
+	}
+	body := strings.TrimSuffix(out, "\n... (truncated)")
+	for i, r := range body {
+		if r == '\uFFFD' {
+			t.Fatalf("truncation split a UTF-8 rune at byte %d", i)
+		}
+	}
+
+	// Short input is returned unchanged.
+	if got := truncateForNotification("small", 800); got != "small" {
+		t.Fatalf("short input altered: %q", got)
+	}
+}


### PR DESCRIPTION
Closes #429.

## Problem

The Telegram/Discord notification body (built in `processEvent`, `scan_session.go`) included Title, Description, Endpoint, Method, CVE, CVSS/Severity, Impact, Technical Analysis, PoC description + script, and Remediation — but **omitted the one thing that proves a finding is real**: `ExploitationProof`, `VerificationMethod`, and the `Verified` status. So every alert read like an unsubstantiated claim and got treated as a false positive. Both channels share the same builder, so both were affected. Confirmed still present on current main.

## The evidence was always on the record

I audited the report path: `report_vulnerability`'s **Gate 1** rejects non-`info` findings with no `verification_method`, **Gate 2** requires/backfills `exploitation_proof`, and the accepted finding is built with all three fields — the PDF report already renders them. So the data model and web UI were never the problem; only the live notification dropped the evidence. (This also addresses the reporter's secondary "evidence empty in web view" question — the fields are consistently persisted for actionable findings.)

## Change

- Extract the notification body into `vulnNotificationDetails(vs)` — a pure, unit-testable function.
- Append **Exploitation Proof** (truncated), **Verification method**, and a **verified vs. needs-manual-review** status. Purely additive, gated on non-empty fields, mirroring the PDF report. No change to severity/notification gating (I deliberately did *not* add "only alert on proven findings" gating — the severity filter already exists; can be a separate opt-in if you want it).
- Add `truncateForNotification`: a rune-safe byte cap, so a proof/PoC block can never be cut mid-UTF-8-rune (the previous inline `poc[:800]` could emit invalid bytes).

## Tests

New `vuln_notification_test.go`: proof + method + verified status present; unverified shows manual-review; empty fields render no section; rune-safe truncation. Full `internal/web` suite passes; `golangci-lint` 0 issues.