### PR TITLE
release: v4.5.151

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.150
+VERSION=4.5.151
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.150" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.5.151" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.150"
+var version = "4.5.151"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
### Changes

- 30bb768 fix(notify): include exploitation evidence in Telegram/Discord vuln alerts (#451)
- 67c283f fix: always ship the latest nuclei engine + templates in the Docker image (#432)
- 13da1ba feat: configurable Gemini safety threshold for authorized security testing (#431)
- 89804fe release: v4.5.150 (#450)