### PR TITLE
docs: add sponsor button and surface screenshots in README

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# Configures the "Sponsor" button shown on github.com/xalgorix/xalgorix.
+# Docs: https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+
+github: [xalgord]
+buy_me_a_coffee: xalgord

--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@
 
 ---
 
+## 📸 Screenshots
+
+**🖥️ Self-hosted dashboard** — runs locally on `127.0.0.1:9137`
+
+| Overview dashboard                                      | Scan detail                                      | Findings                                      |
+| ------------------------------------------------------- | ------------------------------------------------ | --------------------------------------------- |
+| ![Xalgorix overview dashboard](assets/screenshot-1.png) | ![Xalgorix scan detail](assets/screenshot-2.png) | ![Xalgorix findings](assets/screenshot-3.png) |
+
+**☁️ Hosted cloud dashboard** — the fully managed version at [www.xalgorix.com](https://www.xalgorix.com/)
+
+<img src="assets/SaaS-dashboard.png" alt="Xalgorix hosted cloud dashboard showing scan credits, plan status, issue counts, and recent scans" width="860" />
+
+---
+
 ## 🚀 Quick Start
 
 **Install (one line):**
@@ -110,11 +124,11 @@ For merge gating and full exploit-verified pentests in CI, use the [hosted scann
 
 | | | |
 | --- | --- | --- |
-| 🚀 [Quick Start](#-quick-start) | 🔩 [Configuration](#-configuration) | 🧾 [Environment Variables](#-environment-variables) |
-| 🔎 [Overview](#-overview) | 🆙 [Upgrading](#-upgrading-from-previous-versions) | 🔤 [Provider Prefixes](#-provider-prefixes) |
-| 💡 [Why Xalgorix](#-why-xalgorix) | 🏃 [Running](#-running) | 💻 [CLI Reference](#-cli-reference) |
-| 🎯 [Use Cases](#-use-cases) | 🧰 [Service Mode](#-service-mode) | 📡 [API Summary](#-api-summary) |
-| 📸 [Screenshots](#-screenshots) | 🔁 [Web UI Workflow](#-web-ui-workflow) | 💾 [Data Storage](#-data-storage) |
+| 📸 [Screenshots](#-screenshots) | 🔩 [Configuration](#-configuration) | 🧾 [Environment Variables](#-environment-variables) |
+| 🚀 [Quick Start](#-quick-start) | 🆙 [Upgrading](#-upgrading-from-previous-versions) | 🔤 [Provider Prefixes](#-provider-prefixes) |
+| 🔎 [Overview](#-overview) | 🏃 [Running](#-running) | 💻 [CLI Reference](#-cli-reference) |
+| 💡 [Why Xalgorix](#-why-xalgorix) | 🧰 [Service Mode](#-service-mode) | 📡 [API Summary](#-api-summary) |
+| 🎯 [Use Cases](#-use-cases) | 🔁 [Web UI Workflow](#-web-ui-workflow) | 💾 [Data Storage](#-data-storage) |
 | ✨ [Features](#-features) | 🔀 [Scan Modes](#-scan-modes) | 🧪 [Development](#-development) |
 | 📥 [Installation](#-installation) | 📂 [Scan Your Code](#-scan-your-code-no-target-needed) | 🚨 [Safety Notes](#-safety-notes) |
 | 🧭 [Methodology](#-methodology) | 📄 [Reports](#-reports) | 📜 [License](#-license) |
@@ -165,18 +179,6 @@ If Xalgorix saves you a triage cycle, please **[⭐ star the repo](https://githu
 | **Security research** | The novel-vulnerability-discovery phase pushes the agent beyond known template matching. Bring your own LLM (OpenAI, Anthropic, DeepSeek, Gemini, Ollama, MiniMax) to control reasoning depth and cost. |
 | **Continuous security testing** | Run as a system service with `xalgorix --start`. Scan on a schedule, stream findings to Discord or Telegram, and generate branded PDF reports for stakeholders. |
 | **DAST automation** | Browser-driven testing for web applications — auth flows, forms, JavaScript-rendered content, and runtime behavior. Integrates with Caido for proxy traffic inspection. |
-
-## 📸 Screenshots
-
-**🖥️ Self-hosted dashboard** — runs locally on `127.0.0.1:9137`
-
-| Overview dashboard                                      | Scan detail                                      | Findings                                      |
-| ------------------------------------------------------- | ------------------------------------------------ | --------------------------------------------- |
-| ![Xalgorix overview dashboard](assets/screenshot-1.png) | ![Xalgorix scan detail](assets/screenshot-2.png) | ![Xalgorix findings](assets/screenshot-3.png) |
-
-**☁️ Hosted cloud dashboard** — the fully managed version at [www.xalgorix.com](https://www.xalgorix.com/)
-
-<img src="assets/SaaS-dashboard.png" alt="Xalgorix hosted cloud dashboard showing scan credits, plan status, issue counts, and recent scans" width="860" />
 
 ## ✨ Features
 


### PR DESCRIPTION
## Summary

Two small repo-presentation changes:

- **Sponsor button** — adds `.github/FUNDING.yml` so GitHub renders a *Sponsor* button on the repo. Links the active GitHub Sponsors profile (`github: xalgord`) and the Buy Me a Coffee handle already referenced in the README's support links. The org handle was intentionally omitted because `github.com/sponsors/xalgorix` is not an enrolled Sponsors profile (it 302s to the org page), so it would render as a dead entry.
- **Screenshots** — moves the Screenshots section from near the bottom of the README up to directly under the hero banner (above Quick Start), and reorders the Contents index to match. No screenshot files or captions were changed.

## Testing

- Verified `FUNDING.yml` parses as valid YAML and both keys are on GitHub's supported-platform list.
- Confirmed all five referenced image paths exist under `assets/` and all in-page README anchor links still resolve.
- The `#-screenshots` anchor is unchanged, so existing deep links keep working.

## Notes

The Sponsor button only appears once this lands on the default branch.