### PR TITLE
fix(web): eliminate data races on shared resolver and agent-runner globals

### DIFF
--- a/internal/agent/agent_scope_test.go
+++ b/internal/agent/agent_scope_test.go
@@ -1504,9 +1504,8 @@ func TestPreservation_AgentOracleStableAcrossLookupSwap(t *testing.T) {
 // scopeguard.LookupHost is package-level state.
 func withScopeguardLookupHost(t *testing.T, stub func(string) ([]string, error)) {
 	t.Helper()
-	prev := scopeguard.LookupHost
-	scopeguard.LookupHost = stub
-	t.Cleanup(func() { scopeguard.LookupHost = prev })
+	prev := scopeguard.SetLookupHost(stub)
+	t.Cleanup(func() { scopeguard.SetLookupHost(prev) })
 }
 
 // firstLocalInterfaceIP returns the first IP address bound to one of

--- a/internal/scopeguard/scopeguard.go
+++ b/internal/scopeguard/scopeguard.go
@@ -38,6 +38,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync/atomic"
 )
 
 // Config carries the operator's listener identity. Callers set
@@ -122,12 +123,44 @@ func schemeDefaultPort(scheme string) string {
 	}
 }
 
-// LookupHost is the package-level resolver indirection. Tests
-// overwrite this var to feed deterministic resolutions; production
-// uses net.LookupHost. Single var, single call site (inside
-// IsLocalOrListener), mirroring the per-package lookupHost
-// indirection that previously lived in internal/web/server.go.
-var LookupHost = net.LookupHost
+// lookupHostSig is the resolver indirection signature: it mirrors
+// net.LookupHost so production and test stubs are interchangeable.
+type lookupHostSig = func(host string) ([]string, error)
+
+// activeLookupHost holds the resolver behind an atomic pointer. The read
+// side (lookupHost, called from IsLocalOrListener) and the write side
+// (SetLookupHost, used by tests) both go through atomic load/swap, so an
+// in-flight scan goroutine classifying a target never data-races a test
+// swapping the resolver. Production installs net.LookupHost once at init
+// and never changes it.
+var activeLookupHost atomic.Pointer[lookupHostSig]
+
+func init() {
+	def := net.LookupHost
+	activeLookupHost.Store(&def)
+}
+
+// lookupHost resolves host using the currently installed resolver. Single
+// call site (inside IsLocalOrListener).
+func lookupHost(host string) ([]string, error) {
+	return (*activeLookupHost.Load())(host)
+}
+
+// SetLookupHost atomically installs fn as the resolver used by
+// IsLocalOrListener and returns the resolver it replaced, so callers can
+// restore it (the swap/restore pattern tests rely on). A nil fn resets to
+// net.LookupHost. The atomic swap pairs with the atomic load in lookupHost,
+// so installing a stub never races a concurrent classification.
+func SetLookupHost(fn func(host string) ([]string, error)) func(host string) ([]string, error) {
+	if fn == nil {
+		fn = net.LookupHost
+	}
+	prev := activeLookupHost.Swap(&fn)
+	if prev == nil {
+		return net.LookupHost
+	}
+	return *prev
+}
 
 // IsLocalOrListener returns true when target — a bare host,
 // host:port, scheme://host[:port][/path], or [ipv6][:port] —
@@ -208,7 +241,7 @@ func IsLocalOrListener(cfg Config, target string) bool {
 	if ip := net.ParseIP(host); ip != nil {
 		resolvedIPs = []net.IP{ip}
 	} else {
-		addrs, err := LookupHost(host)
+		addrs, err := lookupHost(host)
 		if err != nil || len(addrs) == 0 {
 			return false // can't resolve — let it through, will fail naturally
 		}

--- a/internal/scopeguard/scopeguard_test.go
+++ b/internal/scopeguard/scopeguard_test.go
@@ -14,9 +14,8 @@ import (
 // state.
 func withStubLookupHost(t *testing.T, stub func(string) ([]string, error)) {
 	t.Helper()
-	prev := LookupHost
-	LookupHost = stub
-	t.Cleanup(func() { LookupHost = prev })
+	prev := SetLookupHost(stub)
+	t.Cleanup(func() { SetLookupHost(prev) })
 }
 
 // isLocalOrListenerRow is one row in the table-driven test surface.

--- a/internal/tools/agentsgraph/agentsgraph.go
+++ b/internal/tools/agentsgraph/agentsgraph.go
@@ -38,7 +38,11 @@ type subAgentState struct {
 }
 
 var (
-	runner AgentRunner
+	// runnerPtr holds the injected AgentRunner behind an atomic pointer.
+	// Register is called from agent.NewAgent, and multi-instance scans
+	// construct agents concurrently, so the runner must be installed and
+	// read atomically rather than through a plain shared var.
+	runnerPtr atomic.Pointer[AgentRunner]
 
 	// Async sub-agent tracking
 	agentsMu     sync.Mutex
@@ -52,6 +56,19 @@ var (
 	agentsStopped atomic.Bool
 )
 
+// setRunner atomically installs the injected sub-agent runner.
+func setRunner(fn AgentRunner) { runnerPtr.Store(&fn) }
+
+// currentRunner returns the installed sub-agent runner, or nil if none has
+// been registered yet. The atomic load pairs with setRunner's store so a
+// tool callback fetching the runner never races a concurrent Register.
+func currentRunner() AgentRunner {
+	if p := runnerPtr.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
 // Register adds multi-agent tools to the registry.
 // The agentRunner function is injected to break the import cycle.
 //
@@ -59,7 +76,7 @@ var (
 // check_agent, wait_agent) are disabled — they cause zombie goroutines and
 // semaphore leaks that prevent the watchdog from detecting stuck scans.
 func Register(r *tools.Registry, agentRunner AgentRunner) {
-	runner = agentRunner
+	setRunner(agentRunner)
 
 	// Synchronous sub-agent — blocks until completion
 	r.Register(&tools.Tool{
@@ -121,12 +138,13 @@ func createAgent(args map[string]string) (tools.Result, error) {
 		targets = append(targets, target)
 	}
 
-	if runner == nil {
+	run := currentRunner()
+	if run == nil {
 		return tools.Result{}, fmt.Errorf("agent runner not initialized")
 	}
 
 	start := time.Now()
-	summary, err := runner(name, targets, task)
+	summary, err := run(name, targets, task)
 	elapsed := time.Since(start)
 
 	if err != nil {
@@ -158,7 +176,8 @@ func spawnAgent(args map[string]string) (tools.Result, error) {
 		return tools.Result{}, fmt.Errorf("name and task are required")
 	}
 
-	if runner == nil {
+	run := currentRunner()
+	if run == nil {
 		return tools.Result{}, fmt.Errorf("agent runner not initialized")
 	}
 
@@ -253,7 +272,7 @@ func spawnAgent(args map[string]string) (tools.Result, error) {
 			return
 		}
 
-		summary, err := runner(name, targets, task)
+		summary, err := run(name, targets, task)
 
 		agentsMu.Lock()
 		defer agentsMu.Unlock()

--- a/internal/tools/agentsgraph/agentsgraph_test.go
+++ b/internal/tools/agentsgraph/agentsgraph_test.go
@@ -24,10 +24,10 @@ func TestSpawnCheckWaitAgentSnapshots(t *testing.T) {
 	t.Cleanup(Reset)
 
 	release := make(chan struct{})
-	runner = func(name string, targets []string, task string) (string, error) {
+	setRunner(func(name string, targets []string, task string) (string, error) {
 		<-release
 		return "completed " + name + " on " + strings.Join(targets, ","), nil
-	}
+	})
 
 	res, err := spawnAgent(map[string]string{
 		"name":   "worker",
@@ -65,12 +65,12 @@ func TestResetWhileAgentRunsIsRaceFree(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})
 	done := make(chan struct{})
-	runner = func(name string, targets []string, task string) (string, error) {
+	setRunner(func(name string, targets []string, task string) (string, error) {
 		defer close(done)
 		close(started)
 		<-release
 		return "late result", nil
-	}
+	})
 
 	res, err := spawnAgent(map[string]string{"name": "slow", "task": "wait"})
 	if err != nil {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -2345,9 +2345,8 @@ func TestInstanceAction_GetAndStopSpecificInstance(t *testing.T) {
 // package-level state.
 func withStubLookupHost(t *testing.T, stub func(string) ([]string, error)) {
 	t.Helper()
-	prev := scopeguard.LookupHost
-	scopeguard.LookupHost = stub
-	t.Cleanup(func() { scopeguard.LookupHost = prev })
+	prev := scopeguard.SetLookupHost(stub)
+	t.Cleanup(func() { scopeguard.SetLookupHost(prev) })
 }
 
 // TestIsBlockedTarget_SingleLookup asserts that isBlockedTarget invokes


### PR DESCRIPTION
## Problem

The CI **Unit tests** job (`go test ./... -race -count=1`) is flaky in `internal/web` — it failed on the `v4.5.152` merge to `main`. Reproduced locally under `-race -shuffle=on` (~1 in 6 runs).

## Root cause

`handleScan` launches the scan in a fire-and-forget goroutine (`go func(){ runMultiScan(...) }()`) with no drain. `TestHandleScanAckIsPendingNotStarted` asserts the "pending" ack and returns **without awaiting that goroutine**, so it stays in flight into sibling tests. Under `-race` it concurrently touched two package-level globals:

1. **`scopeguard.LookupHost`** — read by `IsLocalOrListener` during target classification, while the lookup-stub test helpers swapped the var.
2. **`agentsgraph.runner`** — written by `Register` (called from *every* `agent.NewAgent`) with no synchronization.

Both are genuine concurrency hazards in production, not just test artifacts: multi-instance scans classify targets and construct agents concurrently, so the `runner` write in particular was an unsynchronized shared write on the hot path.

## Fix

Make both hooks concurrency-safe with atomic function pointers (no behavior change):

- **scopeguard**: `activeLookupHost atomic.Pointer` + internal `lookupHost()` reader + exported `SetLookupHost()` that atomically swaps and returns the previous resolver (preserves the tests' swap/restore pattern).
- **agentsgraph**: `runnerPtr atomic.Pointer` + `setRunner()`/`currentRunner()`; the tool callbacks snapshot the runner once per call.

Test helpers that swapped these globals now go through the atomic setters.

## Verification

- `go test ./... -race -count=1`: **0 data races**; `internal/web` and `internal/agent` pass.
- `internal/web` under `-race`: 15/15 in CI order, and ~35/36 under `-shuffle=on` (the one miss was a SIGINT artifact from my loop, not a race). Previously failed ~1 in 6.
- `go build ./...` clean; `golangci-lint` clean on the changed packages.

> Note: `internal/tools/browser` tests (`TestBridge_Start`, `TestBridge_StartIdempotent`) fail on my workstation only because they bind a hardcoded port (`127.0.0.1:38401`) already held by a locally-running xalgorix daemon. That package is untouched here and is unaffected in CI's isolated environment.