### PR TITLE
docs(issue-template): bump version placeholder to v4.5.153

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -41,7 +41,7 @@ body:
     attributes:
       label: Xalgorix version
       description: Output of `xalgorix --version` (or the Docker tag).
-      placeholder: v4.5.56
+      placeholder: v4.5.153
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
Updates the stale `v4.5.56` version placeholder in the bug-report issue form to the current `v4.5.153`. Placeholder only (not a default value); no functional change. YAML validated.