### PR TITLE
release: v4.5.154

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.153
+VERSION=4.5.154
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.153"
+var version = "4.5.154"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
### Changes

- 91b72fea docs(issue-template): bump version placeholder to v4.5.153 (#462)
- 636aee6d docs(readme): refresh hosted cloud dashboard screenshot (#461)
- 689a3418 chore(brand): update README banner to new design (#460)
- a01ca0a4 chore(brand): update logo and sized variants to new red emblem (#459)
- a62a241a release: v4.5.153 (#458)