### PR TITLE
test(web): fix flaky TestHandleScanAckIsPendingNotStarted temp-dir cleanup race

### DIFF
--- a/internal/web/scan_lifecycle_test.go
+++ b/internal/web/scan_lifecycle_test.go
@@ -264,6 +264,10 @@ func TestStopReqGlobalFlagDoesNotInterruptPendingScan(t *testing.T) {
 // desync whenever the worker was at its concurrency cap.
 func TestHandleScanAckIsPendingNotStarted(t *testing.T) {
 	s := newTestServer(t, nil)
+	// handleScan runs the scan in a detached goroutine that keeps writing under
+	// s.dataDir after this test returns; use a best-effort-cleaned data dir so
+	// that late write can't fail t.TempDir's strict cleanup.
+	bestEffortDataDir(t, s)
 
 	body := `{"targets":["https://example.com"],"scan_mode":"quick"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/scan", strings.NewReader(body))

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -72,6 +72,23 @@ func newTestServer(t *testing.T, cfg *config.Config) *Server {
 	return s
 }
 
+// bestEffortDataDir points s.dataDir at a temp dir cleaned up best-effort
+// (errors ignored), for tests that POST /api/scan. handleScan acks immediately
+// and runs the scan in a *detached* goroutine that keeps writing scan records
+// under s.dataDir after the test returns. A plain t.TempDir() cleans up with a
+// strict os.RemoveAll that races that late write and flakes with
+// "directory not empty" (observed on TestHandleScanAckIsPendingNotStarted).
+// A best-effort cleanup tolerates the leftover files instead.
+func bestEffortDataDir(t *testing.T, s *Server) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "xalgorix-scan-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	s.dataDir = dir
+}
+
 func resetAuthSessionsForTest() {
 	authSessionsMu.Lock()
 	defer authSessionsMu.Unlock()


### PR DESCRIPTION
## Problem

CI's **Unit tests** job flaked on `internal/web` after the v4.5.154 merge:

```
--- FAIL: TestHandleScanAckIsPendingNotStarted
    testing.go: TempDir RemoveAll cleanup: unlinkat /tmp/...: directory not empty
```

Not a regression from the release (that only bumped version strings). It's a pre-existing test-cleanup race: `handleScan` acks immediately and runs the scan in a **detached goroutine** that keeps writing scan records under `s.dataDir` after the test returns. `newTestServer` points `s.dataDir` at a `t.TempDir()`, whose strict `os.RemoveAll` cleanup then races that late write → `directory not empty`. It only shows up under timing pressure (it passed in the `-race` run and failed in the coverage run of the same CI job).

## Fix

Test-only. Added a `bestEffortDataDir(t, s)` helper (`server_test.go`) that points `s.dataDir` at an `os.MkdirTemp` dir cleaned up **best-effort** (errors ignored), and used it in `TestHandleScanAckIsPendingNotStarted`. The detached scan's leftover writes can no longer fail cleanup. No production code changed.

## Verification

- `go vet ./internal/web/` — clean
- `TestHandleScanAckIsPendingNotStarted` ×30 in coverage mode (the exact CI trigger) — all pass, ~1.8s
- Full `go test ./internal/web/ -covermode=atomic` — passes (2.3s)

## Note

The scan goroutine is still fire-and-forget (unchanged behavior). A deterministic drain would need scan-lifecycle plumbing (a tracked `WaitGroup` + fast cancellation); this change just stops the race from failing CI. Happy to follow up with the lifecycle-level drain if you'd like it.
