### PR TITLE
release: v4.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.5.156
+VERSION=4.6.0
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.5.156" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.6.0" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.5.156"
+var version = "4.6.0"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Version bump to **v4.6.0** — a brand-refresh + UX milestone.

### New in 4.6.0
- New transparent vector logo + regenerated icon sizes (favicon, dashboard/login mark, README assets).

### Recent highlights consolidated under this milestone (landed in the 4.5.x line)
- Light / Dark / System dashboard theme (toggle + persistence + no-flash).
- Multiple Postman file upload (collection + environment) with `{{variable}}` and auth resolution.

Bumps `main.go`, `Makefile`, and the README banner `?v=`. No breaking changes.