### PR TITLE
CLI: LLM token-usage + hosted cost note at scan end

### DIFF
--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -531,6 +531,60 @@ func FormatVulnSummary() string {
 	return b.String()
 }
 
+// FormatCostNote prints an honest end-of-scan LLM-usage line plus a low-key
+// pointer to the hosted service. Self-hosting is free to run, but the tokens the
+// agent just spent were billed to the operator's own LLM provider — a cost
+// that's otherwise invisible until the provider invoice arrives. Surfacing the
+// count makes it visible, and points at the outcome-based hosted alternative.
+// Returns "" when there were no tokens to report (e.g. a run that never called
+// the model), so it stays silent when there's nothing honest to say.
+func FormatCostNote(cfg *config.Config, totalTokens int) string {
+	if totalTokens <= 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("\n  ═══ LLM usage this scan: ~%s tokens ═══\n\n", humanizeTokens(totalTokens)))
+	if isLocalProvider(cfg) {
+		b.WriteString("  Ran on your local model — no API bill, just your own compute and time.\n")
+	} else {
+		b.WriteString("  Those tokens were billed to your own LLM provider.\n")
+	}
+	b.WriteString("  The hosted cloud runs the same exploit-verified scan for 1 credit per\n")
+	b.WriteString("  live host — no API keys, no token bills, infra + OOB managed for you:\n")
+	b.WriteString("    → https://www.xalgorix.com/hosted-vs-self-hosted\n")
+	return b.String()
+}
+
+// humanizeTokens renders a token count compactly (2.34M / 812k / 640).
+func humanizeTokens(n int) string {
+	switch {
+	case n >= 1_000_000:
+		return fmt.Sprintf("%.2fM", float64(n)/1_000_000)
+	case n >= 1_000:
+		return fmt.Sprintf("%.0fk", float64(n)/1_000)
+	default:
+		return fmt.Sprintf("%d", n)
+	}
+}
+
+// isLocalProvider reports whether the active LLM runs locally (Ollama or a
+// loopback endpoint), so the cost note doesn't wrongly claim a provider bill.
+func isLocalProvider(cfg *config.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	if cfg.OllamaCompatible || strings.EqualFold(strings.TrimSpace(cfg.LLMProvider), "ollama") {
+		return true
+	}
+	model := strings.ToLower(cfg.LLM)
+	base := strings.ToLower(cfg.APIBase)
+	return strings.HasPrefix(model, "ollama/") ||
+		strings.Contains(model, "ollama") ||
+		strings.Contains(base, "11434") ||
+		strings.Contains(base, "localhost") ||
+		strings.Contains(base, "127.0.0.1")
+}
+
 func metadataString(metadata map[string]any, key string) (string, bool) {
 	if metadata == nil {
 		return "", false
@@ -605,11 +659,16 @@ func RunCLI(cfg *config.Config, targets []string, instruction string, codeScan s
 	}
 
 	done := make(chan struct{})
+	// The terminal "finished" event carries the run's cumulative token total.
+	// Capturing it here is race-free: the goroutine writes it before close(done),
+	// and RunCLI only reads it after <-done.
+	var totalTokens int
 	go func() {
 		defer close(done)
 		for evt := range events {
 			fmt.Print(FormatEvent(evt))
 			if evt.Type == "finished" {
+				totalTokens = evt.TotalTokens
 				return
 			}
 		}
@@ -620,6 +679,7 @@ func RunCLI(cfg *config.Config, targets []string, instruction string, codeScan s
 	<-done
 
 	fmt.Print(FormatVulnSummary())
+	fmt.Print(FormatCostNote(cfg, totalTokens))
 }
 
 // cliPickLoopbackPort returns a free loopback TCP port for a provision scan.

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1,0 +1,78 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/config"
+)
+
+func TestHumanizeTokens(t *testing.T) {
+	cases := map[int]string{
+		0:         "0",
+		640:       "640",
+		5000:      "5k",
+		812_000:   "812k",
+		2_000_000: "2.00M",
+		2_340_000: "2.34M",
+	}
+	for in, want := range cases {
+		if got := humanizeTokens(in); got != want {
+			t.Errorf("humanizeTokens(%d) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestIsLocalProvider(t *testing.T) {
+	local := []*config.Config{
+		{LLMProvider: "ollama"},
+		{OllamaCompatible: true},
+		{APIBase: "http://localhost:11434"},
+		{APIBase: "http://127.0.0.1:11434/v1"},
+		{LLM: "ollama/llama3.3"},
+	}
+	for _, c := range local {
+		if !isLocalProvider(c) {
+			t.Errorf("isLocalProvider(%+v) = false, want true", c)
+		}
+	}
+	remote := []*config.Config{
+		{LLMProvider: "openai", LLM: "openai/gpt-5.4"},
+		{LLMProvider: "minimax", APIBase: "https://api.minimax.io/v1"},
+		nil,
+	}
+	for _, c := range remote {
+		if isLocalProvider(c) {
+			t.Errorf("isLocalProvider(%+v) = true, want false", c)
+		}
+	}
+}
+
+func TestFormatCostNote(t *testing.T) {
+	// No tokens → stays silent.
+	if got := FormatCostNote(&config.Config{}, 0); got != "" {
+		t.Errorf("FormatCostNote(_, 0) = %q, want empty", got)
+	}
+
+	// Remote provider: names the provider bill, the hosted nudge, and the URL.
+	remote := FormatCostNote(&config.Config{LLMProvider: "openai"}, 2_000_000)
+	for _, want := range []string{
+		"2.00M tokens",
+		"billed to your own LLM provider",
+		"1 credit per",
+		"xalgorix.com/hosted-vs-self-hosted",
+	} {
+		if !strings.Contains(remote, want) {
+			t.Errorf("remote cost note missing %q:\n%s", want, remote)
+		}
+	}
+
+	// Local provider: must NOT claim a provider bill.
+	local := FormatCostNote(&config.Config{LLMProvider: "ollama"}, 500_000)
+	if strings.Contains(local, "billed to your own LLM provider") {
+		t.Errorf("local cost note wrongly claims a provider bill:\n%s", local)
+	}
+	if !strings.Contains(local, "local model") {
+		t.Errorf("local cost note should mention the local model:\n%s", local)
+	}
+}


### PR DESCRIPTION
## What
After a terminal scan (`xalgorix --target …` → `tui.RunCLI`) finishes, print the run's cumulative **LLM token usage** and a low-key pointer to the hosted cloud.

Self-hosting is free to *run*, but the tokens the agent just spent were billed to the operator's own LLM provider — a cost that's otherwise invisible until the provider invoice arrives. Surfacing the count is honest transparency, and it naturally frames the outcome-based hosted alternative.

Example tail of a scan:
```
  ═══ LLM usage this scan: ~2.34M tokens ═══

  Those tokens were billed to your own LLM provider.
  The hosted cloud runs the same exploit-verified scan for 1 credit per
  live host — no API keys, no token bills, infra + OOB managed for you:
    → https://www.xalgorix.com/hosted-vs-self-hosted
```

## Honest by construction
- **Local models** (Ollama / loopback endpoint) are detected and described as *"Ran on your local model — no API bill"* rather than falsely claiming a provider charge.
- **Stays silent** when a run used no tokens (`totalTokens <= 0`).
- Token total is the real cumulative count, read from the `finished` event's `TotalTokens` (race-free via the existing `done` channel) — no fabricated dollar figures, since the engine can't know the operator's exact per-token price.

## Notes
- Single block at the very end of the CLI output, matching `FormatVulnSummary`'s plain `═══`/2-space style. Once per scan, not spammy.
- Adds `internal/tui/tui_test.go` covering `humanizeTokens`, `isLocalProvider`, and `FormatCostNote` (remote vs local vs zero).
- `go build ./...`, `go vet`, and `go test ./internal/tui/` all pass.