### PR TITLE
fix: support macOS ARM64 and multi-arch images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,57 @@ jobs:
           path: coverage.out
           retention-days: 7
           if-no-files-found: warn
+
+  platform-build:
+    name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Build
+        env:
+          CGO_ENABLED: "0"
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: go build ./cmd/xalgorix
+
+  macos-smoke:
+    name: macOS ARM64 smoke test
+    runs-on: macos-15
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify runner architecture
+        run: test "$(uname -m)" = arm64
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Verify native resource metrics
+        run: go test ./internal/resources -count=1
+
+      - name: Build native binary
+        run: go build ./cmd/xalgorix

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,15 +1,12 @@
 # Build and publish the Xalgorix container image.
 #
-# Triggers on version tags (vX.Y.Z, pushed by release.sh) and can be run
-# manually. Publishes the batteries-included amd64 image tagged with the
-# version and `latest` to:
+# Each architecture is built on a native GitHub-hosted runner. This avoids the
+# extreme QEMU cost of compiling the batteries-included Kali toolset, then a
+# final job joins both digests into one linux/amd64 + linux/arm64 manifest.
+# Images are published to:
 #   - GitHub Container Registry: ghcr.io/xalgord/xalgorix   (always)
 #   - Docker Hub:                docker.io/xalgord/xalgorix (when the
 #     DOCKERHUB_USERNAME + DOCKERHUB_TOKEN repo secrets are set)
-#
-# The Docker Hub target is OPTIONAL and self-gating: with no secrets, the run
-# still succeeds and publishes to GHCR only. (Release binaries remain
-# multi-arch via the installer.)
 name: Docker
 
 on:
@@ -27,20 +24,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  publish:
-    name: Build and push image
-    runs-on: ubuntu-latest
+  build:
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 240
-    # Surfaced so steps can gate the Docker Hub path on the secret being set.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
     env:
       DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USERNAME }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # The Kali batteries-included image is many GB; the stock runner (~14GB
-      # free on /) can't hold it mid-build. Reclaim ~25-30GB by dropping
-      # preinstalled SDKs/toolchains we don't need.
+      # The Kali batteries-included image is many GB; reclaim the runner's
+      # preinstalled SDK space before BuildKit starts materializing layers.
       - name: Free disk space
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
@@ -58,7 +63,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Optional: only runs when the Docker Hub secrets are configured.
       - name: Log in to Docker Hub
         if: ${{ env.DOCKERHUB_USER != '' }}
         uses: docker/login-action@v3
@@ -71,8 +75,6 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          # GHCR always; Docker Hub (docker.io/xalgord/xalgorix) only when the
-          # secret is present — the empty line is ignored by the action.
           images: |
             ghcr.io/${{ github.repository }}
             ${{ env.DOCKERHUB_USER != '' && 'docker.io/xalgord/xalgorix' || '' }}
@@ -80,21 +82,146 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+            type=raw,value=edge,enable=${{ github.ref_type != 'tag' }}
 
-      - name: Build and push
+      - name: Select image repositories
+        id: images
+        env:
+          GHCR_IMAGE: ghcr.io/${{ github.repository }}
+        run: |
+          images="$GHCR_IMAGE"
+          if [[ -n "$DOCKERHUB_USER" ]]; then
+            images="${images},docker.io/xalgord/xalgorix"
+          fi
+          echo "names=$images" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
-          # amd64 only: the batteries-included toolset (Go/Rust/apt tools +
-          # nuclei templates) is impractical to build for arm64 under CI
-          # emulation. Release binaries stay multi-arch via the installer.
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          # TOOLS_REFRESH busts the dedicated nuclei engine+template layer on
-          # every run, so each published image ships the latest nuclei + latest
-          # templates (matters if a build-cache backend is added here later).
+          outputs: type=image,"name=${{ steps.images.outputs.names }}",push-by-digest=true,name-canonical=true,push=true
           build-args: |
             VERSION=${{ steps.meta.outputs.version || github.ref_name }}
-            TOOLS_REFRESH=${{ github.run_id }}
+            TOOLS_REFRESH=${{ github.run_id }}-${{ matrix.arch }}
+
+      - name: Export digest
+        env:
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/digests"
+          touch "$RUNNER_TEMP/digests/${IMAGE_DIGEST#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-digest-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Publish multi-architecture manifest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    needs: build
+    env:
+      DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USERNAME }}
+      GHCR_IMAGE: ghcr.io/${{ github.repository }}
+      DOCKERHUB_IMAGE: docker.io/xalgord/xalgorix
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: docker-digest-*
+          merge-multiple: true
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        if: ${{ env.DOCKERHUB_USER != '' }}
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+            ${{ env.DOCKERHUB_USER != '' && 'docker.io/xalgord/xalgorix' || '' }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+            type=raw,value=edge,enable=${{ github.ref_type != 'tag' }}
+
+      - name: Create manifests
+        env:
+          DIGEST_DIR: ${{ runner.temp }}/digests
+          METADATA_JSON: ${{ steps.meta.outputs.json }}
+        run: |
+          mapfile -t digests < <(find "$DIGEST_DIR" -maxdepth 1 -type f -printf '%f\n' | sort)
+          if [[ ${#digests[@]} -ne 2 ]]; then
+            echo "Expected two platform digests, found ${#digests[@]}" >&2
+            exit 1
+          fi
+
+          ghcr_sources=()
+          dockerhub_sources=()
+          for digest in "${digests[@]}"; do
+            ghcr_sources+=("${GHCR_IMAGE}@sha256:${digest}")
+            dockerhub_sources+=("${DOCKERHUB_IMAGE}@sha256:${digest}")
+          done
+
+          ghcr_tags=()
+          dockerhub_tags=()
+          mapfile -t tags < <(jq -r '.tags[]' <<< "$METADATA_JSON")
+          for tag in "${tags[@]}"; do
+            case "$tag" in
+              "${GHCR_IMAGE}:"*) ghcr_tags+=("--tag" "$tag") ;;
+              "${DOCKERHUB_IMAGE}:"*) dockerhub_tags+=("--tag" "$tag") ;;
+            esac
+          done
+
+          if [[ ${#ghcr_tags[@]} -eq 0 ]]; then
+            echo "No GHCR tags were generated" >&2
+            exit 1
+          fi
+          docker buildx imagetools create "${ghcr_tags[@]}" "${ghcr_sources[@]}"
+
+          if [[ -n "$DOCKERHUB_USER" ]]; then
+            if [[ ${#dockerhub_tags[@]} -eq 0 ]]; then
+              echo "No Docker Hub tags were generated" >&2
+              exit 1
+            fi
+            docker buildx imagetools create "${dockerhub_tags[@]}" "${dockerhub_sources[@]}"
+          fi
+
+      - name: Verify published platforms
+        env:
+          METADATA_JSON: ${{ steps.meta.outputs.json }}
+        run: |
+          manifest_tag=$(jq -r --arg prefix "${GHCR_IMAGE}:" '[.tags[] | select(startswith($prefix))][0] // empty' <<< "$METADATA_JSON")
+          if [[ -z "$manifest_tag" ]]; then
+            echo "No GHCR manifest tag was generated" >&2
+            exit 1
+          fi
+          manifest=$(docker buildx imagetools inspect "$manifest_tag")
+          echo "$manifest"
+          grep -q 'Platform:.*linux/amd64' <<< "$manifest"
+          grep -q 'Platform:.*linux/arm64' <<< "$manifest"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Small fixes (typos, docs, obvious bugs) don't need an issue first — just open 
 
 Install the following on your workstation:
 
-- **Go 1.25+** — building and testing the `xalgorix` binary.
+- **Go 1.26+** — building and testing the `xalgorix` binary.
 - **Node.js 20+** and **npm** — building the embedded `webui` dashboard bundle.
 - **GNU Make** — the entry point for every common task.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@
 #
 # Then open http://127.0.0.1:9137
 #
-# amd64 image. The release BINARIES remain multi-arch (Linux amd64/arm64) via
-# the one-line installer.
+# Published for linux/amd64 and linux/arm64. Release binaries also cover native
+# Linux and macOS installs via the one-line installer.
 
 # ── Stage 1: build the React web UI ──────────────────────────────────────────
 FROM node:22-bookworm-slim AS webui
@@ -113,6 +113,7 @@ RUN set -eux; \
 # ── Stage 3: runtime — Kali Linux, full toolset, runs as root ────────────────
 FROM kalilinux/kali-rolling
 
+ARG TARGETARCH
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Kali metapackages = the extensive toolset. Recommends are left ON so the
@@ -171,7 +172,12 @@ ENV PATH="/usr/local/go/bin:/root/go/bin:/root/.cargo/bin:/root/.local/bin:${PAT
 
 # feroxbuster (Rust) — Kali packages it, but grab the latest release binary too
 # so it's current; cargo stays available at runtime as the engine's fallback.
-RUN curl -sSLo /tmp/ferox.zip https://github.com/epi052/feroxbuster/releases/latest/download/x86_64-linux-feroxbuster.zip \
+RUN case "${TARGETARCH}" in \
+      amd64) ferox_arch=x86_64 ;; \
+      arm64) ferox_arch=aarch64 ;; \
+      *) echo "Unsupported Docker target architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSLo /tmp/ferox.zip "https://github.com/epi052/feroxbuster/releases/latest/download/${ferox_arch}-linux-feroxbuster.zip" \
     && unzip -o /tmp/ferox.zip -d /usr/local/bin feroxbuster \
     && chmod +x /usr/local/bin/feroxbuster \
     && rm -f /tmp/ferox.zip \
@@ -203,7 +209,7 @@ RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main
 RUN mkdir -p -m 755 /etc/apt/keyrings \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
     && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-    && echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
          > /etc/apt/sources.list.d/github-cli.list \
     && apt-get update && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/* \

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
 curl -sSL https://www.xalgorix.com/install | bash
 ```
 
-This downloads the prebuilt binary for your platform (Linux amd64/arm64) from the latest release. Then run the interactive setup wizard:
+This downloads the prebuilt binary for your platform (Linux or macOS, amd64/arm64) from the latest release. Then run the interactive setup wizard:
 
 ```bash
 xalgorix --setup
@@ -88,9 +88,9 @@ docker compose up -d
 docker compose logs -f   # shows the generated admin password on first start
 ```
 
-The image ships an extensive offensive-security toolset preinstalled (nmap, nuclei, httpx, subfinder, katana, ffuf, gobuster, sqlmap, masscan, dalfox, feroxbuster, and more) **and** keeps every package manager (apt, go, cargo, pipx, npm) available so the agent can still auto-install anything missing at runtime. It runs as root inside the container by design — treat the container as a disposable, network-isolated scanning sandbox and never expose the dashboard without auth. (amd64 image; the installer above covers arm64.)
+The image ships an extensive offensive-security toolset preinstalled (nmap, nuclei, httpx, subfinder, katana, ffuf, gobuster, sqlmap, masscan, dalfox, feroxbuster, and more) **and** keeps every package manager (apt, go, cargo, pipx, npm) available so the agent can still auto-install anything missing at runtime. It runs as root inside the container by design — treat the container as a disposable, network-isolated scanning sandbox and never expose the dashboard without auth. Images are published for both amd64 and arm64.
 
-**Or build from source** (needs Go 1.25+ and Node.js):
+**Or build from source** (needs Go 1.26+ and Node.js):
 
 ```bash
 git clone https://github.com/xalgorix/xalgorix.git
@@ -226,7 +226,7 @@ The fastest paths need no toolchain at all.
 curl -sSL https://www.xalgorix.com/install | bash
 ```
 
-Downloads the latest release binary for your platform (Linux `amd64`/`arm64`) and installs it to `/usr/local/bin` (or `~/.local/bin` without sudo). Override with `XALGORIX_INSTALL_DIR` or pin a version with `XALGORIX_VERSION=vX.Y.Z`.
+Downloads the latest release binary for your platform (Linux or macOS, `amd64`/`arm64`) and installs it to `/usr/local/bin` (or `~/.local/bin` without sudo). Override with `XALGORIX_INSTALL_DIR` or pin a version with `XALGORIX_VERSION=vX.Y.Z`.
 
 Complete first-time configuration interactively—no manual environment-file editing required:
 
@@ -251,7 +251,7 @@ docker run --rm -p 9137:9137 \
 
 The image is **batteries-included**: an extensive offensive-security toolset is preinstalled (nmap, nuclei, httpx, subfinder, dnsx, naabu, katana, ffuf, gobuster, dalfox, feroxbuster, sqlmap, masscan, nikto, whatweb, hydra, and more), plus Chromium for browser-assisted DAST. It also keeps the full package-manager set (apt, go, cargo, pipx, npm) available, so the agent auto-installs anything missing at runtime. Scan data persists to the `/data` volume, and the server binds `0.0.0.0` inside the container — set `XALGORIX_USERNAME`/`XALGORIX_PASSWORD` before exposing it beyond localhost.
 
-The container runs as root by design (the engine only enables runtime auto-install for uid 0, and apt/go/cargo installs need system write access). Treat it as a disposable, network-isolated scanning sandbox. It's published for `amd64`; use the one-line installer for arm64 hosts.
+The container runs as root by design (the engine only enables runtime auto-install for uid 0, and apt/go/cargo installs need system write access). Treat it as a disposable, network-isolated scanning sandbox. The same tags publish a multi-platform manifest for `linux/amd64` and `linux/arm64`, so Docker selects the native image automatically.
 
 On first run, if you don't set dashboard auth the container **generates a random admin password and prints it to the logs** (the image binds `0.0.0.0`, which the engine won't do without auth). Set `XALGORIX_USERNAME` + `XALGORIX_PASSWORD` (or `XALGORIX_PASSWORD_HASH`) to use your own. The binary never self-updates inside the container (`XALGORIX_NO_AUTO_UPDATE=1`) — pull a new image tag to upgrade. The **nuclei** engine and its vuln templates are refreshed to the latest on every image build (the release CI and `redeploy.sh` force this); pass `--build-arg NUCLEI_VERSION=vX.Y.Z` to pin the engine, or `NUCLEI_REFRESH=0 ./redeploy.sh` to reuse Docker's cache.
 
@@ -259,8 +259,8 @@ On first run, if you don't set dashboard auth the container **generates a random
 
 | Requirement    | Notes                                                        |
 | -------------- | ------------------------------------------------------------ |
-| Linux          | Primary supported platform.                                  |
-| Go             | `1.25` or newer.                                             |
+| OS             | Linux or macOS (`amd64`/`arm64`).                            |
+| Go             | `1.26` or newer.                                             |
 | Node.js + npm  | Required when building the bundled React Web UI from source. |
 | Security tools | Installed on demand only when auto-install is enabled.       |
 

--- a/docs/dockerhub-overview.md
+++ b/docs/dockerhub-overview.md
@@ -63,7 +63,7 @@ An extensive toolset ships preinstalled — `nmap`, `nuclei`, `httpx`, `subfinde
 | `X.Y.Z` (e.g. `4.5.50`) | A specific, immutable release. |
 | `X.Y` (e.g. `4.5`) | Latest patch of that minor line. |
 
-**Platform:** `linux/amd64`. For `arm64` hosts, use the one-line installer or build from source (see the repo).
+**Platforms:** `linux/amd64` and `linux/arm64`. Docker automatically selects the native image for the host.
 
 ## Security notes
 
@@ -76,6 +76,6 @@ An extensive toolset ships preinstalled — `nmap`, `nuclei`, `httpx`, `subfinde
 - **Source & docs:** https://github.com/xalgorix/xalgorix
 - **Documentation:** https://docs.xalgorix.com
 - **Hosted (no install):** https://www.xalgorix.com
-- **One-line install (any Linux, amd64/arm64):** `curl -sSL https://www.xalgorix.com/install | bash`
+- **One-line install (Linux or macOS, amd64/arm64):** `curl -sSL https://www.xalgorix.com/install | bash`
 
 Released under the Apache License 2.0.

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,10 @@ require (
 	github.com/go-rod/rod v0.116.2
 	github.com/gorilla/websocket v1.5.3
 	github.com/projectdiscovery/interactsh v1.3.1
+	github.com/shirou/gopsutil/v3 v3.24.5
 	golang.org/x/crypto v0.52.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/sys v0.45.0
 	golang.org/x/term v0.43.0
 	golang.org/x/time v0.14.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -115,7 +117,6 @@ require (
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/rs/xid v1.6.0 // indirect
 	github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d // indirect
-	github.com/shirou/gopsutil/v3 v3.24.5 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/sorairolake/lzip-go v0.3.8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
@@ -155,7 +156,6 @@ require (
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.31.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect
 	gopkg.in/corvus-ch/zbase32.v1 v1.0.0 // indirect

--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,8 @@ command -v curl >/dev/null 2>&1 || die "curl is required but not installed."
 OS="$(uname -s)"
 case "$OS" in
   Linux) OS="linux" ;;
-  *) die "Unsupported OS '$OS'. Xalgorix ships Linux binaries; build from source for other platforms (see README)." ;;
+  Darwin) OS="darwin" ;;
+  *) die "Unsupported OS '$OS'. Xalgorix ships Linux and macOS binaries; build from source for other platforms (see README)." ;;
 esac
 
 ARCH="$(uname -m)"

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -1,8 +1,8 @@
 // Package resources provides real-time system resource monitoring for
 // dynamic scan admission control and runtime backpressure.
 //
-// It reads Linux /proc files (meminfo, loadavg) and uses syscall.Statfs
-// for disk space. All thresholds are configurable via environment variables.
+// It uses portable host metrics plus syscall.Statfs for disk space. All
+// thresholds are configurable via environment variables.
 package resources
 
 import (
@@ -18,6 +18,10 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/shirou/gopsutil/v3/load"
+	"github.com/shirou/gopsutil/v3/mem"
+	"github.com/shirou/gopsutil/v3/process"
 )
 
 // ── Resource Levels ──
@@ -929,74 +933,39 @@ func ProtectCurrentProcess() {
 	log.Printf("[RESOURCES] xalgorix OOM score set to -500")
 }
 
-// ── Linux /proc readers ──
+// ── Portable host metrics ──
 
-// readLoadAvg reads 1-minute load average from /proc/loadavg.
+// readLoadAvg reads the host's 1-minute load average.
 func readLoadAvg() float64 {
-	data, err := os.ReadFile("/proc/loadavg")
+	stats, err := load.Avg()
 	if err != nil {
-		log.Printf("[RESOURCES] Cannot read /proc/loadavg: %v", err)
+		log.Printf("[RESOURCES] Cannot read load average: %v", err)
 		return 0
 	}
-	fields := strings.Fields(string(data))
-	if len(fields) < 1 {
-		return 0
-	}
-	val, err := strconv.ParseFloat(fields[0], 64)
-	if err != nil {
-		return 0
-	}
-	return val
+	return stats.Load1
 }
 
-// readMemInfo reads total and available memory from /proc/meminfo.
+// readMemInfo reads total and available physical memory. gopsutil maps this to
+// procfs on Linux and the native VM statistics APIs on macOS.
 func readMemInfo() (totalMB, availableMB int64) {
-	data, err := os.ReadFile("/proc/meminfo")
+	stats, err := mem.VirtualMemory()
 	if err != nil {
-		log.Printf("[RESOURCES] Cannot read /proc/meminfo: %v", err)
+		log.Printf("[RESOURCES] Cannot read memory statistics: %v", err)
 		return 0, 0
 	}
-
-	for _, line := range strings.Split(string(data), "\n") {
-		fields := strings.Fields(line)
-		if len(fields) < 2 {
-			continue
-		}
-		val, err := strconv.ParseInt(fields[1], 10, 64)
-		if err != nil {
-			continue
-		}
-		// /proc/meminfo reports in kB
-		switch fields[0] {
-		case "MemTotal:":
-			totalMB = val / 1024
-		case "MemAvailable:":
-			availableMB = val / 1024
-		}
-	}
-	return totalMB, availableMB
+	return int64(stats.Total / (1024 * 1024)), int64(stats.Available / (1024 * 1024)) //nolint:gosec // G115: MB-scaled memory sizes fit int64
 }
 
 func readProcessRSSMB() int64 {
-	data, err := os.ReadFile("/proc/self/status")
+	current, err := process.NewProcess(int32(os.Getpid())) //nolint:gosec // G115: OS process IDs fit int32
 	if err != nil {
 		return 0
 	}
-	for _, line := range strings.Split(string(data), "\n") {
-		if !strings.HasPrefix(line, "VmRSS:") {
-			continue
-		}
-		fields := strings.Fields(line)
-		if len(fields) < 2 {
-			return 0
-		}
-		kb, err := strconv.ParseInt(fields[1], 10, 64)
-		if err != nil {
-			return 0
-		}
-		return kb / 1024
+	stats, err := current.MemoryInfo()
+	if err != nil {
+		return 0
 	}
-	return 0
+	return int64(stats.RSS / (1024 * 1024)) //nolint:gosec // G115: MB-scaled RSS fits int64
 }
 
 // readDiskFree returns free disk space (in MB) for the root filesystem.

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -22,6 +22,22 @@ func TestLevelStringAndMaxLevel(t *testing.T) {
 	}
 }
 
+func TestLiveHostMetricsAreUsable(t *testing.T) {
+	stats := GetStats()
+	if stats.CPUCores < 1 {
+		t.Fatalf("CPU cores = %d, want at least one", stats.CPUCores)
+	}
+	if stats.MemTotalMB <= 0 {
+		t.Fatalf("total memory = %d MB, want a positive host reading", stats.MemTotalMB)
+	}
+	if stats.MemAvailableMB <= 0 {
+		t.Fatalf("available memory = %d MB, want a positive host reading", stats.MemAvailableMB)
+	}
+	if stats.DiskFreeMB <= 0 {
+		t.Fatalf("free disk = %d MB, want a positive filesystem reading", stats.DiskFreeMB)
+	}
+}
+
 func TestEnvHelpers(t *testing.T) {
 	t.Setenv("XALGORIX_TEST_FLOAT", "")
 	if got := envFloat("XALGORIX_TEST_FLOAT", 1.5); got != 1.5 {

--- a/internal/tools/terminal/process_limits_linux.go
+++ b/internal/tools/terminal/process_limits_linux.go
@@ -1,0 +1,42 @@
+//go:build linux
+
+package terminal
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// setProcessLimitsForPID applies Linux OOM and address-space constraints to an
+// already-running child. Keeping this in a Linux-only file prevents Darwin and
+// other Unix builds from compiling Linux syscall numbers or relying on procfs.
+func setProcessLimitsForPID(pid int, memoryLimited bool, memLimitBytes int64) {
+	if pid <= 0 {
+		return
+	}
+
+	// Score 500 = "kill me before most things, but not before 1000". This is
+	// best effort because unprivileged processes may not be allowed to change it.
+	oomPath := fmt.Sprintf("/proc/%d/oom_score_adj", pid)
+	if err := os.WriteFile(oomPath, []byte("500"), 0o644); err != nil { //nolint:gosec // G306: procfs ignores the file mode
+		log.Printf("[RESOURCES] Cannot set OOM score for PID %d: %v", pid, err)
+	}
+
+	if memoryLimited && memLimitBytes > 0 {
+		newLimit := unix.Rlimit{
+			Cur: uint64(memLimitBytes),
+			Max: uint64(memLimitBytes),
+		}
+		if err := unix.Prlimit(pid, unix.RLIMIT_AS, &newLimit, nil); err != nil {
+			log.Printf("[RESOURCES] Cannot set RLIMIT_AS for PID %d: %v", pid, err)
+		} else {
+			log.Printf("[RESOURCES] Tool PID %d: OOM score=500, mem limit=%d MB",
+				pid, memLimitBytes/(1024*1024))
+		}
+	} else {
+		log.Printf("[RESOURCES] PID %d: OOM score set to 500", pid)
+	}
+}

--- a/internal/tools/terminal/process_limits_other.go
+++ b/internal/tools/terminal/process_limits_other.go
@@ -1,0 +1,24 @@
+//go:build !linux
+
+package terminal
+
+import (
+	"log"
+	"runtime"
+	"sync"
+)
+
+var unsupportedProcessLimitWarning sync.Once
+
+// setProcessLimitsForPID is intentionally best-effort outside Linux. The hard
+// address-space limit is disabled by default, and macOS has no prlimit(2)
+// equivalent for changing another process after launch. Process-group cleanup
+// remains active through the shared terminal execution path.
+func setProcessLimitsForPID(pid int, memoryLimited bool, memLimitBytes int64) {
+	if pid <= 0 || !memoryLimited || memLimitBytes <= 0 {
+		return
+	}
+	unsupportedProcessLimitWarning.Do(func() {
+		log.Printf("[RESOURCES] Per-tool hard memory limits are not supported on %s; continuing without RLIMIT_AS", runtime.GOOS)
+	})
+}

--- a/internal/tools/terminal/terminal.go
+++ b/internal/tools/terminal/terminal.go
@@ -18,7 +18,6 @@ import (
 	"syscall"
 	"time"
 	"unicode/utf8"
-	"unsafe"
 
 	"github.com/xalgord/xalgorix/v4/internal/config"
 	"github.com/xalgord/xalgorix/v4/internal/resources"
@@ -601,57 +600,6 @@ func setProcessLimits(cmd *exec.Cmd, memoryLimited bool, memLimitBytes int64) {
 		return
 	}
 	setProcessLimitsForPID(cmd.Process.Pid, memoryLimited, memLimitBytes)
-}
-
-// setProcessLimitsForPID applies the same OOM / RLIMIT_AS constraints as
-// setProcessLimits but works with an already-known PID. This is the path
-// used for processes spawned outside of os/exec (e.g. go-rod's launcher,
-// which exposes only Launcher.PID()).
-func setProcessLimitsForPID(pid int, memoryLimited bool, memLimitBytes int64) {
-	if pid <= 0 {
-		return
-	}
-
-	// ── OOM score adjustment ──
-	// Score 500 = "kill me before most things, but not before 1000"
-	// xalgorix protects itself with a negative score, so the kernel prefers
-	// killing children under memory pressure.
-	oomPath := fmt.Sprintf("/proc/%d/oom_score_adj", pid)
-	if err := os.WriteFile(oomPath, []byte("500"), 0644); err != nil { //nolint:gosec // G306: procfs ignores the file mode
-		// Not fatal — best effort. Fails if not running as root.
-		log.Printf("[RESOURCES] Cannot set OOM score for PID %d: %v", pid, err)
-	}
-
-	// ── Memory limit for scanner subprocesses ──
-	// Uses prlimit64 syscall to set RLIMIT_AS on the child process.
-	// If the tool exceeds this, it gets ENOMEM / SIGSEGV — xalgorix survives.
-	if memoryLimited && memLimitBytes > 0 {
-		newLimit := syscall.Rlimit{
-			Cur: uint64(memLimitBytes),
-			Max: uint64(memLimitBytes),
-		}
-		// prlimit64(pid, resource, new_rlimit*, old_rlimit*)
-		// unsafe.Pointer is required by the syscall ABI to pass the
-		// rlimit struct; there is no safe stdlib wrapper for setting
-		// RLIMIT_AS on another PID. The pointer is to a local struct that
-		// outlives the call.
-		_, _, errno := syscall.RawSyscall6(
-			syscall.SYS_PRLIMIT64,
-			uintptr(pid),
-			uintptr(syscall.RLIMIT_AS),
-			uintptr(unsafe.Pointer(&newLimit)), //nolint:gosec // G103: audited unsafe.Pointer for prlimit64 syscall ABI
-			0,                                  // old limit — don't need it
-			0, 0,
-		)
-		if errno != 0 {
-			log.Printf("[RESOURCES] Cannot set RLIMIT_AS for PID %d: %v", pid, errno)
-		} else {
-			log.Printf("[RESOURCES] Tool PID %d: OOM score=500, mem limit=%d MB",
-				pid, memLimitBytes/(1024*1024))
-		}
-	} else {
-		log.Printf("[RESOURCES] PID %d: OOM score set to 500", pid)
-	}
 }
 
 // ApplyProcessLimits applies the same child-process protections used by

--- a/release.sh
+++ b/release.sh
@@ -192,16 +192,17 @@ if ! go build ./cmd/xalgorix/; then
 fi
 ok "Build successful"
 
-# ─── Step 4: Build release binaries (multi-arch) ───
-# Build both linux/amd64 and linux/arm64 so the one-line installer
-# (install.sh) can serve the right binary for each host. Asset names must
-# match the `${BINARY}-${OS}-${ARCH}` pattern install.sh downloads.
+# ─── Step 4: Build release binaries (multi-platform) ───
+# Build native Linux and macOS binaries for Intel and ARM so the one-line
+# installer can serve the right asset. Names must match the
+# `${BINARY}-${OS}-${ARCH}` pattern install.sh downloads.
 mkdir -p "$BUILD_DIR"
 RELEASE_ASSETS=()
-for arch in amd64 arm64; do
-    info "Building linux/$arch release binary..."
-    out="$BUILD_DIR/xalgorix-linux-$arch"
-    CGO_ENABLED=0 GOOS=linux GOARCH="$arch" go build \
+for target in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
+    IFS=/ read -r target_os target_arch <<< "$target"
+    info "Building $target_os/$target_arch release binary..."
+    out="$BUILD_DIR/xalgorix-$target_os-$target_arch"
+    CGO_ENABLED=0 GOOS="$target_os" GOARCH="$target_arch" go build \
         -ldflags "-s -w -X main.version=$NEW_VERSION" \
         -o "$out" \
         ./cmd/xalgorix/


### PR DESCRIPTION
## Summary

- Move Linux-only OOM and RLIMIT_AS handling behind build tags and use portable host resource metrics so Darwin builds and runtime admission work correctly.
- Add native macOS ARM64 CI plus Linux/macOS amd64/arm64 release assets and Darwin installer support.
- Build Docker images on native amd64 and ARM64 runners, make architecture-specific dependencies portable, and merge and verify a multi-platform manifest.

## Verification

- go test ./...
- go vet ./...
- golangci-lint run ./... (0 issues)
- Linux amd64/arm64 and macOS amd64/arm64 release builds
- actionlint .github/workflows/ci.yml .github/workflows/docker.yml
- bash -n install.sh release.sh
- go mod verify
- git diff --check

Closes #480
Closes #481