### PR TITLE
feat(notify): opt-in "Scan Finished" completion summary (XALGORIX_NOTIFY_SCAN_COMPLETE)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -228,6 +228,11 @@ type Config struct {
 	TelegramChatID      string // XALGORIX_TELEGRAM_CHAT_ID - target chat/channel ID (numeric or @username)
 	TelegramMinSeverity string // XALGORIX_TELEGRAM_MIN_SEVERITY - minimum severity to notify
 
+	// Scan-completion summary notification.
+	// When false (default) the "Scan Finished" summary is suppressed and only
+	// per-vulnerability alerts are sent; set true to also get an end-of-scan summary.
+	NotifyScanComplete bool // XALGORIX_NOTIFY_SCAN_COMPLETE - send the "Scan Finished" summary after every scan
+
 	// Dashboard auth
 	Username     string // XALGORIX_USERNAME - dashboard login username
 	Password     string // XALGORIX_PASSWORD - dashboard login password (DEPRECATED: prefer PasswordHash)
@@ -424,6 +429,9 @@ func load() *Config {
 		TelegramBotToken:    envOr("XALGORIX_TELEGRAM_BOT_TOKEN", ""),
 		TelegramChatID:      envOr("XALGORIX_TELEGRAM_CHAT_ID", ""),
 		TelegramMinSeverity: envOr("XALGORIX_TELEGRAM_MIN_SEVERITY", ""),
+
+		// Scan-completion summary notification (opt-in; default off).
+		NotifyScanComplete: envOrBool("XALGORIX_NOTIFY_SCAN_COMPLETE", false),
 
 		// Dashboard auth
 		Username:     envOr("XALGORIX_USERNAME", ""),

--- a/internal/web/notify_scancomplete_test.go
+++ b/internal/web/notify_scancomplete_test.go
@@ -1,0 +1,66 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/config"
+)
+
+// TestNotifyScanComplete_DefaultsOff verifies the scan-completion summary
+// toggle defaults to false, so a fresh install sends no "Scan Finished"
+// summary after a scan — only per-vulnerability alerts.
+func TestNotifyScanComplete_DefaultsOff(t *testing.T) {
+	s := newTestServer(t, &config.Config{RateLimitRequests: 60, RateLimitWindow: 60})
+	if s.cfg.NotifyScanComplete {
+		t.Fatalf("cfg.NotifyScanComplete should default to false")
+	}
+	if s.notifyScanComplete {
+		t.Fatalf("runtime notifyScanComplete should default to false")
+	}
+}
+
+// TestEnvironmentSettings_AppliesNotifyScanComplete verifies the toggle
+// round-trips through the /api/settings/environment POST path into both
+// cfg.NotifyScanComplete and the server runtime field, and is reported back
+// (as "true") on the subsequent GET so the dashboard renders it.
+func TestEnvironmentSettings_AppliesNotifyScanComplete(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	s := newTestServer(t, &config.Config{RateLimitRequests: 60, RateLimitWindow: 60})
+
+	body := `{"values":{"XALGORIX_NOTIFY_SCAN_COMPLETE":"true"}}`
+	rr := httptest.NewRecorder()
+	s.handleEnvironmentSettings(rr, httptest.NewRequest(http.MethodPost, "/api/settings/environment", strings.NewReader(body)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("environment POST code = %d body=%s", rr.Code, rr.Body.String())
+	}
+	if !s.cfg.NotifyScanComplete || !s.notifyScanComplete {
+		t.Fatalf("notify scan complete not applied: cfg=%v runtime=%v", s.cfg.NotifyScanComplete, s.notifyScanComplete)
+	}
+
+	rr = httptest.NewRecorder()
+	s.handleEnvironmentSettings(rr, httptest.NewRequest(http.MethodGet, "/api/settings/environment", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("environment GET code = %d", rr.Code)
+	}
+	var resp environmentSettingsResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode settings GET: %v", err)
+	}
+	found := false
+	for _, v := range resp.Variables {
+		if v.Key == "XALGORIX_NOTIFY_SCAN_COMPLETE" {
+			found = true
+			if v.Value != "true" {
+				t.Fatalf("expected XALGORIX_NOTIFY_SCAN_COMPLETE value \"true\", got %q", v.Value)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("XALGORIX_NOTIFY_SCAN_COMPLETE missing from settings GET response")
+	}
+}

--- a/internal/web/scan_session.go
+++ b/internal/web/scan_session.go
@@ -430,18 +430,25 @@ func (s *Server) executeScanSession(sess *scanSession) {
 	if sess.genReport {
 		if p, err := s.generateReportAt(sess.record, sess.scanDir); err == nil {
 			log.Printf("PDF report saved: %s", p)
-			vulnCount := len(sess.record.Vulns)
-			if vulnCount > 0 {
-				desc := fmt.Sprintf("**Target:** %s\n**Vulnerabilities:** %d found\n**Completed at:** %s",
-					sess.target, vulnCount, time.Now().Format("15:04:05 MST"))
-				if s.telegramConfigured() {
-					s.sendTelegramWithFile(0x3b82f6, "✅ Scan Finished - Report Ready", desc, p)
-				}
-			} else {
-				desc := fmt.Sprintf("**Target:** %s\n**Result:** No vulnerabilities found (clean scan)\n**Completed at:** %s",
-					sess.target, time.Now().Format("15:04:05 MST"))
-				if s.telegramConfigured() {
-					s.sendTelegramWithFile(0x2dd4bf, "✅ Scan Finished - Clean Report", desc, p)
+			// Scan-completion summary ("Scan Finished") is opt-in via
+			// XALGORIX_NOTIFY_SCAN_COMPLETE (default off) so operators get only
+			// per-vulnerability alerts, not a summary after every scan (including
+			// clean scans). Per-finding notifications are sent separately in
+			// processEvent and are unaffected by this toggle.
+			if s.notifyScanComplete {
+				vulnCount := len(sess.record.Vulns)
+				if vulnCount > 0 {
+					desc := fmt.Sprintf("**Target:** %s\n**Vulnerabilities:** %d found\n**Completed at:** %s",
+						sess.target, vulnCount, time.Now().Format("15:04:05 MST"))
+					if s.telegramConfigured() {
+						s.sendTelegramWithFile(0x3b82f6, "✅ Scan Finished - Report Ready", desc, p)
+					}
+				} else {
+					desc := fmt.Sprintf("**Target:** %s\n**Result:** No vulnerabilities found (clean scan)\n**Completed at:** %s",
+						sess.target, time.Now().Format("15:04:05 MST"))
+					if s.telegramConfigured() {
+						s.sendTelegramWithFile(0x2dd4bf, "✅ Scan Finished - Clean Report", desc, p)
+					}
 				}
 			}
 			if sess.instanceID != "" {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -704,6 +704,7 @@ type Server struct {
 	telegramBotToken       string // XALGORIX_TELEGRAM_BOT_TOKEN (secret, never exposed via API)
 	telegramChatID         string // XALGORIX_TELEGRAM_CHAT_ID (numeric ID or @channelusername)
 	telegramMinSeverity    string // minimum severity to send to Telegram ("info", "low", "medium", "high", "critical")
+	notifyScanComplete     bool   // XALGORIX_NOTIFY_SCAN_COMPLETE - send the "Scan Finished" summary after every scan (default false)
 	rateLimiter            *RateLimiter
 	settingsMu             sync.Mutex
 	instances              map[string]*ScanInstance // concurrent scan instances
@@ -815,6 +816,7 @@ func NewServer(cfg *config.Config, port int) *Server {
 		telegramBotToken:       cfg.TelegramBotToken,
 		telegramChatID:         cfg.TelegramChatID,
 		telegramMinSeverity:    strings.ToLower(strings.TrimSpace(cfg.TelegramMinSeverity)),
+		notifyScanComplete:     cfg.NotifyScanComplete,
 		rateLimiter:            rl,
 		instances:              make(map[string]*ScanInstance),
 		dispatchReservations:   make(map[string]bool),

--- a/internal/web/settings_env.go
+++ b/internal/web/settings_env.go
@@ -159,6 +159,7 @@ func allEnvSettingDefinitions() []envSettingDefinition {
 		{Key: "XALGORIX_TELEGRAM_BOT_TOKEN", Label: "Telegram bot token", Category: "Notifications", Description: "Bot token from @BotFather. Required to enable Telegram notifications.", Placeholder: "123456789:ABC-DEF...", InputType: "secret", Sensitive: true},
 		{Key: "XALGORIX_TELEGRAM_CHAT_ID", Label: "Telegram chat ID", Category: "Notifications", Description: "Target chat/channel ID. Numeric ID (e.g. -1001234567890) or @channelusername.", Placeholder: "-1001234567890", InputType: "text"},
 		{Key: "XALGORIX_TELEGRAM_MIN_SEVERITY", Label: "Telegram minimum severity", Category: "Notifications", Description: "Minimum severity sent to Telegram.", InputType: "select", Options: []string{"", "info", "low", "medium", "high", "critical"}},
+		{Key: "XALGORIX_NOTIFY_SCAN_COMPLETE", Label: "Notify on scan completion", Category: "Notifications", Description: "Send the \"Scan Finished\" summary (report ready / clean scan) to the configured channels after every scan. Off by default so only per-vulnerability alerts are sent.", DefaultValue: "false", InputType: "boolean"},
 
 		{Key: "AGENTMAIL_POD", Label: "AgentMail pod", Category: "AgentMail", Description: "AgentMail pod identifier.", Placeholder: "am_us_pod_47", InputType: "text"},
 		{Key: "AGENTMAIL_API_KEY", Label: "AgentMail API key", Category: "AgentMail", Description: "AgentMail API key for inbound email triage.", Placeholder: "ak_...", InputType: "secret", Sensitive: true},
@@ -825,6 +826,9 @@ func (s *Server) applyEnvironmentToRuntimeConfig(values map[string]string) {
 		case "XALGORIX_TELEGRAM_MIN_SEVERITY":
 			s.cfg.TelegramMinSeverity = value
 			s.telegramMinSeverity = strings.ToLower(strings.TrimSpace(value))
+		case "XALGORIX_NOTIFY_SCAN_COMPLETE":
+			s.cfg.NotifyScanComplete = parseBoolSetting(value, false)
+			s.notifyScanComplete = s.cfg.NotifyScanComplete
 		case "XALGORIX_USERNAME":
 			s.cfg.Username = value
 		case "XALGORIX_PASSWORD":
@@ -942,6 +946,8 @@ func (s *Server) envSettingValue(key string) string {
 		return s.cfg.TelegramChatID
 	case "XALGORIX_TELEGRAM_MIN_SEVERITY":
 		return s.cfg.TelegramMinSeverity
+	case "XALGORIX_NOTIFY_SCAN_COMPLETE":
+		return strconv.FormatBool(s.cfg.NotifyScanComplete)
 	case "XALGORIX_USERNAME":
 		return s.cfg.Username
 	case "XALGORIX_PASSWORD":

--- a/webui/src/pages/settings.tsx
+++ b/webui/src/pages/settings.tsx
@@ -142,6 +142,7 @@ export default function SettingsPage() {
     telegramBotToken: "",
     telegramChatId: "",
     telegramMinSeverity: "",
+    notifyScanComplete: false,
   });
   const [envValues, setEnvValues] = useState<Record<string, string>>({});
   const [envChanges, setEnvChanges] = useState<Record<string, string>>({});
@@ -205,7 +206,8 @@ export default function SettingsPage() {
     const telegramBotToken = envValue(environment.data, "XALGORIX_TELEGRAM_BOT_TOKEN");
     const telegramChatId = envValue(environment.data, "XALGORIX_TELEGRAM_CHAT_ID");
     const telegramMinSeverity = envValue(environment.data, "XALGORIX_TELEGRAM_MIN_SEVERITY");
-    setNotificationForm({ webhook, minSeverity, telegramBotToken, telegramChatId, telegramMinSeverity });
+    const notifyScanComplete = envValue(environment.data, "XALGORIX_NOTIFY_SCAN_COMPLETE") === "true";
+    setNotificationForm({ webhook, minSeverity, telegramBotToken, telegramChatId, telegramMinSeverity, notifyScanComplete });
   }, [environment.data]);
 
   useEffect(() => {
@@ -1095,6 +1097,7 @@ export default function SettingsPage() {
                         XALGORIX_TELEGRAM_BOT_TOKEN: notificationForm.telegramBotToken,
                         XALGORIX_TELEGRAM_CHAT_ID: notificationForm.telegramChatId,
                         XALGORIX_TELEGRAM_MIN_SEVERITY: notificationForm.telegramMinSeverity,
+                        XALGORIX_NOTIFY_SCAN_COMPLETE: notificationForm.notifyScanComplete ? "true" : "false",
                       });
                       setSavedNotifications(true);
                       setTimeout(() => setSavedNotifications(false), 2500);
@@ -1173,6 +1176,26 @@ export default function SettingsPage() {
                       </SelectContent>
                     </Select>
                   </div>
+                </div>
+                <Separator />
+                <div className="flex items-center justify-between gap-4">
+                  <div className="space-y-1">
+                    <Label htmlFor="notify-scan-complete">Notify on scan completion</Label>
+                    <p className="text-xs text-muted-foreground">
+                      Send the &quot;Scan Finished&quot; summary (report ready / clean scan) after every scan.
+                      Off by default — you only receive per-vulnerability alerts.
+                    </p>
+                  </div>
+                  <Switch
+                    id="notify-scan-complete"
+                    checked={notificationForm.notifyScanComplete}
+                    onCheckedChange={(checked) =>
+                      setNotificationForm({
+                        ...notificationForm,
+                        notifyScanComplete: checked,
+                      })
+                    }
+                  />
                 </div>
                 <p className="text-xs text-muted-foreground">
                   Telegram is independent of Discord — configure one or both.


### PR DESCRIPTION
## What & why

The end-of-scan **"✅ Scan Finished"** summary (both *Report Ready* and *Clean Report*) is pushed after **every** scan, including clean scans with no findings. For operators running many scans this is noise layered on top of the per-vulnerability alerts — every clean scan still pings the channel.

This makes the completion summary **opt-in** via a new boolean setting **`XALGORIX_NOTIFY_SCAN_COMPLETE`** (default `false`):

- **Off (default):** no "Scan Finished" summary — operators receive only the per-vulnerability "🐛 Vulnerability Found" notifications (unchanged).
- **On:** previous behavior (summary sent after every scan).

Report generation and the `report_ready` WebSocket event are untouched, so the dashboard and `/api/report/...` are unaffected — only the completion **push notification** is gated.

No linked issue — small quality-of-life change surfaced by operators running continuous scans.

## Type of change

- [x] New feature

## How was it tested?

Validated in-container on the release Go 1.26 toolchain + the CI `golangci-lint` image:

- `gofmt -l` — clean on all touched files
- `go vet ./internal/config/... ./internal/web/...` — passes
- `go test ./internal/config/... ./internal/web/...` — passes, including two new tests:
  - `TestNotifyScanComplete_DefaultsOff`
  - `TestEnvironmentSettings_AppliesNotifyScanComplete`
- `golangci-lint run --config .golangci.yml` (v2.12.2) — **0 issues**
- webui `tsc -b && vite build` — passes (new interactive toggle in Settings → Notifications)

- [x] `make lint` passes (gofmt + go vet)
- [x] `golangci-lint run --config .golangci.yml ./...` passes (0 issues)
- [x] `go test` passes for the changed packages (`internal/config`, `internal/web`) incl. the new tests — full `./... -race` runs in CI
- [x] Added/updated tests for the change

## Checklist

- [x] I read CONTRIBUTING.md.
- [x] The tree is `gofmt`-clean.
- [x] I updated docs — the setting is self-describing via its Notifications-category definition and the dashboard toggle description.
- [x] This does not weaken a security control (scope guard, verifier, false-positive gate) — notification-only change.
- [x] For engine behavior changes: **no impact on findings/severity**. Findings, the PDF report, and the `report_ready` event are unchanged; only the completion push notification is gated.

## Implementation

- `internal/config/config.go` — `NotifyScanComplete` field + `XALGORIX_NOTIFY_SCAN_COMPLETE` (default `false`)
- `internal/web/server.go` — runtime field wired from config
- `internal/web/settings_env.go` — env-setting definition (Notifications category, boolean) + apply/read wiring so it's live-editable from the dashboard
- `internal/web/scan_session.go` — gate the completion summary behind the toggle (report generation + `report_ready` broadcast stay outside the gate)
- `webui/src/pages/settings.tsx` — interactive **Switch** ("Notify on scan completion") in Settings → Notifications, saved with the existing "Save notifications" action
- `internal/web/notify_scancomplete_test.go` — tests

> Note: as of v4.6.4 the completion summary is Telegram-only (the inline Discord completion send was already removed upstream); the toggle is channel-agnostic and gates the summary regardless of which channel carries it.