### PR TITLE
release: v4.6.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.4
+VERSION=4.6.5
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.6.4" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.6.5" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.4"
+var version = "4.6.5"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
### Changes

- Added an opt-in **Notify on scan completion** setting for Discord and Telegram (`XALGORIX_NOTIFY_SCAN_COMPLETE`, default `false`).
- Gated all queue-level and report-level completion summaries while leaving per-vulnerability alerts unchanged.
- Made live notification-setting updates race-safe and added enabled/disabled delivery regression coverage.
- Regenerated the embedded Web UI assets and documented the new setting in the README and architecture guide.
