### PR TITLE
release: v4.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased] — Concurrent admission and restart recovery
+## [v4.6.6](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.6) — Concurrent admission and restart recovery (2026-09-01)
 
 ### Fixed
 - **Healthy scans could remain pending even above the configured instance cap.** The RAM admission model calculated how many *additional* scans fit in currently available memory, but compared that number as though it were the total concurrency ceiling. As running scans consumed RAM, the UI could report an impossible state such as six running with `Max 5`, and new work stayed pending despite `XALGORIX_MAX_INSTANCES=20`. Admission and resource telemetry now add the already-running instances back to remaining RAM headroom, while still enforcing the manual cap and critical RAM/disk safety floors. Newly admitted scans temporarily reserve their estimated slot until their allocations are reflected in host telemetry, so a burst of pending jobs cannot all spend the same RAM snapshot. The Instances resource card now shows total capacity, running instances, and available slots separately.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.5
+VERSION=4.6.6
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.6.5" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.6.6" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.5"
+var version = "4.6.6"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
## v4.6.6

### Fixed

- Correct scan admission when RAM telemetry reports additional headroom: existing running scans are now added back to produce the total concurrency ceiling.
- Preserve XALGORIX_MAX_INSTANCES as the final hard cap while retaining critical RAM and disk safety gates.
- Reserve newly admitted capacity briefly so concurrent pending scans cannot spend the same MemAvailable snapshot.
- Show total capacity, running instances, and available slots separately in scanner telemetry and the Instances UI.

### Release metadata

- Bump the CLI, Makefile, and README asset version from 4.6.5 to 4.6.6.
- Publish the dated v4.6.6 changelog entry.

### Verification

- Embedded React dashboard production build
- go test ./internal/resources ./internal/web
- go vet ./internal/resources ./internal/web
- go build ./cmd/xalgorix/
- Cross-compiled Linux and macOS binaries for amd64 and arm64
