### PR TITLE
release: v4.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [v4.6.7](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.7) — Manual instance capacity (2026-09-01)
 
 ### Fixed
 - **Explicit instance capacity was still reduced by adaptive RAM admission.** When `XALGORIX_MAX_INSTANCES` is set, it now defines the authoritative number of concurrent scan instances instead of acting only as an upper bound on a smaller RAM-derived estimate. Adaptive RAM admission remains the default when the variable is unset, heavy tools remain resource-throttled, and the critical disk floor still blocks new work.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.6
+VERSION=4.6.7
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/banner.png?v=4.6.6" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
+<img src="assets/banner.png?v=4.6.7" alt="Xalgorix — AI Autonomous Penetration Testing Platform" width="860" />
 
 <br />
 

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.6"
+var version = "4.6.7"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
### Fixed

- Make the explicitly configured XALGORIX_MAX_INSTANCES value authoritative for scan admission.
- Keep adaptive RAM admission as the default when no manual maximum is configured.
- Preserve heavy-tool resource throttling and the critical disk safety floor.

### Verification

- go test -count=1 ./internal/resources ./internal/web
- go vet ./internal/resources ./internal/web
- go build ./cmd/xalgorix/
- Embedded React dashboard rebuilt successfully.