### PR TITLE
fix(webui): make the mobile nav drawer an accessible dialog

### DIFF
--- a/webui/src/i18n/translations.ts
+++ b/webui/src/i18n/translations.ts
@@ -62,6 +62,7 @@ const en: Dict = {
   "sidebar.github": "GitHub",
   "sidebar.githubTitle": "View Xalgorix on GitHub",
   "sidebar.securityScanner": "security scanner",
+  "sidebar.navigation": "Main navigation",
 
   // Topbar
   "topbar.searchLong": "Search scans, findings, actions…",
@@ -272,6 +273,7 @@ const zhCN: Dict = {
   "sidebar.github": "GitHub",
   "sidebar.githubTitle": "在 GitHub 上查看 Xalgorix",
   "sidebar.securityScanner": "安全扫描器",
+  "sidebar.navigation": "主导航",
 
   // Topbar
   "topbar.searchLong": "搜索扫描、漏洞、操作…",

--- a/webui/src/layout/app-shell.tsx
+++ b/webui/src/layout/app-shell.tsx
@@ -1,13 +1,18 @@
 import { useCallback, useEffect, useState } from "react";
 import { Outlet, useLocation } from "react-router-dom";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { Sidebar } from "./sidebar";
 import { Topbar } from "./topbar";
 import { ConnectionBanner } from "@/components/connection-status";
 import { LegacyImportBanner } from "@/components/legacy-import-banner";
 import { CommandPalette } from "@/components/command-palette";
 import { useWSStore } from "@/store/ws";
+import { useI18n } from "@/i18n";
+
+const MOBILE_NAV_ID = "mobile-nav";
 
 export function AppShell() {
+  const { t } = useI18n();
   const connect = useWSStore((s) => s.connect);
   const disconnect = useWSStore((s) => s.disconnect);
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -23,6 +28,20 @@ export function AppShell() {
     setSidebarOpen(false);
   }, [location.pathname]);
 
+  // The drawer only exists below `md`. If the viewport grows past the
+  // breakpoint while it is open, the panel is hidden by `md:hidden` but the
+  // dialog stays mounted, which would leave focus trapped inside an invisible
+  // element. Close it as soon as the desktop sidebar takes over.
+  useEffect(() => {
+    const desktop = window.matchMedia("(min-width: 768px)");
+    const sync = () => {
+      if (desktop.matches) setSidebarOpen(false);
+    };
+    sync();
+    desktop.addEventListener("change", sync);
+    return () => desktop.removeEventListener("change", sync);
+  }, []);
+
   const handleSidebarToggle = useCallback(() => setSidebarOpen((o) => !o), []);
   const handleSidebarClose = useCallback(() => setSidebarOpen(false), []);
 
@@ -35,22 +54,31 @@ export function AppShell() {
         <Sidebar />
       </div>
 
-      {/* Mobile sidebar overlay */}
-      {sidebarOpen && (
-        <div className="fixed inset-0 z-40 md:hidden">
-          <div
-            className="absolute inset-0 z-40 bg-black/60 backdrop-blur-sm"
-            onClick={handleSidebarClose}
-            aria-hidden
-          />
-          <div className="absolute inset-y-0 left-0 z-50 w-60 animate-in slide-in-from-left duration-200">
+      {/* Mobile sidebar drawer. Built on the Radix dialog primitive so it gets
+          focus trapping, Escape-to-close and `aria-modal` semantics rather than
+          re-implementing them on a bare div. */}
+      <DialogPrimitive.Root open={sidebarOpen} onOpenChange={setSidebarOpen}>
+        <DialogPrimitive.Portal>
+          <DialogPrimitive.Overlay className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm md:hidden" />
+          <DialogPrimitive.Content
+            id={MOBILE_NAV_ID}
+            aria-describedby={undefined}
+            className="drawer-in fixed inset-y-0 left-0 z-50 w-60 focus:outline-none md:hidden"
+          >
+            <DialogPrimitive.Title className="sr-only">
+              {t("sidebar.navigation")}
+            </DialogPrimitive.Title>
             <Sidebar onNavigate={handleSidebarClose} />
-          </div>
-        </div>
-      )}
+          </DialogPrimitive.Content>
+        </DialogPrimitive.Portal>
+      </DialogPrimitive.Root>
 
       <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-        <Topbar onMenuToggle={handleSidebarToggle} />
+        <Topbar
+          onMenuToggle={handleSidebarToggle}
+          menuOpen={sidebarOpen}
+          menuControls={MOBILE_NAV_ID}
+        />
         <ConnectionBanner />
         <LegacyImportBanner />
         <main className="min-h-0 flex-1 overflow-y-auto">

--- a/webui/src/layout/topbar.tsx
+++ b/webui/src/layout/topbar.tsx
@@ -8,7 +8,15 @@ import { useStatus, useInstances, useStopAll } from "@/api/queries";
 import { useCommandPalette } from "@/components/command-palette";
 import { useI18n } from "@/i18n";
 
-export function Topbar({ onMenuToggle }: { onMenuToggle?: () => void }) {
+export function Topbar({
+  onMenuToggle,
+  menuOpen = false,
+  menuControls,
+}: {
+  onMenuToggle?: () => void;
+  menuOpen?: boolean;
+  menuControls?: string;
+}) {
   const { t } = useI18n();
   const { data: status } = useStatus();
   const { data: instances } = useInstances();
@@ -28,6 +36,8 @@ export function Topbar({ onMenuToggle }: { onMenuToggle?: () => void }) {
         onClick={onMenuToggle}
         className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:text-foreground md:hidden"
         aria-label={t("topbar.toggleMenu")}
+        aria-expanded={menuOpen}
+        aria-controls={menuControls}
       >
         <Menu className="h-5 w-5" />
       </button>

--- a/webui/src/styles.css
+++ b/webui/src/styles.css
@@ -299,7 +299,42 @@
   animation: pulse-dot 1.6s ease-in-out infinite;
 }
 
+/* Mobile navigation drawer slide-in. Written out here because the project does
+   not carry the tailwindcss-animate plugin, so `animate-in` / `slide-in-from-*`
+   utilities do not resolve. */
+@keyframes drawer-in {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+.drawer-in {
+  animation: drawer-in 0.2s ease-out;
+}
+
 /* Mono code block style */
 .mono {
   font-family: var(--font-mono);
+}
+
+/* Respect the OS "reduce motion" setting: WCAG 2.2.2 asks for a way to stop
+   looping animation, and the connection dot pulses indefinitely. Motion is
+   decorative throughout the dashboard, so it is safe to drop entirely rather
+   than substitute a reduced variant. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .pulse-dot {
+    animation: none;
+    opacity: 1;
+  }
 }


### PR DESCRIPTION
## What & why

The mobile sidebar drawer was a hand-rolled `div` overlay. It had no focus
trap, no Escape-to-close, and no dialog semantics, so on a narrow viewport a
keyboard or screen-reader user tabs straight through to the page behind it.
The hamburger button also never exposed its state.

This rebuilds the drawer on `@radix-ui/react-dialog`, which is already a
dependency and already wrapped in `components/ui/dialog.tsx`, so focus
trapping, Escape handling and `aria-modal` come from the primitive instead of
being reimplemented. `aria-expanded` and `aria-controls` are now set on the
topbar menu button.

Two related things surfaced while fixing it:

1. The drawer's `animate-in slide-in-from-left duration-200` classes were
   inert. Those utilities come from `tailwindcss-animate`, which is not in
   `package.json` and not imported in `styles.css`, so the panel appeared with
   no transition at all. Replaced with an explicit `drawer-in` keyframe.
2. The dashboard had no `prefers-reduced-motion` handling anywhere, while
   `.pulse-dot` animates indefinitely. Added a reduce block. Motion here is
   decorative, so it is dropped rather than substituted.

One edge case is also handled: if the viewport crosses the `md` breakpoint
while the drawer is open, `md:hidden` hides the panel but the dialog stays
mounted, which would leave focus trapped in an invisible element. An effect
now closes it when the desktop sidebar takes over.

Adds the `sidebar.navigation` key to `en` and `zh-CN` for the drawer's
accessible name.

No issue filed. CONTRIBUTING.md says small obvious bug fixes can go straight
to a PR, but happy to open one if you would rather track it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Refactor / internal
- [ ] Other:

## How was it tested?

- `cd webui && npm ci && npm run typecheck` passes clean.
- Manually on a narrow viewport: drawer slides in, Escape closes it, Tab stays
  inside the panel, overlay click still closes, and navigating a link closes it
  as before.
- Reduced motion verified with the OS setting enabled: the connection dot stops
  pulsing and the drawer appears without animation.

The Go gates were not run locally, I do not have Go or GNU Make on this
machine. This change touches only `webui/src`, no Go files, so I am relying on
CI for `make lint`, `go vet` and `go test`.

**Note on the embedded bundle:** I did not regenerate `internal/web/static`,
since `make webui` needs the Go toolchain. Let me know if you want the rebuilt
bundle in this PR and I will add it, or feel free to regenerate on merge.

- [ ] `make lint` passes
- [ ] `golangci-lint run --config .golangci.yml ./...` passes
- [ ] `go test ./...` passes
- [ ] Added/updated tests for the change

## Checklist

- [x] I read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md).
- [x] The tree is `gofmt`-clean. (No Go files touched.)
- [ ] I updated docs (`README`, `docs/`, help text) if behavior changed.
- [x] This does not weaken a security control (scope guard, verifier,
      false-positive gate) without explicit discussion.
- [x] For engine behavior changes: I noted any impact on scan
      findings/severity. (None, this is presentation only.)