### PR TITLE
Scan-scoped multi-agent + durable hypothesis/evidence ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased] — Scan-scoped multi-agent assessments
+
+### Added
+- **Coordinator-led parallel specialists are enabled by default.** Full assessments now prompt the coordinator to split mature reconnaissance into two or three non-overlapping, hypothesis-driven roles (authorization/business logic, injection/server-side behavior, and source/data-flow or client/API analysis). `spawn_agent`, `check_agent`, and `wait_agent` are always available, and the root finish gate requires every running or completed delegation to be collected before the scan can finish.
+
+### Fixed
+- **Concurrent scans could cross-wire sub-agents.** The delegation runner, agent map, concurrency semaphore, stop flag, and cleanup path were process-global. Constructing another root or child overwrote the runner; cleanup could clear another live scan; streamed partial results used the internal agent ID instead of the coordinator-visible delegation ID; and reset did not cancel a child already inside `Run`. Each root now owns a cancellable `agentsgraph.Graph`, descendants share only that graph, worker slots are per scan, partial/final evidence uses one stable ID, and shutdown waits briefly for children before persisting and deleting scan stores.
+- **Parallel reports could borrow the wrong Verifier LLM client.** Verifiers were selected through one mutable callback per scan context, so a newly constructed child could replace the callback used by its siblings. `report_vulnerability` now captures the reporting agent's independent verifier in its own tool registry; parallel hunters block on their own verifier client and cannot overwrite or race a sibling's validation loop.
+- **Delegated agents multiplied per-scan resource caps.** Each child previously received fresh duration, iteration, token, and tool-call counters, so a coordinator plus three specialists could consume roughly four times the configured caps. The graph now shares one scan budget: the root starts the wall clock once, agent iterations and tool-call batches atomically reserve the remaining allowance, and token deltas aggregate across agent clients.
+
 ## [v4.6.7](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.7) — Manual instance capacity (2026-09-01)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased] — Evidence-driven orchestration (hypothesis/evidence ledger)
+
+### Added
+- **Durable, scan-shared hypothesis/evidence ledger.** A new typed ledger on the scan context records every attack hypothesis (vulnerability class, endpoint, parameter, role/data-flow, preconditions, baseline, confidence, status, and next action) with append-only evidence. It is deduplicated, memory-bounded, and persisted atomically to `ledger.json`, so the coordinator and every specialist read and write one shared graph that survives restart/resume. New agent tools `record_hypothesis`, `add_hypothesis_evidence`, `update_hypothesis`, and `read_ledger` operate on it.
+- **The ledger now drives scheduling.** Once reconnaissance produces a plan, the ledger is seeded with a hypothesis per candidate class. Delegation is ledger-driven: the coordinator assigns disjoint, contract-bound work to deterministic specialist profiles — authorization/business-logic, injection/server-side, and client/source — each carrying an explicit evidence contract (baseline + concrete proof; out-of-band callbacks for blind classes; browser-confirmed execution for XSS/DOM) and a stopping rule.
+
+### Fixed
+- **A scan could finish with proven work unreported.** A precision finish-gate now blocks completion while any hypothesis is marked proven but has no linked finding, requiring the agent to file it (and link the finding) or downgrade it. The gate is bounded so it can never deadlock a scan, and it complements the existing coverage gate rather than replacing it.
+
 ## [Unreleased] — Scan-scoped multi-agent assessments
 
 ### Added

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -110,6 +110,34 @@ graph also owns one shared resource ledger: duration begins at the root, token
 usage is aggregated across LLM clients, and agent iterations/tool calls are
 atomically reserved against the scan-wide caps.
 
+## Hypothesis/evidence ledger — `internal/scanctx` (`ledger.go`)
+
+The ledger is the scan's durable "global exploitation context": a typed graph of
+attack hypotheses and the evidence gathered for each. It lives on the shared
+`ScanContext` (so the coordinator and every specialist read/write the same
+graph), is deduplicated by normalized class/endpoint/parameter/role, is
+memory-bounded, and persists atomically to `<scanDir>/ledger.json` so it
+survives restart/resume. A hypothesis carries identity, preconditions, a
+baseline/control, confidence, a lifecycle status (`queued`, `testing`, `proven`,
+`rejected`, `blocked`, `exhausted`), the owning specialist, a next-best action,
+and append-only evidence; confirmed findings are referenced by their reporting
+ID rather than duplicated.
+
+The ledger drives orchestration rather than sitting beside it:
+
+- Once recon produces a plan, `hookLedgerSeed` seeds a hypothesis per candidate
+  vulnerability class so the graph is populated deterministically.
+- Delegation is ledger-driven: the coordinator assigns disjoint work to three
+  deterministic specialist profiles (authorization/business-logic,
+  injection/server-side, client/source), each with an explicit evidence
+  contract (baseline + concrete proof; out-of-band callbacks for blind classes;
+  browser-confirmed execution for XSS/DOM) and a stopping rule.
+- Agents record and consult the graph with `record_hypothesis`,
+  `add_hypothesis_evidence`, `update_hypothesis`, and `read_ledger`.
+- A precision finish-gate refuses to complete while a hypothesis is marked
+  proven but has no linked finding (bounded so it cannot deadlock), enforcing
+  verify-by-execution and precision over volume.
+
 ## Tooling — `internal/tools`
 
 `registry.go` is the tool surface presented to the model. Each subpackage is one

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,6 +90,26 @@ Guards keep the agent inside the authorized scope and the selected phases, and
 throttle to the requested request-rate policy. These are the safety boundaries
 that make an autonomous offensive agent safe to point at a target.
 
+## Multi-agent execution — `internal/tools/agentsgraph`
+
+A full assessment uses a coordinator plus up to three hypothesis-driven
+specialists. After reconnaissance, the coordinator divides the observed surface
+into non-overlapping roles (typically authorization/business logic,
+injection/server-side behavior, and source/data-flow or client/API analysis),
+continues its own work, and collects every child result before finishing.
+
+Every root scan owns one `agentsgraph.Graph`: its runner, worker semaphore,
+cancellation context, status, partial evidence, and final results are all
+scan-scoped. Descendants share that graph but cannot replace or stop it. This
+means concurrent scans cannot cross-wire agents or clear one another during
+cleanup. `spawn_agent`, `check_agent`, and `wait_agent` are always registered;
+the finish gate blocks while children are running or their results remain
+uncollected. Stopping a root cancels its descendants and cleanup waits briefly
+for them to unwind before persisting findings and deleting tool stores. The
+graph also owns one shared resource ledger: duration begins at the root, token
+usage is aggregated across LLM clients, and agent iterations/tool calls are
+atomically reserved against the scan-wide caps.
+
 ## Tooling — `internal/tools`
 
 `registry.go` is the tool surface presented to the model. Each subpackage is one
@@ -107,7 +127,10 @@ capability:
 
 Every reported vulnerability passes gates (valid method, mandatory
 exploitation proof, false-positive and claim-consistency checks, dedup,
-severity/CVSS normalization) and is handed to the independent Verifier. Each
+severity/CVSS normalization) and is handed to the reporting agent's independent
+Verifier. The verifier callback is registry-local, so parallel hunters use
+their own idle LLM client while blocked on their own report rather than
+cross-wiring a sibling's client. Each
 finding carries exactly one verification tag:
 
 - `verified` — the Verifier independently reproduced it.
@@ -147,7 +170,8 @@ Multiple targets are processed through the scan queue with resume support.
 ```
 target + instruction
    → web: create scan instance (own goroutine + scanctx)
-   → agent loop: reason → tool call → observe (events stream over WebSocket live)
+   → coordinator: recon → decompose hypotheses → parallel specialist agents
+   → each agent: reason → tool call → observe (events stream over WebSocket live)
    → reporting: gated + verified findings persisted to the scan record
    → storage: atomic scan.json per scan dir
    → report.go / internal/reporting: branded PDF on demand
@@ -159,7 +183,8 @@ target + instruction
 
 - `internal/storage` — atomic file writes (never a torn `scan.json`).
 - `internal/scanctx` — per-scan context keyed by ID; findings stores and the
-  Verifier are scoped to it, so concurrent scans are fully isolated.
+  delegation graph are scoped to it; each agent registry owns its verifier, so
+  concurrent scans and parallel specialists are isolated.
 - Each scan record (metadata, events, findings) is a `scan.json` under its own
   scan directory in the data dir; finished records are immutable and cached.
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -175,6 +175,15 @@ type Agent struct {
 	// history when a scan is resumed/restarted across server restarts.
 	initialIter    int
 	resumeBriefing string
+
+	// agentGraph is shared by every agent delegated from this root, but owned
+	// by the root scan only. The graph itself is scan-scoped, so concurrent
+	// scans cannot overwrite runners or consume one another's worker slots.
+	agentGraph       *agentsgraph.Graph
+	ownsAgentGraph   bool
+	delegatedAgentID string
+	scanBudget       *scanBudget
+	lastBudgetTokens int
 }
 
 // AgentOption configures optional behavior on a *Agent. The
@@ -197,6 +206,27 @@ func WithLLMClient(c *llm.Client) AgentOption {
 	return func(a *Agent) {
 		if c != nil {
 			a.client = c
+		}
+	}
+}
+
+// withAgentGraph makes a delegated agent join its root scan's graph. It is
+// intentionally package-private: only the root runner should construct graph
+// children, and delegated agents must never stop or replace the shared graph.
+func withAgentGraph(graph *agentsgraph.Graph, budget *scanBudget, agentID string) AgentOption {
+	return func(a *Agent) {
+		a.agentGraph = graph
+		a.scanBudget = budget
+		a.delegatedAgentID = agentID
+	}
+}
+
+// withParentContext makes a delegated agent's LLM and tool loop cancel when
+// its root graph is stopped.
+func withParentContext(parent context.Context) AgentOption {
+	return func(a *Agent) {
+		if parent != nil {
+			a.ctx = parent
 		}
 	}
 }
@@ -271,7 +301,6 @@ func NewAgent(cfg *config.Config, name string, events chan Event, localGuard sco
 	// NOTE: playwright.Register removed — it registered the same "browser_action" name
 	// and overwrote the enhanced rod browser with a weaker curl-based stub.
 	notes.Register(reg)
-	reporting.Register(reg)
 	finish.Register(reg)
 	python.Register(reg)
 	websearch.Register(reg)
@@ -310,6 +339,9 @@ func NewAgent(cfg *config.Config, name string, events chan Event, localGuard sco
 	for _, opt := range opts {
 		opt(a)
 	}
+	if a.scanBudget == nil {
+		a.scanBudget = newScanBudget()
+	}
 
 	// Register the structural planner tools (build_plan / update_plan). These
 	// mutate a.state.Plan, so they're registered after the agent exists. They
@@ -323,73 +355,98 @@ func NewAgent(cfg *config.Config, name string, events chan Event, localGuard sco
 	// Wire context to LLM client so cancel interrupts pending HTTP requests
 	a.client.SetContext(a.ctx)
 
-	agentsgraph.Register(reg, func(subName string, targets []string, task string) (string, error) {
-		subEvents := make(chan Event, 256)
-		// Sub-agents inherit the parent's localGuard rather than re-deriving
-		// it. The listener identity is a per-process invariant — every
-		// agent in the graph consults the same bind:port — so propagating
-		// the parent's Config keeps the Local_Or_Listener_Host rule
-		// uniform across the agent tree (Requirement 3.4).
-		subAgent := NewAgent(cfg, subName, subEvents, a.localGuard, sctx)
-		subAgent.SetPhaseRestrictions(a.allowedPhases)
-		subAgent.SetActivityPolicy(a.reconMode, a.scanIntensity, a.activityHosts)
-		// Propagate per-scan auth/source overrides so the sub-agent's prompt
-		// guidance and secret redaction match the parent (tool access is
-		// already shared via the scan-context-keyed stores).
-		subAgent.SetTargetAuth(a.targetAuth)
-		subAgent.SetTargetAuthSecondary(a.targetAuthB)
-		subAgent.SetSourceRepo(a.sourceRepo)
-		subAgent.SetScanContext(a.scanContext)
-		subAgent.SetCodeScanMode(a.codeScanMode)
-		if a.discoveryMode {
-			subAgent.SetDiscoveryMode(true)
-		}
-		var results strings.Builder
-		done := make(chan struct{})
-		// Sub-agent event-forwarder is a long-lived streaming consumer.
-		// Wrap with safe.Go so a panic during forwarding (e.g. on a
-		// closed parent channel) is logged and counted instead of
-		// taking down the parent agent. The inner `defer close(done)`
-		// runs during fn's unwind even on panic, so the parent's
-		// `<-done` rendezvous still completes.
-		safe.Go("agent.subagent_stream", a.scanCtx.ID, func() {
-			defer close(done)
-			for evt := range subEvents {
-				// Forward partial results to sub-agent state
-				if evt.Type == "tool_result" && evt.ToolResult.Output != "" {
-					partial := fmt.Sprintf("[%s] %s", evt.ToolName, truncStr(evt.ToolResult.Output, 200))
-					results.WriteString(partial)
-					results.WriteByte('\n')
-					agentsgraph.AddPartialResult(subAgent.ID, partial)
-				}
-				if evt.Type == "finished" {
-					results.WriteString("\nCompleted: ")
-					results.WriteString(truncStr(evt.Content, 500))
-					results.WriteString("\n")
-				}
-				// Also forward events to parent for UI visibility
-				if a.events != nil {
-					parentEvt := evt
-					parentEvt.AgentID = subAgent.ID
-					safeSend(a.events, parentEvt, 0)
-				}
+	if a.agentGraph == nil {
+		a.ownsAgentGraph = true
+		a.agentGraph = agentsgraph.New(a.ctx, func(ctx context.Context, agentID, subName string, targets []string, task string) (string, error) {
+			subEvents := make(chan Event, 256)
+			// All descendants join this root's graph and inherit its cancellation
+			// context. Creating a child therefore cannot overwrite another scan's
+			// runner or leave an uncancellable worker behind.
+			subAgent := NewAgent(cfg, subName, subEvents, a.localGuard, sctx,
+				withParentContext(ctx), withAgentGraph(a.agentGraph, a.scanBudget, agentID))
+			subAgent.SetPhaseRestrictions(a.allowedPhases)
+			subAgent.SetActivityPolicy(a.reconMode, a.scanIntensity, a.activityHosts)
+			subAgent.SetTargetAuth(a.targetAuth)
+			subAgent.SetTargetAuthSecondary(a.targetAuthB)
+			subAgent.SetSourceRepo(a.sourceRepo)
+			subAgent.SetScanContext(a.scanContext)
+			subAgent.SetCodeScanMode(a.codeScanMode)
+			if a.discoveryMode {
+				subAgent.SetDiscoveryMode(true)
 			}
-		})
-		subAgent.Run(targets, task)
-		close(subEvents)
-		<-done
-		return results.String(), nil
-	})
 
-	// Install the independent finding verifier for THIS scan context (keyed by
-	// scan-context ID so concurrent scans never cross-wire). Every medium+
-	// candidate finding from this agent (or any sub-agent sharing the context)
-	// is re-tested by a.verifyFinding before being persisted. The verifier
-	// builds its own restricted, read-only registry, so it never recurses
-	// through report_vulnerability.
-	reporting.SetFindingVerifier(sctx.ID, a.verifyFinding)
+			var results strings.Builder
+			var delegatedErr error
+			done := make(chan struct{})
+			safe.Go("agent.subagent_stream", a.scanCtx.ID, func() {
+				defer close(done)
+				for evt := range subEvents {
+					if evt.Type == "tool_result" && evt.ToolResult.Output != "" {
+						partial := fmt.Sprintf("[%s] %s", evt.ToolName, truncStr(evt.ToolResult.Output, 200))
+						results.WriteString(partial)
+						results.WriteByte('\n')
+						a.agentGraph.AddPartialResult(agentID, partial)
+					}
+					if evt.Type == "finished" {
+						results.WriteString("\nCompleted: ")
+						results.WriteString(truncStr(evt.Content, 500))
+						results.WriteString("\n")
+						if evt.Aborted {
+							delegatedErr = fmt.Errorf("delegated agent aborted: %s", valueOr(evt.AbortReason, evt.Content))
+						}
+					}
+					if a.events != nil {
+						parentEvt := evt
+						parentEvt.AgentID = agentID
+						safeSend(a.events, parentEvt, 0)
+					}
+				}
+			})
+			// These defers also run if Agent.Run panics and the graph's panic
+			// boundary recovers it, so the event-forwarder cannot become a zombie.
+			defer subAgent.Stop()
+			streamClosed := false
+			defer func() {
+				if !streamClosed {
+					close(subEvents)
+					<-done
+				}
+			}()
+			subAgent.Run(targets, task)
+			close(subEvents)
+			<-done
+			streamClosed = true
+			return results.String(), delegatedErr
+		})
+	}
+	a.agentGraph.Register(reg)
+
+	// A coordinator cannot silently finish while delegated evidence is still
+	// running or has not been collected. Descendants skip this gate because the
+	// root coordinator is responsible for collecting the whole graph.
+	if a.ownsAgentGraph {
+		a.hooks.Register(OnFinishAttempt, a.delegatedWorkFinishGate)
+	}
+
+	// Bind verification to THIS registry/agent. Parallel hunters can now report
+	// concurrently without borrowing another agent's LLM client or overwriting a
+	// scan-context-global verifier callback.
+	reporting.RegisterWithVerifier(reg, a.verifyFinding)
 
 	return a
+}
+
+func (a *Agent) delegatedWorkFinishGate(_ *ScanState, _ map[string]string) HookResult {
+	if a == nil || a.agentGraph == nil {
+		return HookResult{}
+	}
+	if running := a.agentGraph.RunningCount(); running > 0 {
+		return HookResult{Block: true, BlockReason: fmt.Sprintf("%d delegated agent(s) are still running. Collect their evidence before finishing:\n%s", running, a.agentGraph.PendingSummary())}
+	}
+	if pending := a.agentGraph.UncollectedCount(); pending > 0 {
+		return HookResult{Block: true, BlockReason: fmt.Sprintf("%d delegated result(s) have not been collected. Read them before finishing:\n%s", pending, a.agentGraph.PendingSummary())}
+	}
+	return HookResult{}
 }
 
 // SetDiscoveryMode configures the agent to skip minimum iteration checks on finish.
@@ -712,6 +769,9 @@ func (a *Agent) Run(targets []string, instruction string) {
 		return
 	}
 	a.scanStart = time.Now()
+	if a.scanBudget != nil {
+		a.scanBudget.start()
+	}
 	// Wire per-scan auth + whitebox source here (in the scan goroutine) so a
 	// slow git clone never blocks scan creation or the HTTP handler.
 	a.prepareScanEnvironment()
@@ -763,15 +823,14 @@ func (a *Agent) Run(targets []string, instruction string) {
 
 	// Helper to get current token count
 	tokenCount := func() int {
-		_, _, total := a.client.GetTokens()
-		return total
+		return a.syncBudgetTokens()
 	}
 
 	// Running total of tool calls, for the optional resource budget.
 	toolCallsTotal := 0
 
 	iter := a.initialIter
-	for ; (a.maxIter == 0 || iter < a.maxIter) && !a.stopped.Load() && (a.ctx == nil || a.ctx.Err() == nil); iter++ {
+	for ; (a.scanBudget != nil || a.maxIter == 0 || iter < a.maxIter) && !a.stopped.Load() && (a.ctx == nil || a.ctx.Err() == nil); iter++ {
 		// Reset activity watchdog on each iteration — IMMEDIATELY, no delay
 		a.touchActivity()
 		a.state.Iteration = iter
@@ -782,6 +841,12 @@ func (a *Agent) Run(targets []string, instruction string) {
 		if over, why := a.overBudget(toolCallsTotal); over {
 			a.emit(Event{Type: "message", Content: fmt.Sprintf("⏱️ Resource budget reached (%s) — stopping and finalizing. Findings reported so far are preserved.", why), TotalTokens: tokenCount()})
 			a.emit(Event{Type: "finished", Content: fmt.Sprintf("Scan stopped: resource budget reached (%s).", why), TotalTokens: tokenCount()})
+			return
+		}
+		if a.scanBudget != nil && !a.scanBudget.reserveIteration(a.maxIter) {
+			reason := fmt.Sprintf("%d shared agent iterations ≥ scan cap %d", a.scanBudget.iterationCount(), a.maxIter)
+			a.emit(Event{Type: "message", Content: "⏱️ Resource budget reached (" + reason + ") — stopping and finalizing. Findings reported so far are preserved.", TotalTokens: tokenCount()})
+			a.emit(Event{Type: "finished", Content: "Scan stopped: resource budget reached (" + reason + ").", TotalTokens: tokenCount()})
 			return
 		}
 		if guardMsg := a.maybeCompletePassiveReconGuardAtIterationStart(iter); guardMsg != "" {
@@ -1025,18 +1090,28 @@ func (a *Agent) Run(targets []string, instruction string) {
 		// checked at iteration start, so a single response emitting many calls
 		// could otherwise blow past XALGORIX_MAX_TOOL_CALLS. Truncate the batch
 		// to the remaining allowance so the cap is honored precisely.
-		if a.cfg != nil && a.cfg.MaxToolCalls > 0 {
-			if remaining := a.cfg.MaxToolCalls - toolCallsTotal; remaining < len(toolCalls) {
-				if remaining < 0 {
-					remaining = 0
-				}
-				if len(toolCalls) > remaining {
-					a.emit(Event{Type: "message", Content: fmt.Sprintf("⏱️ Tool-call budget: executing %d of %d requested calls (cap %d reached).", remaining, len(toolCalls), a.cfg.MaxToolCalls), TotalTokens: tokenCount()})
-					toolCalls = toolCalls[:remaining]
-				}
+		requestedCalls := len(toolCalls)
+		allowedCalls := requestedCalls
+		maxToolCalls := 0
+		if a.cfg != nil {
+			maxToolCalls = a.cfg.MaxToolCalls
+		}
+		if a.scanBudget != nil {
+			allowedCalls = a.scanBudget.reserveToolCalls(requestedCalls, maxToolCalls)
+		} else if maxToolCalls > 0 {
+			remaining := maxToolCalls - toolCallsTotal
+			if remaining < 0 {
+				remaining = 0
+			}
+			if allowedCalls > remaining {
+				allowedCalls = remaining
 			}
 		}
-		toolCallsTotal += len(toolCalls)
+		if allowedCalls < requestedCalls {
+			a.emit(Event{Type: "message", Content: fmt.Sprintf("⏱️ Shared tool-call budget: executing %d of %d requested calls (scan cap %d reached).", allowedCalls, requestedCalls, maxToolCalls), TotalTokens: tokenCount()})
+			toolCalls = toolCalls[:allowedCalls]
+		}
+		toolCallsTotal += allowedCalls
 
 		// ── Persist the assistant turn ──
 		// When tool calls were parsed OR recovered, store a CANONICAL rendering
@@ -1309,12 +1384,25 @@ func (a *Agent) Stop() {
 	if a.cancel != nil {
 		a.cancel()
 	}
+	if a.ownsAgentGraph && a.agentGraph != nil {
+		a.agentGraph.Stop()
+	}
 
 	// NOTE: Do NOT call terminal.KillAllProcesses() or browser.CleanupBrowser()
 	// here — those are GLOBAL operations that kill processes across ALL instances.
 	// Per-instance cleanup is handled by sctx.Close() in sess.cleanup().
 	// The handleStop handler calls terminal.KillAllProcesses() directly for
 	// user-initiated "Stop All" operations.
+}
+
+// WaitForDelegatedAgents waits for this root's child runners to observe
+// cancellation and unwind. Cleanup uses a bounded wait before deleting shared
+// scan-context stores, preventing a late child from writing after persistence.
+func (a *Agent) WaitForDelegatedAgents(timeout time.Duration) bool {
+	if !a.ownsAgentGraph || a.agentGraph == nil {
+		return true
+	}
+	return a.agentGraph.WaitStopped(timeout)
 }
 
 // SendMessage injects an operator message into the running scan's
@@ -1651,16 +1739,28 @@ func (a *Agent) overBudget(toolCallsTotal int) (bool, string) {
 	if a.cfg == nil {
 		return false, ""
 	}
-	if a.cfg.MaxDurationSec > 0 && !a.scanStart.IsZero() {
-		if elapsed := time.Since(a.scanStart); elapsed >= time.Duration(a.cfg.MaxDurationSec)*time.Second {
+	if a.cfg.MaxDurationSec > 0 {
+		elapsed := time.Duration(0)
+		started := false
+		if a.scanBudget != nil {
+			elapsed, started = a.scanBudget.elapsed()
+		} else if !a.scanStart.IsZero() {
+			elapsed, started = time.Since(a.scanStart), true
+		}
+		if started && elapsed >= time.Duration(a.cfg.MaxDurationSec)*time.Second {
 			return true, fmt.Sprintf("time %s ≥ cap %ds", elapsed.Round(time.Second), a.cfg.MaxDurationSec)
 		}
 	}
-	if a.cfg.MaxToolCalls > 0 && toolCallsTotal >= a.cfg.MaxToolCalls {
-		return true, fmt.Sprintf("%d tool calls ≥ cap %d", toolCallsTotal, a.cfg.MaxToolCalls)
+	usedToolCalls := toolCallsTotal
+	if a.scanBudget != nil {
+		usedToolCalls = a.scanBudget.toolCallCount()
+	}
+	if a.cfg.MaxToolCalls > 0 && usedToolCalls >= a.cfg.MaxToolCalls {
+		return true, fmt.Sprintf("%d tool calls ≥ cap %d", usedToolCalls, a.cfg.MaxToolCalls)
 	}
 	if a.cfg.MaxTokens > 0 && a.client != nil {
-		if _, _, total := a.client.GetTokens(); total >= a.cfg.MaxTokens {
+		total := a.syncBudgetTokens()
+		if total >= a.cfg.MaxTokens {
 			return true, fmt.Sprintf("%d tokens ≥ cap %d", total, a.cfg.MaxTokens)
 		}
 	}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -350,6 +350,13 @@ func NewAgent(cfg *config.Config, name string, events chan Event, localGuard sco
 	// per-iteration nudge + the finish gate all consult the same plan.
 	a.registerPlanTools(reg)
 
+	// Register the durable hypothesis/evidence ledger tools (record_hypothesis,
+	// add_hypothesis_evidence, update_hypothesis, read_ledger). Unlike the plan
+	// (per-agent ScanState), the ledger lives on the shared ScanContext, so the
+	// coordinator and every delegated specialist read/write the same graph and
+	// it persists across restart/resume.
+	a.registerLedgerTools(reg)
+
 	// Create cancellable context
 	a.ctx, a.cancel = context.WithCancel(a.ctx)
 	// Wire context to LLM client so cancel interrupts pending HTTP requests

--- a/internal/agent/agent_budget.go
+++ b/internal/agent/agent_budget.go
@@ -1,0 +1,147 @@
+package agent
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// scanBudget is shared by the root coordinator and every delegated agent.
+// Without a graph-wide ledger, a three-specialist scan would receive four
+// independent copies of each configured cap and could spend roughly 4x the
+// operator's requested tool/token budget.
+type scanBudget struct {
+	startOnce sync.Once
+	startedMu sync.RWMutex
+	startedAt time.Time
+
+	toolCalls  atomic.Int64
+	iterations atomic.Int64
+	tokens     atomic.Int64
+}
+
+func newScanBudget() *scanBudget { return &scanBudget{} }
+
+func (b *scanBudget) start() {
+	if b == nil {
+		return
+	}
+	b.startOnce.Do(func() {
+		b.startedMu.Lock()
+		b.startedAt = time.Now()
+		b.startedMu.Unlock()
+	})
+}
+
+func (b *scanBudget) elapsed() (time.Duration, bool) {
+	if b == nil {
+		return 0, false
+	}
+	b.startedMu.RLock()
+	started := b.startedAt
+	b.startedMu.RUnlock()
+	if started.IsZero() {
+		return 0, false
+	}
+	return time.Since(started), true
+}
+
+// reserveToolCalls atomically reserves up to requested calls beneath cap and
+// returns the number the caller may execute. cap <= 0 means unlimited, but the
+// calls are still counted for telemetry.
+func (b *scanBudget) reserveToolCalls(requested, cap int) int {
+	if b == nil || requested <= 0 {
+		return 0
+	}
+	if cap <= 0 {
+		b.toolCalls.Add(int64(requested))
+		return requested
+	}
+	for {
+		used := b.toolCalls.Load()
+		remaining := int64(cap) - used
+		if remaining <= 0 {
+			return 0
+		}
+		allowed := int64(requested)
+		if allowed > remaining {
+			allowed = remaining
+		}
+		if b.toolCalls.CompareAndSwap(used, used+allowed) {
+			return int(allowed)
+		}
+	}
+}
+
+func (b *scanBudget) toolCallCount() int {
+	if b == nil {
+		return 0
+	}
+	return int(b.toolCalls.Load())
+}
+
+func (b *scanBudget) reserveIteration(cap int) bool {
+	if b == nil {
+		return true
+	}
+	if cap <= 0 {
+		b.iterations.Add(1)
+		return true
+	}
+	for {
+		used := b.iterations.Load()
+		if used >= int64(cap) {
+			return false
+		}
+		if b.iterations.CompareAndSwap(used, used+1) {
+			return true
+		}
+	}
+}
+
+func (b *scanBudget) iterationCount() int {
+	if b == nil {
+		return 0
+	}
+	return int(b.iterations.Load())
+}
+
+func (b *scanBudget) addTokens(delta int) int {
+	if b == nil {
+		return 0
+	}
+	if delta > 0 {
+		return int(b.tokens.Add(int64(delta)))
+	}
+	return int(b.tokens.Load())
+}
+
+func (b *scanBudget) tokenCount() int {
+	if b == nil {
+		return 0
+	}
+	return int(b.tokens.Load())
+}
+
+// syncBudgetTokens folds this agent client's cumulative token count into the
+// graph-wide total exactly once per delta. Each agent owns one client and only
+// advances lastBudgetTokens from its own loop, while scanBudget.tokens is
+// atomic across agents.
+func (a *Agent) syncBudgetTokens() int {
+	if a == nil || a.client == nil {
+		if a != nil && a.scanBudget != nil {
+			return a.scanBudget.tokenCount()
+		}
+		return 0
+	}
+	_, _, current := a.client.GetTokens()
+	if a.scanBudget == nil {
+		return current
+	}
+	delta := current - a.lastBudgetTokens
+	if delta > 0 {
+		a.lastBudgetTokens = current
+		return a.scanBudget.addTokens(delta)
+	}
+	return a.scanBudget.tokenCount()
+}

--- a/internal/agent/agent_budget_test.go
+++ b/internal/agent/agent_budget_test.go
@@ -1,0 +1,106 @@
+package agent
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/xalgord/xalgorix/v4/internal/config"
+)
+
+func TestScanBudgetAtomicallyCapsParallelToolReservations(t *testing.T) {
+	budget := newScanBudget()
+	const cap = 5
+
+	var wg sync.WaitGroup
+	allowed := make(chan int, 20)
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			allowed <- budget.reserveToolCalls(1, cap)
+		}()
+	}
+	wg.Wait()
+	close(allowed)
+
+	total := 0
+	for count := range allowed {
+		total += count
+	}
+	if total != cap {
+		t.Fatalf("parallel reservations allowed %d calls, want exactly %d", total, cap)
+	}
+	if got := budget.toolCallCount(); got != cap {
+		t.Fatalf("recorded tool calls = %d, want %d", got, cap)
+	}
+}
+
+func TestScanBudgetAtomicallyCapsParallelAgentIterations(t *testing.T) {
+	budget := newScanBudget()
+	const cap = 7
+
+	var wg sync.WaitGroup
+	allowed := make(chan bool, 30)
+	for i := 0; i < 30; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			allowed <- budget.reserveIteration(cap)
+		}()
+	}
+	wg.Wait()
+	close(allowed)
+
+	granted := 0
+	for ok := range allowed {
+		if ok {
+			granted++
+		}
+	}
+	if granted != cap || budget.iterationCount() != cap {
+		t.Fatalf("parallel iterations granted=%d recorded=%d, want %d", granted, budget.iterationCount(), cap)
+	}
+}
+
+func TestOverBudgetUsesGraphWideToolAndTokenLedger(t *testing.T) {
+	budget := newScanBudget()
+	if allowed := budget.reserveToolCalls(5, 5); allowed != 5 {
+		t.Fatalf("initial reservation = %d, want 5", allowed)
+	}
+	agent := &Agent{
+		cfg:        &config.Config{MaxToolCalls: 5},
+		scanBudget: budget,
+	}
+	if over, reason := agent.overBudget(0); !over || reason == "" {
+		t.Fatalf("shared tool budget was not enforced: over=%v reason=%q", over, reason)
+	}
+}
+
+func TestScanBudgetStartIsSharedAndStable(t *testing.T) {
+	budget := newScanBudget()
+	budget.start()
+	budget.startedMu.RLock()
+	first := budget.startedAt
+	budget.startedMu.RUnlock()
+	time.Sleep(time.Millisecond)
+	budget.start()
+	budget.startedMu.RLock()
+	second := budget.startedAt
+	budget.startedMu.RUnlock()
+	if !first.Equal(second) {
+		t.Fatalf("delegated start reset root budget clock: first=%v second=%v", first, second)
+	}
+}
+
+func TestDelegatedAgentInheritsRootScanBudget(t *testing.T) {
+	budget := newScanBudget()
+	child := &Agent{}
+	withAgentGraph(nil, budget, "sub_test")(child)
+	if child.scanBudget != budget {
+		t.Fatal("delegated agent did not inherit root scan budget")
+	}
+	if child.delegatedAgentID != "sub_test" {
+		t.Fatalf("delegated id = %q, want sub_test", child.delegatedAgentID)
+	}
+}

--- a/internal/agent/agent_graph_test.go
+++ b/internal/agent/agent_graph_test.go
@@ -1,0 +1,55 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/xalgord/xalgorix/v4/internal/tools"
+	"github.com/xalgord/xalgorix/v4/internal/tools/agentsgraph"
+)
+
+func TestCoordinatorFinishGateRequiresDelegatedResultCollection(t *testing.T) {
+	release := make(chan struct{})
+	graph := agentsgraph.New(context.Background(), func(context.Context, string, string, []string, string) (string, error) {
+		<-release
+		return "specialist evidence", nil
+	})
+	t.Cleanup(graph.Stop)
+	registry := tools.NewRegistry()
+	graph.Register(registry)
+
+	spawned, err := registry.Execute("spawn_agent", map[string]string{
+		"name": "authorization specialist",
+		"task": "test account boundaries with baseline controls",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	agentID, _ := spawned.Metadata["agent_id"].(string)
+	if agentID == "" {
+		t.Fatalf("spawn result missing agent ID: %#v", spawned)
+	}
+
+	coordinator := &Agent{agentGraph: graph}
+	if gate := coordinator.delegatedWorkFinishGate(nil, nil); !gate.Block || !strings.Contains(gate.BlockReason, "still running") {
+		t.Fatalf("running delegation did not block finish: %+v", gate)
+	}
+
+	close(release)
+	deadline := time.Now().Add(2 * time.Second)
+	for graph.RunningCount() != 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if gate := coordinator.delegatedWorkFinishGate(nil, nil); !gate.Block || !strings.Contains(gate.BlockReason, "not been collected") {
+		t.Fatalf("uncollected delegation did not block finish: %+v", gate)
+	}
+
+	if _, err := registry.Execute("check_agent", map[string]string{"agent_id": agentID}); err != nil {
+		t.Fatal(err)
+	}
+	if gate := coordinator.delegatedWorkFinishGate(nil, nil); gate.Block {
+		t.Fatalf("collected delegation still blocked finish: %+v", gate)
+	}
+}

--- a/internal/agent/agent_prompt.go
+++ b/internal/agent/agent_prompt.go
@@ -310,8 +310,15 @@ Example — reporting a vulnerability:
 Commands have automatic timeouts: 10 minutes for most commands, 30 minutes for heavy tools (nmap, nuclei, ffuf, gobuster, sqlmap). If a command times out, use more targeted parameters (fewer ports, specific paths, smaller scope).
 You will receive partial output from long-running commands so you can see progress.
 
-## Parallel Sub-Agents (HIGHLY RECOMMENDED for speed)
-For long-running tasks, use spawn_agent to run them in PARALLEL (max 3 at once):
+## Multi-Agent Coordinator (REQUIRED for full assessments)
+After initial reconnaissance, act as a coordinator and use spawn_agent to run 2–3 NON-OVERLAPPING specialists in parallel (max 3 at once). Delegate bounded hypotheses, not three generic copies of the same scan. Give every specialist: its assigned endpoints/components, the vulnerability classes or data flows to test, the baseline/control it must compare, the concrete proof required, and a stopping condition.
+
+Recommended split (adapt it to the actual surface):
+1. Authorization & business logic — account/role boundaries, session transitions, workflow and state abuse.
+2. Injection & server-side behavior — SQL/NoSQL/template/command injection, SSRF/XXE, deserialization and OOB proof.
+3. Source/data-flow or client/API specialist — trace input to sensitive sinks when source exists; otherwise inspect JavaScript, hidden APIs, GraphQL/WebSocket and parameters.
+
+Long reconnaissance jobs can also be delegated, but specialists must interpret and manually verify results rather than merely paste scanner output. Example:
 
 <function=spawn_agent>
 <parameter=name>Port Scanner</parameter>
@@ -319,13 +326,12 @@ For long-running tasks, use spawn_agent to run them in PARALLEL (max 3 at once):
 <parameter=target>TARGET</parameter>
 </function>
 
-Then continue with other work while it runs. Check status with:
+Continue coordinating while children run. Check partial evidence with:
 <function=check_agent>
 <parameter=agent_id>the_id_returned</parameter>
 </function>
 
-USE THIS for: nmap scans, directory brute-forcing (ffuf/gobuster), nuclei scans, and other slow reconnaissance tasks.
-NOTE: Prefer MANUAL testing (curl, python scripts) over automated scanners for vulnerability discovery.
+Before finishing, call wait_agent/check_agent for EVERY delegation and incorporate its final result. The finish gate rejects running or uncollected children. Prefer MANUAL testing (curl, focused scripts and controlled browser flows) over scanner-only vulnerability claims.
 
 ## 🧠 Deep Knowledge Skills (CRITICAL — USE THESE!)
 

--- a/internal/agent/agent_prompt_test.go
+++ b/internal/agent/agent_prompt_test.go
@@ -1,0 +1,47 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/config"
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+	"github.com/xalgord/xalgorix/v4/internal/tools"
+	"github.com/xalgord/xalgorix/v4/internal/tools/agentsgraph"
+)
+
+func TestSystemPromptIncludesCollectableMultiAgentWorkflow(t *testing.T) {
+	registry := tools.NewRegistry()
+	graph := agentsgraph.New(context.Background(), func(context.Context, string, string, []string, string) (string, error) {
+		return "done", nil
+	})
+	t.Cleanup(graph.Stop)
+	graph.Register(registry)
+
+	agent := &Agent{
+		cfg:      &config.Config{RateLimitRPS: 2},
+		registry: registry,
+	}
+	prompt := agent.buildSystemPrompt(
+		[]string{"https://example.test"},
+		"Perform a full authorized assessment.",
+		scanctx.RequestRatePolicy{MaxRPS: 2, Source: "test"},
+	)
+
+	for _, expected := range []string{
+		"## Multi-Agent Coordinator",
+		"NON-OVERLAPPING specialists",
+		"Authorization & business logic",
+		"call wait_agent/check_agent for EVERY delegation",
+		`<tool name="spawn_agent">`,
+		`<tool name="wait_agent">`,
+	} {
+		if !strings.Contains(prompt, expected) {
+			t.Fatalf("prompt missing %q", expected)
+		}
+	}
+	if strings.Contains(prompt, "%!") {
+		t.Fatalf("prompt contains fmt diagnostic, likely a placeholder/argument mismatch")
+	}
+}

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -182,6 +182,8 @@ type ScanState struct {
 	RedirectDetected     bool
 	DetectedTechs        map[string]bool // e.g. "php", "nodejs", "java"
 	SkillSuggestionFired bool            // prevents hookAutoSkillSuggester from firing more than once
+	DelegationAttempted  bool            // coordinator called spawn_agent/create_agent
+	DelegationNudgeFired bool            // multi-agent role decomposition nudge sent once
 }
 
 // NewScanState creates a zero-value ScanState with initialized maps.
@@ -375,6 +377,7 @@ func RegisterDefaultHooks(reg *HookRegistry) {
 	reg.Register(OnFinishAttempt, hookFinishGatekeeper)
 	reg.Register(OnEmptyResponse, hookEmptyResponseHandler)
 	reg.Register(OnNoToolResponse, hookNoToolHandler)
+	reg.Register(OnIterationStart, hookDelegationCoordinator)
 	reg.Register(OnIterationStart, hookAutoSkillSuggester)
 	reg.Register(OnIterationStart, hookPlanner)
 	reg.Register(OnHealthyResponse, hookResetOnSuccess)
@@ -417,6 +420,9 @@ func hookReportRetryGuard(state *ScanState, args map[string]string) HookResult {
 func hookWorkTracker(state *ScanState, args map[string]string) HookResult {
 	toolName := args["tool_name"]
 	state.UniqueToolsUsed[toolName] = true
+	if toolName == "spawn_agent" || toolName == "create_agent" {
+		state.DelegationAttempted = true
+	}
 
 	if toolName == "terminal_execute" {
 		state.TerminalCalls++
@@ -1832,6 +1838,47 @@ func isRefusal(response string) bool {
 		}
 	}
 	return false
+}
+
+// ── hookDelegationCoordinator ────────────────────────────────────────────────
+// Once the coordinator has enough reconnaissance to divide work intelligently,
+// prompt it to run distinct hypothesis-driven specialists in parallel. This is
+// deliberately a one-time nudge rather than unconditional auto-spawning: small
+// targets and tightly budgeted scans should retain control over provider cost.
+func hookDelegationCoordinator(state *ScanState, args map[string]string) HookResult {
+	if state == nil || state.DiscoveryMode || state.ReconOnlyMode ||
+		state.DelegationAttempted || state.DelegationNudgeFired ||
+		!state.ReconDone || state.Iteration < 5 {
+		return HookResult{}
+	}
+
+	state.DelegationNudgeFired = true
+	contextParts := []string{}
+	if len(state.DetectedTechs) > 0 {
+		techs := make([]string, 0, len(state.DetectedTechs))
+		for tech := range state.DetectedTechs {
+			techs = append(techs, tech)
+		}
+		sort.Strings(techs)
+		contextParts = append(contextParts, "detected stack: "+strings.Join(techs, ", "))
+	}
+	if len(state.DiscoveredEndpoints) > 0 {
+		end := minInt(4, len(state.DiscoveredEndpoints))
+		contextParts = append(contextParts, "representative surface: "+strings.Join(state.DiscoveredEndpoints[:end], ", "))
+	}
+	contextLine := ""
+	if len(contextParts) > 0 {
+		contextLine = "\nCurrent context: " + strings.Join(contextParts, "; ") + "."
+	}
+
+	return HookResult{Nudge: `🧭 MULTI-AGENT DECOMPOSITION: Recon is mature enough to split the assessment. Act as coordinator now: launch 2–3 NON-OVERLAPPING specialists with spawn_agent, each with a bounded hypothesis, assigned endpoints/components, required baseline/control, and expected proof.
+
+Recommended role split:
+1. Authorization & business logic — session state, role/account boundaries, multi-step workflow abuse.
+2. Injection & server-side behavior — SQL/NoSQL/template/command injection, SSRF/XXE, unsafe parsing, OOB proof.
+3. Source/data-flow or client/API specialist — trace attacker input to sensitive sinks when source is available; otherwise inspect JavaScript, hidden APIs, GraphQL/WebSocket, and parameter discovery.
+
+Do not delegate three generic scans or duplicate your own work. Continue coordinating while they run, incorporate every result with wait_agent/check_agent, independently verify candidates, and do not finish with an uncollected delegation.` + contextLine}
 }
 
 // ── hookAutoSkillSuggester ───────────────────────────────────────────────────

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -184,6 +184,7 @@ type ScanState struct {
 	SkillSuggestionFired bool            // prevents hookAutoSkillSuggester from firing more than once
 	DelegationAttempted  bool            // coordinator called spawn_agent/create_agent
 	DelegationNudgeFired bool            // multi-agent role decomposition nudge sent once
+	LedgerSeeded         bool            // hypothesis ledger seeded from the plan once
 }
 
 // NewScanState creates a zero-value ScanState with initialized maps.
@@ -375,11 +376,16 @@ func RegisterDefaultHooks(reg *HookRegistry) {
 	reg.Register(OnToolResult, hookResultRepeatTracker)
 	reg.Register(OnToolResult, hookReportVulnerabilityTracker)
 	reg.Register(OnFinishAttempt, hookFinishGatekeeper)
+	// Registered AFTER the gatekeeper so its coverage BlockReason wins when both
+	// block; this gate only adds the "proven-but-unreported" precision check.
+	reg.Register(OnFinishAttempt, hookLedgerFinishGate)
 	reg.Register(OnEmptyResponse, hookEmptyResponseHandler)
 	reg.Register(OnNoToolResponse, hookNoToolHandler)
 	reg.Register(OnIterationStart, hookDelegationCoordinator)
 	reg.Register(OnIterationStart, hookAutoSkillSuggester)
 	reg.Register(OnIterationStart, hookPlanner)
+	// Registered AFTER the planner so state.Plan exists when we seed the ledger.
+	reg.Register(OnIterationStart, hookLedgerSeed)
 	reg.Register(OnHealthyResponse, hookResetOnSuccess)
 }
 
@@ -1853,32 +1859,11 @@ func hookDelegationCoordinator(state *ScanState, args map[string]string) HookRes
 	}
 
 	state.DelegationNudgeFired = true
-	contextParts := []string{}
-	if len(state.DetectedTechs) > 0 {
-		techs := make([]string, 0, len(state.DetectedTechs))
-		for tech := range state.DetectedTechs {
-			techs = append(techs, tech)
-		}
-		sort.Strings(techs)
-		contextParts = append(contextParts, "detected stack: "+strings.Join(techs, ", "))
-	}
-	if len(state.DiscoveredEndpoints) > 0 {
-		end := minInt(4, len(state.DiscoveredEndpoints))
-		contextParts = append(contextParts, "representative surface: "+strings.Join(state.DiscoveredEndpoints[:end], ", "))
-	}
-	contextLine := ""
-	if len(contextParts) > 0 {
-		contextLine = "\nCurrent context: " + strings.Join(contextParts, "; ") + "."
-	}
-
-	return HookResult{Nudge: `🧭 MULTI-AGENT DECOMPOSITION: Recon is mature enough to split the assessment. Act as coordinator now: launch 2–3 NON-OVERLAPPING specialists with spawn_agent, each with a bounded hypothesis, assigned endpoints/components, required baseline/control, and expected proof.
-
-Recommended role split:
-1. Authorization & business logic — session state, role/account boundaries, multi-step workflow abuse.
-2. Injection & server-side behavior — SQL/NoSQL/template/command injection, SSRF/XXE, unsafe parsing, OOB proof.
-3. Source/data-flow or client/API specialist — trace attacker input to sensitive sinks when source is available; otherwise inspect JavaScript, hidden APIs, GraphQL/WebSocket, and parameter discovery.
-
-Do not delegate three generic scans or duplicate your own work. Continue coordinating while they run, incorporate every result with wait_agent/check_agent, independently verify candidates, and do not finish with an uncollected delegation.` + contextLine}
+	// The nudge is built from the deterministic specialist profiles and the
+	// shared ledger's schedulable hypotheses (see ledger_hooks.go), so the
+	// coordinator assigns disjoint, contract-bound work instead of three generic
+	// scans.
+	return HookResult{Nudge: buildDelegationNudge(state)}
 }
 
 // ── hookAutoSkillSuggester ───────────────────────────────────────────────────

--- a/internal/agent/hooks_test.go
+++ b/internal/agent/hooks_test.go
@@ -1231,8 +1231,13 @@ func TestDelegationCoordinatorNudgesOnceAfterRecon(t *testing.T) {
 	state.DiscoveredEndpoints = []string{"/api/users", "/graphql"}
 
 	result := hookDelegationCoordinator(state, nil)
-	if result.Nudge == "" || !strings.Contains(result.Nudge, "Authorization & business logic") ||
-		!strings.Contains(result.Nudge, "nodejs") || !strings.Contains(result.Nudge, "/graphql") {
+	// The nudge is now ledger-driven and built from the deterministic specialist
+	// profiles, while still carrying the recon context (detected stack + surface).
+	if result.Nudge == "" ||
+		!strings.Contains(result.Nudge, "authz-logic") ||
+		!strings.Contains(result.Nudge, "read_ledger") ||
+		!strings.Contains(result.Nudge, "nodejs") ||
+		!strings.Contains(result.Nudge, "/graphql") {
 		t.Fatalf("unexpected delegation nudge: %q", result.Nudge)
 	}
 	if second := hookDelegationCoordinator(state, nil); second.Nudge != "" {

--- a/internal/agent/hooks_test.go
+++ b/internal/agent/hooks_test.go
@@ -1222,3 +1222,39 @@ func TestHookReportVulnerabilityTracker_CapsMalformedRecovery(t *testing.T) {
 		t.Fatalf("finish must be allowed after the repair limit, got: %s", res.BlockReason)
 	}
 }
+
+func TestDelegationCoordinatorNudgesOnceAfterRecon(t *testing.T) {
+	state := NewScanState()
+	state.Iteration = 8
+	state.ReconDone = true
+	state.DetectedTechs["nodejs"] = true
+	state.DiscoveredEndpoints = []string{"/api/users", "/graphql"}
+
+	result := hookDelegationCoordinator(state, nil)
+	if result.Nudge == "" || !strings.Contains(result.Nudge, "Authorization & business logic") ||
+		!strings.Contains(result.Nudge, "nodejs") || !strings.Contains(result.Nudge, "/graphql") {
+		t.Fatalf("unexpected delegation nudge: %q", result.Nudge)
+	}
+	if second := hookDelegationCoordinator(state, nil); second.Nudge != "" {
+		t.Fatalf("delegation nudge repeated: %q", second.Nudge)
+	}
+}
+
+func TestDelegationCoordinatorSkipsDiscoveryAndExistingDelegation(t *testing.T) {
+	state := NewScanState()
+	state.Iteration = 8
+	state.ReconDone = true
+	state.DiscoveryMode = true
+	if result := hookDelegationCoordinator(state, nil); result.Nudge != "" {
+		t.Fatalf("discovery scan received delegation nudge: %q", result.Nudge)
+	}
+
+	state.DiscoveryMode = false
+	hookWorkTracker(state, map[string]string{"tool_name": "spawn_agent"})
+	if !state.DelegationAttempted {
+		t.Fatal("spawn_agent call did not mark delegation attempted")
+	}
+	if result := hookDelegationCoordinator(state, nil); result.Nudge != "" {
+		t.Fatalf("coordinator with an existing delegation was nudged again: %q", result.Nudge)
+	}
+}

--- a/internal/agent/ledger_hooks.go
+++ b/internal/agent/ledger_hooks.go
@@ -1,0 +1,244 @@
+// Package agent — ledger_hooks.go makes the durable hypothesis/evidence ledger
+// (internal/scanctx.LedgerStore) actually DRIVE the scan, rather than just being
+// a store the model may or may not touch. It provides:
+//
+//   - hookLedgerSeed: once a plan exists, seed the shared ledger with one
+//     hypothesis per planned vuln class so the graph is populated deterministically
+//     (not solely dependent on the LLM calling record_hypothesis).
+//   - buildDelegationNudge + specialist profiles: the coordinator's one-time
+//     delegation prompt now assigns work from the ledger to well-defined
+//     specialists, each with an explicit evidence contract and stopping rule.
+//   - hookLedgerFinishGate: a precision gate that refuses to finish while a
+//     hypothesis is marked proven but has no linked finding — enforcing
+//     verify-by-execution and precision-over-volume.
+//
+// Hooks receive only *ScanState, so the ledger is resolved through the shared
+// ScanContext via ScanContextID (nil-safe: unit tests without an active context
+// simply no-op).
+package agent
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+)
+
+// ledgerForState resolves the durable ledger for a scan state, or nil when the
+// state has no owning context or the context is not active (e.g. unit tests).
+func ledgerForState(state *ScanState) *scanctx.LedgerStore {
+	if state == nil || state.ScanContextID == "" {
+		return nil
+	}
+	if sc := scanctx.Get(state.ScanContextID); sc != nil {
+		return sc.Ledger
+	}
+	return nil
+}
+
+// ── Deterministic specialist profiles ───────────────────────────────────────
+//
+// These formalize the three non-overlapping roles the coordinator delegates to.
+// Encoding them as data (rather than free prose) makes the decomposition
+// deterministic and testable, and lets each specialist carry an explicit
+// evidence contract + stopping rule — the mechanism that turns "run more agents"
+// into precise, verify-by-execution work. The class coverage deliberately targets
+// the classes autonomous scanners are weakest at (blind injection via OOB, XSS
+// via browser confirmation, multi-role authorization).
+type specialistProfile struct {
+	Role             string
+	Focus            string
+	VulnClasses      []string
+	EvidenceContract string
+	StoppingRule     string
+}
+
+var defaultSpecialistProfiles = []specialistProfile{
+	{
+		Role:             "authz-logic",
+		Focus:            "Authorization, access control, and business-logic abuse",
+		VulnClasses:      []string{"idor", "bola", "bfla", "privilege-escalation", "auth-bypass", "business-logic"},
+		EvidenceContract: "a baseline request as the legitimate role AND the same request as another/lower-privileged role, showing a concrete cross-role difference (cross-user/cross-tenant data or a state-changing action)",
+		StoppingRule:     "stop once a cross-role difference is proven, or reject with the baseline when both roles behave identically across the object/action set",
+	},
+	{
+		Role:             "injection-serverside",
+		Focus:            "Injection and server-side behavior",
+		VulnClasses:      []string{"sqli", "blind-sqli", "nosqli", "ssti", "cmdi", "ssrf", "xxe", "lfi", "deserialization"},
+		EvidenceContract: "a concrete exploitation outcome — extracted data, command/template output, or an out-of-band (interactsh/OAST) callback for blind classes — not merely a reflected payload or a timing hunch",
+		StoppingRule:     "stop after one class is proven on an endpoint with a reproducible PoC, or reject when control payloads confirm the input is safely handled",
+	},
+	{
+		Role:             "client-source",
+		Focus:            "Client/API surface, and source-to-sink data flow when source is available",
+		VulnClasses:      []string{"xss", "dom-xss", "csrf", "open-redirect", "cors", "secret-exposure", "api-auth"},
+		EvidenceContract: "for XSS/DOM: browser-confirmed script execution (dialog fired or DOM mutation), not just reflection; for source review: an attacker-input→sensitive-sink path plus a live request that exercises it",
+		StoppingRule:     "stop after browser-confirmed execution or a proven source-to-sink path; reject when output encoding / framework defenses demonstrably block the vector",
+	},
+}
+
+// renderSpecialistProfiles formats the profiles as a numbered contract list.
+func renderSpecialistProfiles() string {
+	var b strings.Builder
+	for i, p := range defaultSpecialistProfiles {
+		fmt.Fprintf(&b, "%d. %s (role \"%s\") — classes: %s.\n   Required proof: %s.\n   Stop rule: %s.\n",
+			i+1, p.Focus, p.Role, strings.Join(p.VulnClasses, ", "), p.EvidenceContract, p.StoppingRule)
+	}
+	return b.String()
+}
+
+// buildDelegationNudge builds the coordinator's one-time multi-agent
+// decomposition prompt. It assigns work from the shared ledger to the
+// deterministic specialist profiles, each with an evidence contract, and points
+// the coordinator at concrete schedulable hypotheses when the ledger is already
+// populated.
+func buildDelegationNudge(state *ScanState) string {
+	var b strings.Builder
+	b.WriteString(`🧭 MULTI-AGENT DECOMPOSITION: Recon is mature enough to split the assessment. Act as coordinator now: launch 2–3 NON-OVERLAPPING specialists with spawn_agent, each owning a bounded set of hypotheses from the shared ledger.
+
+Specialist roles (use these exact roles and hold each to its evidence contract):
+`)
+	b.WriteString(renderSpecialistProfiles())
+	b.WriteString(`
+Drive the work from the shared hypothesis ledger so specialists never overlap:
+- Call read_ledger(filter=schedulable) to see the open hypotheses.
+- Give each specialist a DISJOINT set and mark ownership with update_hypothesis(assigned_to=<agent_id>).
+- Require each specialist to record findings as they go with add_hypothesis_evidence, and to set a final status: proven (with a linked finding via kind=finding_ref) or rejected (with the baseline that ruled it out).
+- Keep coordinating while they run: incorporate every result with wait_agent/check_agent, independently verify candidates, and do not finish with an uncollected delegation or a proven-but-unreported hypothesis.
+Do not delegate three generic scans or duplicate your own work.`)
+
+	// Surface concrete schedulable hypotheses if the ledger is already seeded,
+	// so the coordinator has something specific to assign.
+	if l := ledgerForState(state); l != nil {
+		if sched := l.Schedulable(8); len(sched) > 0 {
+			b.WriteString("\n\nCurrently schedulable hypotheses:\n")
+			for _, h := range sched {
+				loc := strings.TrimSpace(h.VulnClass + " " + h.Endpoint)
+				if h.Parameter != "" {
+					loc += " [" + h.Parameter + "]"
+				}
+				fmt.Fprintf(&b, "  • %s: %s (confidence %.2f)\n", h.ID, loc, h.Confidence)
+			}
+		}
+	}
+
+	// Preserve the original recon context line (detected stack + surface).
+	contextParts := []string{}
+	if len(state.DetectedTechs) > 0 {
+		techs := make([]string, 0, len(state.DetectedTechs))
+		for tech := range state.DetectedTechs {
+			techs = append(techs, tech)
+		}
+		sort.Strings(techs)
+		contextParts = append(contextParts, "detected stack: "+strings.Join(techs, ", "))
+	}
+	if len(state.DiscoveredEndpoints) > 0 {
+		end := minInt(4, len(state.DiscoveredEndpoints))
+		contextParts = append(contextParts, "representative surface: "+strings.Join(state.DiscoveredEndpoints[:end], ", "))
+	}
+	if len(contextParts) > 0 {
+		b.WriteString("\nCurrent context: " + strings.Join(contextParts, "; ") + ".")
+	}
+	return b.String()
+}
+
+// ── hookLedgerSeed ───────────────────────────────────────────────────────────
+// Once a plan exists, seed the shared ledger with one hypothesis per planned
+// vuln class so the graph is populated deterministically. This is a side effect
+// only (no nudge) and runs once per agent; the ledger dedups, so the coordinator
+// and any specialist that also seeds cannot create duplicates.
+func hookLedgerSeed(state *ScanState, args map[string]string) HookResult {
+	if state == nil || state.ReconOnlyMode || state.LedgerSeeded || state.Plan == nil {
+		return HookResult{}
+	}
+	if l := ledgerForState(state); l != nil {
+		seedLedgerFromPlan(state, l)
+		state.LedgerSeeded = true
+	}
+	return HookResult{}
+}
+
+// seedLedgerFromPlan creates a class-level hypothesis for every planned task
+// that targets a vuln class (structural tasks like recon/dirbust/verify/report
+// carry no VulnClass and are skipped). Returns the number of new hypotheses.
+func seedLedgerFromPlan(state *ScanState, l *scanctx.LedgerStore) int {
+	if state == nil || state.Plan == nil || l == nil {
+		return 0
+	}
+	seeded := 0
+	for _, t := range state.Plan.Tasks {
+		if strings.TrimSpace(t.VulnClass) == "" {
+			continue
+		}
+		before := l.Len()
+		l.Upsert(scanctx.Hypothesis{
+			Title:      t.Title,
+			VulnClass:  t.VulnClass,
+			Endpoint:   t.Endpoint,
+			Status:     scanctx.HypothesisQueued,
+			Confidence: 0.4,
+			Origin:     "auto-plan",
+			NextAction: "Probe " + t.VulnClass + " across the discovered surface; record specific endpoints/params as their own hypotheses.",
+		})
+		if l.Len() > before {
+			seeded++
+		}
+	}
+	return seeded
+}
+
+// ── hookLedgerFinishGate ─────────────────────────────────────────────────────
+// Precision gate: refuse to finish while a hypothesis is marked proven but has
+// no linked finding. A proven hypothesis must become a reported, evidence-backed
+// finding (or be downgraded if it was not actually exploitable). Registered
+// AFTER hookFinishGatekeeper, so when both block the coverage reason surfaces
+// first; self-bounded by FinishAttempts so it can never deadlock the scan.
+func hookLedgerFinishGate(state *ScanState, args map[string]string) HookResult {
+	if state == nil || state.DiscoveryMode || state.ReconOnlyMode {
+		return HookResult{}
+	}
+	// hookFinishGatekeeper has already incremented FinishAttempts for this
+	// attempt. Give the model a few chances to report, then get out of the way.
+	if state.FinishAttempts > 3 {
+		return HookResult{}
+	}
+	l := ledgerForState(state)
+	if l == nil {
+		return HookResult{}
+	}
+	unreported := provenUnreportedHypotheses(l)
+	if len(unreported) == 0 {
+		return HookResult{}
+	}
+	return HookResult{
+		Block: true,
+		BlockReason: "⚠️ PROVEN BUT UNREPORTED: ledger hypotheses " + strings.Join(unreported, ", ") +
+			" are marked proven but have no linked finding. Either file each with report_vulnerability and then link it via add_hypothesis_evidence(kind=finding_ref, finding_id=XALG-...), or — if a hypothesis is not actually exploitable — downgrade it with update_hypothesis(status=rejected). Do not finish with proven work unreported.",
+	}
+}
+
+// provenUnreportedHypotheses returns the IDs of hypotheses marked proven that
+// carry no finding reference (no finding_ref evidence and no evidence FindingID).
+func provenUnreportedHypotheses(l *scanctx.LedgerStore) []string {
+	if l == nil {
+		return nil
+	}
+	var out []string
+	for _, h := range l.All() {
+		if h.Status != scanctx.HypothesisProven {
+			continue
+		}
+		linked := false
+		for _, ev := range h.Evidence {
+			if ev.Kind == scanctx.EvidenceFindingRef || strings.TrimSpace(ev.FindingID) != "" {
+				linked = true
+				break
+			}
+		}
+		if !linked {
+			out = append(out, h.ID)
+		}
+	}
+	return out
+}

--- a/internal/agent/ledger_hooks_test.go
+++ b/internal/agent/ledger_hooks_test.go
@@ -1,0 +1,208 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+)
+
+// newTestCtxState creates an active ScanContext (with an in-memory ledger, no
+// persist path) and a ScanState wired to it. The context is deactivated on
+// cleanup so tests do not leak active contexts into one another.
+func newTestCtxState(t *testing.T) (*scanctx.ScanContext, *ScanState) {
+	t.Helper()
+	id := "ledger-hooks-test-" + t.Name()
+	ctx := scanctx.New(id, "")
+	scanctx.Activate(ctx)
+	t.Cleanup(func() { scanctx.Deactivate(id) })
+	state := NewScanState()
+	state.ScanContextID = id
+	return ctx, state
+}
+
+func TestSeedLedgerFromPlan(t *testing.T) {
+	ctx, state := newTestCtxState(t)
+	plan := NewPlan()
+	plan.add(&Task{ID: "recon", Title: "Recon", Phase: 1, Status: TaskPending})
+	plan.add(&Task{ID: "test-sqli", Title: "Test SQLi", Phase: 6, VulnClass: "sqli", Status: TaskPending})
+	plan.add(&Task{ID: "test-xss", Title: "Test XSS", Phase: 7, VulnClass: "xss", Status: TaskPending})
+	plan.add(&Task{ID: "report", Title: "Report", Phase: 22, Status: TaskPending})
+	state.Plan = plan
+
+	n := seedLedgerFromPlan(state, ctx.Ledger)
+	if n != 2 {
+		t.Fatalf("expected 2 class hypotheses seeded (structural tasks skipped), got %d", n)
+	}
+	if ctx.Ledger.Len() != 2 {
+		t.Fatalf("expected ledger length 2, got %d", ctx.Ledger.Len())
+	}
+	// Idempotent: re-seeding the same plan dedups to zero new.
+	if again := seedLedgerFromPlan(state, ctx.Ledger); again != 0 {
+		t.Fatalf("expected 0 new hypotheses on reseed, got %d", again)
+	}
+}
+
+func TestHookLedgerSeedLifecycle(t *testing.T) {
+	ctx, state := newTestCtxState(t)
+
+	// No plan yet -> no-op, not marked seeded.
+	if r := hookLedgerSeed(state, nil); r.Nudge != "" || state.LedgerSeeded {
+		t.Fatal("expected no-op before a plan exists")
+	}
+
+	plan := NewPlan()
+	plan.add(&Task{ID: "test-idor", VulnClass: "idor", Status: TaskPending})
+	state.Plan = plan
+
+	hookLedgerSeed(state, nil)
+	if !state.LedgerSeeded {
+		t.Fatal("expected LedgerSeeded to be set")
+	}
+	if ctx.Ledger.Len() != 1 {
+		t.Fatalf("expected 1 hypothesis after seed, got %d", ctx.Ledger.Len())
+	}
+
+	// Second call is a no-op (already seeded).
+	before := ctx.Ledger.Len()
+	hookLedgerSeed(state, nil)
+	if ctx.Ledger.Len() != before {
+		t.Fatal("expected a second hookLedgerSeed call to be a no-op")
+	}
+}
+
+func TestHookLedgerSeedNoActiveContext(t *testing.T) {
+	state := NewScanState()
+	state.ScanContextID = "no-such-active-context"
+	plan := NewPlan()
+	plan.add(&Task{ID: "test-sqli", VulnClass: "sqli", Status: TaskPending})
+	state.Plan = plan
+
+	if r := hookLedgerSeed(state, nil); r.Nudge != "" {
+		t.Fatal("expected no nudge without an active context")
+	}
+	if state.LedgerSeeded {
+		t.Fatal("expected LedgerSeeded to stay false when no ledger is reachable")
+	}
+}
+
+func TestProvenUnreportedHypotheses(t *testing.T) {
+	ctx, _ := newTestCtxState(t)
+	l := ctx.Ledger
+
+	l.Upsert(scanctx.Hypothesis{VulnClass: "sqli", Endpoint: "/a"}) // queued — ignored
+
+	proven := l.Upsert(scanctx.Hypothesis{VulnClass: "idor", Endpoint: "/b"})
+	l.SetStatus(proven.ID, scanctx.HypothesisProven, "") // proven, no finding — listed
+
+	reported := l.Upsert(scanctx.Hypothesis{VulnClass: "ssrf", Endpoint: "/c"})
+	l.SetStatus(reported.ID, scanctx.HypothesisProven, "")
+	l.AddEvidence(reported.ID, scanctx.Evidence{Kind: scanctx.EvidenceFindingRef, FindingID: "XALG-1", Summary: "confirmed"})
+
+	un := provenUnreportedHypotheses(l)
+	if len(un) != 1 || un[0] != proven.ID {
+		t.Fatalf("expected only %s unreported, got %v", proven.ID, un)
+	}
+}
+
+func TestHookLedgerFinishGate(t *testing.T) {
+	ctx, state := newTestCtxState(t)
+	state.FinishAttempts = 1
+	l := ctx.Ledger
+
+	p := l.Upsert(scanctx.Hypothesis{VulnClass: "rce", Endpoint: "/x"})
+	l.SetStatus(p.ID, scanctx.HypothesisProven, "")
+
+	r := hookLedgerFinishGate(state, nil)
+	if !r.Block {
+		t.Fatal("expected finish blocked while a proven hypothesis is unreported")
+	}
+	if !strings.Contains(r.BlockReason, p.ID) {
+		t.Fatalf("expected block reason to name %s, got: %s", p.ID, r.BlockReason)
+	}
+
+	// Linking a finding clears the gate.
+	l.AddEvidence(p.ID, scanctx.Evidence{Kind: scanctx.EvidenceFindingRef, FindingID: "XALG-2", Summary: "poc"})
+	if hookLedgerFinishGate(state, nil).Block {
+		t.Fatal("expected gate to clear after linking a finding")
+	}
+
+	// Even with a fresh proven-unreported hypothesis, the gate must release once
+	// the attempt bound is exceeded so it can never deadlock the scan.
+	p2 := l.Upsert(scanctx.Hypothesis{VulnClass: "sqli", Endpoint: "/y"})
+	l.SetStatus(p2.ID, scanctx.HypothesisProven, "")
+	state.FinishAttempts = 4
+	if hookLedgerFinishGate(state, nil).Block {
+		t.Fatal("expected gate to release after FinishAttempts exceeds the bound")
+	}
+}
+
+func TestHookLedgerFinishGateDiscoveryModeBypass(t *testing.T) {
+	ctx, state := newTestCtxState(t)
+	state.DiscoveryMode = true
+	state.FinishAttempts = 1
+	p := ctx.Ledger.Upsert(scanctx.Hypothesis{VulnClass: "idor", Endpoint: "/x"})
+	ctx.Ledger.SetStatus(p.ID, scanctx.HypothesisProven, "")
+
+	if hookLedgerFinishGate(state, nil).Block {
+		t.Fatal("expected discovery mode to bypass the ledger finish gate")
+	}
+}
+
+func TestBuildDelegationNudgeIsLedgerDriven(t *testing.T) {
+	ctx, state := newTestCtxState(t)
+	state.DetectedTechs = map[string]bool{"php": true}
+	state.DiscoveredEndpoints = []string{"/api/users", "/login"}
+	ctx.Ledger.Upsert(scanctx.Hypothesis{VulnClass: "sqli", Endpoint: "/api/users", Parameter: "id", Confidence: 0.6})
+
+	nudge := buildDelegationNudge(state)
+	for _, want := range []string{
+		"authz-logic", "injection-serverside", "client-source", // specialist roles
+		"read_ledger", "assigned_to", // ledger-driven assignment
+		"detected stack: php", "/api/users", // recon context + schedulable hypothesis
+	} {
+		if !strings.Contains(nudge, want) {
+			t.Fatalf("expected delegation nudge to contain %q\n---\n%s", want, nudge)
+		}
+	}
+}
+
+func TestSpecialistProfilesCoverWeakClasses(t *testing.T) {
+	covered := map[string]bool{}
+	for _, p := range defaultSpecialistProfiles {
+		if p.Role == "" || p.EvidenceContract == "" || p.StoppingRule == "" {
+			t.Fatalf("specialist profile %q is missing required fields", p.Role)
+		}
+		for _, c := range p.VulnClasses {
+			covered[c] = true
+		}
+	}
+	// The classes autonomous scanners are weakest at must be owned by a profile.
+	for _, want := range []string{"blind-sqli", "xss", "idor", "ssrf"} {
+		if !covered[want] {
+			t.Fatalf("expected specialist profiles to cover %q", want)
+		}
+	}
+}
+
+func TestHookDelegationCoordinatorFiresOnceWithLedger(t *testing.T) {
+	ctx, state := newTestCtxState(t)
+	state.ReconDone = true
+	state.Iteration = 6
+	ctx.Ledger.Upsert(scanctx.Hypothesis{VulnClass: "idor", Endpoint: "/api/orders", Confidence: 0.7})
+
+	r := hookDelegationCoordinator(state, nil)
+	if r.Nudge == "" {
+		t.Fatal("expected a delegation nudge once recon is mature")
+	}
+	if !strings.Contains(r.Nudge, "read_ledger") || !strings.Contains(r.Nudge, "injection-serverside") {
+		t.Fatalf("expected a ledger-driven, profile-based nudge, got:\n%s", r.Nudge)
+	}
+	if !state.DelegationNudgeFired {
+		t.Fatal("expected DelegationNudgeFired to be set")
+	}
+	// One-time: subsequent calls are silent.
+	if hookDelegationCoordinator(state, nil).Nudge != "" {
+		t.Fatal("expected the delegation nudge to fire only once")
+	}
+}

--- a/internal/agent/ledger_tools.go
+++ b/internal/agent/ledger_tools.go
@@ -1,0 +1,356 @@
+// Package agent — ledger_tools.go registers the hypothesis/evidence ledger
+// tools: record_hypothesis, add_hypothesis_evidence, update_hypothesis, and
+// read_ledger.
+//
+// The ledger (internal/scanctx.LedgerStore) is the durable, scan-shared
+// "global exploitation context": a typed graph of attack hypotheses and the
+// evidence gathered for each. Unlike the in-memory planner Plan (which lives on
+// the per-agent ScanState and is neither shared nor persisted), the ledger
+// lives on the ScanContext, so the coordinator and every delegated specialist
+// read and write the SAME graph, and it survives restart/resume via
+// <scanDir>/ledger.json.
+//
+// These tools let agents:
+//   - record_hypothesis: register or refine an attack hypothesis (deduped by
+//     vuln class + endpoint + parameter + role).
+//   - add_hypothesis_evidence: attach an observation (baseline, probe, exploit
+//     attempt, artifact) or link a confirmed finding by its XALG-* id.
+//   - update_hypothesis: transition status (queued/testing/proven/rejected/
+//     blocked/exhausted), assign an owner, set the next-best action, or record
+//     an exploit attempt.
+//   - read_ledger: read the current hypotheses (all / schedulable / open).
+//
+// Like plan_tools.go, the tools are deliberately tolerant of malformed input —
+// they return a corrective tool result rather than erroring out of the loop.
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+	"github.com/xalgord/xalgorix/v4/internal/tools"
+)
+
+// ledger returns the scan-shared ledger, or nil if this agent has no scan
+// context (e.g. some unit tests). Callers must nil-check.
+func (a *Agent) ledger() *scanctx.LedgerStore {
+	if a.scanCtx == nil {
+		return nil
+	}
+	return a.scanCtx.Ledger
+}
+
+// registerLedgerTools adds the four ledger tools. The agent is captured by
+// closure so the tools operate on the shared ScanContext ledger.
+func (a *Agent) registerLedgerTools(reg *tools.Registry) {
+	reg.Register(&tools.Tool{
+		Name: "record_hypothesis",
+		Description: "Record or refine an attack hypothesis in the shared, durable ledger — the " +
+			"team's single source of truth for what to test and what has been proven. Call this as " +
+			"soon as recon suggests a plausible weakness (e.g. 'IDOR on /api/orders?id= as user'). " +
+			"Hypotheses are deduplicated by vuln_class + endpoint + parameter + role, so re-recording " +
+			"the same target refines the existing entry instead of duplicating it. The coordinator " +
+			"and every specialist share this ledger, so recording here is how parallel agents avoid " +
+			"overlapping and how work is scheduled.",
+		Parameters: []tools.Parameter{
+			{Name: "vuln_class", Description: "Vulnerability class, e.g. sqli, xss, idor, ssrf, ssti, rce, auth, csrf, lfi, xxe.", Required: true},
+			{Name: "endpoint", Description: "Target endpoint/path, e.g. /api/orders. Query string is ignored for dedup.", Required: false},
+			{Name: "parameter", Description: "Input/parameter under test, e.g. id, q, redirect.", Required: false},
+			{Name: "role", Description: "Auth context this applies to: anonymous, user, admin, or a named role.", Required: false},
+			{Name: "title", Description: "Short human-readable title.", Required: false},
+			{Name: "target", Description: "Target host/base URL if multi-target.", Required: false},
+			{Name: "data_flow", Description: "For whitebox: source->sink path, e.g. 'req.query.id -> db.query'.", Required: false},
+			{Name: "required_privilege", Description: "Privilege needed to test (e.g. 'authenticated user').", Required: false},
+			{Name: "baseline", Description: "Control/baseline result that distinguishes a real bug from intended behavior.", Required: false},
+			{Name: "preconditions", Description: "Preconditions before testing: a JSON array or a comma-separated list.", Required: false},
+			{Name: "next_action", Description: "The next concrete step to attempt.", Required: false},
+			{Name: "confidence", Description: "0.0-1.0 belief this is exploitable (default 0.5).", Required: false},
+			{Name: "status", Description: "Optional initial status: queued (default), testing, blocked.", Required: false},
+		},
+		Execute: a.recordHypothesisTool,
+	})
+
+	reg.Register(&tools.Tool{
+		Name: "add_hypothesis_evidence",
+		Description: "Attach an observation to a hypothesis: a baseline/control result, a probe " +
+			"response, an exploit attempt, an artifact, or a link to a confirmed finding. This is how " +
+			"evidence accumulates toward a proof and how other agents see your progress. When you have " +
+			"filed a finding with report_vulnerability, link it here with kind=finding_ref and its " +
+			"XALG-* id so the hypothesis is backed by the authoritative finding.",
+		Parameters: []tools.Parameter{
+			{Name: "hypothesis_id", Description: "The hypothesis id from record_hypothesis (e.g. H-3).", Required: true},
+			{Name: "kind", Description: "One of: baseline, probe, exploit, artifact, finding_ref.", Required: false},
+			{Name: "summary", Description: "What was observed and why it matters.", Required: true},
+			{Name: "request", Description: "Optional raw request evidence (bounded).", Required: false},
+			{Name: "response", Description: "Optional raw response evidence (bounded).", Required: false},
+			{Name: "finding_id", Description: "When kind=finding_ref, the reported finding id (e.g. XALG-3).", Required: false},
+			{Name: "confidence", Description: "0.0-1.0 quality of this observation.", Required: false},
+		},
+		Execute: a.addHypothesisEvidenceTool,
+	})
+
+	reg.Register(&tools.Tool{
+		Name: "update_hypothesis",
+		Description: "Update a hypothesis's lifecycle: set its status, assign an owner, record the " +
+			"next-best action, or log an exploit attempt. Statuses: queued (identified, untested), " +
+			"testing (being worked), proven (exploited with evidence), rejected (disproven by a " +
+			"baseline), blocked (needs a precondition), exhausted (attempts spent, no proof). Keep this " +
+			"current so the shared ledger reflects reality and the scheduler does not re-open settled work.",
+		Parameters: []tools.Parameter{
+			{Name: "hypothesis_id", Description: "The hypothesis id (e.g. H-3).", Required: true},
+			{Name: "status", Description: "One of: queued, testing, proven, rejected, blocked, exhausted.", Required: false},
+			{Name: "next_action", Description: "The next concrete step to attempt.", Required: false},
+			{Name: "assigned_to", Description: "Owner (agent/delegation id) taking this hypothesis.", Required: false},
+			{Name: "record_attempt", Description: "Set to true to increment the exploit-attempt counter.", Required: false},
+		},
+		Execute: a.updateHypothesisTool,
+	})
+
+	reg.Register(&tools.Tool{
+		Name: "read_ledger",
+		Description: "Read the shared hypothesis/evidence ledger. Use filter=schedulable to get the " +
+			"highest-value untested hypotheses to work next, filter=open for active/queued work, or " +
+			"filter=all for everything. Check this before starting new work so you build on the team's " +
+			"findings instead of repeating them.",
+		Parameters: []tools.Parameter{
+			{Name: "filter", Description: "One of: open (default), schedulable, all.", Required: false},
+			{Name: "limit", Description: "Max hypotheses to return for schedulable (default 10).", Required: false},
+		},
+		Execute: a.readLedgerTool,
+	})
+}
+
+func (a *Agent) recordHypothesisTool(args map[string]string) (tools.Result, error) {
+	l := a.ledger()
+	if l == nil {
+		return tools.Result{Error: "ledger unavailable in this context"}, nil
+	}
+	vc := strings.TrimSpace(args["vuln_class"])
+	if vc == "" {
+		return tools.Result{Error: "vuln_class is required (e.g. sqli, idor, ssrf)"}, nil
+	}
+	conf := 0.5
+	if raw := strings.TrimSpace(args["confidence"]); raw != "" {
+		if f, err := strconv.ParseFloat(raw, 64); err == nil {
+			conf = f
+		}
+	}
+	h := scanctx.Hypothesis{
+		VulnClass:         vc,
+		Endpoint:          strings.TrimSpace(args["endpoint"]),
+		Parameter:         strings.TrimSpace(args["parameter"]),
+		Role:              strings.TrimSpace(args["role"]),
+		Title:             strings.TrimSpace(args["title"]),
+		Target:            strings.TrimSpace(args["target"]),
+		DataFlow:          strings.TrimSpace(args["data_flow"]),
+		RequiredPrivilege: strings.TrimSpace(args["required_privilege"]),
+		Baseline:          strings.TrimSpace(args["baseline"]),
+		NextAction:        strings.TrimSpace(args["next_action"]),
+		Preconditions:     parsePreconditions(args["preconditions"]),
+		Confidence:        conf,
+		Origin:            a.ledgerOrigin(),
+	}
+	if st := strings.TrimSpace(args["status"]); st != "" {
+		h.Status = scanctx.NormalizeHypothesisStatus(st)
+	}
+	stored := l.Upsert(h)
+	return tools.Result{
+		Output: fmt.Sprintf("Hypothesis %s recorded [%s] %s%s (confidence %.2f). Update it as you gather evidence.",
+			stored.ID, stored.Status, stored.VulnClass, formatLoc(stored), stored.Confidence),
+		Metadata: map[string]any{"hypothesis_id": stored.ID},
+	}, nil
+}
+
+func (a *Agent) addHypothesisEvidenceTool(args map[string]string) (tools.Result, error) {
+	l := a.ledger()
+	if l == nil {
+		return tools.Result{Error: "ledger unavailable in this context"}, nil
+	}
+	id := strings.TrimSpace(args["hypothesis_id"])
+	if id == "" {
+		return tools.Result{Error: "hypothesis_id is required"}, nil
+	}
+	summary := strings.TrimSpace(args["summary"])
+	if summary == "" {
+		return tools.Result{Error: "summary is required"}, nil
+	}
+	conf := 0.0
+	if raw := strings.TrimSpace(args["confidence"]); raw != "" {
+		if f, err := strconv.ParseFloat(raw, 64); err == nil {
+			conf = f
+		}
+	}
+	ev := scanctx.Evidence{
+		Kind:       strings.TrimSpace(args["kind"]),
+		Summary:    summary,
+		Request:    args["request"],
+		Response:   args["response"],
+		FindingID:  strings.TrimSpace(args["finding_id"]),
+		AgentID:    a.ledgerOrigin(),
+		Confidence: conf,
+	}
+	if !l.AddEvidence(id, ev) {
+		return tools.Result{Error: fmt.Sprintf("unknown hypothesis id %q — call record_hypothesis first or read_ledger to list ids", id)}, nil
+	}
+	got, _ := l.Get(id)
+	return tools.Result{
+		Output: fmt.Sprintf("Evidence added to %s (%d total, confidence now %.2f).", id, len(got.Evidence), got.Confidence),
+	}, nil
+}
+
+func (a *Agent) updateHypothesisTool(args map[string]string) (tools.Result, error) {
+	l := a.ledger()
+	if l == nil {
+		return tools.Result{Error: "ledger unavailable in this context"}, nil
+	}
+	id := strings.TrimSpace(args["hypothesis_id"])
+	if id == "" {
+		return tools.Result{Error: "hypothesis_id is required"}, nil
+	}
+	if _, ok := l.Get(id); !ok {
+		return tools.Result{Error: fmt.Sprintf("unknown hypothesis id %q — use read_ledger to list ids", id)}, nil
+	}
+	var applied []string
+	if st := strings.TrimSpace(args["status"]); st != "" {
+		status := scanctx.NormalizeHypothesisStatus(st)
+		l.SetStatus(id, status, strings.TrimSpace(args["next_action"]))
+		applied = append(applied, "status="+string(status))
+	} else if na := strings.TrimSpace(args["next_action"]); na != "" {
+		// next_action without a status change still updates the field.
+		if cur, ok := l.Get(id); ok {
+			l.SetStatus(id, cur.Status, na)
+			applied = append(applied, "next_action")
+		}
+	}
+	if owner := strings.TrimSpace(args["assigned_to"]); owner != "" {
+		l.Assign(id, owner)
+		applied = append(applied, "assigned_to="+owner)
+	}
+	if isTrue(args["record_attempt"]) {
+		l.RecordAttempt(id)
+		applied = append(applied, "attempt+1")
+	}
+	if len(applied) == 0 {
+		return tools.Result{Error: "nothing to update — pass status, next_action, assigned_to, or record_attempt"}, nil
+	}
+	got, _ := l.Get(id)
+	return tools.Result{
+		Output: fmt.Sprintf("Hypothesis %s updated (%s). Now [%s] confidence %.2f, attempts %d.",
+			id, strings.Join(applied, ", "), got.Status, got.Confidence, got.Attempts),
+	}, nil
+}
+
+func (a *Agent) readLedgerTool(args map[string]string) (tools.Result, error) {
+	l := a.ledger()
+	if l == nil {
+		return tools.Result{Error: "ledger unavailable in this context"}, nil
+	}
+	filter := strings.ToLower(strings.TrimSpace(args["filter"]))
+	if filter == "" {
+		filter = "open"
+	}
+	switch filter {
+	case "schedulable", "next":
+		limit := 10
+		if raw := strings.TrimSpace(args["limit"]); raw != "" {
+			if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+				limit = n
+			}
+		}
+		sched := l.Schedulable(limit)
+		if len(sched) == 0 {
+			return tools.Result{Output: "No schedulable hypotheses. Record new ones from recon, or the surface is exhausted."}, nil
+		}
+		var b strings.Builder
+		b.WriteString(fmt.Sprintf("Top %d hypotheses to work next (highest confidence first):\n", len(sched)))
+		for _, h := range sched {
+			b.WriteString(fmt.Sprintf("• %s [%s] %s%s conf=%.2f", h.ID, h.Status, h.VulnClass, formatLoc(h), h.Confidence))
+			if h.NextAction != "" {
+				b.WriteString(" → " + h.NextAction)
+			}
+			b.WriteString("\n")
+		}
+		return tools.Result{Output: b.String()}, nil
+	case "all":
+		all := l.All()
+		if len(all) == 0 {
+			return tools.Result{Output: "Ledger is empty. Record hypotheses as recon reveals attack surface."}, nil
+		}
+		var b strings.Builder
+		counts := l.Counts()
+		b.WriteString(fmt.Sprintf("Ledger: %d hypotheses (queued=%d testing=%d proven=%d rejected=%d blocked=%d exhausted=%d)\n",
+			len(all), counts[scanctx.HypothesisQueued], counts[scanctx.HypothesisTesting], counts[scanctx.HypothesisProven],
+			counts[scanctx.HypothesisRejected], counts[scanctx.HypothesisBlocked], counts[scanctx.HypothesisExhausted]))
+		for _, h := range all {
+			b.WriteString(fmt.Sprintf("• %s [%s] %s%s conf=%.2f evidence=%d\n", h.ID, h.Status, h.VulnClass, formatLoc(h), h.Confidence, len(h.Evidence)))
+		}
+		return tools.Result{Output: b.String()}, nil
+	default: // "open"
+		out := l.FormatForContext()
+		if out == "" {
+			return tools.Result{Output: "Ledger is empty. Record hypotheses as recon reveals attack surface."}, nil
+		}
+		return tools.Result{Output: out}, nil
+	}
+}
+
+// ledgerOrigin identifies the writing agent: the delegation ID for a specialist,
+// or "coordinator" for the root.
+func (a *Agent) ledgerOrigin() string {
+	if a.delegatedAgentID != "" {
+		return a.delegatedAgentID
+	}
+	return "coordinator"
+}
+
+// formatLoc renders the endpoint/parameter/role suffix for display.
+func formatLoc(h scanctx.Hypothesis) string {
+	var parts []string
+	if h.Endpoint != "" {
+		parts = append(parts, h.Endpoint)
+	}
+	if h.Parameter != "" {
+		parts = append(parts, "["+h.Parameter+"]")
+	}
+	if h.Role != "" {
+		parts = append(parts, "as "+h.Role)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return " " + strings.Join(parts, " ")
+}
+
+// parsePreconditions accepts either a JSON array or a comma-separated list.
+func parsePreconditions(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	if strings.HasPrefix(raw, "[") {
+		var arr []string
+		if err := json.Unmarshal([]byte(raw), &arr); err == nil {
+			return arr
+		}
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// isTrue interprets common truthy tool-argument spellings.
+func isTrue(s string) bool {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "true", "yes", "1", "y":
+		return true
+	}
+	return false
+}

--- a/internal/scanctx/context.go
+++ b/internal/scanctx/context.go
@@ -82,6 +82,11 @@ type ScanContext struct {
 	Notes    *NoteStore
 	Terminal *TerminalState
 	Browser  *BrowserState
+	// Ledger is the durable, scan-shared hypothesis/evidence graph. It is the
+	// one place the coordinator and every delegated specialist record and read
+	// attack hypotheses, evidence, and status, and it persists to
+	// <ScanDir>/ledger.json so it survives restart/resume.
+	Ledger *LedgerStore
 
 	// ctx/cancel for the scan's lifecycle
 	Ctx    context.Context
@@ -101,6 +106,7 @@ func New(id, scanDir string) *ScanContext {
 		Notes:    NewNoteStore(),
 		Terminal: NewTerminalState(),
 		Browser:  NewBrowserState(),
+		Ledger:   NewLedgerStore(),
 		Ctx:      ctx,
 		Cancel:   cancel,
 	}

--- a/internal/scanctx/ledger.go
+++ b/internal/scanctx/ledger.go
@@ -1,0 +1,846 @@
+package scanctx
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/xalgord/xalgorix/v4/internal/storage"
+)
+
+// HypothesisStatus is the lifecycle state of an attack hypothesis in the
+// ledger. It is a strict superset of the in-memory planner TaskStatus, adding
+// the states an evidence-driven scheduler needs to reason about what is worth
+// spending budget on next.
+type HypothesisStatus string
+
+const (
+	// HypothesisQueued means the hypothesis has been identified from recon but
+	// not yet investigated. Queued hypotheses are the primary schedulable pool.
+	HypothesisQueued HypothesisStatus = "queued"
+	// HypothesisTesting means a specialist is actively probing it right now.
+	HypothesisTesting HypothesisStatus = "testing"
+	// HypothesisProven means it was exploited with concrete, reproducible
+	// evidence (typically linked to a reported finding by ID).
+	HypothesisProven HypothesisStatus = "proven"
+	// HypothesisRejected means it was investigated and disproven / not
+	// exploitable (a control/baseline showed the behavior is intended).
+	HypothesisRejected HypothesisStatus = "rejected"
+	// HypothesisBlocked means it needs a precondition (e.g. credentials, a
+	// reachable endpoint, a prior chain step) that is not yet satisfied.
+	HypothesisBlocked HypothesisStatus = "blocked"
+	// HypothesisExhausted means the attempt/budget was spent without proof;
+	// kept so the scheduler does not re-open it indefinitely.
+	HypothesisExhausted HypothesisStatus = "exhausted"
+)
+
+// validHypothesisStatuses gates external (tool/LLM-supplied) status values so a
+// malformed update cannot corrupt scheduling.
+var validHypothesisStatuses = map[HypothesisStatus]bool{
+	HypothesisQueued:    true,
+	HypothesisTesting:   true,
+	HypothesisProven:    true,
+	HypothesisRejected:  true,
+	HypothesisBlocked:   true,
+	HypothesisExhausted: true,
+}
+
+// NormalizeHypothesisStatus maps a free-form string to a known status, falling
+// back to queued for anything unrecognized so scheduling never sees garbage.
+func NormalizeHypothesisStatus(s string) HypothesisStatus {
+	st := HypothesisStatus(strings.ToLower(strings.TrimSpace(s)))
+	if validHypothesisStatuses[st] {
+		return st
+	}
+	return HypothesisQueued
+}
+
+// Terminal reports whether a status is a settled outcome that the scheduler
+// should not normally re-open (proven/rejected/exhausted).
+func (s HypothesisStatus) Terminal() bool {
+	return s == HypothesisProven || s == HypothesisRejected || s == HypothesisExhausted
+}
+
+const (
+	maxEvidencePerHypothesis = 40   // keep memory/disk bounded (DoD)
+	maxEvidenceStringLen     = 4096 // request/response fields
+	maxSummaryLen            = 2048
+	maxHypothesisFieldLen    = 512
+
+	// EvidenceFindingRef marks evidence that references a confirmed, reported
+	// finding by its reporting ID (e.g. XALG-3). This kind is never evicted by
+	// the per-hypothesis evidence cap.
+	EvidenceFindingRef = "finding_ref"
+)
+
+// Evidence is a single append-only observation attached to a hypothesis.
+// Specialists accumulate observations (baselines, probes, exploit attempts,
+// artifacts); confirmed findings are referenced by the authoritative reporting
+// ID rather than duplicating the full proof payload here.
+type Evidence struct {
+	ID string `json:"id"`
+	// Kind is a coarse category: "baseline"/"control", "probe", "exploit",
+	// "artifact", or EvidenceFindingRef. Free-form but lower-cased on store.
+	Kind    string `json:"kind"`
+	Summary string `json:"summary"`
+	// Request/Response are optional raw control/PoC evidence, bounded in size.
+	Request  string `json:"request,omitempty"`
+	Response string `json:"response,omitempty"`
+	// FindingID links this evidence to a reported reporting.Vulnerability
+	// (e.g. "XALG-3") when Kind == EvidenceFindingRef.
+	FindingID string `json:"finding_id,omitempty"`
+	// AgentID records which agent (coordinator or a specialist delegation ID)
+	// contributed the evidence.
+	AgentID string `json:"agent_id,omitempty"`
+	// Confidence is the quality of THIS observation in [0,1].
+	Confidence float64   `json:"confidence,omitempty"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
+// Hypothesis is one attack hypothesis: a (vulnerability class × target surface)
+// claim with its lifecycle status, accumulated evidence, and scheduling
+// metadata. It is the durable, scan-shared unit that drives specialist
+// scheduling — a superset of the in-memory planner Task.
+type Hypothesis struct {
+	ID       string `json:"id"`
+	DedupKey string `json:"dedup_key"`
+	Title    string `json:"title"`
+
+	// Identity — what and where.
+	VulnClass string `json:"vuln_class"`
+	Target    string `json:"target,omitempty"`
+	Endpoint  string `json:"endpoint,omitempty"`
+	Parameter string `json:"parameter,omitempty"`
+	// Role is the auth context this hypothesis applies to (anonymous, user,
+	// admin, or a named role) — central to authorization/IDOR testing.
+	Role string `json:"role,omitempty"`
+	// DataFlow captures a source->sink path for whitebox/source-driven work.
+	DataFlow string `json:"data_flow,omitempty"`
+
+	// Preconditions / privileges required before this is testable.
+	Preconditions     []string `json:"preconditions,omitempty"`
+	RequiredPrivilege string   `json:"required_privilege,omitempty"`
+	// Baseline is the control/negative result used to distinguish a real
+	// vulnerability from intended behavior.
+	Baseline string `json:"baseline,omitempty"`
+
+	Status HypothesisStatus `json:"status"`
+	// Confidence is the current belief (in [0,1]) that this is exploitable.
+	Confidence float64 `json:"confidence"`
+	// AssignedTo is the delegation/agent ID that currently owns the work.
+	AssignedTo string `json:"assigned_to,omitempty"`
+	// NextAction is the next-best concrete step for whoever picks this up.
+	NextAction string `json:"next_action,omitempty"`
+	// Attempts counts exploit attempts spent (for exhaustion/economics).
+	Attempts int `json:"attempts"`
+
+	Evidence []Evidence `json:"evidence,omitempty"`
+
+	// Origin records who created it: "recon", "auto", "llm", or a specialist.
+	Origin    string    `json:"origin,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// clone returns a deep copy so callers cannot mutate stored state without going
+// through the store's locked methods.
+func (h *Hypothesis) clone() Hypothesis {
+	cp := *h
+	if h.Preconditions != nil {
+		cp.Preconditions = append([]string(nil), h.Preconditions...)
+	}
+	if h.Evidence != nil {
+		cp.Evidence = append([]Evidence(nil), h.Evidence...)
+	}
+	return cp
+}
+
+// LedgerStore is the durable, concurrency-safe hypothesis/evidence graph for a
+// single scan. It is shared by the coordinator and every specialist (they hold
+// the same *ScanContext), persists to <scanDir>/ledger.json via atomic writes,
+// and survives process restart/resume.
+//
+// It mirrors NoteStore's locking discipline: mutations serialize on mu, the
+// on-disk snapshot is marshaled under mu, and the actual file write happens
+// outside mu (serialized by writeMu) so disk I/O never blocks readers.
+type LedgerStore struct {
+	mu      sync.RWMutex
+	hyps    map[string]*Hypothesis
+	order   []string          // insertion order for stable rendering
+	byDedup map[string]string // dedupKey -> hypothesis ID
+	seq     int               // hypothesis ID sequence
+	evSeq   int               // evidence ID sequence
+
+	persistPath string
+
+	// writeMu serializes disk writes only; see NoteStore for rationale.
+	writeMu sync.Mutex
+}
+
+// NewLedgerStore creates an empty ledger with no persistence configured.
+func NewLedgerStore() *LedgerStore {
+	return &LedgerStore{
+		hyps:    make(map[string]*Hypothesis),
+		byDedup: make(map[string]string),
+	}
+}
+
+// SetPersistPath configures disk persistence. An empty dir disables it.
+//
+// Path policy mirrors NoteStore: the path is dir + "/ledger.json" with no
+// user-supplied component, and in production dir is the per-scan ScanDir (an
+// Allow_List descendant by construction), so no sandbox.CheckResolve is needed
+// here (and cannot be called — sandbox imports scanctx).
+func (ls *LedgerStore) SetPersistPath(dir string) {
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	if dir != "" {
+		ls.persistPath = filepath.Join(dir, "ledger.json")
+	} else {
+		ls.persistPath = ""
+	}
+}
+
+// Upsert inserts a new hypothesis or merges into an existing one that shares
+// the same dedup key. It returns a copy of the stored hypothesis.
+//
+// Dedup: if in.DedupKey is empty it is derived from (VulnClass, Endpoint,
+// Parameter, Role). Non-empty scalar fields on `in` overwrite blanks on the
+// existing record; identity fields are never blanked once set. Status and
+// Confidence are only advanced by the dedicated methods, so Upsert does not
+// silently regress a proven hypothesis back to queued.
+func (ls *LedgerStore) Upsert(in Hypothesis) Hypothesis {
+	now := time.Now().UTC()
+	in.sanitize()
+	key := in.DedupKey
+	if key == "" {
+		key = dedupKey(in.VulnClass, in.Endpoint, in.Parameter, in.Role)
+	}
+
+	ls.mu.Lock()
+	var stored *Hypothesis
+	if id, ok := ls.byDedup[key]; ok {
+		if existing := ls.hyps[id]; existing != nil {
+			existing.mergeFrom(in)
+			existing.UpdatedAt = now
+			stored = existing
+		}
+	}
+	if stored == nil {
+		ls.seq++
+		id := fmt.Sprintf("H-%d", ls.seq)
+		h := in
+		h.ID = id
+		h.DedupKey = key
+		if h.Status == "" {
+			h.Status = HypothesisQueued
+		}
+		if h.CreatedAt.IsZero() {
+			h.CreatedAt = now
+		}
+		h.UpdatedAt = now
+		ls.hyps[id] = &h
+		ls.order = append(ls.order, id)
+		ls.byDedup[key] = id
+		stored = &h
+	}
+	out := stored.clone()
+	data, path := ls.marshalLocked()
+	ls.mu.Unlock()
+
+	ls.writeFile(data, path)
+	return out
+}
+
+// AddEvidence appends an observation to a hypothesis and lightly nudges the
+// hypothesis's confidence toward the evidence's own confidence. Returns false
+// if the hypothesis does not exist.
+func (ls *LedgerStore) AddEvidence(hypID string, ev Evidence) bool {
+	now := time.Now().UTC()
+	ev.sanitize()
+	if ev.CreatedAt.IsZero() {
+		ev.CreatedAt = now
+	}
+
+	ls.mu.Lock()
+	h := ls.hyps[hypID]
+	if h == nil {
+		ls.mu.Unlock()
+		return false
+	}
+	ls.evSeq++
+	ev.ID = fmt.Sprintf("EV-%d", ls.evSeq)
+	h.Evidence = append(h.Evidence, ev)
+	capEvidence(h)
+	// Evidence quality raises belief but never lowers it here; rejection is an
+	// explicit status transition, not a side effect of adding an observation.
+	if ev.Confidence > h.Confidence {
+		h.Confidence = clampConfidence(ev.Confidence)
+	}
+	h.UpdatedAt = now
+	data, path := ls.marshalLocked()
+	ls.mu.Unlock()
+
+	ls.writeFile(data, path)
+	return true
+}
+
+// SetStatus transitions a hypothesis's lifecycle state and optionally records
+// the next-best action. Returns false if the hypothesis does not exist.
+func (ls *LedgerStore) SetStatus(hypID string, status HypothesisStatus, nextAction string) bool {
+	if !validHypothesisStatuses[status] {
+		status = NormalizeHypothesisStatus(string(status))
+	}
+	now := time.Now().UTC()
+
+	ls.mu.Lock()
+	h := ls.hyps[hypID]
+	if h == nil {
+		ls.mu.Unlock()
+		return false
+	}
+	h.Status = status
+	if strings.TrimSpace(nextAction) != "" {
+		h.NextAction = truncate(nextAction, maxSummaryLen)
+	}
+	if status == HypothesisProven && h.Confidence < 1.0 {
+		h.Confidence = 1.0
+	}
+	if status == HypothesisRejected {
+		h.Confidence = 0
+	}
+	h.UpdatedAt = now
+	data, path := ls.marshalLocked()
+	ls.mu.Unlock()
+
+	ls.writeFile(data, path)
+	return true
+}
+
+// Assign records the owning agent/delegation ID and moves a queued hypothesis
+// into "testing". Returns false if the hypothesis does not exist.
+func (ls *LedgerStore) Assign(hypID, agentID string) bool {
+	now := time.Now().UTC()
+	ls.mu.Lock()
+	h := ls.hyps[hypID]
+	if h == nil {
+		ls.mu.Unlock()
+		return false
+	}
+	h.AssignedTo = truncate(strings.TrimSpace(agentID), maxHypothesisFieldLen)
+	if h.Status == HypothesisQueued {
+		h.Status = HypothesisTesting
+	}
+	h.UpdatedAt = now
+	data, path := ls.marshalLocked()
+	ls.mu.Unlock()
+
+	ls.writeFile(data, path)
+	return true
+}
+
+// RecordAttempt increments the exploit-attempt counter (economics/exhaustion).
+func (ls *LedgerStore) RecordAttempt(hypID string) bool {
+	ls.mu.Lock()
+	h := ls.hyps[hypID]
+	if h == nil {
+		ls.mu.Unlock()
+		return false
+	}
+	h.Attempts++
+	h.UpdatedAt = time.Now().UTC()
+	data, path := ls.marshalLocked()
+	ls.mu.Unlock()
+
+	ls.writeFile(data, path)
+	return true
+}
+
+// Get returns a copy of a hypothesis by ID.
+func (ls *LedgerStore) Get(id string) (Hypothesis, bool) {
+	ls.mu.RLock()
+	defer ls.mu.RUnlock()
+	h, ok := ls.hyps[id]
+	if !ok {
+		return Hypothesis{}, false
+	}
+	return h.clone(), true
+}
+
+// All returns copies of every hypothesis in insertion order.
+func (ls *LedgerStore) All() []Hypothesis {
+	ls.mu.RLock()
+	defer ls.mu.RUnlock()
+	out := make([]Hypothesis, 0, len(ls.order))
+	for _, id := range ls.order {
+		if h := ls.hyps[id]; h != nil {
+			out = append(out, h.clone())
+		}
+	}
+	return out
+}
+
+// Schedulable returns the non-terminal hypotheses that are candidates for a
+// specialist to pick up (queued or blocked), highest-confidence first, then by
+// insertion order. "testing" is excluded because it is already owned.
+func (ls *LedgerStore) Schedulable(limit int) []Hypothesis {
+	ls.mu.RLock()
+	cands := make([]Hypothesis, 0, len(ls.order))
+	for _, id := range ls.order {
+		h := ls.hyps[id]
+		if h == nil {
+			continue
+		}
+		if h.Status == HypothesisQueued || h.Status == HypothesisBlocked {
+			cands = append(cands, h.clone())
+		}
+	}
+	ls.mu.RUnlock()
+
+	sort.SliceStable(cands, func(i, j int) bool {
+		if cands[i].Confidence != cands[j].Confidence {
+			return cands[i].Confidence > cands[j].Confidence
+		}
+		// Queued before blocked when confidence ties (blocked needs a
+		// precondition that may not be met yet).
+		if cands[i].Status != cands[j].Status {
+			return cands[i].Status == HypothesisQueued
+		}
+		return false
+	})
+	if limit > 0 && len(cands) > limit {
+		cands = cands[:limit]
+	}
+	return cands
+}
+
+// Counts returns the number of hypotheses in each status.
+func (ls *LedgerStore) Counts() map[HypothesisStatus]int {
+	ls.mu.RLock()
+	defer ls.mu.RUnlock()
+	out := make(map[HypothesisStatus]int)
+	for _, id := range ls.order {
+		if h := ls.hyps[id]; h != nil {
+			out[h.Status]++
+		}
+	}
+	return out
+}
+
+// Len returns the number of hypotheses.
+func (ls *LedgerStore) Len() int {
+	ls.mu.RLock()
+	defer ls.mu.RUnlock()
+	return len(ls.hyps)
+}
+
+// Reset clears all hypotheses (used when a scan is explicitly reset).
+func (ls *LedgerStore) Reset() {
+	ls.mu.Lock()
+	ls.hyps = make(map[string]*Hypothesis)
+	ls.byDedup = make(map[string]string)
+	ls.order = nil
+	ls.seq = 0
+	ls.evSeq = 0
+	data, path := ls.marshalLocked()
+	ls.mu.Unlock()
+	ls.writeFile(data, path)
+}
+
+// Merge folds another ledger's hypotheses into this one (child -> parent
+// rollup), deduplicating by dedup key. Evidence from the source is appended to
+// the matching parent hypothesis; new hypotheses are inserted. Returns the
+// number of source hypotheses that resulted in an insert or an evidence merge.
+// Mirrors reporting.MergeVulnsToContext for the ledger.
+func (ls *LedgerStore) Merge(other *LedgerStore) int {
+	if other == nil || other == ls {
+		return 0
+	}
+	src := other.All()
+	merged := 0
+	for _, s := range src {
+		key := s.DedupKey
+		if key == "" {
+			key = dedupKey(s.VulnClass, s.Endpoint, s.Parameter, s.Role)
+		}
+		ls.mu.Lock()
+		if id, ok := ls.byDedup[key]; ok && ls.hyps[id] != nil {
+			dst := ls.hyps[id]
+			dst.mergeFrom(s)
+			// Advance status toward the more-settled/proven of the two.
+			if statusRank(s.Status) > statusRank(dst.Status) {
+				dst.Status = s.Status
+			}
+			if s.Confidence > dst.Confidence {
+				dst.Confidence = s.Confidence
+			}
+			for _, ev := range s.Evidence {
+				ls.evSeq++
+				ev.ID = fmt.Sprintf("EV-%d", ls.evSeq)
+				dst.Evidence = append(dst.Evidence, ev)
+			}
+			capEvidence(dst)
+			dst.UpdatedAt = time.Now().UTC()
+		} else {
+			ls.seq++
+			id := fmt.Sprintf("H-%d", ls.seq)
+			h := s
+			h.ID = id
+			h.DedupKey = key
+			// Re-ID evidence into this store's sequence.
+			for i := range h.Evidence {
+				ls.evSeq++
+				h.Evidence[i].ID = fmt.Sprintf("EV-%d", ls.evSeq)
+			}
+			ls.hyps[id] = &h
+			ls.order = append(ls.order, id)
+			ls.byDedup[key] = id
+		}
+		merged++
+		ls.mu.Unlock()
+	}
+	ls.mu.Lock()
+	data, path := ls.marshalLocked()
+	ls.mu.Unlock()
+	ls.writeFile(data, path)
+	return merged
+}
+
+// FormatForContext renders a compact, LLM-friendly view of the open work and
+// proven findings for injection into agent context. Empty when the ledger is
+// empty.
+func (ls *LedgerStore) FormatForContext() string {
+	ls.mu.RLock()
+	defer ls.mu.RUnlock()
+	if len(ls.order) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("=== HYPOTHESIS LEDGER (shared, durable) ===\n")
+	counts := map[HypothesisStatus]int{}
+	for _, id := range ls.order {
+		if h := ls.hyps[id]; h != nil {
+			counts[h.Status]++
+		}
+	}
+	b.WriteString(fmt.Sprintf("queued=%d testing=%d proven=%d rejected=%d blocked=%d exhausted=%d\n",
+		counts[HypothesisQueued], counts[HypothesisTesting], counts[HypothesisProven],
+		counts[HypothesisRejected], counts[HypothesisBlocked], counts[HypothesisExhausted]))
+	shown := 0
+	for _, id := range ls.order {
+		h := ls.hyps[id]
+		if h == nil || h.Status == HypothesisRejected || h.Status == HypothesisExhausted {
+			continue
+		}
+		if shown >= 25 {
+			b.WriteString("… (more hypotheses; use read_ledger for the full list)\n")
+			break
+		}
+		loc := h.Endpoint
+		if h.Parameter != "" {
+			loc += " [" + h.Parameter + "]"
+		}
+		if h.Role != "" {
+			loc += " as " + h.Role
+		}
+		b.WriteString(fmt.Sprintf("• %s [%s] %s conf=%.2f %s", h.ID, h.Status, h.VulnClass, h.Confidence, strings.TrimSpace(loc)))
+		if h.NextAction != "" {
+			b.WriteString(" → " + h.NextAction)
+		}
+		b.WriteString("\n")
+		shown++
+	}
+	b.WriteString("=== END LEDGER ===")
+	return b.String()
+}
+
+// LoadFromDisk merges a persisted ledger into this (empty or partial) store.
+// Existing in-memory hypotheses (by dedup key) are preserved; only unseen
+// hypotheses from disk are inserted, so a resume never clobbers live state.
+// Returns the number of hypotheses loaded.
+func (ls *LedgerStore) LoadFromDisk() int {
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+
+	if ls.persistPath == "" {
+		return 0
+	}
+	data, err := os.ReadFile(ls.persistPath)
+	if err != nil {
+		return 0
+	}
+	var snap ledgerSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		log.Printf("[ledger] Warning: failed to parse %s: %v", ls.persistPath, err)
+		return 0
+	}
+	count := 0
+	for _, h := range snap.Hypotheses {
+		if h == nil {
+			continue
+		}
+		key := h.DedupKey
+		if key == "" {
+			key = dedupKey(h.VulnClass, h.Endpoint, h.Parameter, h.Role)
+			h.DedupKey = key
+		}
+		if _, exists := ls.byDedup[key]; exists {
+			continue // do not clobber live state
+		}
+		if h.ID == "" {
+			ls.seq++
+			h.ID = fmt.Sprintf("H-%d", ls.seq)
+		}
+		ls.hyps[h.ID] = h
+		ls.order = append(ls.order, h.ID)
+		ls.byDedup[key] = h.ID
+		count++
+	}
+	// Advance sequences past anything loaded so new IDs never collide.
+	if snap.Seq > ls.seq {
+		ls.seq = snap.Seq
+	}
+	if snap.EvSeq > ls.evSeq {
+		ls.evSeq = snap.EvSeq
+	}
+	if count > 0 {
+		log.Printf("[ledger] Loaded %d hypotheses from: %s", count, ls.persistPath)
+	}
+	return count
+}
+
+// ledgerSnapshot is the on-disk JSON shape.
+type ledgerSnapshot struct {
+	Seq        int           `json:"seq"`
+	EvSeq      int           `json:"ev_seq"`
+	Order      []string      `json:"order"`
+	Hypotheses []*Hypothesis `json:"hypotheses"`
+}
+
+// marshalLocked serializes the store. Must be called with ls.mu held. Returns
+// (nil, "") when persistence is disabled.
+func (ls *LedgerStore) marshalLocked() ([]byte, string) {
+	if ls.persistPath == "" {
+		return nil, ""
+	}
+	snap := ledgerSnapshot{
+		Seq:   ls.seq,
+		EvSeq: ls.evSeq,
+		Order: append([]string(nil), ls.order...),
+	}
+	for _, id := range ls.order {
+		if h := ls.hyps[id]; h != nil {
+			snap.Hypotheses = append(snap.Hypotheses, h)
+		}
+	}
+	data, err := json.MarshalIndent(snap, "", "  ")
+	if err != nil {
+		log.Printf("[ledger] Warning: failed to marshal ledger: %v", err)
+		return nil, ""
+	}
+	return data, ls.persistPath
+}
+
+// writeFile persists serialized data atomically. Safe to call without holding
+// mu; writeMu serializes concurrent writers. Uses storage.WriteAtomic so a
+// crash mid-write can never leave a torn ledger.json.
+func (ls *LedgerStore) writeFile(data []byte, path string) {
+	if data == nil || path == "" {
+		return
+	}
+	ls.writeMu.Lock()
+	defer ls.writeMu.Unlock()
+	if err := storage.WriteAtomic(path, data); err != nil {
+		log.Printf("[ledger] Warning: failed to save ledger to %s: %v", path, err)
+	}
+}
+
+// --- helpers ---
+
+// statusRank orders statuses by "settledness" for merge conflict resolution:
+// proven wins over everything; otherwise more-progressed states win.
+func statusRank(s HypothesisStatus) int {
+	switch s {
+	case HypothesisProven:
+		return 5
+	case HypothesisTesting:
+		return 3
+	case HypothesisBlocked:
+		return 2
+	case HypothesisExhausted:
+		return 2
+	case HypothesisRejected:
+		return 1
+	case HypothesisQueued:
+		return 0
+	default:
+		return 0
+	}
+}
+
+// mergeFrom copies non-empty scalar identity/metadata fields from src into h
+// without blanking existing values. It does not touch ID, DedupKey, status,
+// confidence, attempts, or timestamps (those are managed by the store).
+func (h *Hypothesis) mergeFrom(src Hypothesis) {
+	if h.Title == "" && src.Title != "" {
+		h.Title = src.Title
+	}
+	if h.VulnClass == "" && src.VulnClass != "" {
+		h.VulnClass = src.VulnClass
+	}
+	if h.Target == "" && src.Target != "" {
+		h.Target = src.Target
+	}
+	if h.Endpoint == "" && src.Endpoint != "" {
+		h.Endpoint = src.Endpoint
+	}
+	if h.Parameter == "" && src.Parameter != "" {
+		h.Parameter = src.Parameter
+	}
+	if h.Role == "" && src.Role != "" {
+		h.Role = src.Role
+	}
+	if h.DataFlow == "" && src.DataFlow != "" {
+		h.DataFlow = src.DataFlow
+	}
+	if h.RequiredPrivilege == "" && src.RequiredPrivilege != "" {
+		h.RequiredPrivilege = src.RequiredPrivilege
+	}
+	if h.Baseline == "" && src.Baseline != "" {
+		h.Baseline = src.Baseline
+	}
+	if src.NextAction != "" {
+		h.NextAction = src.NextAction
+	}
+	if len(src.Preconditions) > 0 {
+		h.Preconditions = mergeStringSet(h.Preconditions, src.Preconditions)
+	}
+	if h.Origin == "" && src.Origin != "" {
+		h.Origin = src.Origin
+	}
+}
+
+// sanitize bounds and normalizes external hypothesis input.
+func (h *Hypothesis) sanitize() {
+	h.Title = truncate(strings.TrimSpace(h.Title), maxSummaryLen)
+	h.VulnClass = strings.ToLower(truncate(strings.TrimSpace(h.VulnClass), maxHypothesisFieldLen))
+	h.Target = truncate(strings.TrimSpace(h.Target), maxHypothesisFieldLen)
+	h.Endpoint = truncate(strings.TrimSpace(h.Endpoint), maxHypothesisFieldLen)
+	h.Parameter = truncate(strings.TrimSpace(h.Parameter), maxHypothesisFieldLen)
+	h.Role = truncate(strings.TrimSpace(h.Role), maxHypothesisFieldLen)
+	h.DataFlow = truncate(strings.TrimSpace(h.DataFlow), maxSummaryLen)
+	h.RequiredPrivilege = truncate(strings.TrimSpace(h.RequiredPrivilege), maxHypothesisFieldLen)
+	h.Baseline = truncate(strings.TrimSpace(h.Baseline), maxSummaryLen)
+	h.NextAction = truncate(strings.TrimSpace(h.NextAction), maxSummaryLen)
+	h.Origin = truncate(strings.TrimSpace(h.Origin), maxHypothesisFieldLen)
+	h.Confidence = clampConfidence(h.Confidence)
+	if h.Status != "" {
+		h.Status = NormalizeHypothesisStatus(string(h.Status))
+	}
+	if len(h.Preconditions) > 0 {
+		cleaned := make([]string, 0, len(h.Preconditions))
+		for _, p := range h.Preconditions {
+			if p = truncate(strings.TrimSpace(p), maxHypothesisFieldLen); p != "" {
+				cleaned = append(cleaned, p)
+			}
+		}
+		h.Preconditions = cleaned
+	}
+}
+
+func (ev *Evidence) sanitize() {
+	ev.Kind = strings.ToLower(truncate(strings.TrimSpace(ev.Kind), maxHypothesisFieldLen))
+	if ev.Kind == "" {
+		ev.Kind = "probe"
+	}
+	ev.Summary = truncate(strings.TrimSpace(ev.Summary), maxSummaryLen)
+	ev.Request = truncate(ev.Request, maxEvidenceStringLen)
+	ev.Response = truncate(ev.Response, maxEvidenceStringLen)
+	ev.FindingID = truncate(strings.TrimSpace(ev.FindingID), maxHypothesisFieldLen)
+	ev.AgentID = truncate(strings.TrimSpace(ev.AgentID), maxHypothesisFieldLen)
+	ev.Confidence = clampConfidence(ev.Confidence)
+}
+
+// capEvidence bounds evidence per hypothesis, evicting the oldest non-finding
+// observations first so confirmed-finding references are always retained.
+func capEvidence(h *Hypothesis) {
+	if len(h.Evidence) <= maxEvidencePerHypothesis {
+		return
+	}
+	over := len(h.Evidence) - maxEvidencePerHypothesis
+	kept := make([]Evidence, 0, maxEvidencePerHypothesis)
+	// First pass: drop oldest non-finding evidence.
+	for _, ev := range h.Evidence {
+		if over > 0 && ev.Kind != EvidenceFindingRef {
+			over--
+			continue
+		}
+		kept = append(kept, ev)
+	}
+	// If still over (all remaining were finding refs), trim oldest.
+	if len(kept) > maxEvidencePerHypothesis {
+		kept = kept[len(kept)-maxEvidencePerHypothesis:]
+	}
+	h.Evidence = kept
+}
+
+// dedupKey builds a normalized identity for a hypothesis.
+func dedupKey(vulnClass, endpoint, parameter, role string) string {
+	return strings.Join([]string{
+		strings.ToLower(strings.TrimSpace(vulnClass)),
+		normalizeEndpoint(endpoint),
+		strings.ToLower(strings.TrimSpace(parameter)),
+		strings.ToLower(strings.TrimSpace(role)),
+	}, "|")
+}
+
+// normalizeEndpoint lowercases, drops the query/fragment, and trims a trailing
+// slash so "/a/?x=1" and "/A/" collapse to the same key.
+func normalizeEndpoint(endpoint string) string {
+	e := strings.TrimSpace(endpoint)
+	if i := strings.IndexAny(e, "?#"); i >= 0 {
+		e = e[:i]
+	}
+	e = strings.ToLower(e)
+	if len(e) > 1 {
+		e = strings.TrimRight(e, "/")
+	}
+	return e
+}
+
+func clampConfidence(f float64) float64 {
+	if f < 0 {
+		return 0
+	}
+	if f > 1 {
+		return 1
+	}
+	return f
+}
+
+func truncate(s string, max int) string {
+	if max <= 0 || len(s) <= max {
+		return s
+	}
+	return s[:max] + "…(truncated)"
+}
+
+func mergeStringSet(existing, additions []string) []string {
+	seen := make(map[string]bool, len(existing))
+	for _, e := range existing {
+		seen[e] = true
+	}
+	for _, a := range additions {
+		if a = strings.TrimSpace(a); a != "" && !seen[a] {
+			existing = append(existing, a)
+			seen[a] = true
+		}
+	}
+	return existing
+}

--- a/internal/scanctx/ledger_test.go
+++ b/internal/scanctx/ledger_test.go
@@ -1,0 +1,363 @@
+package scanctx
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestLedgerUpsertAssignsIDAndStatus(t *testing.T) {
+	ls := NewLedgerStore()
+	h := ls.Upsert(Hypothesis{VulnClass: "SQLI", Endpoint: "/api/users", Parameter: "id"})
+	if h.ID == "" {
+		t.Fatal("expected an assigned ID")
+	}
+	if h.Status != HypothesisQueued {
+		t.Fatalf("expected default status queued, got %q", h.Status)
+	}
+	if h.VulnClass != "sqli" {
+		t.Fatalf("expected vuln class lowercased to sqli, got %q", h.VulnClass)
+	}
+	if h.DedupKey == "" {
+		t.Fatal("expected a derived dedup key")
+	}
+	if ls.Len() != 1 {
+		t.Fatalf("expected 1 hypothesis, got %d", ls.Len())
+	}
+}
+
+func TestLedgerUpsertDedupMergesBlanks(t *testing.T) {
+	ls := NewLedgerStore()
+	first := ls.Upsert(Hypothesis{VulnClass: "idor", Endpoint: "/api/orders", Parameter: "oid"})
+	// Same identity, adds a title + baseline that were blank before.
+	second := ls.Upsert(Hypothesis{
+		VulnClass: "idor", Endpoint: "/api/orders", Parameter: "oid",
+		Title:    "Order IDOR",
+		Baseline: "own order returns 200",
+	})
+	if first.ID != second.ID {
+		t.Fatalf("expected dedup to reuse ID %q, got %q", first.ID, second.ID)
+	}
+	if ls.Len() != 1 {
+		t.Fatalf("expected 1 hypothesis after dedup, got %d", ls.Len())
+	}
+	got, _ := ls.Get(first.ID)
+	if got.Title != "Order IDOR" || got.Baseline != "own order returns 200" {
+		t.Fatalf("expected blank fields filled by merge, got title=%q baseline=%q", got.Title, got.Baseline)
+	}
+}
+
+func TestLedgerEndpointNormalizationDedup(t *testing.T) {
+	ls := NewLedgerStore()
+	a := ls.Upsert(Hypothesis{VulnClass: "xss", Endpoint: "/Search/?q=1"})
+	b := ls.Upsert(Hypothesis{VulnClass: "xss", Endpoint: "/search"})
+	if a.ID != b.ID {
+		t.Fatalf("expected /Search/?q=1 and /search to dedup to one hypothesis, got %q and %q", a.ID, b.ID)
+	}
+	if ls.Len() != 1 {
+		t.Fatalf("expected 1 hypothesis, got %d", ls.Len())
+	}
+}
+
+func TestLedgerAddEvidenceRaisesConfidence(t *testing.T) {
+	ls := NewLedgerStore()
+	h := ls.Upsert(Hypothesis{VulnClass: "ssrf", Endpoint: "/fetch", Confidence: 0.2})
+	if !ls.AddEvidence(h.ID, Evidence{Kind: "probe", Summary: "internal 169.254 reachable", Confidence: 0.8}) {
+		t.Fatal("AddEvidence returned false for existing hypothesis")
+	}
+	got, _ := ls.Get(h.ID)
+	if len(got.Evidence) != 1 {
+		t.Fatalf("expected 1 evidence, got %d", len(got.Evidence))
+	}
+	if got.Evidence[0].ID == "" {
+		t.Fatal("expected evidence to get an ID")
+	}
+	if got.Confidence != 0.8 {
+		t.Fatalf("expected confidence raised to 0.8, got %v", got.Confidence)
+	}
+	// A weaker observation must not lower confidence.
+	ls.AddEvidence(h.ID, Evidence{Kind: "probe", Summary: "weak signal", Confidence: 0.1})
+	got, _ = ls.Get(h.ID)
+	if got.Confidence != 0.8 {
+		t.Fatalf("expected confidence to stay 0.8, got %v", got.Confidence)
+	}
+	if ls.AddEvidence("H-nope", Evidence{Summary: "x"}) {
+		t.Fatal("expected AddEvidence to unknown hypothesis to return false")
+	}
+}
+
+func TestLedgerSetStatusConfidenceEffects(t *testing.T) {
+	ls := NewLedgerStore()
+	h := ls.Upsert(Hypothesis{VulnClass: "rce", Endpoint: "/exec", Confidence: 0.5})
+
+	ls.SetStatus(h.ID, HypothesisProven, "attach XALG finding")
+	got, _ := ls.Get(h.ID)
+	if got.Status != HypothesisProven || got.Confidence != 1.0 {
+		t.Fatalf("proven should force confidence 1.0, got status=%q conf=%v", got.Status, got.Confidence)
+	}
+	if got.NextAction != "attach XALG finding" {
+		t.Fatalf("expected next action recorded, got %q", got.NextAction)
+	}
+
+	h2 := ls.Upsert(Hypothesis{VulnClass: "sqli", Endpoint: "/login", Confidence: 0.6})
+	ls.SetStatus(h2.ID, HypothesisRejected, "")
+	got2, _ := ls.Get(h2.ID)
+	if got2.Status != HypothesisRejected || got2.Confidence != 0 {
+		t.Fatalf("rejected should zero confidence, got status=%q conf=%v", got2.Status, got2.Confidence)
+	}
+}
+
+func TestLedgerSetStatusNormalizesUnknown(t *testing.T) {
+	ls := NewLedgerStore()
+	h := ls.Upsert(Hypothesis{VulnClass: "xss", Endpoint: "/x"})
+	if !ls.SetStatus(h.ID, HypothesisStatus("banana"), "") {
+		t.Fatal("SetStatus returned false")
+	}
+	got, _ := ls.Get(h.ID)
+	if got.Status != HypothesisQueued {
+		t.Fatalf("expected unknown status normalized to queued, got %q", got.Status)
+	}
+}
+
+func TestLedgerAssignMovesToTesting(t *testing.T) {
+	ls := NewLedgerStore()
+	h := ls.Upsert(Hypothesis{VulnClass: "idor", Endpoint: "/a"})
+	if !ls.Assign(h.ID, "agent-2") {
+		t.Fatal("Assign returned false")
+	}
+	got, _ := ls.Get(h.ID)
+	if got.AssignedTo != "agent-2" || got.Status != HypothesisTesting {
+		t.Fatalf("expected assigned+testing, got assigned=%q status=%q", got.AssignedTo, got.Status)
+	}
+}
+
+func TestLedgerSchedulableOrdering(t *testing.T) {
+	ls := NewLedgerStore()
+	ls.Upsert(Hypothesis{VulnClass: "a", Endpoint: "/1", Confidence: 0.3})
+	high := ls.Upsert(Hypothesis{VulnClass: "b", Endpoint: "/2", Confidence: 0.9})
+	blocked := ls.Upsert(Hypothesis{VulnClass: "c", Endpoint: "/3", Confidence: 0.9})
+	ls.SetStatus(blocked.ID, HypothesisBlocked, "")
+	proven := ls.Upsert(Hypothesis{VulnClass: "d", Endpoint: "/4", Confidence: 0.95})
+	ls.SetStatus(proven.ID, HypothesisProven, "")
+
+	sched := ls.Schedulable(0)
+	// proven is excluded; three remain.
+	if len(sched) != 3 {
+		t.Fatalf("expected 3 schedulable, got %d", len(sched))
+	}
+	// Highest confidence first; queued before blocked on tie.
+	if sched[0].ID != high.ID {
+		t.Fatalf("expected highest-confidence queued first (%s), got %s", high.ID, sched[0].ID)
+	}
+	if sched[1].ID != blocked.ID {
+		t.Fatalf("expected blocked (conf 0.9) second, got %s", sched[1].ID)
+	}
+	// Limit is respected.
+	if len(ls.Schedulable(1)) != 1 {
+		t.Fatal("expected Schedulable(1) to return 1")
+	}
+}
+
+func TestLedgerEvidenceBounding(t *testing.T) {
+	ls := NewLedgerStore()
+	h := ls.Upsert(Hypothesis{VulnClass: "sqli", Endpoint: "/b"})
+	// One finding ref that must survive eviction.
+	ls.AddEvidence(h.ID, Evidence{Kind: EvidenceFindingRef, FindingID: "XALG-1", Summary: "confirmed"})
+	for i := 0; i < maxEvidencePerHypothesis+20; i++ {
+		ls.AddEvidence(h.ID, Evidence{Kind: "probe", Summary: fmt.Sprintf("probe %d", i)})
+	}
+	got, _ := ls.Get(h.ID)
+	if len(got.Evidence) > maxEvidencePerHypothesis {
+		t.Fatalf("expected evidence capped at %d, got %d", maxEvidencePerHypothesis, len(got.Evidence))
+	}
+	foundFinding := false
+	for _, ev := range got.Evidence {
+		if ev.Kind == EvidenceFindingRef && ev.FindingID == "XALG-1" {
+			foundFinding = true
+		}
+	}
+	if !foundFinding {
+		t.Fatal("expected finding_ref evidence to be retained after eviction")
+	}
+}
+
+func TestLedgerEvidenceStringTruncation(t *testing.T) {
+	ls := NewLedgerStore()
+	h := ls.Upsert(Hypothesis{VulnClass: "sqli", Endpoint: "/c"})
+	big := strings.Repeat("A", maxEvidenceStringLen+1000)
+	ls.AddEvidence(h.ID, Evidence{Kind: "exploit", Summary: "x", Response: big})
+	got, _ := ls.Get(h.ID)
+	if len(got.Evidence[0].Response) > maxEvidenceStringLen+len("…(truncated)") {
+		t.Fatalf("expected response truncated near %d, got %d", maxEvidenceStringLen, len(got.Evidence[0].Response))
+	}
+}
+
+func TestLedgerPersistenceRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	ls := NewLedgerStore()
+	ls.SetPersistPath(dir)
+	h := ls.Upsert(Hypothesis{VulnClass: "ssrf", Endpoint: "/fetch", Parameter: "url", Confidence: 0.7})
+	ls.AddEvidence(h.ID, Evidence{Kind: "exploit", Summary: "hit metadata", FindingID: "XALG-2"})
+	ls.SetStatus(h.ID, HypothesisProven, "report it")
+
+	// Confirm the file exists.
+	if _, err := filepathGlobFirst(filepath.Join(dir, "ledger.json")); err != nil {
+		t.Fatalf("expected ledger.json written: %v", err)
+	}
+
+	// Fresh store loads the same data.
+	ls2 := NewLedgerStore()
+	ls2.SetPersistPath(dir)
+	n := ls2.LoadFromDisk()
+	if n != 1 {
+		t.Fatalf("expected to load 1 hypothesis, got %d", n)
+	}
+	got, ok := ls2.Get(h.ID)
+	if !ok {
+		t.Fatalf("expected hypothesis %s after load", h.ID)
+	}
+	if got.Status != HypothesisProven || got.Confidence != 1.0 {
+		t.Fatalf("expected proven+1.0 after load, got status=%q conf=%v", got.Status, got.Confidence)
+	}
+	if len(got.Evidence) != 1 || got.Evidence[0].FindingID != "XALG-2" {
+		t.Fatalf("expected evidence with finding XALG-2 after load, got %+v", got.Evidence)
+	}
+	// New upserts on the loaded store must not collide IDs with loaded ones.
+	h2 := ls2.Upsert(Hypothesis{VulnClass: "xss", Endpoint: "/new"})
+	if h2.ID == h.ID {
+		t.Fatalf("expected a fresh ID distinct from loaded %s, got %s", h.ID, h2.ID)
+	}
+}
+
+func TestLedgerLoadDoesNotClobberLiveState(t *testing.T) {
+	dir := t.TempDir()
+	// Persist a proven hypothesis to disk.
+	disk := NewLedgerStore()
+	disk.SetPersistPath(dir)
+	dh := disk.Upsert(Hypothesis{VulnClass: "sqli", Endpoint: "/login", Parameter: "u"})
+	disk.SetStatus(dh.ID, HypothesisProven, "")
+
+	// A live store already has the SAME identity in "testing" — load must not
+	// overwrite it back to proven-from-disk (live wins).
+	live := NewLedgerStore()
+	live.SetPersistPath(dir)
+	lh := live.Upsert(Hypothesis{VulnClass: "sqli", Endpoint: "/login", Parameter: "u"})
+	live.Assign(lh.ID, "agent-1")
+	live.LoadFromDisk()
+
+	got, _ := live.Get(lh.ID)
+	if got.Status != HypothesisTesting {
+		t.Fatalf("expected live testing state preserved, got %q", got.Status)
+	}
+	if live.Len() != 1 {
+		t.Fatalf("expected dedup to keep a single hypothesis, got %d", live.Len())
+	}
+}
+
+func TestLedgerMergeChildIntoParent(t *testing.T) {
+	parent := NewLedgerStore()
+	child := NewLedgerStore()
+
+	// Shared identity: child has stronger status + extra evidence.
+	shared := parent.Upsert(Hypothesis{VulnClass: "idor", Endpoint: "/api/orders", Parameter: "id"})
+	_ = shared
+	cShared := child.Upsert(Hypothesis{VulnClass: "idor", Endpoint: "/api/orders", Parameter: "id", Confidence: 0.9})
+	child.AddEvidence(cShared.ID, Evidence{Kind: "exploit", Summary: "cross-user read", FindingID: "XALG-5"})
+	child.SetStatus(cShared.ID, HypothesisProven, "")
+
+	// Child-only hypothesis.
+	child.Upsert(Hypothesis{VulnClass: "ssrf", Endpoint: "/img"})
+
+	merged := parent.Merge(child)
+	if merged != 2 {
+		t.Fatalf("expected 2 merged, got %d", merged)
+	}
+	if parent.Len() != 2 {
+		t.Fatalf("expected parent to hold 2 hypotheses, got %d", parent.Len())
+	}
+	// The shared one should now be proven with the child's evidence.
+	got, _ := parent.Get(shared.ID)
+	if got.Status != HypothesisProven {
+		t.Fatalf("expected merged status proven, got %q", got.Status)
+	}
+	foundEv := false
+	for _, ev := range got.Evidence {
+		if ev.FindingID == "XALG-5" {
+			foundEv = true
+		}
+	}
+	if !foundEv {
+		t.Fatal("expected child evidence merged into parent")
+	}
+}
+
+func TestLedgerFormatForContext(t *testing.T) {
+	ls := NewLedgerStore()
+	if ls.FormatForContext() != "" {
+		t.Fatal("expected empty format for empty ledger")
+	}
+	h := ls.Upsert(Hypothesis{VulnClass: "sqli", Endpoint: "/login", Parameter: "u", NextAction: "try boolean blind"})
+	out := ls.FormatForContext()
+	if !strings.Contains(out, "HYPOTHESIS LEDGER") || !strings.Contains(out, h.ID) {
+		t.Fatalf("expected rendered ledger to contain header and ID, got:\n%s", out)
+	}
+	if !strings.Contains(out, "try boolean blind") {
+		t.Fatalf("expected next action in render, got:\n%s", out)
+	}
+}
+
+func TestLedgerConcurrentAccess(t *testing.T) {
+	dir := t.TempDir()
+	ls := NewLedgerStore()
+	ls.SetPersistPath(dir)
+
+	const workers = 16
+	const per = 25
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < per; i++ {
+				h := ls.Upsert(Hypothesis{
+					VulnClass: fmt.Sprintf("class-%d", w),
+					Endpoint:  fmt.Sprintf("/e/%d/%d", w, i),
+				})
+				ls.AddEvidence(h.ID, Evidence{Kind: "probe", Summary: "x", Confidence: 0.5})
+				ls.SetStatus(h.ID, HypothesisTesting, "next")
+				_ = ls.All()
+				_ = ls.FormatForContext()
+				_ = ls.Schedulable(5)
+				_ = ls.Counts()
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	if ls.Len() != workers*per {
+		t.Fatalf("expected %d hypotheses, got %d", workers*per, ls.Len())
+	}
+	// Reload from disk into a fresh store to confirm persistence survived the
+	// concurrent writes (count may lag by in-flight writes, but must be > 0
+	// and never exceed the total).
+	ls2 := NewLedgerStore()
+	ls2.SetPersistPath(dir)
+	loaded := ls2.LoadFromDisk()
+	if loaded <= 0 || loaded > workers*per {
+		t.Fatalf("expected 1..%d loaded from disk, got %d", workers*per, loaded)
+	}
+}
+
+// filepathGlobFirst is a tiny helper: returns nil if the exact path exists.
+func filepathGlobFirst(path string) (string, error) {
+	matches, err := filepath.Glob(path)
+	if err != nil {
+		return "", err
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("no file at %s", path)
+	}
+	return matches[0], nil
+}

--- a/internal/tools/agentsgraph/agentsgraph.go
+++ b/internal/tools/agentsgraph/agentsgraph.go
@@ -1,296 +1,253 @@
-// Package agentsgraph provides multi-agent delegation tools with async spawning.
+// Package agentsgraph provides scan-scoped multi-agent delegation tools.
 package agentsgraph
 
 import (
+	"context"
 	"fmt"
 	"log"
-	"os"
 	"runtime/debug"
+	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/xalgord/xalgorix/v4/internal/tools"
 )
 
-const maxConcurrentAgents = 3
+const DefaultMaxConcurrentAgents = 3
 
-// AgentRunner is a function that runs a sub-agent. This breaks the import cycle
-// between agent and agentsgraph. The agent package injects this at registration time.
-type AgentRunner func(name string, targets []string, task string) (string, error)
+// AgentRunner runs one delegated agent. agentID is the graph ID exposed to the
+// coordinator; event forwarders use it to attach partial results to the right
+// delegation. Implementations must stop when ctx is canceled.
+type AgentRunner func(ctx context.Context, agentID, name string, targets []string, task string) (string, error)
 
-// subAgentState tracks an async sub-agent.
 type subAgentState struct {
 	ID          string
 	Name        string
 	Task        string
 	Targets     []string
-	Status      string // "running", "completed", "failed"
+	Status      string // running, completed, failed
 	StartedAt   time.Time
 	CompletedAt time.Time
 	Result      string
 	Error       string
-
-	// Partial results accumulated during execution
-	partialMu      sync.Mutex
-	partialResults []string
+	Observed    bool
+	Partial     []string
+	done        chan struct{}
+	doneOnce    sync.Once
 }
 
-var (
-	// runnerPtr holds the injected AgentRunner behind an atomic pointer.
-	// Register is called from agent.NewAgent, and multi-instance scans
-	// construct agents concurrently, so the runner must be installed and
-	// read atomically rather than through a plain shared var.
-	runnerPtr atomic.Pointer[AgentRunner]
+// Graph owns all delegation state for exactly one root scan. Nothing in this
+// type is package-global: concurrent scans therefore cannot overwrite each
+// other's runner, consume each other's semaphore slots, or clear each other's
+// results during cleanup.
+type Graph struct {
+	ctx       context.Context
+	cancel    context.CancelFunc
+	runner    AgentRunner
+	maxAgents int
 
-	// Async sub-agent tracking
-	agentsMu     sync.Mutex
-	agentCounter int
-	agents       = make(map[string]*subAgentState)
+	mu      sync.Mutex
+	stopped bool
+	counter uint64
+	agents  map[string]*subAgentState
+	slots   chan struct{}
+	wg      sync.WaitGroup
+}
 
-	// Semaphore to limit concurrent sub-agents
-	agentSemaphore = make(chan struct{}, maxConcurrentAgents)
+// New creates a scan-scoped graph with the production concurrency limit.
+func New(parent context.Context, runner AgentRunner) *Graph {
+	return NewWithLimit(parent, DefaultMaxConcurrentAgents, runner)
+}
 
-	// Reset signal — when true, running goroutines should exit early
-	agentsStopped atomic.Bool
-)
-
-// setRunner atomically installs the injected sub-agent runner.
-func setRunner(fn AgentRunner) { runnerPtr.Store(&fn) }
-
-// currentRunner returns the installed sub-agent runner, or nil if none has
-// been registered yet. The atomic load pairs with setRunner's store so a
-// tool callback fetching the runner never races a concurrent Register.
-func currentRunner() AgentRunner {
-	if p := runnerPtr.Load(); p != nil {
-		return *p
+// NewWithLimit is exported for deterministic tests and advanced embedders.
+func NewWithLimit(parent context.Context, maxAgents int, runner AgentRunner) *Graph {
+	if parent == nil {
+		parent = context.Background()
 	}
-	return nil
+	if maxAgents <= 0 {
+		maxAgents = DefaultMaxConcurrentAgents
+	}
+	ctx, cancel := context.WithCancel(parent)
+	return &Graph{
+		ctx:       ctx,
+		cancel:    cancel,
+		runner:    runner,
+		maxAgents: maxAgents,
+		agents:    make(map[string]*subAgentState),
+		slots:     make(chan struct{}, maxAgents),
+	}
 }
 
-// Register adds multi-agent tools to the registry.
-// The agentRunner function is injected to break the import cycle.
-//
-// NOTE: Only synchronous create_agent is registered. Async tools (spawn_agent,
-// check_agent, wait_agent) are disabled — they cause zombie goroutines and
-// semaphore leaks that prevent the watchdog from detecting stuck scans.
-func Register(r *tools.Registry, agentRunner AgentRunner) {
-	setRunner(agentRunner)
-
-	// Synchronous sub-agent — blocks until completion
+// Register installs synchronous and asynchronous delegation tools. Async
+// delegation is always available: lifecycle safety comes from scan scoping and
+// cancellation, rather than an environment flag that silently contradicts the
+// coordinator prompt.
+func (g *Graph) Register(r *tools.Registry) {
 	r.Register(&tools.Tool{
 		Name:        "create_agent",
-		Description: "Create and run a sub-agent synchronously. Blocks until the sub-agent completes and returns its results. Use for delegating focused tasks like 'scan this endpoint for SQLi' or 'fuzz this API for IDOR'.",
+		Description: "Create and run a focused sub-agent synchronously. The call returns only after the delegated work completes.",
 		Parameters: []tools.Parameter{
-			{Name: "name", Description: "Name for the sub-agent (e.g. 'SQLi Scanner')", Required: true},
-			{Name: "task", Description: "Task description for the sub-agent", Required: true},
-			{Name: "target", Description: "Target URL/path for the sub-agent", Required: false},
+			{Name: "name", Description: "Short specialist role name", Required: true},
+			{Name: "task", Description: "Bounded task, expected evidence, and stopping condition", Required: true},
+			{Name: "target", Description: "Target URL/path for the specialist", Required: false},
 		},
-		Execute: createAgent,
+		Execute: g.createAgent,
 	})
 
-	// Async sub-agent tools are gated behind XALGORIX_ENABLE_ASYNC_AGENTS to prevent zombie goroutines & semaphore leaks
-	if os.Getenv("XALGORIX_ENABLE_ASYNC_AGENTS") == "true" {
-		r.Register(&tools.Tool{
-			Name:        "spawn_agent",
-			Description: "Spawn a sub-agent asynchronously and return an agent_id immediately. You can continue doing other work and use check_agent or wait_agent later to get results. Max 3 concurrent sub-agents allowed.",
-			Parameters: []tools.Parameter{
-				{Name: "name", Description: "Name for the sub-agent (e.g. 'Directory Brute-forcing')", Required: true},
-				{Name: "task", Description: "Task description for the sub-agent", Required: true},
-				{Name: "target", Description: "Target URL/path for the sub-agent", Required: false},
-			},
-			Execute: spawnAgent,
-		})
+	r.Register(&tools.Tool{
+		Name:        "spawn_agent",
+		Description: fmt.Sprintf("Spawn a focused sub-agent asynchronously. Returns an agent_id immediately; use check_agent or wait_agent to collect its result. At most %d delegated agents run at once.", g.maxAgents),
+		Parameters: []tools.Parameter{
+			{Name: "name", Description: "Short specialist role name", Required: true},
+			{Name: "task", Description: "Bounded task, expected evidence, and stopping condition", Required: true},
+			{Name: "target", Description: "Target URL/path for the specialist", Required: false},
+		},
+		Execute: g.spawnAgent,
+	})
 
-		r.Register(&tools.Tool{
-			Name:        "check_agent",
-			Description: "Check the status and partial results of an asynchronously spawned sub-agent.",
-			Parameters: []tools.Parameter{
-				{Name: "agent_id", Description: "The ID returned by spawn_agent", Required: true},
-			},
-			Execute: checkAgent,
-		})
+	r.Register(&tools.Tool{
+		Name:        "check_agent",
+		Description: "Check a delegated agent's status and recent partial evidence. A completed result is marked collected.",
+		Parameters: []tools.Parameter{
+			{Name: "agent_id", Description: "ID returned by spawn_agent", Required: true},
+		},
+		Execute: g.checkAgent,
+	})
 
-		r.Register(&tools.Tool{
-			Name:        "wait_agent",
-			Description: "Block and wait until a spawned sub-agent completes or fails.",
-			Parameters: []tools.Parameter{
-				{Name: "agent_id", Description: "The ID returned by spawn_agent", Required: true},
-				{Name: "timeout", Description: "Timeout in seconds to wait (default 600)", Required: false},
-			},
-			Execute: waitAgent,
-		})
+	r.Register(&tools.Tool{
+		Name:        "wait_agent",
+		Description: "Wait for a delegated agent to complete or fail, then collect its result.",
+		Parameters: []tools.Parameter{
+			{Name: "agent_id", Description: "ID returned by spawn_agent", Required: true},
+			{Name: "timeout", Description: "Seconds to wait (default 600, maximum 3600)", Required: false},
+		},
+		Execute: g.waitAgent,
+	})
+}
+
+func (g *Graph) validateArgs(args map[string]string) (string, string, []string, error) {
+	name := strings.TrimSpace(args["name"])
+	task := strings.TrimSpace(args["task"])
+	if name == "" || task == "" {
+		return "", "", nil, fmt.Errorf("name and task are required")
+	}
+	if g == nil || g.runner == nil {
+		return "", "", nil, fmt.Errorf("agent runner not initialized")
+	}
+	targets := []string{}
+	if target := strings.TrimSpace(args["target"]); target != "" {
+		targets = append(targets, target)
+	}
+	return name, task, targets, nil
+}
+
+func (g *Graph) tryAcquire() bool {
+	g.mu.Lock()
+	stopped := g.stopped
+	g.mu.Unlock()
+	if stopped || g.ctx.Err() != nil {
+		return false
+	}
+	select {
+	case g.slots <- struct{}{}:
+		return true
+	default:
+		return false
 	}
 }
 
-func createAgent(args map[string]string) (tools.Result, error) {
-	name := args["name"]
-	task := args["task"]
-	target := args["target"]
+func (g *Graph) release() { <-g.slots }
 
-	if name == "" || task == "" {
-		return tools.Result{}, fmt.Errorf("name and task are required")
+func (g *Graph) capacityResult(action string) tools.Result {
+	if g.ctx.Err() != nil {
+		return tools.Result{Output: "Cannot " + action + ": the parent scan is stopping."}
 	}
+	return tools.Result{Output: fmt.Sprintf("Cannot %s: %d/%d delegated agents are already running. Collect or wait for one before delegating more.\nRunning agents:\n%s", action, g.RunningCount(), g.maxAgents, g.listRunningAgents())}
+}
 
-	targets := []string{}
-	if target != "" {
-		targets = append(targets, target)
-	}
+func (g *Graph) nextID(prefix string) string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.counter++
+	return fmt.Sprintf("%s_%d_%d", prefix, g.counter, time.Now().UnixNano())
+}
 
-	run := currentRunner()
-	if run == nil {
-		return tools.Result{}, fmt.Errorf("agent runner not initialized")
-	}
-
-	start := time.Now()
-	summary, err := run(name, targets, task)
-	elapsed := time.Since(start)
-
+func (g *Graph) createAgent(args map[string]string) (tools.Result, error) {
+	name, task, targets, err := g.validateArgs(args)
 	if err != nil {
-		return tools.Result{
-			Output: fmt.Sprintf("Sub-agent '%s' failed after %s: %s", name, elapsed.Round(time.Second), err.Error()),
-		}, nil
+		return tools.Result{}, err
 	}
+	if !g.tryAcquire() {
+		return g.capacityResult("create agent"), nil
+	}
+	defer g.release()
 
-	var b strings.Builder
-	b.WriteString(fmt.Sprintf("Sub-agent '%s' completed in %s\n", name, elapsed.Round(time.Second)))
-	b.WriteString(summary)
-
+	agentID := g.nextID("sync")
+	start := time.Now()
+	summary, runErr := g.runner(g.ctx, agentID, name, targets, task)
+	elapsed := time.Since(start)
+	if runErr != nil {
+		return tools.Result{Output: fmt.Sprintf("Sub-agent %q failed after %s: %s", name, elapsed.Round(time.Second), runErr)}, nil
+	}
 	return tools.Result{
-		Output: b.String(),
+		Output: fmt.Sprintf("Sub-agent %q completed in %s\n%s", name, elapsed.Round(time.Second), summary),
 		Metadata: map[string]any{
+			"agent_id":   agentID,
 			"agent_name": name,
 			"elapsed":    elapsed.Seconds(),
 		},
 	}, nil
 }
 
-// spawnAgent launches a sub-agent asynchronously and returns immediately.
-func spawnAgent(args map[string]string) (tools.Result, error) {
-	name := args["name"]
-	task := args["task"]
-	target := args["target"]
-
-	if name == "" || task == "" {
-		return tools.Result{}, fmt.Errorf("name and task are required")
+func (g *Graph) spawnAgent(args map[string]string) (tools.Result, error) {
+	name, task, targets, err := g.validateArgs(args)
+	if err != nil {
+		return tools.Result{}, err
+	}
+	if !g.tryAcquire() {
+		return g.capacityResult("spawn agent"), nil
 	}
 
-	run := currentRunner()
-	if run == nil {
-		return tools.Result{}, fmt.Errorf("agent runner not initialized")
-	}
-
-	targets := []string{}
-	if target != "" {
-		targets = append(targets, target)
-	}
-
-	// Check concurrent limit
-	agentsMu.Lock()
-	runningCount := 0
-	for _, a := range agents {
-		if a.Status == "running" {
-			runningCount++
-		}
-	}
-	agentsMu.Unlock()
-
-	if runningCount >= maxConcurrentAgents {
-		return tools.Result{
-			Output: fmt.Sprintf("❌ Cannot spawn agent: %d/%d sub-agents already running. Wait for one to finish or use check_agent/wait_agent first.\nRunning agents:\n%s",
-				runningCount, maxConcurrentAgents, listRunningAgents()),
-		}, nil
-	}
-
-	// Create agent state
-	agentsMu.Lock()
-	agentCounter++
-	agentID := fmt.Sprintf("sub_%d_%d", agentCounter, time.Now().Unix())
+	agentID := g.nextID("sub")
 	state := &subAgentState{
 		ID:        agentID,
 		Name:      name,
 		Task:      task,
-		Targets:   targets,
+		Targets:   append([]string(nil), targets...),
 		Status:    "running",
 		StartedAt: time.Now(),
+		done:      make(chan struct{}),
 	}
-	agents[agentID] = state
-	agentsMu.Unlock()
+	g.mu.Lock()
+	if g.stopped || g.ctx.Err() != nil {
+		g.mu.Unlock()
+		g.release()
+		return g.capacityResult("spawn agent"), nil
+	}
+	g.agents[agentID] = state
+	g.wg.Add(1)
+	g.mu.Unlock()
 
-	// Launch in background goroutine
 	go func() {
+		defer g.wg.Done()
+		defer g.release()
 		defer func() {
-			if r := recover(); r != nil {
-				log.Printf("[PANIC] spawnAgent goroutine panicked: %v\n%s", r, debug.Stack())
-				agentsMu.Lock()
-				state.Status = "failed"
-				state.Error = fmt.Sprintf("panic: %v", r)
-				state.CompletedAt = time.Now()
-				agentsMu.Unlock()
+			if recovered := recover(); recovered != nil {
+				log.Printf("[PANIC] delegated agent %s panicked: %v\n%s", agentID, recovered, debug.Stack())
+				g.complete(agentID, "", fmt.Errorf("panic: %v", recovered))
 			}
 		}()
-
-		// Check if reset was requested before acquiring slot
-		if agentsStopped.Load() {
-			agentsMu.Lock()
-			state.Status = "failed"
-			state.Error = "reset: parent scan session ended before agent could start"
-			state.CompletedAt = time.Now()
-			agentsMu.Unlock()
-			return
-		}
-
-		// Acquire semaphore slot (blocks until available)
-		select {
-		case agentSemaphore <- struct{}{}:
-			// Got slot
-		case <-time.After(30 * time.Second):
-			// Timeout — shouldn't happen normally
-			agentsMu.Lock()
-			state.Status = "failed"
-			state.Error = "timeout: could not acquire agent slot within 30s"
-			state.CompletedAt = time.Now()
-			agentsMu.Unlock()
-			return
-		}
-		defer func() { <-agentSemaphore }()
-
-		// Check stopped flag again after acquiring semaphore
-		if agentsStopped.Load() {
-			completedAt := time.Now()
-			agentsMu.Lock()
-			state.Status = "failed"
-			state.Error = "reset: parent scan session ended"
-			state.CompletedAt = completedAt
-			if s, ok := agents[agentID]; ok {
-				s.Status = "failed"
-				s.Error = "reset: parent scan session ended"
-				s.CompletedAt = completedAt
-			}
-			agentsMu.Unlock()
-			return
-		}
-
-		summary, err := run(name, targets, task)
-
-		agentsMu.Lock()
-		defer agentsMu.Unlock()
-
-		state.CompletedAt = time.Now()
-		if err != nil {
-			state.Status = "failed"
-			state.Error = err.Error()
-			state.Result = fmt.Sprintf("Sub-agent '%s' failed: %s", name, err.Error())
-		} else {
-			state.Status = "completed"
-			state.Result = summary
-		}
+		summary, runErr := g.runner(g.ctx, agentID, name, targets, task)
+		g.complete(agentID, summary, runErr)
 	}()
 
+	target := ""
+	if len(targets) > 0 {
+		target = targets[0]
+	}
 	return tools.Result{
-		Output: fmt.Sprintf("✅ Sub-agent '%s' spawned with ID: %s\nTask: %s\nTarget: %s\n\nUse check_agent(agent_id=%s) to poll for results, or wait_agent(agent_id=%s) to block until done.",
-			name, agentID, truncTask(task, 200), target, agentID, agentID),
+		Output: fmt.Sprintf("Sub-agent %q spawned with ID %s\nTask: %s\nTarget: %s\n\nContinue coordinating, then call wait_agent(agent_id=%s) before finishing.", name, agentID, truncTask(task, 200), target, agentID),
 		Metadata: map[string]any{
 			"agent_id":   agentID,
 			"agent_name": name,
@@ -299,27 +256,50 @@ func spawnAgent(args map[string]string) (tools.Result, error) {
 	}, nil
 }
 
-type agentSnapshot struct {
-	ID             string
-	Name           string
-	Task           string
-	Status         string
-	StartedAt      time.Time
-	CompletedAt    time.Time
-	Result         string
-	Error          string
-	PartialResults []string
+func (g *Graph) complete(agentID, summary string, runErr error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	state, ok := g.agents[agentID]
+	if !ok || state.Status != "running" {
+		return
+	}
+	state.CompletedAt = time.Now()
+	if runErr != nil {
+		state.Status = "failed"
+		state.Error = runErr.Error()
+		state.Result = summary
+	} else {
+		state.Status = "completed"
+		state.Result = summary
+	}
+	state.doneOnce.Do(func() { close(state.done) })
 }
 
-func snapshotAgent(agentID string) (agentSnapshot, bool) {
-	agentsMu.Lock()
-	defer agentsMu.Unlock()
-	state, exists := agents[agentID]
-	if !exists {
+type agentSnapshot struct {
+	ID          string
+	Name        string
+	Task        string
+	Status      string
+	StartedAt   time.Time
+	CompletedAt time.Time
+	Result      string
+	Error       string
+	Observed    bool
+	Partial     []string
+	done        <-chan struct{}
+}
+
+func (g *Graph) snapshot(agentID string, observeCompleted bool) (agentSnapshot, bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	state, ok := g.agents[agentID]
+	if !ok {
 		return agentSnapshot{}, false
 	}
-
-	snap := agentSnapshot{
+	if observeCompleted && state.Status != "running" {
+		state.Observed = true
+	}
+	return agentSnapshot{
 		ID:          state.ID,
 		Name:        state.Name,
 		Task:        state.Task,
@@ -328,219 +308,248 @@ func snapshotAgent(agentID string) (agentSnapshot, bool) {
 		CompletedAt: state.CompletedAt,
 		Result:      state.Result,
 		Error:       state.Error,
-	}
-	state.partialMu.Lock()
-	snap.PartialResults = append([]string(nil), state.partialResults...)
-	state.partialMu.Unlock()
-	return snap, true
+		Observed:    state.Observed,
+		Partial:     append([]string(nil), state.Partial...),
+		done:        state.done,
+	}, true
 }
 
-// checkAgent returns status and partial results of a spawned sub-agent.
-func checkAgent(args map[string]string) (tools.Result, error) {
-	agentID := args["agent_id"]
+func (g *Graph) checkAgent(args map[string]string) (tools.Result, error) {
+	agentID := strings.TrimSpace(args["agent_id"])
 	if agentID == "" {
 		return tools.Result{}, fmt.Errorf("agent_id is required")
 	}
-
-	state, exists := snapshotAgent(agentID)
-	if !exists {
-		return tools.Result{
-			Output: fmt.Sprintf("❌ Agent '%s' not found.\n\nAvailable agents:\n%s", agentID, listAllAgents()),
-		}, nil
+	state, ok := g.snapshot(agentID, true)
+	if !ok {
+		return tools.Result{Output: fmt.Sprintf("Agent %q not found.\nAvailable agents:\n%s", agentID, g.listAllAgents())}, nil
 	}
+	return renderSnapshot(state), nil
+}
 
+func renderSnapshot(state agentSnapshot) tools.Result {
 	var b strings.Builder
 	elapsed := time.Since(state.StartedAt).Round(time.Second)
-
 	switch state.Status {
 	case "running":
-		b.WriteString(fmt.Sprintf("🔄 Agent '%s' (%s) — RUNNING for %s\n", state.Name, state.ID, elapsed))
-		b.WriteString(fmt.Sprintf("Task: %s\n", truncTask(state.Task, 150)))
-		if len(state.PartialResults) > 0 {
-			b.WriteString("\n--- Partial Results ---\n")
-			start := 0
-			if len(state.PartialResults) > 5 {
-				start = len(state.PartialResults) - 5
-			}
-			for _, pr := range state.PartialResults[start:] {
-				b.WriteString(pr + "\n")
-			}
+		fmt.Fprintf(&b, "Agent %q (%s) — RUNNING for %s\nTask: %s\n", state.Name, state.ID, elapsed, truncTask(state.Task, 150))
+		if len(state.Partial) == 0 {
+			b.WriteString("\n(No partial evidence yet.)\n")
 		} else {
-			b.WriteString("\n(No partial results yet — agent is still working)\n")
+			b.WriteString("\n--- Recent partial evidence ---\n")
+			start := 0
+			if len(state.Partial) > 5 {
+				start = len(state.Partial) - 5
+			}
+			for _, partial := range state.Partial[start:] {
+				b.WriteString(partial)
+				b.WriteByte('\n')
+			}
 		}
-
 	case "completed":
-		completedElapsed := state.CompletedAt.Sub(state.StartedAt).Round(time.Second)
-		b.WriteString(fmt.Sprintf("✅ Agent '%s' (%s) — COMPLETED in %s\n", state.Name, state.ID, completedElapsed))
-		b.WriteString("\n--- Results ---\n")
-		result := state.Result
-		if len(result) > 5000 {
-			result = result[:5000] + "\n... [truncated]"
-		}
-		b.WriteString(result)
-
+		elapsed = state.CompletedAt.Sub(state.StartedAt).Round(time.Second)
+		fmt.Fprintf(&b, "Agent %q (%s) — COMPLETED in %s\n\n--- Results ---\n%s", state.Name, state.ID, elapsed, truncTask(state.Result, 10000))
 	case "failed":
-		b.WriteString(fmt.Sprintf("❌ Agent '%s' (%s) — FAILED after %s\n", state.Name, state.ID, elapsed))
-		b.WriteString(fmt.Sprintf("Error: %s\n", state.Error))
+		if !state.CompletedAt.IsZero() {
+			elapsed = state.CompletedAt.Sub(state.StartedAt).Round(time.Second)
+		}
+		fmt.Fprintf(&b, "Agent %q (%s) — FAILED after %s\nError: %s", state.Name, state.ID, elapsed, state.Error)
 		if state.Result != "" {
-			b.WriteString("\n--- Partial Results ---\n")
-			b.WriteString(state.Result)
+			fmt.Fprintf(&b, "\n\n--- Partial results ---\n%s", truncTask(state.Result, 10000))
 		}
 	}
-
 	return tools.Result{
 		Output: b.String(),
 		Metadata: map[string]any{
-			"agent_id": agentID,
+			"agent_id": state.ID,
 			"status":   state.Status,
 			"elapsed":  elapsed.Seconds(),
 		},
-	}, nil
+	}
 }
 
-// waitAgent blocks until a sub-agent completes.
-func waitAgent(args map[string]string) (tools.Result, error) {
-	agentID := args["agent_id"]
+func (g *Graph) waitAgent(args map[string]string) (tools.Result, error) {
+	agentID := strings.TrimSpace(args["agent_id"])
 	if agentID == "" {
 		return tools.Result{}, fmt.Errorf("agent_id is required")
 	}
-
-	timeout := 600 // 10 minutes default
-	if t := args["timeout"]; t != "" {
-		_, _ = fmt.Sscanf(t, "%d", &timeout)
+	state, ok := g.snapshot(agentID, false)
+	if !ok {
+		return tools.Result{Output: fmt.Sprintf("Agent %q not found.\nAvailable agents:\n%s", agentID, g.listAllAgents())}, nil
+	}
+	if state.Status != "running" {
+		state, _ = g.snapshot(agentID, true)
+		return renderSnapshot(state), nil
 	}
 
-	state, exists := snapshotAgent(agentID)
-	if !exists {
+	timeout := 600 * time.Second
+	if raw := strings.TrimSpace(args["timeout"]); raw != "" {
+		seconds, err := strconv.Atoi(raw)
+		if err != nil || seconds < 0 {
+			return tools.Result{}, fmt.Errorf("timeout must be a non-negative number of seconds")
+		}
+		if seconds == 0 {
+			timeout = time.Hour
+		} else {
+			if seconds > 3600 {
+				seconds = 3600
+			}
+			timeout = time.Duration(seconds) * time.Second
+		}
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-state.done:
+		state, ok = g.snapshot(agentID, true)
+		if !ok {
+			return tools.Result{Output: fmt.Sprintf("Agent %q was removed before its result could be collected.", agentID)}, nil
+		}
+		return renderSnapshot(state), nil
+	case <-timer.C:
+		state, _ = g.snapshot(agentID, false)
 		return tools.Result{
-			Output: fmt.Sprintf("❌ Agent '%s' not found.\n\nAvailable agents:\n%s", agentID, listAllAgents()),
+			Output:   fmt.Sprintf("Timeout waiting for agent %q (%s) after %s. It is still running; use check_agent or wait_agent again.", state.Name, state.ID, time.Since(state.StartedAt).Round(time.Second)),
+			Metadata: map[string]any{"agent_id": agentID, "status": "timeout"},
 		}, nil
-	}
-
-	// If already done, return immediately
-	if state.Status != "running" {
-		return checkAgent(args)
-	}
-
-	// Poll until done or timeout
-	deadline := time.Now().Add(time.Duration(timeout) * time.Second)
-	if timeout == 0 {
-		deadline = time.Now().Add(24 * time.Hour) // "forever"
-	}
-
-	ticker := time.NewTicker(2 * time.Second)
-	defer ticker.Stop()
-
-	for range ticker.C {
-		state, exists = snapshotAgent(agentID)
-		if !exists {
-			return tools.Result{
-				Output: fmt.Sprintf("❌ Agent '%s' not found.\n\nAvailable agents:\n%s", agentID, listAllAgents()),
-			}, nil
+	case <-g.ctx.Done():
+		state, ok = g.snapshot(agentID, true)
+		if ok && state.Status != "running" {
+			return renderSnapshot(state), nil
 		}
-		if state.Status != "running" {
-			return checkAgent(args)
-		}
-		if time.Now().After(deadline) {
-			elapsed := time.Since(state.StartedAt).Round(time.Second)
-			return tools.Result{
-				Output: fmt.Sprintf("⏰ Timeout waiting for agent '%s' (%s) after %s. Agent is still running.\nUse check_agent to poll later, or wait_agent with a longer timeout.",
-					state.Name, state.ID, elapsed),
-				Metadata: map[string]any{
-					"agent_id": agentID,
-					"status":   "timeout",
-				},
-			}, nil
-		}
+		return tools.Result{Output: fmt.Sprintf("Parent scan stopped while waiting for agent %q.", agentID)}, nil
 	}
-	// unreachable — ticker.C never closes, but compiler requires a return
-	return tools.Result{}, nil
 }
 
-// AddPartialResult adds a partial result to a running sub-agent (called from agent event handler).
-func AddPartialResult(agentID string, result string) {
-	agentsMu.Lock()
-	state, exists := agents[agentID]
-	if !exists {
-		agentsMu.Unlock()
+// AddPartialResult attaches streaming evidence to the coordinator-visible ID.
+func (g *Graph) AddPartialResult(agentID, result string) {
+	if g == nil || strings.TrimSpace(result) == "" {
 		return
 	}
-	// Hold agentsMu while acquiring partialMu to prevent CleanupCompleted from freeing state
-	if state.Status != "running" {
-		agentsMu.Unlock()
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	state, ok := g.agents[agentID]
+	if !ok || state.Status != "running" {
 		return
 	}
-	state.partialMu.Lock()
-	agentsMu.Unlock()
-
-	state.partialResults = append(state.partialResults, result)
-	if len(state.partialResults) > 50 {
-		state.partialResults = state.partialResults[len(state.partialResults)-50:]
+	state.Partial = append(state.Partial, result)
+	if len(state.Partial) > 50 {
+		state.Partial = append([]string(nil), state.Partial[len(state.Partial)-50:]...)
 	}
-	state.partialMu.Unlock()
 }
 
-// GetRunningCount returns the number of running sub-agents.
-func GetRunningCount() int {
-	agentsMu.Lock()
-	defer agentsMu.Unlock()
+// RunningCount returns the number of active delegated agents in this scan.
+func (g *Graph) RunningCount() int {
+	if g == nil {
+		return 0
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	count := 0
-	for _, a := range agents {
-		if a.Status == "running" {
+	for _, state := range g.agents {
+		if state.Status == "running" {
 			count++
 		}
 	}
 	return count
 }
 
-// Reset clears ALL sub-agent state and signals running goroutines to exit.
-// Call this between scan sessions to prevent memory leaks.
-// Goroutines check agentsStopped flag and will exit early, releasing their
-// semaphore slots via the defer statement.
-func Reset() {
-	// Signal all running goroutines to stop
-	agentsStopped.Store(true)
-
-	agentsMu.Lock()
-	// Mark all running agents as failed so their state is correct
-	for _, a := range agents {
-		if a.Status == "running" {
-			a.Status = "failed"
-			a.Error = "reset: parent scan session ended"
-			a.CompletedAt = time.Now()
+// UncollectedCount returns completed/failed delegations whose final result has
+// not yet been read by check_agent or wait_agent.
+func (g *Graph) UncollectedCount() int {
+	if g == nil {
+		return 0
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	count := 0
+	for _, state := range g.agents {
+		if state.Status != "running" && !state.Observed {
+			count++
 		}
 	}
-	// Clear the entire map to free memory
-	agents = make(map[string]*subAgentState)
-	agentCounter = 0
-	agentsMu.Unlock()
-
-	// Reset the stopped flag so new agents can spawn
-	agentsStopped.Store(false)
+	return count
 }
 
-// CleanupCompleted removes finished/failed sub-agents from the map to free memory.
-// Lighter alternative to Reset() — safe to call between subdomain scans.
-func CleanupCompleted() {
-	agentsMu.Lock()
-	defer agentsMu.Unlock()
-	for id, a := range agents {
-		if a.Status == "completed" || a.Status == "failed" {
-			delete(agents, id)
+// PendingSummary gives the coordinator actionable IDs for finish gating.
+func (g *Graph) PendingSummary() string {
+	if g == nil {
+		return ""
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	var lines []string
+	for _, state := range g.agents {
+		switch {
+		case state.Status == "running":
+			lines = append(lines, fmt.Sprintf("- %s (%s): running — call wait_agent", state.Name, state.ID))
+		case !state.Observed:
+			lines = append(lines, fmt.Sprintf("- %s (%s): %s, result not collected — call check_agent", state.Name, state.ID, state.Status))
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// Stop cancels this scan's delegated agents and unblocks all waiters. It never
+// touches any other scan graph. Runner implementations receive the cancellation
+// through their context and are expected to unwind promptly.
+func (g *Graph) Stop() {
+	if g == nil {
+		return
+	}
+	g.mu.Lock()
+	if g.stopped {
+		g.mu.Unlock()
+		return
+	}
+	g.stopped = true
+	g.cancel()
+	now := time.Now()
+	for _, state := range g.agents {
+		if state.Status == "running" {
+			state.Status = "failed"
+			state.Error = "parent scan stopped"
+			state.CompletedAt = now
+			state.doneOnce.Do(func() { close(state.done) })
+		}
+	}
+	g.mu.Unlock()
+}
+
+// WaitStopped waits for delegated runner goroutines to unwind. It is mainly
+// useful for shutdown paths and race tests; normal scan cleanup may remain
+// non-blocking after calling Stop.
+func (g *Graph) WaitStopped(timeout time.Duration) bool {
+	if g == nil {
+		return true
+	}
+	if timeout <= 0 {
+		g.wg.Wait()
+		return true
+	}
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if len(g.slots) == 0 {
+			return true
+		}
+		select {
+		case <-ticker.C:
+		case <-deadline.C:
+			return len(g.slots) == 0
 		}
 	}
 }
 
-// helpers
-
-func listRunningAgents() string {
-	agentsMu.Lock()
-	defer agentsMu.Unlock()
+func (g *Graph) listRunningAgents() string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	var b strings.Builder
-	for _, a := range agents {
-		if a.Status == "running" {
-			elapsed := time.Since(a.StartedAt).Round(time.Second)
-			b.WriteString(fmt.Sprintf("  - %s (%s): %s — running for %s\n", a.Name, a.ID, truncTask(a.Task, 80), elapsed))
+	for _, state := range g.agents {
+		if state.Status == "running" {
+			fmt.Fprintf(&b, "  - %s (%s): %s — %s\n", state.Name, state.ID, truncTask(state.Task, 80), time.Since(state.StartedAt).Round(time.Second))
 		}
 	}
 	if b.Len() == 0 {
@@ -549,13 +558,12 @@ func listRunningAgents() string {
 	return b.String()
 }
 
-func listAllAgents() string {
-	agentsMu.Lock()
-	defer agentsMu.Unlock()
+func (g *Graph) listAllAgents() string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	var b strings.Builder
-	for _, a := range agents {
-		elapsed := time.Since(a.StartedAt).Round(time.Second)
-		b.WriteString(fmt.Sprintf("  - %s (%s): %s [%s] — %s\n", a.Name, a.ID, truncTask(a.Task, 80), a.Status, elapsed))
+	for _, state := range g.agents {
+		fmt.Fprintf(&b, "  - %s (%s): %s [%s]\n", state.Name, state.ID, truncTask(state.Task, 80), state.Status)
 	}
 	if b.Len() == 0 {
 		return "  (none)"
@@ -563,9 +571,9 @@ func listAllAgents() string {
 	return b.String()
 }
 
-func truncTask(s string, max int) string {
-	if len(s) > max {
-		return s[:max] + "..."
+func truncTask(value string, max int) string {
+	if len(value) > max {
+		return value[:max] + "..."
 	}
-	return s
+	return value
 }

--- a/internal/tools/agentsgraph/agentsgraph_test.go
+++ b/internal/tools/agentsgraph/agentsgraph_test.go
@@ -1,100 +1,210 @@
 package agentsgraph
 
 import (
+	"context"
 	"strings"
 	"sync"
 	"testing"
+	"time"
+
+	"github.com/xalgord/xalgorix/v4/internal/tools"
 )
 
-func agentIDFromResult(t *testing.T, res any) string {
+func agentIDFromResult(t *testing.T, metadata map[string]any) string {
 	t.Helper()
-	result, ok := res.(map[string]any)
-	if !ok {
-		t.Fatalf("metadata type = %T, want map[string]any", res)
-	}
-	agentID, ok := result["agent_id"].(string)
+	agentID, ok := metadata["agent_id"].(string)
 	if !ok || agentID == "" {
-		t.Fatalf("missing agent_id in metadata: %#v", result)
+		t.Fatalf("missing agent_id in metadata: %#v", metadata)
 	}
 	return agentID
 }
 
-func TestSpawnCheckWaitAgentSnapshots(t *testing.T) {
-	Reset()
-	t.Cleanup(Reset)
-
-	release := make(chan struct{})
-	setRunner(func(name string, targets []string, task string) (string, error) {
-		<-release
-		return "completed " + name + " on " + strings.Join(targets, ","), nil
+func TestRegisterAlwaysExposesAsyncTools(t *testing.T) {
+	graph := New(context.Background(), func(context.Context, string, string, []string, string) (string, error) {
+		return "done", nil
 	})
+	t.Cleanup(graph.Stop)
+	registry := tools.NewRegistry()
+	graph.Register(registry)
 
-	res, err := spawnAgent(map[string]string{
-		"name":   "worker",
-		"task":   "scan target",
-		"target": "https://example.test",
-	})
-	if err != nil {
-		t.Fatalf("spawnAgent: %v", err)
-	}
-	agentID := agentIDFromResult(t, res.Metadata)
-
-	AddPartialResult(agentID, "partial finding")
-	checked, err := checkAgent(map[string]string{"agent_id": agentID})
-	if err != nil {
-		t.Fatalf("checkAgent: %v", err)
-	}
-	if !strings.Contains(checked.Output, "RUNNING") || !strings.Contains(checked.Output, "partial finding") {
-		t.Fatalf("unexpected check output:\n%s", checked.Output)
-	}
-
-	close(release)
-	waited, err := waitAgent(map[string]string{"agent_id": agentID, "timeout": "5"})
-	if err != nil {
-		t.Fatalf("waitAgent: %v", err)
-	}
-	if !strings.Contains(waited.Output, "COMPLETED") || !strings.Contains(waited.Output, "completed worker") {
-		t.Fatalf("unexpected wait output:\n%s", waited.Output)
+	for _, name := range []string{"create_agent", "spawn_agent", "check_agent", "wait_agent"} {
+		if _, ok := registry.Get(name); !ok {
+			t.Fatalf("tool %q was not registered", name)
+		}
 	}
 }
 
-func TestResetWhileAgentRunsIsRaceFree(t *testing.T) {
-	Reset()
-	t.Cleanup(Reset)
-
-	started := make(chan struct{})
+func TestSpawnPartialWaitAndCollection(t *testing.T) {
 	release := make(chan struct{})
-	done := make(chan struct{})
-	setRunner(func(name string, targets []string, task string) (string, error) {
-		defer close(done)
-		close(started)
+	graph := New(context.Background(), func(_ context.Context, agentID, name string, targets []string, task string) (string, error) {
+		graphPartial := "runner=" + agentID
+		_ = graphPartial
 		<-release
-		return "late result", nil
+		return "completed " + name + " on " + strings.Join(targets, ","), nil
 	})
+	t.Cleanup(graph.Stop)
 
-	res, err := spawnAgent(map[string]string{"name": "slow", "task": "wait"})
+	result, err := graph.spawnAgent(map[string]string{
+		"name":   "authorization specialist",
+		"task":   "test horizontal access controls",
+		"target": "https://example.test/api",
+	})
 	if err != nil {
 		t.Fatalf("spawnAgent: %v", err)
 	}
-	agentID := agentIDFromResult(t, res.Metadata)
+	agentID := agentIDFromResult(t, result.Metadata)
+	graph.AddPartialResult(agentID, "baseline 403; cross-account request pending")
+
+	checked, err := graph.checkAgent(map[string]string{"agent_id": agentID})
+	if err != nil {
+		t.Fatalf("checkAgent: %v", err)
+	}
+	if !strings.Contains(checked.Output, "RUNNING") || !strings.Contains(checked.Output, "baseline 403") {
+		t.Fatalf("unexpected running output:\n%s", checked.Output)
+	}
+
+	close(release)
+	waited, err := graph.waitAgent(map[string]string{"agent_id": agentID, "timeout": "5"})
+	if err != nil {
+		t.Fatalf("waitAgent: %v", err)
+	}
+	if !strings.Contains(waited.Output, "COMPLETED") || !strings.Contains(waited.Output, "completed authorization specialist") {
+		t.Fatalf("unexpected wait output:\n%s", waited.Output)
+	}
+	if got := graph.UncollectedCount(); got != 0 {
+		t.Fatalf("uncollected count = %d, want 0 after wait", got)
+	}
+}
+
+func TestGraphsAreIsolatedAcrossConcurrentScans(t *testing.T) {
+	graphA := New(context.Background(), func(_ context.Context, _ string, _ string, _ []string, _ string) (string, error) {
+		return "result from scan A", nil
+	})
+	graphB := New(context.Background(), func(_ context.Context, _ string, _ string, _ []string, _ string) (string, error) {
+		return "result from scan B", nil
+	})
+	t.Cleanup(graphA.Stop)
+	t.Cleanup(graphB.Stop)
+
+	resultA, err := graphA.spawnAgent(map[string]string{"name": "A", "task": "scan A"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resultB, err := graphB.spawnAgent(map[string]string{"name": "B", "task": "scan B"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	waitA, err := graphA.waitAgent(map[string]string{"agent_id": agentIDFromResult(t, resultA.Metadata), "timeout": "5"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitB, err := graphB.waitAgent(map[string]string{"agent_id": agentIDFromResult(t, resultB.Metadata), "timeout": "5"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(waitA.Output, "result from scan A") || strings.Contains(waitA.Output, "scan B") {
+		t.Fatalf("scan A cross-wired result:\n%s", waitA.Output)
+	}
+	if !strings.Contains(waitB.Output, "result from scan B") || strings.Contains(waitB.Output, "scan A") {
+		t.Fatalf("scan B cross-wired result:\n%s", waitB.Output)
+	}
+}
+
+func TestConcurrencyLimitIsPerGraph(t *testing.T) {
+	release := make(chan struct{})
+	started := make(chan struct{}, 2)
+	graph := NewWithLimit(context.Background(), 2, func(_ context.Context, _ string, _ string, _ []string, _ string) (string, error) {
+		started <- struct{}{}
+		<-release
+		return "done", nil
+	})
+	t.Cleanup(graph.Stop)
+
+	for i := 0; i < 2; i++ {
+		result, err := graph.spawnAgent(map[string]string{"name": "worker", "task": "hold slot"})
+		if err != nil || result.Metadata == nil {
+			t.Fatalf("spawn %d: result=%#v err=%v", i, result, err)
+		}
+	}
+	<-started
+	<-started
+	blocked, err := graph.spawnAgent(map[string]string{"name": "overflow", "task": "must not run"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(blocked.Output, "2/2") || blocked.Metadata != nil {
+		t.Fatalf("unexpected capacity result: %#v", blocked)
+	}
+	close(release)
+	if !graph.WaitStopped(2 * time.Second) {
+		t.Fatal("workers did not stop")
+	}
+}
+
+func TestStopCancelsRunnersAndUnblocksWaiters(t *testing.T) {
+	started := make(chan struct{})
+	graph := New(context.Background(), func(ctx context.Context, _ string, _ string, _ []string, _ string) (string, error) {
+		close(started)
+		<-ctx.Done()
+		return "", ctx.Err()
+	})
+
+	result, err := graph.spawnAgent(map[string]string{"name": "slow", "task": "wait for cancellation"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	agentID := agentIDFromResult(t, result.Metadata)
 	<-started
 
 	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			AddPartialResult(agentID, "still running")
-			_, _ = checkAgent(map[string]string{"agent_id": agentID})
-		}()
+	wg.Add(1)
+	waited := make(chan tools.Result, 1)
+	go func() {
+		defer wg.Done()
+		res, _ := graph.waitAgent(map[string]string{"agent_id": agentID, "timeout": "30"})
+		waited <- res
+	}()
+
+	graph.Stop()
+	if !graph.WaitStopped(2 * time.Second) {
+		t.Fatal("canceled runner did not unwind")
 	}
-
-	Reset()
-	close(release)
 	wg.Wait()
-	<-done
+	res := <-waited
+	if !strings.Contains(res.Output, "FAILED") || !strings.Contains(res.Output, "parent scan stopped") {
+		t.Fatalf("unexpected stopped result:\n%s", res.Output)
+	}
+	if got := graph.RunningCount(); got != 0 {
+		t.Fatalf("running count after stop = %d, want 0", got)
+	}
+}
 
-	if got := GetRunningCount(); got != 0 {
-		t.Fatalf("running count after reset = %d, want 0", got)
+func TestCompletedResultMustBeCollected(t *testing.T) {
+	graph := New(context.Background(), func(context.Context, string, string, []string, string) (string, error) {
+		return "evidence", nil
+	})
+	t.Cleanup(graph.Stop)
+	result, err := graph.spawnAgent(map[string]string{"name": "specialist", "task": "produce evidence"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	agentID := agentIDFromResult(t, result.Metadata)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for graph.RunningCount() != 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := graph.UncollectedCount(); got != 1 {
+		t.Fatalf("uncollected count = %d, want 1", got)
+	}
+	if summary := graph.PendingSummary(); !strings.Contains(summary, agentID) || !strings.Contains(summary, "not collected") {
+		t.Fatalf("unexpected pending summary: %q", summary)
+	}
+	if _, err := graph.checkAgent(map[string]string{"agent_id": agentID}); err != nil {
+		t.Fatal(err)
+	}
+	if got := graph.UncollectedCount(); got != 0 {
+		t.Fatalf("uncollected count after check = %d, want 0", got)
 	}
 }

--- a/internal/tools/reporting/reporting.go
+++ b/internal/tools/reporting/reporting.go
@@ -140,10 +140,9 @@ var (
 	findingVerifierMu sync.RWMutex
 )
 
-// SetFindingVerifier installs the finding verifier for a specific scan context.
-// The agent package calls this so report_vulnerability validates before
-// persisting. Passing a nil verifier clears the entry for that context
-// (CLI/tests with no verifier fall back to the heuristic gates).
+// SetFindingVerifier installs a legacy scan-context verifier for callers that
+// use Register. Production agents use RegisterWithVerifier so each parallel
+// registry owns its callback. Passing nil clears the compatibility entry.
 func SetFindingVerifier(contextID string, v FindingVerifier) {
 	findingVerifierMu.Lock()
 	defer findingVerifierMu.Unlock()
@@ -256,10 +255,17 @@ func getStoreForContext(contextID string) *vulnStore {
 	return s
 }
 
-// Register adds reporting tools to the registry.
-// The registry is captured in the closure so tools resolve the correct
-// ScanContext via registry.GetScanContextID() instead of scanctx.Default().
+// Register adds reporting tools without an agent-local verifier. It is kept for
+// CLI/tests and falls back to the legacy scan-context verifier lookup.
 func Register(r *tools.Registry) {
+	RegisterWithVerifier(r, nil)
+}
+
+// RegisterWithVerifier binds an independent verifier to this exact registry.
+// This is required for multi-agent scans: each hunter blocks on and uses its
+// own LLM client while validating a report, so parallel agents never borrow a
+// busy sibling's verifier or overwrite a process-global callback.
+func RegisterWithVerifier(r *tools.Registry, verifier FindingVerifier) {
 	r.Register(&tools.Tool{
 		Name: "report_vulnerability",
 		Description: `Report a VERIFIED, EXPLOITABLE vulnerability with proof. CRITICAL RULES:
@@ -298,14 +304,13 @@ func Register(r *tools.Registry) {
 			{Name: "owasp", Description: "OWASP Top 10 (2021) category if known, e.g. A03 for Injection, A01 for Broken Access Control", Required: false},
 		},
 		Execute: func(args map[string]string) (tools.Result, error) {
-			return reportVulnForRegistry(r, args)
+			return reportVulnForRegistryWithVerifier(r, verifier, args)
 		},
 	})
 }
 
-// reportVulnForRegistry resolves the correct store via the registry's ScanContextID.
-func reportVulnForRegistry(reg *tools.Registry, args map[string]string) (tools.Result, error) {
-	return reportVulnWithContextID(reg.GetScanContextID(), args)
+func reportVulnForRegistryWithVerifier(reg *tools.Registry, verifier FindingVerifier, args map[string]string) (tools.Result, error) {
+	return reportVulnWithContextIDAndVerifier(reg.GetScanContextID(), verifier, args)
 }
 
 // reportVuln is the backward-compatible version using scanctx.Default().
@@ -316,6 +321,10 @@ func reportVuln(args map[string]string) (tools.Result, error) {
 }
 
 func reportVulnWithContextID(contextID string, args map[string]string) (tools.Result, error) {
+	return reportVulnWithContextIDAndVerifier(contextID, nil, args)
+}
+
+func reportVulnWithContextIDAndVerifier(contextID string, verifier FindingVerifier, args map[string]string) (tools.Result, error) {
 	severity := strings.ToLower(strings.TrimSpace(args["severity"]))
 	proof := strings.TrimSpace(args["exploitation_proof"])
 	method := strings.ToLower(strings.TrimSpace(args["verification_method"]))
@@ -474,7 +483,11 @@ If you cannot exploit it, downgrade severity to 'info' and report as information
 	// Only 'info' (advisory, non-exploitable) is exempt — requiresValidation is
 	// false for it — matching the Gate 2 proof requirement.
 	if requiresValidation {
-		if vf := getFindingVerifier(contextID); vf != nil {
+		vf := verifier
+		if vf == nil {
+			vf = getFindingVerifier(contextID)
+		}
+		if vf != nil {
 			verdict := vf(VerificationRequest{
 				Title:              title,
 				Severity:           severity,

--- a/internal/tools/reporting/reporting_test.go
+++ b/internal/tools/reporting/reporting_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/tools"
 )
 
 func TestCheckFalsePositive_MissingHeaders(t *testing.T) {
@@ -829,6 +831,59 @@ func TestReportVuln_IndependentVerifierGate(t *testing.T) {
 			t.Fatalf("expected 1 vuln verified by heuristic fallback, got %d (%s)", len(vulns), res.Output)
 		}
 	})
+}
+
+func TestRegistryLocalVerifiersDoNotCrossWire(t *testing.T) {
+	ctx := "registry-local-verifier-isolation"
+	CleanupContext(ctx)
+	defer CleanupContext(ctx)
+
+	// A legacy context callback must not be consulted when an agent-local
+	// verifier was bound to the reporting tool.
+	SetFindingVerifier(ctx, func(VerificationRequest) VerificationVerdict {
+		t.Fatal("context-global verifier was called instead of registry-local verifier")
+		return VerificationVerdict{Inconclusive: true}
+	})
+
+	registryA := tools.NewRegistry()
+	registryA.SetScanContextID(ctx)
+	registryB := tools.NewRegistry()
+	registryB.SetScanContextID(ctx)
+
+	var callsA, callsB int
+	RegisterWithVerifier(registryA, func(VerificationRequest) VerificationVerdict {
+		callsA++
+		return VerificationVerdict{Confirmed: true, Reason: "agent A reproduced it"}
+	})
+	RegisterWithVerifier(registryB, func(VerificationRequest) VerificationVerdict {
+		callsB++
+		return VerificationVerdict{Reason: "agent B disproved it"}
+	})
+
+	argsA := validReportArgs()
+	argsA["title"] = "Agent A SQL injection"
+	argsA["endpoint"] = "https://example.com/api/a?id=1"
+	argsB := validReportArgs()
+	argsB["title"] = "Agent B SQL injection"
+	argsB["endpoint"] = "https://example.com/api/b?id=1"
+
+	resultA, err := registryA.Execute("report_vulnerability", argsA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resultB, err := registryB.Execute("report_vulnerability", argsB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if callsA != 1 || callsB != 1 {
+		t.Fatalf("local verifier calls = A:%d B:%d, want 1 each", callsA, callsB)
+	}
+	if _, ok := resultA.Metadata["vuln_id"]; !ok {
+		t.Fatalf("agent A finding was not persisted: %s", resultA.Output)
+	}
+	if !strings.Contains(resultB.Output, "REJECTED by independent verifier") {
+		t.Fatalf("agent B's rejecting verifier was not honored: %s", resultB.Output)
+	}
 }
 
 func TestCheckClaimConsistency(t *testing.T) {

--- a/internal/web/scan_session.go
+++ b/internal/web/scan_session.go
@@ -226,6 +226,18 @@ func (s *Server) executeScanSession(sess *scanSession) {
 		notes.LoadFromDiskForContext(sctx.ID)
 	}
 
+	// 1c. Configure hypothesis/evidence ledger persistence → ledger.json.
+	// The ledger lives on the ScanContext and is shared by the coordinator and
+	// every delegated specialist, so persisting it makes the whole hypothesis
+	// graph durable across restart/resume (not just findings and notes).
+	sctx.Ledger.SetPersistPath(sess.scanDir)
+	if sess.resetState {
+		sctx.Ledger.Reset()
+	} else {
+		// Resume scenario: reload the durable hypothesis/evidence graph.
+		sctx.Ledger.LoadFromDisk()
+	}
+
 	// 2. Set working directory (context-aware)
 	sctx.Terminal.SetWorkDir(sess.scanDir)
 	sctx.Browser.SetSessionPath(sess.scanDir)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -40,7 +40,6 @@ import (
 	"github.com/xalgord/xalgorix/v4/internal/safe"
 	"github.com/xalgord/xalgorix/v4/internal/sandbox"
 	"github.com/xalgord/xalgorix/v4/internal/scanctx"
-	"github.com/xalgord/xalgorix/v4/internal/tools/agentsgraph"
 	"github.com/xalgord/xalgorix/v4/internal/tools/browser"
 	"github.com/xalgord/xalgorix/v4/internal/tools/notes"
 	"github.com/xalgord/xalgorix/v4/internal/tools/reporting"
@@ -2902,6 +2901,21 @@ type scanSession struct {
 // cleanup tears down all per-session resources. Every sub-operation
 // has its own panic guard so cleanup NEVER panics upward.
 func (sess *scanSession) cleanup() {
+	// Stop the root and its scan-scoped delegation graph before closing tool
+	// stores or persisting findings. Otherwise a late child can report after
+	// the final merge, or access a terminal/browser context that cleanup has
+	// already destroyed. The wait is bounded so a broken external process can
+	// never stall server cleanup indefinitely.
+	if sess.agent != nil {
+		func() {
+			defer logRecover("cleanup.agent.stop")
+			sess.agent.Stop()
+			if !sess.agent.WaitForDelegatedAgents(5 * time.Second) {
+				log.Printf("[cleanup] delegated agents for session %s did not unwind within 5s", sess.id)
+			}
+		}()
+	}
+
 	// Deactivate and close the per-session ScanContext (if set).
 	// Close() calls Terminal.KillAll() and Browser.Close() internally,
 	// so no redundant calls are needed below.
@@ -2989,34 +3003,6 @@ func (sess *scanSession) cleanup() {
 		func() {
 			defer logRecover("cleanup.terminal.killAll")
 			terminal.KillAllProcesses()
-		}()
-	}
-
-	// Stop agent if still running
-	if sess.agent != nil {
-		func() {
-			defer logRecover("cleanup.agent.stop")
-			sess.agent.Stop()
-		}()
-	}
-
-	// Clear sub-agent state to prevent memory/goroutine leaks across scans.
-	// Only safe when this is the sole running scan — global reset would corrupt
-	// concurrent sessions.
-	sess.server.instancesMu.RLock()
-	runningCount := 0
-	for _, inst := range sess.server.instances {
-		inst.mu.RLock()
-		if inst.Status == "running" {
-			runningCount++
-		}
-		inst.mu.RUnlock()
-	}
-	sess.server.instancesMu.RUnlock()
-	if runningCount <= 1 {
-		func() {
-			defer logRecover("cleanup.agentsgraph.reset")
-			agentsgraph.Reset()
 		}()
 	}
 


### PR DESCRIPTION
## Summary

This PR advances Xalgorix toward the architecture that makes autonomous web-security agents effective (per the MAPTA and AWE research and the BugBunny product signals): **scan-scoped parallel specialists** plus a **durable, shared hypothesis/evidence ledger that drives the scan**. It is built on top of `v4.6.7` and lands in three reviewable commits.

The goal is not "more agents" or "more reports." It is more unique, exploit-proven findings per authorized assessment, at a measurable cost and false-positive rate.

## What changed (by commit)

1. **`feat(agent): scan-scoped multi-agent foundation`** — Recovers the interrupted multi-agent work cleanly onto `v4.6.7`:
   - one cancellable `agentsgraph.Graph` per root scan (runner, semaphore, agent map, lifecycle all scan-scoped; no process-global reset);
   - the root owns the graph, descendants share it; stable delegation IDs; finish gate on running/uncollected children;
   - one atomic scan-wide budget (duration/iterations/tokens/tool-calls) shared by coordinator + specialists;
   - per-registry verifier isolation so parallel reports never borrow a sibling's verifier client;
   - server cleanup stops the root and waits (bounded) for delegated workers before closing scan stores.

2. **`feat(ledger): durable hypothesis/evidence ledger foundation`** — A typed, concurrency-safe ledger on the shared `ScanContext`:
   - `Hypothesis` nodes (class, endpoint, parameter, role, data-flow, preconditions, baseline, confidence, status, next action) with append-only `Evidence`;
   - deduplicated, memory-bounded, persisted atomically to `ledger.json` (survives restart/resume), with child→parent merge;
   - agent tools `record_hypothesis`, `add_hypothesis_evidence`, `update_hypothesis`, `read_ledger`.

3. **`feat(agent): make the hypothesis ledger drive orchestration`** — The ledger now schedules the scan:
   - seeded from the plan after recon so it is populated deterministically;
   - **deterministic specialist profiles** (authorization/business-logic, injection/server-side, client/source), each with an explicit evidence contract and stopping rule targeting the classes scanners are weakest at (blind injection via OOB, XSS via browser confirmation, multi-role authorization);
   - ledger-driven delegation (assign disjoint hypotheses to specialists, track ownership/evidence/status);
   - a **precision finish-gate** that blocks completion while a hypothesis is proven but unreported (bounded so it cannot deadlock; complements the existing coverage gate).

## Testing

- `go build ./...`, `gofmt`, `go vet` — clean.
- Package tests pass: `internal/agent`, `internal/scanctx`, `internal/tools/agentsgraph`, `internal/tools/reporting`, `internal/web`.
- Race detector (`-race`) passes on `internal/agent`, `internal/scanctx`, `internal/tools/agentsgraph`, `internal/tools/reporting`.
- New tests cover graph isolation, shared budget, verifier isolation, the ledger (dedup, persistence round-trip, resume no-clobber, evidence bounding, child→parent merge, concurrent stress), and the new hooks (seeding, ledger-driven delegation nudge, precision finish-gate incl. bound release, specialist profile coverage).
- Lint: the only findings are a pre-existing `staticcheck` (SA5011) baseline in files this PR does not touch; the changed packages lint clean.

## Follow-ups (not in this PR)

Deliberately scoped as separate efforts because they are larger, new subsystems that deserve their own design + tests:

- **P2 — testing depth:** first-class multi-role/state authorization matrix, source-to-runtime data-flow with an exploit-replay harness, a browser-backed XSS/DOM verification engine, and OOB-capable blind-injection pipelines.
- **P3 — measurement:** a repeatable benchmark harness (e.g. the XBOW challenge set) to baseline per-class success, false-positive/duplicate rate, and cost, plus a triage-outcome feedback loop.

## Notes

- Based on `main` (`v4.6.7`). Excludes the instance-admission and regenerated Web-UI changes already shipped in `v4.6.6`/`v4.6.7`.
- The ledger uses atomic writes (`storage.WriteAtomic`); a future optimization could debounce writes if per-mutation persistence becomes hot, though mutations occur at LLM-iteration cadence in practice.
- Happy to split into stacked PRs (graph isolation / ledger foundation / orchestration) if that is easier to review.
