### PR TITLE
P2: multi-role authorization matrix + browser XSS verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased] — Deep testing: authorization matrix + browser XSS verification
+
+### Added
+- **Multi-role authorization matrix (`authz_matrix`).** Replays a single request as every configured identity — the primary session (role A), a second account (role B) when the scan has one, and anonymous — and reports the access-control differential. When a lower-privileged identity receives the same successful response as the authorized one, that is broken access control (IDOR/BOLA for a second user, auth bypass/BFLA for anonymous). It enforces scope (never probes the operator's own machine) and the per-scan request-rate policy, and records role-scoped hypotheses with the differential as evidence in the shared ledger. This targets the authorization classes where autonomous scanners are weakest.
+- **Browser-backed XSS execution verification (`browser_action command=verify_xss`).** The headless browser now records JavaScript dialogs as execution signals; the new action navigates a payload that raises a dialog carrying a unique nonce and confirms XSS only when that dialog actually fires — proof of execution rather than mere reflection. Confirmed results are recorded as browser-confirmed XSS evidence in the ledger. This directly addresses the low XSS precision of reflection-only detection.
+- The injection/server-side and client/source specialist profiles now point at these tools in their evidence contracts, so specialists produce the required proof automatically.
+
 ## [Unreleased] — Evidence-driven orchestration (hypothesis/evidence ledger)
 
 ### Added

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -138,6 +138,30 @@ The ledger drives orchestration rather than sitting beside it:
   proven but has no linked finding (bounded so it cannot deadlock), enforcing
   verify-by-execution and precision over volume.
 
+## Deep testing — authorization matrix & XSS verification
+
+Two capabilities give the specialists deterministic, evidence-producing tools
+for the vulnerability classes that are hardest to get right:
+
+- **`authz_matrix`** (`internal/agent/authz_matrix.go`) replays one request as
+  each configured identity — primary session (role A), a second account
+  (role B), and anonymous — using the exported `httpclient.SendRaw` primitive,
+  and compares the outcomes. A lower-privileged identity receiving the same
+  successful response as the authorized one is broken access control (IDOR/BOLA
+  horizontally, auth bypass/BFLA vertically). It enforces scope
+  (`scopeguard.IsLocalOrListener`) and the per-scan request-rate policy, and
+  records role-scoped ledger hypotheses (keyed by the ledger's `Role` dimension)
+  with the differential as evidence.
+- **`browser_action command=verify_xss`** (`internal/tools/browser`) turns the
+  headless browser's JavaScript dialogs into captured execution signals
+  (`execsignals.go`). The action navigates a payload that raises a dialog
+  carrying a unique nonce and confirms XSS only when that exact dialog fires —
+  execution proof, not reflection — recording browser-confirmed XSS evidence in
+  the ledger.
+
+Both tools feed the shared ledger, so their results flow through the same
+scheduling, verification, and precision finish-gate as everything else.
+
 ## Tooling — `internal/tools`
 
 `registry.go` is the tool surface presented to the model. Each subpackage is one

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -357,6 +357,12 @@ func NewAgent(cfg *config.Config, name string, events chan Event, localGuard sco
 	// it persists across restart/resume.
 	a.registerLedgerTools(reg)
 
+	// Register the multi-role authorization matrix (authz_matrix). It replays a
+	// request as role A / role B / anonymous and records the access-control
+	// differential to the ledger. Agent-bound because it needs both configured
+	// account credentials, the scope config, and the ledger.
+	a.registerAuthzMatrixTool(reg)
+
 	// Create cancellable context
 	a.ctx, a.cancel = context.WithCancel(a.ctx)
 	// Wire context to LLM client so cancel interrupts pending HTTP requests

--- a/internal/agent/agent_guard.go
+++ b/internal/agent/agent_guard.go
@@ -325,7 +325,7 @@ func (a *Agent) shouldBlockForOutOfScope(toolName string, toolArgs map[string]st
 	lowerTool := strings.ToLower(toolName)
 	switch lowerTool {
 	case "terminal_execute", "python_action", "browser_action", "page_agent", "pageagent",
-		"report_vulnerability":
+		"report_vulnerability", "authz_matrix":
 		// gated
 	default:
 		return false, ""

--- a/internal/agent/authz_matrix.go
+++ b/internal/agent/authz_matrix.go
@@ -1,0 +1,300 @@
+// Package agent — authz_matrix.go implements the multi-role authorization
+// matrix: replay one request across every configured identity (primary session
+// "role A", a second account "role B", and anonymous) and report the
+// access-control differential.
+//
+// This is the core primitive for the classes autonomous scanners are weakest
+// at — IDOR/BOLA (horizontal), BFLA/privilege escalation and auth bypass
+// (vertical). Instead of asking the model to eyeball whether a request "looks
+// authorized", it deterministically sends the SAME request as each identity and
+// compares the outcomes: if a lower-privileged identity gets the same successful
+// response as the authorized one on a resource that should be restricted, that
+// is broken access control. Positive signals are recorded as role-scoped
+// hypotheses in the shared ledger (with the differential as evidence) so the
+// coordinator/specialist can confirm and report them.
+package agent
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+	"github.com/xalgord/xalgorix/v4/internal/scopeguard"
+	"github.com/xalgord/xalgorix/v4/internal/tools"
+	"github.com/xalgord/xalgorix/v4/internal/tools/httpclient"
+)
+
+// authzIdentity is one identity the matrix replays a request as.
+type authzIdentity struct {
+	label   string            // human label, e.g. "second account (role B)"
+	role    string            // ledger Role dimension: role-a | role-b | anonymous
+	headers map[string]string // credential headers; nil for anonymous
+}
+
+// authzResult pairs an identity with its replay outcome.
+type authzResult struct {
+	identity authzIdentity
+	resp     *httpclient.RawResponse
+	err      error
+}
+
+// registerAuthzMatrixTool registers the Agent-bound authz_matrix tool. It is
+// Agent-bound (not a standalone package) because it needs BOTH configured
+// account credentials (a.targetAuth / a.targetAuthB), the scope config
+// (a.localGuard), and the shared ledger — all of which live on the Agent.
+func (a *Agent) registerAuthzMatrixTool(reg *tools.Registry) {
+	reg.Register(&tools.Tool{
+		Name:        "authz_matrix",
+		Description: "Test access control by replaying ONE request as every configured identity — your primary session (role A), a second account (role B) if the scan has one, and anonymous (no credentials) — then report the differential. This is the definitive check for IDOR/BOLA (a second user reading role A's object) and auth bypass/BFLA (anonymous reaching a protected resource). Point it at a resource that SHOULD be restricted to role A (e.g. role A's own object by id); if a lower identity gets the same successful response, that is broken access control. Positive signals are recorded as role-scoped hypotheses in the ledger with the differential as proof.",
+		Parameters: []tools.Parameter{
+			{Name: "url", Description: "URL of the object/action under test, ideally one owned by/authorized for role A (e.g. https://app/api/orders/1042).", Required: true},
+			{Name: "method", Description: "HTTP method (default GET).", Required: false},
+			{Name: "body", Description: "Request body for POST/PUT/PATCH.", Required: false},
+			{Name: "headers", Description: `Optional JSON object of EXTRA headers common to all identities (e.g. {"Content-Type":"application/json"}). Do NOT put credentials here — identity credentials come from the scan's configured accounts.`, Required: false},
+			{Name: "parameter", Description: "The object identifier/parameter under test (e.g. 'id'), used to label the hypothesis.", Required: false},
+			{Name: "expect", Description: "Optional free-text note describing what an authorized response contains (recorded as the baseline).", Required: false},
+		},
+		Execute: a.authzMatrixTool,
+	})
+}
+
+func (a *Agent) authzMatrixTool(args map[string]string) (tools.Result, error) {
+	rawURL := strings.TrimSpace(args["url"])
+	if rawURL == "" {
+		return tools.Result{Error: "url is required"}, nil
+	}
+	method := strings.ToUpper(strings.TrimSpace(args["method"]))
+	if method == "" {
+		method = "GET"
+	}
+	body := args["body"]
+	parameter := strings.TrimSpace(args["parameter"])
+	expect := strings.TrimSpace(args["expect"])
+
+	extra := map[string]string{}
+	if h := strings.TrimSpace(args["headers"]); h != "" {
+		var m map[string]any
+		if err := json.Unmarshal([]byte(h), &m); err != nil {
+			return tools.Result{Error: "invalid headers JSON: " + err.Error()}, nil
+		}
+		for k, v := range m {
+			extra[k] = fmt.Sprint(v)
+		}
+	}
+
+	if !strings.HasPrefix(rawURL, "http://") && !strings.HasPrefix(rawURL, "https://") {
+		rawURL = "https://" + rawURL
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return tools.Result{Error: fmt.Sprintf("invalid url %q", args["url"])}, nil
+	}
+	// Defense-in-depth scope check (the agent loop also gates this tool): never
+	// probe the operator's own machine/listener.
+	if scopeguard.IsLocalOrListener(a.localGuard, u.Host) {
+		return tools.Result{Error: fmt.Sprintf("%q points at the operator's machine or local network — refusing to run an authorization matrix against it.", u.Host)}, nil
+	}
+
+	identities := a.authzIdentities()
+	if len(identities) < 2 {
+		return tools.Result{Output: "authz_matrix needs at least two identities to compare, but this scan only has anonymous access configured. Provide a primary session (target auth) and ideally a second account so the matrix can reveal a cross-identity access-control difference."}, nil
+	}
+
+	var delay time.Duration
+	if a.scanCtx != nil {
+		delay = a.scanCtx.RequestRatePolicy().Delay()
+	}
+	results := make([]authzResult, 0, len(identities))
+	for i, id := range identities {
+		if a.ctx != nil && a.ctx.Err() != nil {
+			return tools.Result{Error: "scan canceled during authorization matrix"}, nil
+		}
+		if i > 0 && delay > 0 {
+			time.Sleep(delay)
+		}
+		resp, sErr := httpclient.SendRaw(httpclient.RawRequest{
+			Method:          method,
+			URL:             u.String(),
+			Headers:         mergeHeaders(extra, id.headers),
+			Body:            body,
+			FollowRedirects: false, // observe 3xx→login as a restriction signal
+			TimeoutSec:      30,
+		})
+		results = append(results, authzResult{identity: id, resp: resp, err: sErr})
+	}
+
+	return a.analyzeAuthzMatrix(u, method, parameter, expect, results), nil
+}
+
+// authzIdentities returns the identities to test, highest privilege first.
+// Anonymous is always included; role A/B only when their credentials are set.
+func (a *Agent) authzIdentities() []authzIdentity {
+	var ids []authzIdentity
+	if hdrs := httpclient.ParseAuthHeaders(a.targetAuth); len(hdrs) > 0 {
+		ids = append(ids, authzIdentity{label: "primary session (role A)", role: "role-a", headers: hdrs})
+	}
+	if hdrs := httpclient.ParseAuthHeaders(a.targetAuthB); len(hdrs) > 0 {
+		ids = append(ids, authzIdentity{label: "second account (role B)", role: "role-b", headers: hdrs})
+	}
+	ids = append(ids, authzIdentity{label: "anonymous", role: "anonymous", headers: nil})
+	return ids
+}
+
+// analyzeAuthzMatrix compares each identity against the authorized baseline
+// (role A, or the first authenticated identity), renders a report, and records
+// broken-access-control signals as role-scoped ledger hypotheses.
+func (a *Agent) analyzeAuthzMatrix(u *url.URL, method, parameter, expect string, results []authzResult) tools.Result {
+	// Baseline = the first authenticated identity (role A preferred).
+	var baseline *httpclient.RawResponse
+	var baselineLabel string
+	for _, r := range results {
+		if r.identity.role != "anonymous" && r.resp != nil {
+			baseline = r.resp
+			baselineLabel = r.identity.label
+			break
+		}
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Authorization matrix for %s %s (host %s):\n", method, u.EscapedPath(), u.Host)
+	if expect != "" {
+		fmt.Fprintf(&b, "Expected authorized response: %s\n", expect)
+	}
+
+	baselineDesc := "authorized baseline unavailable"
+	if baseline != nil {
+		baselineDesc = fmt.Sprintf("%s → status %d, %d bytes", baselineLabel, baseline.StatusCode, baseline.BodyLen)
+	}
+
+	l := a.ledger()
+	recorded := 0
+	for _, r := range results {
+		if r.err != nil {
+			fmt.Fprintf(&b, "  • %s: request error: %v\n", r.identity.label, r.err)
+			continue
+		}
+		if r.resp == nil {
+			fmt.Fprintf(&b, "  • %s: no response\n", r.identity.label)
+			continue
+		}
+		// The baseline identity is annotated, not compared to itself.
+		if r.identity.label == baselineLabel {
+			fmt.Fprintf(&b, "  • %s: status %d, %d bytes  [authorized baseline]\n", r.identity.label, r.resp.StatusCode, r.resp.BodyLen)
+			continue
+		}
+		verdict, broken, confidence := classifyAccess(baseline, r.resp)
+		fmt.Fprintf(&b, "  • %s: status %d, %d bytes  → %s\n", r.identity.label, r.resp.StatusCode, r.resp.BodyLen, verdict)
+
+		if broken && l != nil {
+			class := "idor"
+			if r.identity.role == "anonymous" {
+				class = "auth-bypass"
+			}
+			h := l.Upsert(scanctx.Hypothesis{
+				Title:      fmt.Sprintf("%s can access %s", r.identity.label, u.EscapedPath()),
+				VulnClass:  class,
+				Target:     u.Host,
+				Endpoint:   u.EscapedPath(),
+				Parameter:  parameter,
+				Role:       r.identity.role,
+				Baseline:   baselineDesc,
+				Confidence: confidence,
+				Status:     scanctx.HypothesisTesting,
+				Origin:     "authz_matrix",
+				NextAction: "Confirm the resource is meant to be restricted, then report as broken access control using this cross-identity differential as proof.",
+			})
+			l.AddEvidence(h.ID, scanctx.Evidence{
+				Kind:       "exploit",
+				Summary:    fmt.Sprintf("%s; %s got status %d / %d bytes for the same request — %s", baselineDesc, r.identity.label, r.resp.StatusCode, r.resp.BodyLen, verdict),
+				Request:    fmt.Sprintf("%s %s  (identity: %s)", method, u.String(), r.identity.label),
+				Response:   truncateForEvidence(r.resp.Body),
+				Confidence: confidence,
+				AgentID:    a.ledgerOrigin(),
+			})
+			recorded++
+		}
+	}
+
+	if recorded > 0 {
+		fmt.Fprintf(&b, "\nRecorded %d broken-access-control hypothesis(es) in the ledger. Confirm the resource is restricted, then report with report_vulnerability and link the finding via add_hypothesis_evidence(kind=finding_ref).\n", recorded)
+	} else {
+		b.WriteString("\nNo cross-identity access-control difference detected (lower identities were denied or returned their own content). This is evidence the endpoint enforces authorization for the tested object.\n")
+	}
+	return tools.Result{Output: b.String(), Metadata: map[string]any{"recorded_hypotheses": recorded}}
+}
+
+// classifyAccess compares a lower identity's response to the authorized
+// baseline and returns a human verdict, whether it looks like broken access
+// control, and a confidence in [0,1].
+func classifyAccess(baseline, other *httpclient.RawResponse) (verdict string, broken bool, confidence float64) {
+	switch {
+	case other.StatusCode == 401 || other.StatusCode == 403:
+		return "properly restricted (denied)", false, 0
+	case other.StatusCode >= 300 && other.StatusCode < 400:
+		return "redirected (likely to authentication) — restricted", false, 0
+	case other.StatusCode >= 200 && other.StatusCode < 300:
+		if baseline != nil && baseline.StatusCode >= 200 && baseline.StatusCode < 300 {
+			if bodiesEquivalent(baseline.Body, other.Body) {
+				return "SAME successful response as the authorized identity — likely broken access control", true, 0.85
+			}
+			return "accessible (2xx) but different content — may be this identity's own data; verify before reporting", false, 0.4
+		}
+		return "accessible (2xx) while the authorized baseline was not successful — verify", true, 0.5
+	default:
+		return fmt.Sprintf("status %d", other.StatusCode), false, 0
+	}
+}
+
+// bodiesEquivalent reports whether two response bodies represent the same
+// resource. Small bodies require an exact match; larger bodies tolerate a tiny
+// length delta so dynamic tokens/timestamps don't mask a real match.
+func bodiesEquivalent(a, b []byte) bool {
+	ta := bytes.TrimSpace(a)
+	tb := bytes.TrimSpace(b)
+	if bytes.Equal(ta, tb) {
+		return true
+	}
+	la, lb := len(ta), len(tb)
+	if la < 64 || lb < 64 {
+		return false
+	}
+	diff := la - lb
+	if diff < 0 {
+		diff = -diff
+	}
+	maxLen := la
+	if lb > maxLen {
+		maxLen = lb
+	}
+	return float64(diff)/float64(maxLen) < 0.03
+}
+
+// mergeHeaders combines common extra headers with an identity's credential
+// headers (credentials win on conflict). Returns nil when both are empty.
+func mergeHeaders(extra, creds map[string]string) map[string]string {
+	if len(extra) == 0 && len(creds) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(extra)+len(creds))
+	for k, v := range extra {
+		out[k] = v
+	}
+	for k, v := range creds {
+		out[k] = v
+	}
+	return out
+}
+
+// truncateForEvidence bounds a response body for ledger evidence. The ledger
+// truncates again, but keeping this small avoids copying large bodies around.
+func truncateForEvidence(body []byte) string {
+	const max = 1024
+	if len(body) <= max {
+		return string(body)
+	}
+	return string(body[:max]) + "…(truncated)"
+}

--- a/internal/agent/authz_matrix_test.go
+++ b/internal/agent/authz_matrix_test.go
@@ -1,0 +1,144 @@
+package agent
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+	"github.com/xalgord/xalgorix/v4/internal/scopeguard"
+)
+
+// authzTestServer returns a server with a /broken endpoint (no authorization
+// check — anyone gets the owner's data) and a /secure endpoint (only role A's
+// token succeeds; role B is forbidden; anonymous is redirected to login).
+func authzTestServer() *httptest.Server {
+	const ownerData = "SECRET-ORDER-DATA-1042-owner-record-padding-padding-padding-padding"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/broken", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(ownerData))
+	})
+	mux.HandleFunc("/secure", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Header.Get("Authorization") {
+		case "Bearer AAA":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(ownerData))
+		case "":
+			http.Redirect(w, r, "/login", http.StatusFound)
+		default:
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte("forbidden"))
+		}
+	})
+	return httptest.NewServer(mux)
+}
+
+func newAuthzAgent(t *testing.T, allowLocal bool) *Agent {
+	t.Helper()
+	return &Agent{
+		targetAuth:  "Authorization: Bearer AAA",
+		targetAuthB: "Authorization: Bearer BBB",
+		localGuard:  scopeguard.Config{AllowLocalTargets: allowLocal},
+		scanCtx:     scanctx.New("authz-test-"+t.Name(), ""),
+		ctx:         context.Background(),
+	}
+}
+
+func TestAuthzMatrixDetectsBrokenAccessControl(t *testing.T) {
+	srv := authzTestServer()
+	defer srv.Close()
+	ag := newAuthzAgent(t, true)
+
+	res, err := ag.authzMatrixTool(map[string]string{"url": srv.URL + "/broken", "parameter": "id"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Error != "" {
+		t.Fatalf("unexpected tool error: %s", res.Error)
+	}
+	if !strings.Contains(res.Output, "likely broken access control") {
+		t.Fatalf("expected a broken-access-control verdict, got:\n%s", res.Output)
+	}
+	if got, _ := res.Metadata["recorded_hypotheses"].(int); got != 2 {
+		t.Fatalf("expected 2 recorded hypotheses (role B + anonymous), got %v", res.Metadata["recorded_hypotheses"])
+	}
+
+	l := ag.scanCtx.Ledger
+	if l.Len() != 2 {
+		t.Fatalf("expected 2 ledger hypotheses, got %d", l.Len())
+	}
+	var roles, classes []string
+	for _, h := range l.All() {
+		roles = append(roles, h.Role)
+		classes = append(classes, h.VulnClass)
+		if len(h.Evidence) == 0 {
+			t.Fatalf("hypothesis %s has no evidence", h.ID)
+		}
+		if h.Status != scanctx.HypothesisTesting {
+			t.Fatalf("expected status testing (not auto-proven), got %q", h.Status)
+		}
+	}
+	if !contains(roles, "role-b") || !contains(roles, "anonymous") {
+		t.Fatalf("expected role-b and anonymous hypotheses, got roles %v", roles)
+	}
+	if !contains(classes, "idor") || !contains(classes, "auth-bypass") {
+		t.Fatalf("expected idor + auth-bypass classes, got %v", classes)
+	}
+}
+
+func TestAuthzMatrixProperlyRestricted(t *testing.T) {
+	srv := authzTestServer()
+	defer srv.Close()
+	ag := newAuthzAgent(t, true)
+
+	res, err := ag.authzMatrixTool(map[string]string{"url": srv.URL + "/secure"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, _ := res.Metadata["recorded_hypotheses"].(int); got != 0 {
+		t.Fatalf("expected 0 recorded hypotheses for a restricted endpoint, got %v", res.Metadata["recorded_hypotheses"])
+	}
+	if !strings.Contains(res.Output, "No cross-identity access-control difference") {
+		t.Fatalf("expected a restricted verdict, got:\n%s", res.Output)
+	}
+	if ag.scanCtx.Ledger.Len() != 0 {
+		t.Fatalf("expected an empty ledger for a properly-restricted endpoint, got %d", ag.scanCtx.Ledger.Len())
+	}
+}
+
+func TestAuthzMatrixRefusesOperatorMachine(t *testing.T) {
+	srv := authzTestServer()
+	defer srv.Close()
+	// Default scope config (AllowLocalTargets false) must refuse loopback.
+	ag := newAuthzAgent(t, false)
+
+	res, err := ag.authzMatrixTool(map[string]string{"url": srv.URL + "/broken"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Error == "" || !strings.Contains(res.Error, "operator's machine") {
+		t.Fatalf("expected refusal for a loopback target, got error=%q output=%q", res.Error, res.Output)
+	}
+	if ag.scanCtx.Ledger.Len() != 0 {
+		t.Fatal("expected no ledger writes when the target is refused")
+	}
+}
+
+func TestAuthzMatrixNeedsTwoIdentities(t *testing.T) {
+	srv := authzTestServer()
+	defer srv.Close()
+	ag := newAuthzAgent(t, true)
+	ag.targetAuth = ""  // no primary session
+	ag.targetAuthB = "" // no second account → only anonymous remains
+
+	res, err := ag.authzMatrixTool(map[string]string{"url": srv.URL + "/broken"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(res.Output, "at least two identities") {
+		t.Fatalf("expected a two-identities-required message, got:\n%s", res.Output)
+	}
+}

--- a/internal/agent/ledger_hooks.go
+++ b/internal/agent/ledger_hooks.go
@@ -59,7 +59,7 @@ var defaultSpecialistProfiles = []specialistProfile{
 		Role:             "authz-logic",
 		Focus:            "Authorization, access control, and business-logic abuse",
 		VulnClasses:      []string{"idor", "bola", "bfla", "privilege-escalation", "auth-bypass", "business-logic"},
-		EvidenceContract: "a baseline request as the legitimate role AND the same request as another/lower-privileged role, showing a concrete cross-role difference (cross-user/cross-tenant data or a state-changing action)",
+		EvidenceContract: "a baseline request as the legitimate role AND the same request as another/lower-privileged role, showing a concrete cross-role difference (cross-user/cross-tenant data or a state-changing action) — the authz_matrix tool produces this differential automatically across role A / role B / anonymous",
 		StoppingRule:     "stop once a cross-role difference is proven, or reject with the baseline when both roles behave identically across the object/action set",
 	},
 	{
@@ -73,7 +73,7 @@ var defaultSpecialistProfiles = []specialistProfile{
 		Role:             "client-source",
 		Focus:            "Client/API surface, and source-to-sink data flow when source is available",
 		VulnClasses:      []string{"xss", "dom-xss", "csrf", "open-redirect", "cors", "secret-exposure", "api-auth"},
-		EvidenceContract: "for XSS/DOM: browser-confirmed script execution (dialog fired or DOM mutation), not just reflection; for source review: an attacker-input→sensitive-sink path plus a live request that exercises it",
+		EvidenceContract: "for XSS/DOM: browser-confirmed script execution, not just reflection (confirm with browser_action command=verify_xss using a unique nonce); for source review: an attacker-input→sensitive-sink path plus a live request that exercises it",
 		StoppingRule:     "stop after browser-confirmed execution or a proven source-to-sink path; reject when output encoding / framework defenses demonstrably block the vector",
 	},
 }

--- a/internal/tools/browser/browser.go
+++ b/internal/tools/browser/browser.go
@@ -219,6 +219,7 @@ ACTIONS:
   new_tab      — Open a new browser tab
   switch_tab   — Switch between tabs
   close        — Close browser
+  verify_xss   — CONFIRM an XSS payload actually executes in the browser. Navigate to a URL whose payload raises a dialog carrying a unique nonce (e.g. alert('XV-8f3a')) and pass nonce=XV-8f3a; returns confirmed only if that dialog fires. This is proof of execution, not reflection — use it before reporting XSS.
 
 SIGNUP/LOGIN WORKFLOW:
   1. launch url=https://target.com/signup
@@ -237,6 +238,8 @@ SIGNUP/LOGIN WORKFLOW:
 			{Name: "selector", Description: "CSS selector or semantic @eX ID from snapshot (for click/type/submit/wait/iframe/get_html/select)", Required: false},
 			{Name: "text", Description: "Text to type (for type), option value (for select), or cookie value (for set_cookie)", Required: false},
 			{Name: "code", Description: "JavaScript code to execute (for execute_js)", Required: false},
+			{Name: "nonce", Description: "Unique marker your XSS payload raises via alert()/confirm()/prompt() (for verify_xss). Execution is confirmed only if a dialog carrying this nonce fires.", Required: false},
+			{Name: "parameter", Description: "The injected parameter under test (for verify_xss), used to label the ledger hypothesis.", Required: false},
 			{Name: "direction", Description: "Scroll direction: up or down (for scroll)", Required: false},
 			{Name: "tab_id", Description: "Tab ID (for switch_tab)", Required: false},
 			{Name: "proxy", Description: "Proxy: 'caido', 'none', or proxy URL", Required: false},
@@ -530,14 +533,22 @@ func browserWaitContext(ctxID string) context.Context {
 	return context.Background()
 }
 
-// setupDialogHandler sets up auto-dismiss for JavaScript dialogs (alert/confirm/prompt)
-// on a page. Without this, calling alert() in headless Chrome blocks page.Eval() forever.
-// The dialog text is logged as proof of triggered XSS payloads.
-func setupDialogHandler(p *rod.Page) {
+// setupDialogHandler auto-dismisses JavaScript dialogs (alert/confirm/prompt)
+// on a page — without this, calling alert() in headless Chrome blocks
+// page.Eval() forever — AND records each dialog as an ExecSignal for the scan
+// context. A fired dialog is concrete proof that an injected payload EXECUTED
+// (not merely reflected), which the verify_xss action uses to confirm XSS.
+func setupDialogHandler(ctxID string, p *rod.Page) {
 	go p.EachEvent(func(e *proto.PageJavascriptDialogOpening) {
 		dialogType := string(e.Type)
 		msg := e.Message
 		log.Printf("[browser] Auto-dismissing JS %s dialog: %q", dialogType, msg)
+		recordExecSignal(ctxID, ExecSignal{
+			Kind:    "dialog:" + dialogType,
+			Message: msg,
+			URL:     e.URL,
+			At:      time.Now(),
+		})
 		_ = proto.PageHandleJavaScriptDialog{
 			Accept:     true,
 			PromptText: "",
@@ -605,8 +616,10 @@ func browserActionWithContext(ctxID string, args map[string]string) (tools.Resul
 		return switchTab(ctxID, args["tab_id"])
 	case "close":
 		return closeBrowser(ctxID)
+	case "verify_xss":
+		return verifyXSS(ctxID, args["url"], args["nonce"], args["parameter"])
 	default:
-		return tools.Result{}, fmt.Errorf("unknown browser action: %s. Available: launch, goto, snapshot, click, type, submit, scroll, screenshot, get_html, execute_js, get_cookies, set_cookie, save_session, load_session, list_sessions, wait, select, fill_form, get_url, iframe, main_frame, extract_links, new_tab, switch_tab, close", command)
+		return tools.Result{}, fmt.Errorf("unknown browser action: %s. Available: launch, goto, snapshot, click, type, submit, scroll, screenshot, get_html, execute_js, get_cookies, set_cookie, save_session, load_session, list_sessions, wait, select, fill_form, get_url, iframe, main_frame, extract_links, new_tab, switch_tab, close, verify_xss", command)
 	}
 }
 
@@ -624,8 +637,9 @@ func launchBrowser(ctxID, rawURL, proxy string) (tools.Result, error) {
 	s.page = p
 
 	// Auto-dismiss JavaScript dialogs (alert/confirm/prompt) to prevent
-	// page.Eval() from blocking forever in headless mode during XSS testing.
-	setupDialogHandler(p)
+	// page.Eval() from blocking forever in headless mode during XSS testing,
+	// and record them as execution proof for verify_xss.
+	setupDialogHandler(ctxID, p)
 
 	// Set a realistic user agent for login flows
 	s.page.MustSetUserAgent(&proto.NetworkSetUserAgentOverride{
@@ -1504,7 +1518,7 @@ func newTab(ctxID, rawURL string) (tools.Result, error) {
 	s.page = p
 
 	// Auto-dismiss JavaScript dialogs on new tabs too
-	setupDialogHandler(p)
+	setupDialogHandler(ctxID, p)
 
 	if rawURL != "" {
 		err := p.Timeout(20 * time.Second).Navigate(rawURL)

--- a/internal/tools/browser/execsignals.go
+++ b/internal/tools/browser/execsignals.go
@@ -1,0 +1,81 @@
+package browser
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+// ExecSignal is a captured client-side JavaScript execution signal. Today that
+// is a JavaScript dialog (alert/confirm/prompt) opened during navigation —
+// the strongest, simplest proof that an injected payload actually EXECUTED in
+// the browser, as opposed to merely being reflected in the HTTP response. This
+// is what turns an XSS candidate into a confirmed finding and is exactly the
+// gap that keeps reflection-only scanners' XSS precision low.
+type ExecSignal struct {
+	Kind    string    // "dialog:alert" | "dialog:confirm" | "dialog:prompt" | "dialog:beforeunload"
+	Message string    // the dialog text (carries the payload's nonce)
+	URL     string    // page URL that raised it
+	At      time.Time // capture time
+}
+
+const maxExecSignalsPerCtx = 50
+
+var (
+	execSignalsMu sync.Mutex
+	execSignals   = map[string][]ExecSignal{}
+)
+
+// recordExecSignal appends a signal for a scan context, bounded so a page that
+// loops alert() cannot grow memory without limit.
+func recordExecSignal(ctxID string, s ExecSignal) {
+	if ctxID == "" {
+		return
+	}
+	execSignalsMu.Lock()
+	defer execSignalsMu.Unlock()
+	sigs := append(execSignals[ctxID], s)
+	if len(sigs) > maxExecSignalsPerCtx {
+		sigs = sigs[len(sigs)-maxExecSignalsPerCtx:]
+	}
+	execSignals[ctxID] = sigs
+}
+
+// clearExecSignals drops all recorded signals for a context. Callers verifying
+// a payload clear first so a stale dialog from an earlier navigation cannot
+// produce a false positive.
+func clearExecSignals(ctxID string) {
+	execSignalsMu.Lock()
+	defer execSignalsMu.Unlock()
+	delete(execSignals, ctxID)
+}
+
+// execSignalsFor returns a copy of the recorded signals for a context.
+func execSignalsFor(ctxID string) []ExecSignal {
+	execSignalsMu.Lock()
+	defer execSignalsMu.Unlock()
+	src := execSignals[ctxID]
+	if len(src) == 0 {
+		return nil
+	}
+	out := make([]ExecSignal, len(src))
+	copy(out, src)
+	return out
+}
+
+// matchExecNonce returns the first signal whose message contains the nonce
+// (case-insensitive substring), which proves that the specific injected
+// payload — not some unrelated dialog — executed.
+func matchExecNonce(signals []ExecSignal, nonce string) (ExecSignal, bool) {
+	nonce = strings.TrimSpace(nonce)
+	if nonce == "" {
+		return ExecSignal{}, false
+	}
+	ln := strings.ToLower(nonce)
+	for _, s := range signals {
+		if strings.Contains(strings.ToLower(s.Message), ln) {
+			return s, true
+		}
+	}
+	return ExecSignal{}, false
+}

--- a/internal/tools/browser/xssverify.go
+++ b/internal/tools/browser/xssverify.go
@@ -1,0 +1,112 @@
+package browser
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+	"github.com/xalgord/xalgorix/v4/internal/tools"
+)
+
+// verifyXSS confirms that an XSS payload actually EXECUTES in the browser
+// (rather than merely being reflected). The caller injects a payload that
+// raises a JavaScript dialog carrying a unique nonce — e.g. alert('XV-8f3a') —
+// and passes that nonce here. We clear prior signals, navigate to the payload
+// URL (dialogs are captured + auto-dismissed by setupDialogHandler), then poll
+// briefly for a dialog whose message carries the nonce. A match is concrete
+// proof of execution and is recorded as browser-confirmed XSS evidence in the
+// shared ledger. This directly addresses the low XSS precision of
+// reflection-only scanners.
+func verifyXSS(ctxID, rawURL, nonce, parameter string) (tools.Result, error) {
+	nonce = strings.TrimSpace(nonce)
+	if nonce == "" {
+		return tools.Result{Error: "nonce is required — inject a unique marker via alert()/confirm()/prompt() (e.g. alert('XV-8f3a')) and pass that same marker as nonce so execution can be confirmed unambiguously."}, nil
+	}
+
+	s := getBrowserStoreByID(ctxID)
+	if s == nil || s.page == nil {
+		return tools.Result{Error: "browser not launched — run browser_action command=launch first, then verify_xss with the URL carrying your payload."}, nil
+	}
+
+	// Clear stale signals so only this navigation can satisfy the match.
+	clearExecSignals(ctxID)
+
+	if strings.TrimSpace(rawURL) != "" {
+		if err := s.page.Timeout(20 * time.Second).Navigate(rawURL); err != nil {
+			return tools.Result{Error: fmt.Sprintf("navigation to %q failed: %v", rawURL, err)}, nil
+		}
+		_ = s.page.Timeout(10 * time.Second).WaitStable(time.Second)
+	}
+
+	// Dialogs fire asynchronously during/after load; poll a short window until
+	// the nonce matches or the deadline elapses, then decide on what we saw.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, ok := matchExecNonce(execSignalsFor(ctxID), nonce); ok {
+			break
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+
+	return finalizeXSSVerdict(ctxID, rawURL, nonce, parameter, execSignalsFor(ctxID)), nil
+}
+
+// finalizeXSSVerdict decides confirmed/not from the captured signals and, when
+// confirmed, records browser-confirmed XSS evidence in the ledger. Split out
+// from verifyXSS so the verdict + ledger logic is unit-testable without a real
+// browser (the caller supplies the signals).
+func finalizeXSSVerdict(ctxID, rawURL, nonce, parameter string, signals []ExecSignal) tools.Result {
+	matched, ok := matchExecNonce(signals, nonce)
+	if !ok {
+		msg := fmt.Sprintf("XSS NOT confirmed: no JavaScript dialog carrying the nonce %q fired.", nonce)
+		if len(signals) > 0 {
+			msg += fmt.Sprintf(" %d unrelated dialog(s) did fire — check that your payload raises a dialog containing exactly this nonce.", len(signals))
+		} else {
+			msg += " The payload may be reflected but not executing (encoded/sanitized/CSP-blocked), or it uses a non-dialog sink. Try a dialog payload such as \"'><script>alert('" + nonce + "')</script>\"."
+		}
+		return tools.Result{Output: msg, Metadata: map[string]any{"xss_confirmed": false}}
+	}
+
+	endpoint := rawURL
+	if u, err := url.Parse(rawURL); err == nil && u.Path != "" {
+		endpoint = u.EscapedPath()
+	}
+	confirm := fmt.Sprintf("Browser-confirmed XSS: a %s dialog carrying the nonce %q fired while loading %s.", matched.Kind, nonce, rawURL)
+
+	if l := ledgerForCtx(ctxID); l != nil {
+		h := l.Upsert(scanctx.Hypothesis{
+			Title:      "Browser-confirmed XSS at " + endpoint,
+			VulnClass:  "xss",
+			Endpoint:   endpoint,
+			Parameter:  parameter,
+			Confidence: 0.9,
+			Status:     scanctx.HypothesisTesting,
+			Origin:     "verify_xss",
+			NextAction: "Report as XSS using the browser-confirmed dialog execution as proof, then link the finding via add_hypothesis_evidence(kind=finding_ref).",
+		})
+		l.AddEvidence(h.ID, scanctx.Evidence{
+			Kind:       "exploit",
+			Summary:    confirm,
+			Request:    rawURL,
+			Response:   matched.Kind + " message: " + matched.Message,
+			Confidence: 0.9,
+			AgentID:    "browser",
+		})
+	}
+
+	return tools.Result{
+		Output:   confirm + " Recorded in the ledger — report it and link the finding.",
+		Metadata: map[string]any{"xss_confirmed": true},
+	}
+}
+
+// ledgerForCtx resolves the shared hypothesis ledger for a scan context, or nil
+// when the context is not active (mirrors ledger access elsewhere).
+func ledgerForCtx(ctxID string) *scanctx.LedgerStore {
+	if sc := scanctx.Get(ctxID); sc != nil {
+		return sc.Ledger
+	}
+	return nil
+}

--- a/internal/tools/browser/xssverify_test.go
+++ b/internal/tools/browser/xssverify_test.go
@@ -1,0 +1,124 @@
+package browser
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+)
+
+func TestExecSignalSinkRecordClearAndBound(t *testing.T) {
+	ctxID := "xss-sink-" + t.Name()
+	clearExecSignals(ctxID)
+
+	recordExecSignal(ctxID, ExecSignal{Kind: "dialog:alert", Message: "hello", At: time.Now()})
+	if got := execSignalsFor(ctxID); len(got) != 1 || got[0].Message != "hello" {
+		t.Fatalf("expected 1 recorded signal, got %#v", got)
+	}
+
+	// Bounded to maxExecSignalsPerCtx.
+	for i := 0; i < maxExecSignalsPerCtx+10; i++ {
+		recordExecSignal(ctxID, ExecSignal{Kind: "dialog:alert", Message: "m"})
+	}
+	if got := len(execSignalsFor(ctxID)); got != maxExecSignalsPerCtx {
+		t.Fatalf("expected sink bounded to %d, got %d", maxExecSignalsPerCtx, got)
+	}
+
+	clearExecSignals(ctxID)
+	if got := execSignalsFor(ctxID); got != nil {
+		t.Fatalf("expected empty sink after clear, got %#v", got)
+	}
+}
+
+func TestMatchExecNonce(t *testing.T) {
+	signals := []ExecSignal{
+		{Kind: "dialog:alert", Message: "some other dialog"},
+		{Kind: "dialog:alert", Message: "payload fired: XV-8f3a done"},
+	}
+	if _, ok := matchExecNonce(signals, ""); ok {
+		t.Fatal("empty nonce must never match")
+	}
+	if _, ok := matchExecNonce(signals, "NOPE"); ok {
+		t.Fatal("unrelated nonce must not match")
+	}
+	// Case-insensitive substring.
+	m, ok := matchExecNonce(signals, "xv-8f3a")
+	if !ok || !strings.Contains(m.Message, "XV-8f3a") {
+		t.Fatalf("expected case-insensitive nonce match, got ok=%v msg=%q", ok, m.Message)
+	}
+}
+
+func TestFinalizeXSSVerdictConfirmedRecordsLedger(t *testing.T) {
+	ctxID := "xss-confirm-" + t.Name()
+	sc := scanctx.New(ctxID, "")
+	scanctx.Activate(sc)
+	defer scanctx.Deactivate(ctxID)
+
+	signals := []ExecSignal{{Kind: "dialog:alert", Message: "XV-abc123", URL: "https://app/x"}}
+	res := finalizeXSSVerdict(ctxID, "https://app/search?q=payload", "XV-abc123", "q", signals)
+
+	if ok, _ := res.Metadata["xss_confirmed"].(bool); !ok {
+		t.Fatalf("expected xss_confirmed=true, got metadata %#v (output: %s)", res.Metadata, res.Output)
+	}
+	if !strings.Contains(res.Output, "Browser-confirmed XSS") {
+		t.Fatalf("expected a confirmation message, got: %s", res.Output)
+	}
+
+	all := sc.Ledger.All()
+	if len(all) != 1 {
+		t.Fatalf("expected 1 ledger hypothesis, got %d", len(all))
+	}
+	h := all[0]
+	if h.VulnClass != "xss" || h.Parameter != "q" || h.Endpoint != "/search" {
+		t.Fatalf("unexpected hypothesis identity: class=%q param=%q endpoint=%q", h.VulnClass, h.Parameter, h.Endpoint)
+	}
+	if len(h.Evidence) != 1 || h.Evidence[0].Kind != "exploit" {
+		t.Fatalf("expected one exploit evidence, got %#v", h.Evidence)
+	}
+	if h.Status != scanctx.HypothesisTesting {
+		t.Fatalf("expected status testing (agent still reports/verifies), got %q", h.Status)
+	}
+}
+
+func TestFinalizeXSSVerdictNotConfirmed(t *testing.T) {
+	ctxID := "xss-noconfirm-" + t.Name()
+	sc := scanctx.New(ctxID, "")
+	scanctx.Activate(sc)
+	defer scanctx.Deactivate(ctxID)
+
+	// Unrelated dialog fired, but not our nonce.
+	res := finalizeXSSVerdict(ctxID, "https://app/x", "XV-zzz", "q",
+		[]ExecSignal{{Kind: "dialog:alert", Message: "cookie consent"}})
+	if ok, _ := res.Metadata["xss_confirmed"].(bool); ok {
+		t.Fatal("expected xss_confirmed=false when the nonce did not fire")
+	}
+	if !strings.Contains(res.Output, "unrelated dialog") {
+		t.Fatalf("expected mention of unrelated dialogs, got: %s", res.Output)
+	}
+	if sc.Ledger.Len() != 0 {
+		t.Fatalf("expected no ledger writes when unconfirmed, got %d", sc.Ledger.Len())
+	}
+
+	// No dialogs at all → guidance to use a dialog payload.
+	res2 := finalizeXSSVerdict(ctxID, "https://app/x", "XV-zzz", "q", nil)
+	if ok, _ := res2.Metadata["xss_confirmed"].(bool); ok {
+		t.Fatal("expected xss_confirmed=false with no signals")
+	}
+	if !strings.Contains(res2.Output, "alert('XV-zzz')") {
+		t.Fatalf("expected a suggested dialog payload carrying the nonce, got: %s", res2.Output)
+	}
+}
+
+func TestVerifyXSSErrorPaths(t *testing.T) {
+	ctxID := "xss-err-" + t.Name()
+
+	// Missing nonce → corrective error, no browser needed.
+	if res, _ := verifyXSS(ctxID, "https://app/x", "", ""); res.Error == "" || !strings.Contains(res.Error, "nonce is required") {
+		t.Fatalf("expected nonce-required error, got %#v", res)
+	}
+	// Nonce present but no browser launched → clear "launch first" error.
+	if res, _ := verifyXSS(ctxID, "https://app/x", "XV-1", ""); res.Error == "" || !strings.Contains(res.Error, "browser not launched") {
+		t.Fatalf("expected browser-not-launched error, got %#v", res)
+	}
+}

--- a/internal/tools/httpclient/sendraw.go
+++ b/internal/tools/httpclient/sendraw.go
@@ -1,0 +1,135 @@
+package httpclient
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/xalgord/xalgorix/v4/internal/config"
+	"github.com/xalgord/xalgorix/v4/internal/scanheaders"
+)
+
+// defaultBrowserUA mirrors the User-Agent the http_request tool sends so raw
+// replays look identical to normal scan traffic.
+const defaultBrowserUA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+// RawRequest is a single explicit HTTP request for SendRaw.
+//
+// Unlike the http_request tool, SendRaw does NOT auto-inject the scan's session
+// auth: the caller supplies the exact headers for the identity under test. This
+// is what makes it usable for multi-role authorization testing, where the whole
+// point is to control precisely which credentials each replay carries (role A,
+// role B, or none). Operator attribution headers (scanheaders) are still
+// applied so replays remain identifiable as authorized scan traffic, and the
+// upstream proxy + TLS config are honored via the shared buildClient.
+type RawRequest struct {
+	Method          string
+	URL             string
+	Headers         map[string]string
+	Body            string
+	FollowRedirects bool
+	TimeoutSec      int // <=0 → 30, capped at 60
+	MaxBodyBytes    int // <=0 → default cap, capped at the hard ceiling
+}
+
+// RawResponse is the structured result of SendRaw.
+type RawResponse struct {
+	StatusCode int
+	Status     string
+	Proto      string
+	Header     http.Header
+	Body       []byte
+	BodyLen    int // full body length observed before truncation
+	Truncated  bool
+	Elapsed    time.Duration
+}
+
+// SendRaw performs one HTTP request with exactly the supplied headers and
+// returns a structured response. It reuses the package's client construction
+// (proxy, TLS-skip-verify) and applies operator scan headers, but never adds
+// per-scan session credentials — callers control the identity explicitly.
+func SendRaw(req RawRequest) (*RawResponse, error) {
+	method := strings.ToUpper(strings.TrimSpace(req.Method))
+	if method == "" {
+		method = "GET"
+	}
+	if !validMethod(method) {
+		return nil, fmt.Errorf("invalid HTTP method: %s", method)
+	}
+
+	targetURL := strings.TrimSpace(req.URL)
+	if targetURL == "" {
+		return nil, fmt.Errorf("url is required")
+	}
+	if !strings.HasPrefix(targetURL, "http://") && !strings.HasPrefix(targetURL, "https://") {
+		targetURL = "https://" + targetURL
+	}
+
+	timeout := req.TimeoutSec
+	if timeout <= 0 {
+		timeout = 30
+	}
+	if timeout > 60 {
+		timeout = 60
+	}
+
+	var bodyReader io.Reader
+	if req.Body != "" {
+		bodyReader = strings.NewReader(req.Body)
+	}
+
+	httpReq, err := http.NewRequest(method, targetURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	for k, v := range req.Headers {
+		if strings.TrimSpace(k) == "" {
+			continue
+		}
+		httpReq.Header.Set(k, v)
+	}
+	scanheaders.Apply(httpReq.Header, config.Get().ScanHeaders)
+	if httpReq.Header.Get("User-Agent") == "" {
+		httpReq.Header.Set("User-Agent", defaultBrowserUA)
+	}
+
+	client := buildClient(timeout, req.FollowRedirects, config.Get().TLSSkipVerify)
+
+	start := time.Now()
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	elapsed := time.Since(start)
+
+	bodyCap := req.MaxBodyBytes
+	if bodyCap <= 0 {
+		bodyCap = maxBodyBytes
+	}
+	if bodyCap > maxBodyBytesHard {
+		bodyCap = maxBodyBytesHard
+	}
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, int64(bodyCap)+1))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+	truncated := len(raw) > bodyCap
+	bodyLen := len(raw)
+	if truncated {
+		raw = raw[:bodyCap]
+	}
+
+	return &RawResponse{
+		StatusCode: resp.StatusCode,
+		Status:     resp.Status,
+		Proto:      resp.Proto,
+		Header:     resp.Header,
+		Body:       raw,
+		BodyLen:    bodyLen,
+		Truncated:  truncated,
+		Elapsed:    elapsed,
+	}, nil
+}


### PR DESCRIPTION
## Summary

P2 "deep testing": deterministic, evidence-producing tools for the two vulnerability classes autonomous web scanners are weakest at — **broken authorization** and **XSS** — both wired into the P1 hypothesis/evidence ledger so their results flow through the same scheduling, verification, and precision finish-gate.

**Stacked on #494** (base branch `feat/scan-scoped-multi-agent`). Review/merge that first; this PR's diff is P2-only. Retarget to `main` once #494 lands.

## What's added

### 1. Multi-role authorization matrix — `authz_matrix`
Replays a single request as every configured identity — primary session (role A), a second account (role B) when the scan has one, and anonymous — and reports the access-control differential.
- If a lower-privileged identity gets the **same successful response** as the authorized one, that is broken access control: IDOR/BOLA horizontally (role B reads role A's object), auth bypass/BFLA vertically (anonymous reaches a protected resource).
- New exported `httpclient.SendRaw` primitive does the per-identity replay (reusing the existing client/proxy/TLS/scan-header logic) with **no** auto-injected session auth, so each identity is controlled precisely.
- Enforces scope (`scopeguard.IsLocalOrListener` — never probes the operator's own machine) and the per-scan request-rate policy.
- Records **role-scoped** ledger hypotheses (keyed by the ledger's `Role` dimension) with the differential as evidence, at `testing` status — the agent still reports and the precision gate still applies (no auto-"proven").

### 2. Browser-backed XSS execution verification — `browser_action command=verify_xss`
- The headless browser now records JavaScript dialogs as per-context execution signals (`execsignals.go`).
- `verify_xss` navigates a payload that raises a dialog carrying a unique nonce and confirms XSS **only when that exact dialog fires** — proof of execution, not reflection — and records browser-confirmed XSS evidence in the ledger.
- The verdict + ledger logic is split into `finalizeXSSVerdict` so it is unit-tested without a real Chrome.

### 3. Specialist wiring
The injection/server-side and client/source specialist evidence contracts now name these tools, so specialists produce the required proof automatically.

## Testing

- `go build ./...`, `gofmt`, `go vet` — clean.
- New tests: authorization differential (broken-access vs properly-restricted, scope refusal, needs-two-identities) and the XSS signal core + verdict/ledger recording (confirmed, unrelated-dialog, no-signal, error paths).
- Package tests pass: `internal/agent`, `internal/tools/httpclient`, `internal/scanctx`, and the new `internal/tools/browser` tests.
- Race detector clean on `internal/agent`, `internal/tools/httpclient`, and the new browser tests.
- Lint clean on the changed files.

> Note: the full `internal/tools/browser` package has a pre-existing `wsbridge_test` failure caused by a hardcoded listener port (`127.0.0.1:38401`) already bound in the CI/dev environment. It is unrelated to this change (this PR only touches `browser.go` + new files, not `wsbridge*`); the new tests pass in isolation.

## Follow-ups (still P2/P3, not in this PR)

- Source-to-runtime data-flow with an exploit-replay harness (needs a build/run sandbox).
- Console/DOM-mutation execution signals (in addition to dialogs) for DOM-only XSS sinks.
- OOB-capable blind-injection pipelines.
- P3: a repeatable benchmark harness (e.g. XBOW) to measure per-class success/false-positive/cost, plus a triage feedback loop.
