### PR TITLE
Broaden XSS verification: console + DOM-marker execution oracles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased] — Broader XSS execution verification (console + DOM oracles)
+
+### Added
+- **`verify_xss` now confirms execution via console calls and DOM markers, not just dialogs.** The headless browser captures `console.*` API output as execution signals, and the verifier also reads DOM markers (`document.title` / `window.name`) after navigation. A payload can therefore prove execution by firing a dialog, by logging the nonce to the console (useful when a filter strips `alert()`), or by mutating a DOM marker to the nonce — extending confirmed XSS coverage to non-dialog and DOM-only sinks while keeping the same "proof of execution, not reflection" bar.
+
 ## [v4.6.8](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.8) — Evidence-driven multi-agent assessments (2026-09-01)
 
 Scan-scoped parallel specialists coordinated by a durable hypothesis/evidence ledger, plus deep-testing tools for the vulnerability classes autonomous scanners are weakest at (broken authorization, XSS).

--- a/internal/tools/browser/browser.go
+++ b/internal/tools/browser/browser.go
@@ -219,7 +219,7 @@ ACTIONS:
   new_tab      — Open a new browser tab
   switch_tab   — Switch between tabs
   close        — Close browser
-  verify_xss   — CONFIRM an XSS payload actually executes in the browser. Navigate to a URL whose payload raises a dialog carrying a unique nonce (e.g. alert('XV-8f3a')) and pass nonce=XV-8f3a; returns confirmed only if that dialog fires. This is proof of execution, not reflection — use it before reporting XSS.
+  verify_xss   — CONFIRM an XSS payload actually executes in the browser (proof of execution, not reflection). Navigate to a URL whose payload emits a unique nonce and pass nonce=<that value>; confirmed only if the nonce is observed executing. Three oracles are accepted: a JS dialog (alert/confirm/prompt('XV-8f3a')), a console call (console.log('XV-8f3a')) — useful when a filter strips alert — or a DOM marker (document.title='XV-8f3a' or window.name='XV-8f3a') for DOM-only sinks. Use before reporting XSS.
 
 SIGNUP/LOGIN WORKFLOW:
   1. launch url=https://target.com/signup
@@ -238,7 +238,7 @@ SIGNUP/LOGIN WORKFLOW:
 			{Name: "selector", Description: "CSS selector or semantic @eX ID from snapshot (for click/type/submit/wait/iframe/get_html/select)", Required: false},
 			{Name: "text", Description: "Text to type (for type), option value (for select), or cookie value (for set_cookie)", Required: false},
 			{Name: "code", Description: "JavaScript code to execute (for execute_js)", Required: false},
-			{Name: "nonce", Description: "Unique marker your XSS payload raises via alert()/confirm()/prompt() (for verify_xss). Execution is confirmed only if a dialog carrying this nonce fires.", Required: false},
+			{Name: "nonce", Description: "Unique marker your XSS payload emits (for verify_xss) via a dialog (alert/confirm/prompt), console.log(), or a DOM marker (document.title / window.name). Execution is confirmed only if this nonce is observed executing.", Required: false},
 			{Name: "parameter", Description: "The injected parameter under test (for verify_xss), used to label the ledger hypothesis.", Required: false},
 			{Name: "direction", Description: "Scroll direction: up or down (for scroll)", Required: false},
 			{Name: "tab_id", Description: "Tab ID (for switch_tab)", Required: false},
@@ -556,6 +556,41 @@ func setupDialogHandler(ctxID string, p *rod.Page) {
 	})()
 }
 
+// setupConsoleHandler records console.* API calls (console.log/error/warn/…) as
+// ExecSignals for the scan context. Many XSS payloads prove execution without a
+// dialog — a filter may strip alert() while console.log() runs, and DOM/JS-sink
+// payloads commonly log a marker — so capturing the console broadens what
+// verify_xss can confirm as real execution (not mere reflection). The Runtime
+// domain is enabled explicitly so the events flow regardless of rod's lazy
+// enabling.
+func setupConsoleHandler(ctxID string, p *rod.Page) {
+	_ = proto.RuntimeEnable{}.Call(p)
+	go p.EachEvent(func(e *proto.RuntimeConsoleAPICalled) {
+		var parts []string
+		for _, arg := range e.Args {
+			if arg == nil {
+				continue
+			}
+			v := arg.Value.String()
+			if v == "" {
+				v = arg.Description
+			}
+			if v != "" {
+				parts = append(parts, v)
+			}
+		}
+		msg := strings.Join(parts, " ")
+		if strings.TrimSpace(msg) == "" {
+			return
+		}
+		recordExecSignal(ctxID, ExecSignal{
+			Kind:    "console:" + string(e.Type),
+			Message: msg,
+			At:      time.Now(),
+		})
+	})()
+}
+
 // browserActionForRegistry resolves the correct browser store via the registry's ScanContextID.
 func browserActionForRegistry(reg *tools.Registry, args map[string]string) (tools.Result, error) {
 	ctxID := reg.GetScanContextID()
@@ -640,6 +675,7 @@ func launchBrowser(ctxID, rawURL, proxy string) (tools.Result, error) {
 	// page.Eval() from blocking forever in headless mode during XSS testing,
 	// and record them as execution proof for verify_xss.
 	setupDialogHandler(ctxID, p)
+	setupConsoleHandler(ctxID, p)
 
 	// Set a realistic user agent for login flows
 	s.page.MustSetUserAgent(&proto.NetworkSetUserAgentOverride{
@@ -1517,8 +1553,9 @@ func newTab(ctxID, rawURL string) (tools.Result, error) {
 	s.currentTab = tabID
 	s.page = p
 
-	// Auto-dismiss JavaScript dialogs on new tabs too
+	// Auto-dismiss JavaScript dialogs on new tabs too, and capture console output
 	setupDialogHandler(ctxID, p)
+	setupConsoleHandler(ctxID, p)
 
 	if rawURL != "" {
 		err := p.Timeout(20 * time.Second).Navigate(rawURL)

--- a/internal/tools/browser/xssverify.go
+++ b/internal/tools/browser/xssverify.go
@@ -40,14 +40,27 @@ func verifyXSS(ctxID, rawURL, nonce, parameter string) (tools.Result, error) {
 		_ = s.page.Timeout(10 * time.Second).WaitStable(time.Second)
 	}
 
-	// Dialogs fire asynchronously during/after load; poll a short window until
-	// the nonce matches or the deadline elapses, then decide on what we saw.
+	// Dialogs and console messages fire asynchronously during/after load; poll a
+	// short window until the nonce matches (a dialog or console signal) or the
+	// deadline elapses.
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
 		if _, ok := matchExecNonce(execSignalsFor(ctxID), nonce); ok {
 			break
 		}
 		time.Sleep(150 * time.Millisecond)
+	}
+
+	// DOM-marker fallback: some payloads prove execution by mutating the DOM
+	// (e.g. document.title=nonce or window.name=nonce) rather than firing a
+	// dialog or logging to the console. If nothing matched yet, read those
+	// markers once and record a signal when the nonce is present.
+	if _, ok := matchExecNonce(execSignalsFor(ctxID), nonce); !ok && s.page != nil {
+		if res, err := s.page.Timeout(5 * time.Second).Eval(`() => [document.title, window.name, (window.__xss || "")].join("\u0001")`); err == nil {
+			if v := res.Value.String(); strings.Contains(strings.ToLower(v), strings.ToLower(nonce)) {
+				recordExecSignal(ctxID, ExecSignal{Kind: "dom:marker", Message: v, At: time.Now()})
+			}
+		}
 	}
 
 	return finalizeXSSVerdict(ctxID, rawURL, nonce, parameter, execSignalsFor(ctxID)), nil
@@ -64,7 +77,7 @@ func finalizeXSSVerdict(ctxID, rawURL, nonce, parameter string, signals []ExecSi
 		if len(signals) > 0 {
 			msg += fmt.Sprintf(" %d unrelated dialog(s) did fire — check that your payload raises a dialog containing exactly this nonce.", len(signals))
 		} else {
-			msg += " The payload may be reflected but not executing (encoded/sanitized/CSP-blocked), or it uses a non-dialog sink. Try a dialog payload such as \"'><script>alert('" + nonce + "')</script>\"."
+			msg += " The payload may be reflected but not executing (encoded/sanitized/CSP-blocked). Try an execution oracle carrying the nonce: a dialog (\"'><script>alert('" + nonce + "')</script>\"), a console call (console.log('" + nonce + "')), or a DOM marker (document.title='" + nonce + "')."
 		}
 		return tools.Result{Output: msg, Metadata: map[string]any{"xss_confirmed": false}}
 	}

--- a/internal/tools/browser/xssverify_test.go
+++ b/internal/tools/browser/xssverify_test.go
@@ -110,6 +110,33 @@ func TestFinalizeXSSVerdictNotConfirmed(t *testing.T) {
 	}
 }
 
+func TestFinalizeXSSVerdictConfirmsConsoleAndDOMSignals(t *testing.T) {
+	// verify_xss now accepts dialog, console, and DOM-marker execution oracles.
+	// Each flows through the same sink + verdict + ledger path, so a signal of
+	// any kind carrying the nonce confirms XSS and records evidence.
+	for _, kind := range []string{"console:log", "console:error", "dom:marker"} {
+		t.Run(kind, func(t *testing.T) {
+			ctxID := "xss-kind-" + strings.ReplaceAll(kind, ":", "-")
+			sc := scanctx.New(ctxID, "")
+			scanctx.Activate(sc)
+			defer scanctx.Deactivate(ctxID)
+
+			signals := []ExecSignal{{Kind: kind, Message: "prefix XV-kind-9 suffix"}}
+			res := finalizeXSSVerdict(ctxID, "https://app/search?q=1", "XV-kind-9", "q", signals)
+			if ok, _ := res.Metadata["xss_confirmed"].(bool); !ok {
+				t.Fatalf("expected confirmed for kind %s, got metadata %#v (%s)", kind, res.Metadata, res.Output)
+			}
+			all := sc.Ledger.All()
+			if len(all) != 1 || all[0].VulnClass != "xss" {
+				t.Fatalf("expected 1 xss hypothesis for kind %s, got %d", kind, len(all))
+			}
+			if len(all[0].Evidence) != 1 {
+				t.Fatalf("expected one evidence entry for kind %s", kind)
+			}
+		})
+	}
+}
+
 func TestVerifyXSSErrorPaths(t *testing.T) {
 	ctxID := "xss-err-" + t.Name()
 


### PR DESCRIPTION
Extends the P2 browser XSS verifier (verify_xss) beyond dialog-only detection.

## What
- **Console capture**: the headless browser now records `console.*` API calls as execution signals (Runtime domain enabled), wired at launch + new-tab alongside the dialog handler.
- **DOM-marker fallback**: after navigation, verify_xss reads `document.title` / `window.name` / `window.__xss` and records a signal when the nonce is present.
- All three oracles (dialog, console, DOM marker) flow through the same execsignals sink + `matchExecNonce` + `finalizeXSSVerdict`, so the verdict/ledger-evidence path is unchanged.

## Why
Many real XSS payloads execute without firing a dialog — a filter may strip `alert()` while `console.log()` runs, and DOM/JS-sink payloads mutate the DOM. This broadens confirmed XSS coverage (a MAPTA weak spot) while keeping the same 'proof of execution, not reflection' bar.

## Tests
finalizeXSSVerdict confirms across dialog/console/DOM signal kinds + records ledger evidence; existing sink/matcher/error-path tests still pass. Build, gofmt, vet, lint clean on changed files.

Builds on v4.6.8 (base main).