### PR TITLE
verify_oob: out-of-band blind-vulnerability verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased] — Out-of-band blind-vulnerability verification
+
+### Added
+- **`verify_oob` confirms blind vulnerabilities via the OAST oracle and records them in the ledger.** After minting a callback with `oob_callback` and planting it in a target-side payload, `verify_oob` polls the token and applies a class-aware verdict: SSRF requires an assessed non-scanner HTTP interaction, while blind RCE / command injection / XXE / SQL injection are confirmed by any genuine non-scanner callback (HTTP or a DNS lookup of the unique token). Confirmed results are recorded as role-scoped ledger evidence, giving Xalgorix a deterministic proof path for the classes that leave no in-band signal — directly targeting the blind-injection gap where autonomous scanners are weakest.
+
 ## [v4.6.9](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.9) — Broader XSS execution verification (console + DOM oracles) (2026-09-01)
 
 ### Added

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -363,6 +363,12 @@ func NewAgent(cfg *config.Config, name string, events chan Event, localGuard sco
 	// account credentials, the scope config, and the ledger.
 	a.registerAuthzMatrixTool(reg)
 
+	// Register the out-of-band blind-vulnerability verifier (verify_oob). It
+	// polls the OAST oracle for a planted token and records blind-execution
+	// proof to the ledger. Agent-bound for ledger access; makes no outbound
+	// request itself, so no scope gate is needed.
+	a.registerOOBVerifyTool(reg)
+
 	// Create cancellable context
 	a.ctx, a.cancel = context.WithCancel(a.ctx)
 	// Wire context to LLM client so cancel interrupts pending HTTP requests

--- a/internal/agent/oob_verify.go
+++ b/internal/agent/oob_verify.go
@@ -1,0 +1,202 @@
+// Package agent — oob_verify.go implements verify_oob: a ledger-integrated
+// out-of-band (OAST) verifier for BLIND vulnerabilities.
+//
+// Blind injection is where autonomous scanners are weakest (MAPTA reports 0% on
+// blind SQLi) because in-band responses reveal nothing — the only proof is the
+// target reaching out to a callback the attacker controls. The existing
+// oob_callback tool mints callbacks and polls raw interactions; verify_oob adds
+// the missing piece: it correlates a token to a specific hypothesis, applies a
+// class-aware verdict over the interactions, and records the blind-execution
+// proof in the shared ledger so it flows through the same scheduling +
+// precision finish-gate as every other finding.
+//
+// Verdict policy (deliberately conservative to preserve precision-over-volume):
+//   - SSRF: only an ASSESSED NON-SCANNER HTTP interaction confirms. DNS-only,
+//     scanner-origin, and origin-unassessed hits are leads, not proof — this
+//     mirrors oob_callback's own SSRF guidance (the scanner can follow a
+//     redirect to its own callback).
+//   - blind RCE / CMDi / XXE / SQLi / XSS: the callback is embedded in a
+//     TARGET-side payload (e.g. `curl <token>` executed by the target), so any
+//     genuine non-scanner callback — a non-scanner HTTP hit, or a DNS lookup of
+//     the unique token by the target's resolver — proves the payload executed.
+//     Scanner-origin-only hits do NOT confirm.
+package agent
+
+import (
+	"fmt"
+	"strings"
+
+	oobsrv "github.com/xalgord/xalgorix/v4/internal/oob"
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+	"github.com/xalgord/xalgorix/v4/internal/tools"
+)
+
+// registerOOBVerifyTool registers the Agent-bound verify_oob tool. It is
+// Agent-bound so it can record to the shared ledger; it makes no outbound
+// request itself (it only reads the local OAST interaction store), so it needs
+// no scope gate.
+func (a *Agent) registerOOBVerifyTool(reg *tools.Registry) {
+	reg.Register(&tools.Tool{
+		Name:        "verify_oob",
+		Description: "Confirm a BLIND vulnerability out-of-band and record it in the ledger. Workflow: (1) oob_callback action=generate to mint a callback + token; (2) plant the callback in the target-side payload (blind SQLi/RCE/CMDi/XXE/SSRF); (3) call verify_oob with the token and the hypothesis (vuln_class, endpoint, parameter). It polls the OAST oracle and records proof when the target genuinely reached your callback. For SSRF an assessed non-scanner HTTP interaction is required; for blind RCE/CMDi/XXE/SQLi any genuine non-scanner callback — DNS or HTTP — proves the payload executed on the target. This is the primary way to confirm classes that leave no in-band signal.",
+		Parameters: []tools.Parameter{
+			{Name: "token", Description: "The token from oob_callback action=generate, planted in the payload.", Required: true},
+			{Name: "vuln_class", Description: "Blind class under test: blind-sqli, blind-rce, blind-cmdi, xxe, blind-ssrf (or ssrf), blind-xss.", Required: true},
+			{Name: "endpoint", Description: "Target endpoint where the payload was injected.", Required: false},
+			{Name: "parameter", Description: "Parameter/input that carried the payload.", Required: false},
+			{Name: "role", Description: "Auth context (anonymous/user/admin) if relevant.", Required: false},
+		},
+		Execute: a.oobVerifyTool,
+	})
+}
+
+func (a *Agent) oobVerifyTool(args map[string]string) (tools.Result, error) {
+	token := strings.TrimSpace(args["token"])
+	if token == "" {
+		return tools.Result{Error: "token is required (mint one with oob_callback action=generate and plant it in your payload first)"}, nil
+	}
+	class := normalizeBlindClass(args["vuln_class"])
+	if class == "" {
+		return tools.Result{Error: "vuln_class is required (e.g. blind-sqli, blind-rce, blind-cmdi, xxe, blind-ssrf)"}, nil
+	}
+	hits := oobsrv.Poll(token)
+	return a.finalizeOOBVerdict(token, class, strings.TrimSpace(args["endpoint"]), strings.TrimSpace(args["parameter"]), strings.TrimSpace(args["role"]), hits), nil
+}
+
+// oobTally summarizes a set of interactions by provenance.
+type oobTally struct {
+	nonScannerHTTP int
+	scannerHTTP    int
+	unassessedHTTP int
+	dns            int
+	total          int
+}
+
+func tallyOOB(hits []oobsrv.Interaction) oobTally {
+	var t oobTally
+	for _, h := range hits {
+		t.total++
+		proto := strings.ToLower(strings.TrimSpace(h.Protocol))
+		switch proto {
+		case "dns":
+			t.dns++
+		case "http", "https":
+			switch {
+			case !h.OriginAssessed:
+				t.unassessedHTTP++
+			case h.ScannerOrigin:
+				t.scannerHTTP++
+			default:
+				t.nonScannerHTTP++
+			}
+		default:
+			// Unknown protocol with a resolvable remote is treated like DNS —
+			// a lead, not scanner-attributable.
+			t.dns++
+		}
+	}
+	return t
+}
+
+// finalizeOOBVerdict applies the class-aware verdict, records ledger evidence
+// when confirmed, and returns the tool result. Split from oobVerifyTool so the
+// verdict + ledger logic is unit-testable with synthetic interactions.
+func (a *Agent) finalizeOOBVerdict(token, class, endpoint, parameter, role string, hits []oobsrv.Interaction) tools.Result {
+	if len(hits) == 0 {
+		return tools.Result{
+			Output:   fmt.Sprintf("No OOB interactions for token %s. If you just sent the payload, wait a few seconds and call verify_oob again. Sustained silence means the sink is not reaching the callback (not blind-exploitable over the tried egress, or egress is filtered).", token),
+			Metadata: map[string]any{"oob_confirmed": false, "oob_hits": 0},
+		}
+	}
+
+	t := tallyOOB(hits)
+	ssrf := isSSRFClass(class)
+
+	var confirmed bool
+	var confidence float64
+	var verdict string
+	switch {
+	case ssrf:
+		if t.nonScannerHTTP > 0 {
+			confirmed, confidence = true, 0.85
+			verdict = fmt.Sprintf("assessed non-scanner HTTP callback received (%d) — SSRF confirmed out-of-band", t.nonScannerHTTP)
+		} else {
+			verdict = "only DNS-only / scanner-origin / origin-unassessed interactions arrived — SSRF NOT confirmed (leads only; re-test with redirects disabled and require a non-scanner HTTP hit)"
+		}
+	default:
+		switch {
+		case t.nonScannerHTTP > 0:
+			confirmed, confidence = true, 0.9
+			verdict = fmt.Sprintf("non-scanner HTTP callback received (%d) — the target executed the payload out-of-band", t.nonScannerHTTP)
+		case t.dns > 0:
+			confirmed, confidence = true, 0.75
+			verdict = fmt.Sprintf("DNS callback for the unique token received (%d) — the target's resolver looked up your callback, proving payload execution", t.dns)
+		default:
+			verdict = "only scanner-origin / origin-unassessed HTTP interactions arrived — NOT confirmed (a scanner-side hit is ambiguous); re-test so the callback is reached from the target"
+		}
+	}
+
+	if !confirmed {
+		return tools.Result{
+			Output:   fmt.Sprintf("Token %s: %d interaction(s), but %s.", token, t.total, verdict),
+			Metadata: map[string]any{"oob_confirmed": false, "oob_hits": t.total},
+		}
+	}
+
+	summary := fmt.Sprintf("Out-of-band %s proof for token %s: %s (interactions: %d non-scanner-HTTP, %d DNS, %d scanner-origin, %d unassessed).",
+		class, token, verdict, t.nonScannerHTTP, t.dns, t.scannerHTTP, t.unassessedHTTP)
+
+	if l := a.ledger(); l != nil {
+		h := l.Upsert(scanctx.Hypothesis{
+			Title:      "Out-of-band confirmed " + class + " at " + endpoint,
+			VulnClass:  class,
+			Endpoint:   endpoint,
+			Parameter:  parameter,
+			Role:       role,
+			Confidence: confidence,
+			Status:     scanctx.HypothesisTesting,
+			Origin:     "verify_oob",
+			NextAction: "Report as " + class + " using the out-of-band callback as proof, then link the finding via add_hypothesis_evidence(kind=finding_ref).",
+		})
+		l.AddEvidence(h.ID, scanctx.Evidence{
+			Kind:       "exploit",
+			Summary:    summary,
+			Request:    "OOB token: " + token,
+			Response:   firstHitSummary(hits),
+			Confidence: confidence,
+			AgentID:    a.ledgerOrigin(),
+		})
+	}
+
+	return tools.Result{
+		Output:   summary + " Recorded in the ledger — report it and link the finding.",
+		Metadata: map[string]any{"oob_confirmed": true, "oob_hits": t.total},
+	}
+}
+
+// firstHitSummary renders a compact description of the strongest interaction
+// for ledger evidence.
+func firstHitSummary(hits []oobsrv.Interaction) string {
+	// Prefer a non-scanner HTTP hit, then DNS, then anything.
+	pick := hits[0]
+	for _, h := range hits {
+		proto := strings.ToLower(strings.TrimSpace(h.Protocol))
+		if (proto == "http" || proto == "https") && h.OriginAssessed && !h.ScannerOrigin {
+			pick = h
+			break
+		}
+	}
+	return fmt.Sprintf("%s %s %s from %s at %s", strings.ToUpper(pick.Protocol), pick.Method, pick.Path, pick.RemoteAddr, pick.Time.Format("2006-01-02T15:04:05Z07:00"))
+}
+
+// normalizeBlindClass lower-cases and hyphenates a class label.
+func normalizeBlindClass(s string) string {
+	c := strings.ToLower(strings.TrimSpace(s))
+	return strings.ReplaceAll(c, "_", "-")
+}
+
+// isSSRFClass reports whether a class should be held to the stricter SSRF
+// (assessed-non-scanner-HTTP-only) verdict.
+func isSSRFClass(c string) bool {
+	return strings.Contains(c, "ssrf")
+}

--- a/internal/agent/oob_verify_test.go
+++ b/internal/agent/oob_verify_test.go
@@ -1,0 +1,81 @@
+package agent
+
+import (
+	"testing"
+	"time"
+
+	oobsrv "github.com/xalgord/xalgorix/v4/internal/oob"
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+)
+
+func newOOBAgent(t *testing.T) *Agent {
+	t.Helper()
+	// verify_oob reaches the ledger via a.scanCtx.Ledger directly (no active-
+	// context registry lookup), so a bare ScanContext is enough.
+	return &Agent{scanCtx: scanctx.New("oob-test-"+t.Name(), "")}
+}
+
+func httpHit(assessed, scanner bool) oobsrv.Interaction {
+	return oobsrv.Interaction{Protocol: "http", Method: "GET", Path: "/", RemoteAddr: "203.0.113.9", OriginAssessed: assessed, ScannerOrigin: scanner, Time: time.Now()}
+}
+
+func dnsHit() oobsrv.Interaction {
+	return oobsrv.Interaction{Protocol: "dns", Method: "DNS", RemoteAddr: "198.51.100.7", Time: time.Now()}
+}
+
+func TestFinalizeOOBVerdict(t *testing.T) {
+	cases := []struct {
+		name          string
+		class         string
+		hits          []oobsrv.Interaction
+		wantConfirmed bool
+	}{
+		{"ssrf assessed non-scanner HTTP confirms", "blind-ssrf", []oobsrv.Interaction{httpHit(true, false)}, true},
+		{"ssrf dns-only is a lead, not proof", "blind-ssrf", []oobsrv.Interaction{dnsHit()}, false},
+		{"ssrf scanner-origin HTTP does not confirm", "ssrf", []oobsrv.Interaction{httpHit(true, true)}, false},
+		{"ssrf origin-unassessed HTTP does not confirm", "blind-ssrf", []oobsrv.Interaction{httpHit(false, false)}, false},
+		{"blind-rce non-scanner HTTP confirms", "blind-rce", []oobsrv.Interaction{httpHit(true, false)}, true},
+		{"blind-rce DNS callback confirms", "blind-rce", []oobsrv.Interaction{dnsHit()}, true},
+		{"blind-cmdi DNS callback confirms", "blind-cmdi", []oobsrv.Interaction{dnsHit()}, true},
+		{"blind-rce scanner-origin only does not confirm", "blind-rce", []oobsrv.Interaction{httpHit(true, true)}, false},
+		{"no interactions", "blind-sqli", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ag := newOOBAgent(t)
+			res := ag.finalizeOOBVerdict("tok-"+tc.name, tc.class, "/api/x", "q", "user", tc.hits)
+			got, _ := res.Metadata["oob_confirmed"].(bool)
+			if got != tc.wantConfirmed {
+				t.Fatalf("confirmed=%v want %v (output: %s)", got, tc.wantConfirmed, res.Output)
+			}
+			ledgerLen := ag.scanCtx.Ledger.Len()
+			if tc.wantConfirmed {
+				if ledgerLen != 1 {
+					t.Fatalf("expected 1 ledger hypothesis on confirm, got %d", ledgerLen)
+				}
+				h := ag.scanCtx.Ledger.All()[0]
+				if h.VulnClass != normalizeBlindClass(tc.class) {
+					t.Fatalf("expected class %q, got %q", normalizeBlindClass(tc.class), h.VulnClass)
+				}
+				if h.Status != scanctx.HypothesisTesting {
+					t.Fatalf("expected status testing (not auto-proven), got %q", h.Status)
+				}
+				if len(h.Evidence) != 1 || h.Evidence[0].Kind != "exploit" {
+					t.Fatalf("expected one exploit evidence, got %#v", h.Evidence)
+				}
+			} else if ledgerLen != 0 {
+				t.Fatalf("expected empty ledger when not confirmed, got %d", ledgerLen)
+			}
+		})
+	}
+}
+
+func TestOOBVerifyToolValidation(t *testing.T) {
+	ag := newOOBAgent(t)
+	if res, _ := ag.oobVerifyTool(map[string]string{"vuln_class": "blind-rce"}); res.Error == "" {
+		t.Fatal("expected error when token is missing")
+	}
+	if res, _ := ag.oobVerifyTool(map[string]string{"token": "abc"}); res.Error == "" {
+		t.Fatal("expected error when vuln_class is missing")
+	}
+}


### PR DESCRIPTION
Adds the blind-injection analog of verify_xss / authz_matrix — a ledger-integrated OAST verifier for the classes that leave no in-band signal (MAPTA reports 0% on blind SQLi).

## What
- `verify_oob` (Agent-bound tool): after `oob_callback action=generate` mints a callback and you plant it in a target-side payload, `verify_oob` polls the token and applies a **class-aware verdict**:
  - **SSRF** — requires an *assessed non-scanner HTTP* interaction (DNS-only/scanner-origin/unassessed are leads, matching oob_callback's own SSRF guidance).
  - **blind RCE / CMDi / XXE / SQLi** — confirmed by any genuine non-scanner callback (HTTP, or a DNS lookup of the unique token by the target's resolver).
- Confirmed results record a role-scoped ledger hypothesis (status `testing`, not auto-proven) + exploit evidence, so they flow through the same scheduling and precision finish-gate.
- Verdict/ledger logic is split into `finalizeOOBVerdict` for unit testing with synthetic interactions; reuses `internal/oob`'s origin-assessment fields. No scope gate needed (reads the local OAST store; makes no outbound request).

## Tests
Table-driven `finalizeOOBVerdict` across SSRF/blind-rce/blind-cmdi × HTTP(assessed/scanner/unassessed)/DNS/none, asserting confirmation + ledger recording; plus token/class validation. Build, gofmt, vet, lint, full agent suite green.

Builds on v4.6.9 (base main).