### PR TITLE
Auto-link reported findings to their ledger hypothesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased] — Auto-link reported findings to their ledger hypothesis
+
+### Added
+- **`report_vulnerability` accepts an optional `hypothesis_id`.** When the agent reports a finding that proves a ledger hypothesis (its id comes straight from `authz_matrix` / `verify_xss` / `verify_oob` / `record_hypothesis`), the finding is linked to that hypothesis and the hypothesis is marked proven on a successful report — closing the loop the precision finish-gate enforces without a separate `add_hypothesis_evidence` call. The link is deterministic (the agent names the exact id, no fuzzy matching) and best-effort: an empty or unknown id is a silent no-op, so it can never fail a valid report.
+
 ## [v4.6.10](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.10) — Out-of-band blind-vulnerability verification (2026-09-01)
 
 ### Added

--- a/internal/tools/reporting/ledger_link_test.go
+++ b/internal/tools/reporting/ledger_link_test.go
@@ -1,0 +1,61 @@
+package reporting
+
+import (
+	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+)
+
+func TestLinkFindingToLedger(t *testing.T) {
+	ctxID := "report-link-" + t.Name()
+	sc := scanctx.New(ctxID, "")
+	scanctx.Activate(sc)
+	defer scanctx.Deactivate(ctxID)
+
+	h := sc.Ledger.Upsert(scanctx.Hypothesis{
+		VulnClass: "idor",
+		Endpoint:  "/api/orders",
+		Status:    scanctx.HypothesisTesting,
+	})
+
+	note := linkFindingToLedger(ctxID, "XALG-7", h.ID)
+	if note == "" {
+		t.Fatal("expected a non-empty link note when a valid hypothesis id is supplied")
+	}
+	got, ok := sc.Ledger.Get(h.ID)
+	if !ok {
+		t.Fatalf("hypothesis %s missing after link", h.ID)
+	}
+	if got.Status != scanctx.HypothesisProven {
+		t.Fatalf("expected hypothesis marked proven, got %q", got.Status)
+	}
+	linked := false
+	for _, ev := range got.Evidence {
+		if ev.Kind == scanctx.EvidenceFindingRef && ev.FindingID == "XALG-7" {
+			linked = true
+		}
+	}
+	if !linked {
+		t.Fatal("expected a finding_ref evidence entry linking XALG-7")
+	}
+}
+
+func TestLinkFindingToLedgerNoOps(t *testing.T) {
+	ctxID := "report-link-noop-" + t.Name()
+	sc := scanctx.New(ctxID, "")
+	scanctx.Activate(sc)
+	defer scanctx.Deactivate(ctxID)
+	h := sc.Ledger.Upsert(scanctx.Hypothesis{VulnClass: "xss", Endpoint: "/x", Status: scanctx.HypothesisTesting})
+
+	// Empty hypothesis id → no-op, no link note, hypothesis unchanged.
+	if linkFindingToLedger(ctxID, "XALG-1", "") != "" {
+		t.Fatal("empty hypothesis id must be a no-op")
+	}
+	// Unknown hypothesis id → no-op (never fabricate a link).
+	if linkFindingToLedger(ctxID, "XALG-1", "H-999") != "" {
+		t.Fatal("unknown hypothesis id must be a no-op")
+	}
+	if got, _ := sc.Ledger.Get(h.ID); got.Status != scanctx.HypothesisTesting {
+		t.Fatalf("unrelated hypothesis must stay testing, got %q", got.Status)
+	}
+}

--- a/internal/tools/reporting/reporting.go
+++ b/internal/tools/reporting/reporting.go
@@ -302,6 +302,7 @@ func RegisterWithVerifier(r *tools.Registry, verifier FindingVerifier) {
 			{Name: "fix", Description: "CONCRETE fix — ideally a minimal code/config patch or diff the developer can apply directly (e.g. replace string-concatenated SQL with a parameterized query, add the missing authorization check, HTML-escape the output). Include the file/function when known from source. This is what makes the report actionable.", Required: false},
 			{Name: "cwe_id", Description: "CWE identifier if known, e.g. CWE-79 for XSS, CWE-89 for SQLi, CWE-78 for command injection", Required: false},
 			{Name: "owasp", Description: "OWASP Top 10 (2021) category if known, e.g. A03 for Injection, A01 for Broken Access Control", Required: false},
+			{Name: "hypothesis_id", Description: "Optional ledger hypothesis id this finding proves (e.g. H-3 from record_hypothesis / authz_matrix / verify_xss / verify_oob). On success the finding is linked to that hypothesis and it is marked proven — this satisfies the finish gate without a separate add_hypothesis_evidence call.", Required: false},
 		},
 		Execute: func(args map[string]string) (tools.Result, error) {
 			return reportVulnForRegistryWithVerifier(r, verifier, args)
@@ -664,7 +665,16 @@ If you cannot exploit it, downgrade severity to 'info' and report as information
 	// MergeVulnsToContext at session finalization does not lose it.
 	promoteIfChildOfWildcard(contextID, vuln.ID)
 
+	// Close the evidence loop: if the agent named the ledger hypothesis this
+	// finding proves, link the finding to it and mark it proven, so the
+	// precision finish-gate sees the proven work as reported without requiring
+	// a separate add_hypothesis_evidence call. Best-effort; never blocks report.
+	ledgerNote := linkFindingToLedger(contextID, vuln.ID, strings.TrimSpace(args["hypothesis_id"]))
+
 	msg := fmt.Sprintf("✅ Vulnerability reported: [%s] %s (%s | CVSS %.1f) — Verified: %v", vuln.ID, vuln.Title, strings.ToUpper(vuln.Severity), vuln.CVSS, vuln.Verified)
+	if ledgerNote != "" {
+		msg += "\n" + ledgerNote
+	}
 	if verifierConfirmed {
 		msg += "\n✅ Independently CONFIRMED by the verifier."
 	} else if exploitProven {
@@ -684,6 +694,32 @@ If you cannot exploit it, downgrade severity to 'info' and report as information
 		Output:   msg,
 		Metadata: map[string]any{"vuln_id": vuln.ID, "verified": vuln.Verified},
 	}, nil
+}
+
+// linkFindingToLedger links a persisted finding to the ledger hypothesis it
+// proves (when the agent supplied its id) and marks that hypothesis proven.
+// This closes the loop the precision finish-gate enforces. It is deterministic
+// (the agent names the exact hypothesis id — no fuzzy matching) and best-effort:
+// an empty or unknown id is a silent no-op so it can never fail a valid report.
+func linkFindingToLedger(contextID, findingID, hypID string) string {
+	hypID = strings.TrimSpace(hypID)
+	if hypID == "" || contextID == "" {
+		return ""
+	}
+	sc := scanctx.Get(contextID)
+	if sc == nil || sc.Ledger == nil {
+		return ""
+	}
+	if _, ok := sc.Ledger.Get(hypID); !ok {
+		return "" // unknown id (mistyped/foreign) — do not fabricate a link
+	}
+	sc.Ledger.AddEvidence(hypID, scanctx.Evidence{
+		Kind:      scanctx.EvidenceFindingRef,
+		FindingID: findingID,
+		Summary:   "Reported as finding " + findingID,
+	})
+	sc.Ledger.SetStatus(hypID, scanctx.HypothesisProven, "Reported as "+findingID)
+	return fmt.Sprintf("🔗 Linked to ledger hypothesis %s (marked proven).", hypID)
 }
 
 func duplicateResult(existing Vulnerability, msg string) tools.Result {


### PR DESCRIPTION
Closes the P1 precision-gate loop. `report_vulnerability` now accepts an optional `hypothesis_id`; on a successful report the finding is linked to that ledger hypothesis (finding_ref evidence) and the hypothesis is marked proven — resolving the 'proven but unreported' finish-gate without a separate `add_hypothesis_evidence` call. Deterministic (agent names the exact id from authz_matrix/verify_xss/verify_oob/record_hypothesis) and best-effort (empty/unknown id = silent no-op). Tests + green locally.