### PR TITLE
release: v4.6.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased] — Auto-link reported findings to their ledger hypothesis
+## [v4.6.11](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.11) — Auto-link reported findings to their ledger hypothesis (2026-09-01)
 
 ### Added
 - **`report_vulnerability` accepts an optional `hypothesis_id`.** When the agent reports a finding that proves a ledger hypothesis (its id comes straight from `authz_matrix` / `verify_xss` / `verify_oob` / `record_hypothesis`), the finding is linked to that hypothesis and the hypothesis is marked proven on a successful report — closing the loop the precision finish-gate enforces without a separate `add_hypothesis_evidence` call. The link is deterministic (the agent names the exact id, no fuzzy matching) and best-effort: an empty or unknown id is a silent no-op, so it can never fail a valid report.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.10
+VERSION=4.6.11
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.10"
+var version = "4.6.11"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.11 — report_vulnerability auto-links findings to their ledger hypothesis (optional hypothesis_id), closing the precision finish-gate loop. See CHANGELOG.md.