### PR TITLE
ingest_har: start scans from a real authenticated HAR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased] — Authenticated-context ingestion from HAR
+
+### Added
+- **`ingest_har` starts a scan from a real logged-in session.** Point it at a HAR captured while authenticated and it (1) registers the session credentials it carries (Authorization / Cookie / API-key headers) so subsequent `http_request` and `authz_matrix` calls are authenticated, and (2) seeds the ledger with the HAR's authenticated endpoints — the prime IDOR/BOLA surface — as role-scoped (`role=authenticated`) authorization hypotheses for the specialist to work. A new `internal/har` parser extracts the exercised endpoints (static assets skipped), their query/body parameters, and the session headers, with host-scope filtering. This gives Xalgorix the authenticated business-logic surface that unauthenticated crawling never reaches.
+
 ## [v4.6.11](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.11) — Auto-link reported findings to their ledger hypothesis (2026-09-01)
 
 ### Added

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -369,6 +369,11 @@ func NewAgent(cfg *config.Config, name string, events chan Event, localGuard sco
 	// request itself, so no scope gate is needed.
 	a.registerOOBVerifyTool(reg)
 
+	// Register HAR ingestion (ingest_har): turns a logged-in HAR into live
+	// authenticated scan context — registers session auth and seeds the ledger
+	// with authenticated-endpoint authorization hypotheses.
+	a.registerHARIngestTool(reg)
+
 	// Create cancellable context
 	a.ctx, a.cancel = context.WithCancel(a.ctx)
 	// Wire context to LLM client so cancel interrupts pending HTTP requests

--- a/internal/agent/har_ingest.go
+++ b/internal/agent/har_ingest.go
@@ -1,0 +1,148 @@
+// Package agent — har_ingest.go implements ingest_har: it turns a recorded,
+// logged-in HAR into live authenticated scan context.
+//
+// Starting from a real session is the single biggest practical advantage an
+// autonomous web scanner can have: the HAR hands over the exact endpoints,
+// parameters, and session credentials a real user exercised, so the agent tests
+// authenticated, business-logic surface instead of rediscovering everything
+// from an unauthenticated URL. ingest_har (1) registers the HAR's session auth
+// so subsequent http_request / authz_matrix calls are authenticated, and
+// (2) seeds the ledger with authorization hypotheses for the authenticated
+// endpoints — the prime IDOR/BOLA surface — so the authz specialist has
+// concrete, role-scoped targets to work.
+package agent
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/xalgord/xalgorix/v4/internal/har"
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+	"github.com/xalgord/xalgorix/v4/internal/tools"
+	"github.com/xalgord/xalgorix/v4/internal/tools/httpclient"
+)
+
+const (
+	maxHARBytes    = 64 << 20 // 64 MB cap on the HAR file
+	maxHARSeed     = 25       // cap on ledger hypotheses seeded from a HAR
+	authRole       = "authenticated"
+	harHypEndpoint = "idor" // authenticated endpoints are the IDOR/BOLA surface
+)
+
+// harIngestSummary is the structured outcome of an ingest.
+type harIngestSummary struct {
+	Endpoints       int
+	AuthHeaderNames []string
+	Seeded          int
+}
+
+func (a *Agent) registerHARIngestTool(reg *tools.Registry) {
+	reg.Register(&tools.Tool{
+		Name:        "ingest_har",
+		Description: "Ingest a recorded, logged-in HAR file to start testing from a real authenticated session. Give it the path to a HAR captured while logged in and exercising the app. It (1) registers the session credentials (Authorization/Cookie/API-key headers) so your subsequent http_request and authz_matrix calls are authenticated, and (2) seeds the ledger with authenticated endpoints (the prime IDOR/BOLA surface) as role-scoped hypotheses for the authorization specialist. Use this at the start of an authenticated assessment when a HAR is available.",
+		Parameters: []tools.Parameter{
+			{Name: "path", Description: "Filesystem path to the HAR file captured from the authenticated session.", Required: true},
+			{Name: "target", Description: "Optional target host to scope endpoints to (e.g. app.example.com). Endpoints on other hosts in the HAR are ignored. Omit to ingest all.", Required: false},
+		},
+		Execute: a.harIngestTool,
+	})
+}
+
+func (a *Agent) harIngestTool(args map[string]string) (tools.Result, error) {
+	path := strings.TrimSpace(args["path"])
+	if path == "" {
+		return tools.Result{Error: "path is required (the HAR file captured from the authenticated session)"}, nil
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return tools.Result{Error: fmt.Sprintf("cannot read HAR %q: %v", path, err)}, nil
+	}
+	if info.Size() > maxHARBytes {
+		return tools.Result{Error: fmt.Sprintf("HAR is too large (%d bytes, max %d)", info.Size(), maxHARBytes)}, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return tools.Result{Error: fmt.Sprintf("cannot read HAR %q: %v", path, err)}, nil
+	}
+	h, err := har.Parse(data)
+	if err != nil {
+		return tools.Result{Error: err.Error()}, nil
+	}
+
+	sum := a.seedFromHAR(h, strings.TrimSpace(args["target"]))
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Ingested HAR: %d authenticated endpoint(s).\n", sum.Endpoints)
+	if len(sum.AuthHeaderNames) > 0 {
+		fmt.Fprintf(&b, "Session auth registered (%s) — your http_request and authz_matrix calls are now authenticated for this scan.\n", strings.Join(sum.AuthHeaderNames, ", "))
+	} else {
+		b.WriteString("No session credentials found in the HAR — testing continues unauthenticated. Re-capture the HAR while logged in if authenticated coverage is needed.\n")
+	}
+	if sum.Seeded > 0 {
+		fmt.Fprintf(&b, "Seeded %d authorization hypotheses (role=%s) into the ledger. Use read_ledger(filter=schedulable) and authz_matrix to test cross-role access on these endpoints.", sum.Seeded, authRole)
+	}
+	return tools.Result{Output: b.String(), Metadata: map[string]any{"endpoints": sum.Endpoints, "seeded": sum.Seeded}}, nil
+}
+
+// seedFromHAR registers the HAR's session auth and seeds the ledger with
+// bounded, role-scoped authorization hypotheses. Split from harIngestTool so it
+// is unit-testable with a parsed HAR and no filesystem.
+func (a *Agent) seedFromHAR(h *har.HAR, targetHost string) harIngestSummary {
+	var sum harIngestSummary
+
+	// (1) Register session auth for this scan context.
+	if a.scanCtx != nil {
+		if auth := h.AuthHeaders(); len(auth) > 0 {
+			httpclient.SetSessionAuth(a.scanCtx.ID, auth)
+			for name := range auth {
+				sum.AuthHeaderNames = append(sum.AuthHeaderNames, name)
+			}
+			sortStrings(sum.AuthHeaderNames)
+		}
+	}
+
+	// (2) Seed authorization hypotheses for the authenticated endpoints.
+	endpoints := h.InScopeEndpoints(targetHost)
+	sum.Endpoints = len(endpoints)
+	l := a.ledger()
+	if l == nil {
+		return sum
+	}
+	for _, e := range endpoints {
+		if sum.Seeded >= maxHARSeed {
+			break
+		}
+		param := ""
+		if len(e.Params) > 0 {
+			param = e.Params[0]
+		}
+		before := l.Len()
+		l.Upsert(scanctx.Hypothesis{
+			Title:      "Authenticated endpoint " + e.Method + " " + e.Path,
+			VulnClass:  harHypEndpoint,
+			Target:     e.Host,
+			Endpoint:   e.Path,
+			Parameter:  param,
+			Role:       authRole,
+			Confidence: 0.4,
+			Status:     scanctx.HypothesisQueued,
+			Origin:     "har",
+			NextAction: "Test cross-role/object access with authz_matrix (role A vs role B vs anonymous) on this authenticated endpoint.",
+		})
+		if l.Len() > before {
+			sum.Seeded++
+		}
+	}
+	return sum
+}
+
+// sortStrings is a tiny helper to keep summaries deterministic without pulling
+// sort into this file's import set for a single call site.
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}

--- a/internal/agent/har_ingest_test.go
+++ b/internal/agent/har_ingest_test.go
@@ -1,0 +1,67 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/har"
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+	"github.com/xalgord/xalgorix/v4/internal/tools/httpclient"
+)
+
+const harIngestSample = `{"log":{"entries":[
+ {"request":{"method":"GET","url":"https://app.example.com/api/orders?id=42","headers":[{"name":"Authorization","value":"Bearer TOKEN"}],"queryString":[{"name":"id","value":"42"}]}},
+ {"request":{"method":"GET","url":"https://app.example.com/api/users/7","headers":[{"name":"Cookie","value":"session=abc"}]}},
+ {"request":{"method":"GET","url":"https://cdn.other.com/lib.js","headers":[]}}
+]}}`
+
+func TestSeedFromHAR(t *testing.T) {
+	ctxID := "har-seed-" + t.Name()
+	ag := &Agent{scanCtx: scanctx.New(ctxID, "")}
+
+	h, err := har.Parse([]byte(harIngestSample))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	sum := ag.seedFromHAR(h, "app.example.com")
+
+	// Two in-scope endpoints (cdn .js skipped).
+	if sum.Endpoints != 2 {
+		t.Fatalf("expected 2 in-scope endpoints, got %d", sum.Endpoints)
+	}
+	if sum.Seeded != 2 {
+		t.Fatalf("expected 2 seeded hypotheses, got %d", sum.Seeded)
+	}
+
+	// Session auth registered for the context (Authorization + Cookie merged).
+	auth := httpclient.SessionAuthForContext(ctxID)
+	if auth["Authorization"] != "Bearer TOKEN" || auth["Cookie"] != "session=abc" {
+		t.Fatalf("expected merged session auth registered, got %#v", auth)
+	}
+
+	// Ledger seeded with role-scoped authorization hypotheses.
+	all := ag.scanCtx.Ledger.All()
+	if len(all) != 2 {
+		t.Fatalf("expected 2 ledger hypotheses, got %d", len(all))
+	}
+	for _, hyp := range all {
+		if hyp.Role != authRole {
+			t.Fatalf("expected role %q, got %q", authRole, hyp.Role)
+		}
+		if hyp.VulnClass != harHypEndpoint {
+			t.Fatalf("expected class %q, got %q", harHypEndpoint, hyp.VulnClass)
+		}
+		if hyp.Origin != "har" {
+			t.Fatalf("expected origin har, got %q", hyp.Origin)
+		}
+	}
+}
+
+func TestHarIngestToolMissingPath(t *testing.T) {
+	ag := &Agent{scanCtx: scanctx.New("har-nopath-"+t.Name(), "")}
+	if res, _ := ag.harIngestTool(map[string]string{}); res.Error == "" {
+		t.Fatal("expected an error when path is missing")
+	}
+	if res, _ := ag.harIngestTool(map[string]string{"path": "/nonexistent/does-not-exist.har"}); res.Error == "" {
+		t.Fatal("expected an error when the HAR file cannot be read")
+	}
+}

--- a/internal/har/har.go
+++ b/internal/har/har.go
@@ -1,0 +1,273 @@
+// Package har parses HTTP Archive (HAR) files into the authenticated-context
+// signals a security assessment needs: the endpoints actually exercised, the
+// parameters seen on them, and the session credentials carried in the requests.
+//
+// This is the foundation for the biggest practical edge an autonomous scanner
+// can have — starting from a real, logged-in session instead of rediscovering
+// everything from an unauthenticated URL. The agent's ingest_har tool feeds the
+// output here into the scan's session auth and the hypothesis ledger.
+package har
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// HAR is the minimal subset of the HAR 1.2 schema we consume.
+type HAR struct {
+	Log struct {
+		Entries []Entry `json:"entries"`
+	} `json:"log"`
+}
+
+// Entry is one recorded request/response pair.
+type Entry struct {
+	Request Request `json:"request"`
+}
+
+// Request is the recorded request.
+type Request struct {
+	Method      string      `json:"method"`
+	URL         string      `json:"url"`
+	Headers     []NameValue `json:"headers"`
+	QueryString []NameValue `json:"queryString"`
+	Cookies     []NameValue `json:"cookies"`
+	PostData    *PostData   `json:"postData,omitempty"`
+}
+
+// PostData is the request body descriptor.
+type PostData struct {
+	MimeType string      `json:"mimeType"`
+	Text     string      `json:"text"`
+	Params   []NameValue `json:"params"`
+}
+
+// NameValue is a HAR name/value pair (header, query param, cookie, post param).
+type NameValue struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// EndpointInfo is one unique (method, scheme://host/path) surface with the
+// union of parameter names observed on it.
+type EndpointInfo struct {
+	Method string
+	URL    string // scheme://host/path (no query)
+	Host   string
+	Path   string
+	Params []string
+}
+
+// authHeaderNames are request headers that carry a session/identity and are
+// worth replaying so the scan is authenticated. Matched case-insensitively.
+var authHeaderNames = map[string]bool{
+	"authorization":       true,
+	"cookie":              true,
+	"x-api-key":           true,
+	"x-auth-token":        true,
+	"x-access-token":      true,
+	"x-csrf-token":        true,
+	"x-xsrf-token":        true,
+	"authentication":      true,
+	"proxy-authorization": true,
+}
+
+// Parse decodes HAR bytes. It tolerates the common wrapping where the HAR is a
+// bare {"log":{...}} object.
+func Parse(data []byte) (*HAR, error) {
+	var h HAR
+	if err := json.Unmarshal(data, &h); err != nil {
+		return nil, fmt.Errorf("invalid HAR JSON: %w", err)
+	}
+	if len(h.Log.Entries) == 0 {
+		return nil, fmt.Errorf("HAR contains no entries")
+	}
+	return &h, nil
+}
+
+// Endpoints returns the unique (method, scheme://host/path) surfaces with the
+// union of parameter names (query + body) seen on each, sorted for stability.
+// Static asset requests (images/fonts/styles/scripts) are skipped — they are
+// not interesting attack surface.
+func (h *HAR) Endpoints() []EndpointInfo {
+	type acc struct {
+		info   EndpointInfo
+		params map[string]bool
+	}
+	byKey := map[string]*acc{}
+	var order []string
+
+	for i := range h.Log.Entries {
+		req := h.Log.Entries[i].Request
+		u, err := url.Parse(strings.TrimSpace(req.URL))
+		if err != nil || u.Host == "" {
+			continue
+		}
+		if isStaticAssetPath(u.Path) {
+			continue
+		}
+		method := strings.ToUpper(strings.TrimSpace(req.Method))
+		if method == "" {
+			method = "GET"
+		}
+		base := u.Scheme + "://" + u.Host + u.Path
+		key := method + " " + base
+		a := byKey[key]
+		if a == nil {
+			a = &acc{
+				info:   EndpointInfo{Method: method, URL: base, Host: u.Host, Path: u.Path},
+				params: map[string]bool{},
+			}
+			byKey[key] = a
+			order = append(order, key)
+		}
+		for _, q := range req.QueryString {
+			if n := strings.TrimSpace(q.Name); n != "" {
+				a.params[n] = true
+			}
+		}
+		// Query params embedded in the URL but not in queryString.
+		for n := range u.Query() {
+			if n = strings.TrimSpace(n); n != "" {
+				a.params[n] = true
+			}
+		}
+		if req.PostData != nil {
+			for _, p := range req.PostData.Params {
+				if n := strings.TrimSpace(p.Name); n != "" {
+					a.params[n] = true
+				}
+			}
+			// JSON body keys (top level) are useful parameters too.
+			for _, n := range topLevelJSONKeys(req.PostData) {
+				a.params[n] = true
+			}
+		}
+	}
+
+	sort.Strings(order)
+	out := make([]EndpointInfo, 0, len(order))
+	for _, key := range order {
+		a := byKey[key]
+		params := make([]string, 0, len(a.params))
+		for p := range a.params {
+			params = append(params, p)
+		}
+		sort.Strings(params)
+		a.info.Params = params
+		out = append(out, a.info)
+	}
+	return out
+}
+
+// AuthHeaders returns the session/identity headers to replay, taken from the
+// most recent entry that carries any (later entries reflect the fully
+// authenticated state). Cookies are assembled from the Cookies array when no
+// explicit Cookie header is present.
+func (h *HAR) AuthHeaders() map[string]string {
+	merged := map[string]string{}
+	for i := range h.Log.Entries {
+		req := h.Log.Entries[i].Request
+		for _, hdr := range req.Headers {
+			name := strings.ToLower(strings.TrimSpace(hdr.Name))
+			if authHeaderNames[name] && strings.TrimSpace(hdr.Value) != "" {
+				// Accumulate across entries; a later entry's value for the same
+				// header wins (reflecting the freshest authenticated state).
+				merged[canonicalHeader(hdr.Name)] = hdr.Value
+			}
+		}
+		if _, hasCookie := merged["Cookie"]; !hasCookie && len(req.Cookies) > 0 {
+			var parts []string
+			for _, c := range req.Cookies {
+				if strings.TrimSpace(c.Name) != "" {
+					parts = append(parts, c.Name+"="+c.Value)
+				}
+			}
+			if len(parts) > 0 {
+				merged["Cookie"] = strings.Join(parts, "; ")
+			}
+		}
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
+}
+
+// InScopeEndpoints filters endpoints to those whose host matches (or is a
+// subdomain of) the given target host. An empty target returns all endpoints.
+func (h *HAR) InScopeEndpoints(targetHost string) []EndpointInfo {
+	targetHost = strings.ToLower(strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(targetHost, "https://"), "http://")))
+	if i := strings.IndexByte(targetHost, '/'); i >= 0 {
+		targetHost = targetHost[:i]
+	}
+	if h2, _, err := splitHostPort(targetHost); err == nil {
+		targetHost = h2
+	}
+	all := h.Endpoints()
+	if targetHost == "" {
+		return all
+	}
+	out := make([]EndpointInfo, 0, len(all))
+	for _, e := range all {
+		host := strings.ToLower(e.Host)
+		if hh, _, err := splitHostPort(host); err == nil {
+			host = hh
+		}
+		if host == targetHost || strings.HasSuffix(host, "."+targetHost) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// --- helpers ---
+
+func canonicalHeader(name string) string {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "authorization":
+		return "Authorization"
+	case "cookie":
+		return "Cookie"
+	default:
+		return strings.TrimSpace(name)
+	}
+}
+
+func isStaticAssetPath(p string) bool {
+	p = strings.ToLower(p)
+	for _, ext := range []string{".css", ".js", ".png", ".jpg", ".jpeg", ".gif", ".svg", ".ico", ".woff", ".woff2", ".ttf", ".map", ".webp", ".mp4", ".pdf"} {
+		if strings.HasSuffix(p, ext) {
+			return true
+		}
+	}
+	return false
+}
+
+func topLevelJSONKeys(pd *PostData) []string {
+	if pd == nil || !strings.Contains(strings.ToLower(pd.MimeType), "json") {
+		return nil
+	}
+	var m map[string]json.RawMessage
+	if json.Unmarshal([]byte(pd.Text), &m) != nil {
+		return nil
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// splitHostPort is net.SplitHostPort with a nil-safe wrapper that returns the
+// host unchanged when there is no port.
+func splitHostPort(hostport string) (host, port string, err error) {
+	if !strings.Contains(hostport, ":") {
+		return hostport, "", nil
+	}
+	i := strings.LastIndexByte(hostport, ':')
+	return hostport[:i], hostport[i+1:], nil
+}

--- a/internal/har/har_test.go
+++ b/internal/har/har_test.go
@@ -1,0 +1,79 @@
+package har
+
+import "testing"
+
+const sampleHAR = `{"log":{"entries":[
+ {"request":{"method":"GET","url":"https://app.example.com/api/orders?id=42","headers":[{"name":"Authorization","value":"Bearer TOKEN"},{"name":"Accept","value":"*/*"}],"queryString":[{"name":"id","value":"42"}],"cookies":[{"name":"session","value":"abc"}]}},
+ {"request":{"method":"POST","url":"https://app.example.com/api/orders","headers":[{"name":"Cookie","value":"session=abc"}],"postData":{"mimeType":"application/json","text":"{\"item\":\"x\",\"qty\":2}"}}},
+ {"request":{"method":"GET","url":"https://app.example.com/static/app.js","headers":[]}},
+ {"request":{"method":"GET","url":"https://cdn.other.com/lib.js","headers":[]}}
+]}}`
+
+func TestParseAndEndpoints(t *testing.T) {
+	h, err := Parse([]byte(sampleHAR))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	eps := h.Endpoints()
+	// Two API endpoints (GET + POST /api/orders); static .js requests skipped.
+	if len(eps) != 2 {
+		t.Fatalf("expected 2 endpoints (static assets skipped), got %d: %+v", len(eps), eps)
+	}
+	var get, post *EndpointInfo
+	for i := range eps {
+		switch eps[i].Method {
+		case "GET":
+			get = &eps[i]
+		case "POST":
+			post = &eps[i]
+		}
+	}
+	if get == nil || post == nil {
+		t.Fatalf("expected GET and POST endpoints, got %+v", eps)
+	}
+	if get.URL != "https://app.example.com/api/orders" || !hasParam(get.Params, "id") {
+		t.Fatalf("GET endpoint wrong: %+v", get)
+	}
+	if !hasParam(post.Params, "item") || !hasParam(post.Params, "qty") {
+		t.Fatalf("expected POST JSON body keys item+qty, got %+v", post.Params)
+	}
+}
+
+func TestAuthHeadersMerged(t *testing.T) {
+	h, _ := Parse([]byte(sampleHAR))
+	auth := h.AuthHeaders()
+	if auth["Authorization"] != "Bearer TOKEN" {
+		t.Fatalf("expected merged Authorization header, got %q", auth["Authorization"])
+	}
+	if auth["Cookie"] != "session=abc" {
+		t.Fatalf("expected Cookie header, got %q", auth["Cookie"])
+	}
+}
+
+func TestInScopeEndpoints(t *testing.T) {
+	h, _ := Parse([]byte(sampleHAR))
+	if n := len(h.InScopeEndpoints("app.example.com")); n != 2 {
+		t.Fatalf("expected 2 in-scope endpoints for app.example.com, got %d", n)
+	}
+	if n := len(h.InScopeEndpoints("nope.com")); n != 0 {
+		t.Fatalf("expected 0 endpoints for an out-of-scope host, got %d", n)
+	}
+}
+
+func TestParseRejectsEmpty(t *testing.T) {
+	if _, err := Parse([]byte(`{"log":{"entries":[]}}`)); err == nil {
+		t.Fatal("expected error for a HAR with no entries")
+	}
+	if _, err := Parse([]byte(`not json`)); err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func hasParam(ps []string, want string) bool {
+	for _, p := range ps {
+		if p == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tools/httpclient/sessionauth.go
+++ b/internal/tools/httpclient/sessionauth.go
@@ -37,6 +37,13 @@ func SetSessionAuth(contextID string, headers map[string]string) {
 	sessionAuth[contextID] = cp
 }
 
+// SessionAuthForContext returns a copy of the registered session-auth headers
+// for a context (or nil). Exported for callers that register auth from an
+// external source (e.g. HAR ingestion) and want to confirm what was applied.
+func SessionAuthForContext(contextID string) map[string]string {
+	return getSessionAuth(contextID)
+}
+
 // getSessionAuth returns a copy of the auth headers for a context (or nil).
 func getSessionAuth(contextID string) map[string]string {
 	sessionAuthMu.RLock()


### PR DESCRIPTION
Adds authenticated-context ingestion — the biggest practical edge an autonomous scanner can have (BugBunny's core input).

## What
- **`internal/har` parser**: extracts exercised endpoints (static assets skipped) + query/body params, and session headers (Authorization/Cookie/API-key) merged across entries, with subdomain-aware host scoping.
- **`ingest_har` (Agent-bound tool)**: reads a HAR path (64MB cap), registers the session credentials via `httpclient.SetSessionAuth` so subsequent `http_request`/`authz_matrix` calls are authenticated, and seeds the ledger with the authenticated endpoints (prime IDOR/BOLA surface) as `role=authenticated` authorization hypotheses (bounded to 25) for the specialist.
- Exported `httpclient.SessionAuthForContext` for introspection/testing.

## Why
Authenticated business-logic surface is exactly what unauthenticated crawling never reaches. This wires a logged-in HAR straight into session auth + the evidence-driven ledger + authz_matrix.

## Tests
Parser (endpoints/params/auth-merge/scope/reject-empty) + seedFromHAR (auth registered, bounded role-scoped hypotheses) + tool error paths. Build, gofmt, vet, lint, full agent suite green.

Builds on v4.6.11 (base main).