### PR TITLE
release: v4.6.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased] — Authenticated-context ingestion from HAR
+## [v4.6.12](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.12) — Authenticated-context ingestion from HAR (2026-09-01)
 
 ### Added
 - **`ingest_har` starts a scan from a real logged-in session.** Point it at a HAR captured while authenticated and it (1) registers the session credentials it carries (Authorization / Cookie / API-key headers) so subsequent `http_request` and `authz_matrix` calls are authenticated, and (2) seeds the ledger with the HAR's authenticated endpoints — the prime IDOR/BOLA surface — as role-scoped (`role=authenticated`) authorization hypotheses for the specialist to work. A new `internal/har` parser extracts the exercised endpoints (static assets skipped), their query/body parameters, and the session headers, with host-scope filtering. This gives Xalgorix the authenticated business-logic surface that unauthenticated crawling never reaches.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.11
+VERSION=4.6.12
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.11"
+var version = "4.6.12"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.12 — Authenticated-context ingestion from HAR.

Bumps version (main.go, Makefile) and promotes the CHANGELOG [Unreleased] section to v4.6.12.

Ships `ingest_har` (merged in #503): start a scan from a real logged-in session — registers the HAR's session credentials so testing is authenticated, and seeds the ledger with the authenticated endpoints (prime IDOR/BOLA surface) as role-scoped authorization hypotheses feeding authz_matrix.