### PR TITLE
authz_matrix: adopt an ingested HAR session as role A

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased] — Ingested session drives the authorization matrix
+
+### Changed
+- **An ingested authenticated session now powers `authz_matrix` directly.** When a scan's credentials come from a logged-in HAR (`ingest_har`) rather than a separately configured operator account, `authz_matrix` now adopts that session as role A. Previously the HAR seeded IDOR/BOLA hypotheses but the matrix meant to test them saw only anonymous access and refused to run — so the authenticated surface never got exercised. Role A is the operator account when one is configured (unchanged, deterministic precedence) and otherwise the ingested session, closing the loop from `ingest_har` → session auth → cross-identity access-control testing.
+
 ## [v4.6.12](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.12) — Authenticated-context ingestion from HAR (2026-09-01)
 
 ### Added

--- a/internal/agent/authz_matrix.go
+++ b/internal/agent/authz_matrix.go
@@ -49,7 +49,7 @@ type authzResult struct {
 func (a *Agent) registerAuthzMatrixTool(reg *tools.Registry) {
 	reg.Register(&tools.Tool{
 		Name:        "authz_matrix",
-		Description: "Test access control by replaying ONE request as every configured identity — your primary session (role A), a second account (role B) if the scan has one, and anonymous (no credentials) — then report the differential. This is the definitive check for IDOR/BOLA (a second user reading role A's object) and auth bypass/BFLA (anonymous reaching a protected resource). Point it at a resource that SHOULD be restricted to role A (e.g. role A's own object by id); if a lower identity gets the same successful response, that is broken access control. Positive signals are recorded as role-scoped hypotheses in the ledger with the differential as proof.",
+		Description: "Test access control by replaying ONE request as every configured identity — your primary session (role A; from configured target auth, or a logged-in HAR registered via ingest_har), a second account (role B) if the scan has one, and anonymous (no credentials) — then report the differential. This is the definitive check for IDOR/BOLA (a second user reading role A's object) and auth bypass/BFLA (anonymous reaching a protected resource). Point it at a resource that SHOULD be restricted to role A (e.g. role A's own object by id); if a lower identity gets the same successful response, that is broken access control. Positive signals are recorded as role-scoped hypotheses in the ledger with the differential as proof.",
 		Parameters: []tools.Parameter{
 			{Name: "url", Description: "URL of the object/action under test, ideally one owned by/authorized for role A (e.g. https://app/api/orders/1042).", Required: true},
 			{Name: "method", Description: "HTTP method (default GET).", Required: false},
@@ -101,7 +101,7 @@ func (a *Agent) authzMatrixTool(args map[string]string) (tools.Result, error) {
 
 	identities := a.authzIdentities()
 	if len(identities) < 2 {
-		return tools.Result{Output: "authz_matrix needs at least two identities to compare, but this scan only has anonymous access configured. Provide a primary session (target auth) and ideally a second account so the matrix can reveal a cross-identity access-control difference."}, nil
+		return tools.Result{Output: "authz_matrix needs at least two identities to compare, but this scan only has anonymous access configured. Provide a primary session — configure target auth, or run ingest_har on a logged-in HAR to register one — and ideally a second account, so the matrix can reveal a cross-identity access-control difference."}, nil
 	}
 
 	var delay time.Duration
@@ -132,16 +132,35 @@ func (a *Agent) authzMatrixTool(args map[string]string) (tools.Result, error) {
 
 // authzIdentities returns the identities to test, highest privilege first.
 // Anonymous is always included; role A/B only when their credentials are set.
+//
+// Role A is the operator-configured primary account (a.targetAuth) when set;
+// otherwise it falls back to the scan's authenticated session — the credentials
+// registered by ingest_har from a logged-in HAR. Without that fallback an
+// authenticated HAR would seed IDOR/BOLA hypotheses but the matrix meant to
+// test them would have only anonymous access and refuse to run.
 func (a *Agent) authzIdentities() []authzIdentity {
 	var ids []authzIdentity
 	if hdrs := httpclient.ParseAuthHeaders(a.targetAuth); len(hdrs) > 0 {
 		ids = append(ids, authzIdentity{label: "primary session (role A)", role: "role-a", headers: hdrs})
+	} else if hdrs := a.sessionAuthHeaders(); len(hdrs) > 0 {
+		ids = append(ids, authzIdentity{label: "primary session (role A, ingested)", role: "role-a", headers: hdrs})
 	}
 	if hdrs := httpclient.ParseAuthHeaders(a.targetAuthB); len(hdrs) > 0 {
 		ids = append(ids, authzIdentity{label: "second account (role B)", role: "role-b", headers: hdrs})
 	}
 	ids = append(ids, authzIdentity{label: "anonymous", role: "anonymous", headers: nil})
 	return ids
+}
+
+// sessionAuthHeaders returns the authenticated-session headers registered for
+// this scan context (e.g. by ingest_har), or nil when none. This lets the
+// authorization matrix adopt an ingested session as role A when the operator
+// did not configure a separate primary account.
+func (a *Agent) sessionAuthHeaders() map[string]string {
+	if a.scanCtx == nil {
+		return nil
+	}
+	return httpclient.SessionAuthForContext(a.scanCtx.ID)
 }
 
 // analyzeAuthzMatrix compares each identity against the authorized baseline

--- a/internal/agent/authz_matrix_test.go
+++ b/internal/agent/authz_matrix_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/xalgord/xalgorix/v4/internal/scanctx"
 	"github.com/xalgord/xalgorix/v4/internal/scopeguard"
+	"github.com/xalgord/xalgorix/v4/internal/tools/httpclient"
 )
 
 // authzTestServer returns a server with a /broken endpoint (no authorization
@@ -140,5 +141,69 @@ func TestAuthzMatrixNeedsTwoIdentities(t *testing.T) {
 	}
 	if !strings.Contains(res.Output, "at least two identities") {
 		t.Fatalf("expected a two-identities-required message, got:\n%s", res.Output)
+	}
+}
+
+// TestAuthzIdentitiesUsesIngestedSessionAsRoleA verifies that when no operator
+// account is configured, the scan's ingested authenticated session (registered
+// via httpclient.SetSessionAuth, e.g. by ingest_har) becomes role A.
+func TestAuthzIdentitiesUsesIngestedSessionAsRoleA(t *testing.T) {
+	ag := &Agent{scanCtx: scanctx.New("authz-session-"+t.Name(), ""), ctx: context.Background()}
+	httpclient.SetSessionAuth(ag.scanCtx.ID, map[string]string{"Authorization": "Bearer SESSION"})
+	defer httpclient.SetSessionAuth(ag.scanCtx.ID, nil)
+
+	ids := ag.authzIdentities()
+	if len(ids) != 2 {
+		t.Fatalf("expected role-a (from ingested session) + anonymous, got %d identities: %+v", len(ids), ids)
+	}
+	if ids[0].role != "role-a" || ids[0].headers["Authorization"] != "Bearer SESSION" {
+		t.Fatalf("expected role-a carrying the ingested session, got %+v", ids[0])
+	}
+	if ids[1].role != "anonymous" || ids[1].headers != nil {
+		t.Fatalf("expected anonymous with no headers, got %+v", ids[1])
+	}
+}
+
+// TestAuthzIdentitiesPrefersOperatorAuthOverSession verifies deterministic
+// precedence: a configured operator account is role A even when an ingested
+// session also exists, and the session is not double-added.
+func TestAuthzIdentitiesPrefersOperatorAuthOverSession(t *testing.T) {
+	ag := &Agent{targetAuth: "Authorization: Bearer OPERATOR", scanCtx: scanctx.New("authz-prec-"+t.Name(), ""), ctx: context.Background()}
+	httpclient.SetSessionAuth(ag.scanCtx.ID, map[string]string{"Authorization": "Bearer SESSION"})
+	defer httpclient.SetSessionAuth(ag.scanCtx.ID, nil)
+
+	ids := ag.authzIdentities()
+	if len(ids) != 2 {
+		t.Fatalf("expected role-a (operator) + anonymous, got %d identities: %+v", len(ids), ids)
+	}
+	if ids[0].role != "role-a" || ids[0].headers["Authorization"] != "Bearer OPERATOR" {
+		t.Fatalf("expected role-a to use the operator account, got %+v", ids[0])
+	}
+}
+
+// TestAuthzMatrixRunsWithIngestedSession is the end-to-end proof: with only an
+// ingested session (no operator accounts), the matrix runs and flags /broken —
+// anonymous receives the same owner record as the authenticated session.
+func TestAuthzMatrixRunsWithIngestedSession(t *testing.T) {
+	srv := authzTestServer()
+	defer srv.Close()
+	ag := newAuthzAgent(t, true)
+	ag.targetAuth = ""
+	ag.targetAuthB = ""
+	httpclient.SetSessionAuth(ag.scanCtx.ID, map[string]string{"Authorization": "Bearer AAA"})
+	defer httpclient.SetSessionAuth(ag.scanCtx.ID, nil)
+
+	res, err := ag.authzMatrixTool(map[string]string{"url": srv.URL + "/broken", "parameter": "id"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(res.Output, "at least two identities") {
+		t.Fatalf("expected the matrix to run with an ingested session, got:\n%s", res.Output)
+	}
+	if !strings.Contains(res.Output, "likely broken access control") {
+		t.Fatalf("expected a broken-access-control verdict, got:\n%s", res.Output)
+	}
+	if got, _ := res.Metadata["recorded_hypotheses"].(int); got != 1 {
+		t.Fatalf("expected 1 recorded hypothesis (anonymous vs ingested role A), got %v", res.Metadata["recorded_hypotheses"])
 	}
 }


### PR DESCRIPTION
Closes the loop between `ingest_har` (v4.6.12) and `authz_matrix`.

## Problem
`ingest_har` registers a logged-in HAR's session (`httpclient.SetSessionAuth`) and seeds `role=authenticated` IDOR/BOLA hypotheses. But `authz_matrix` built **role A** only from the operator-configured account (`a.targetAuth`). When the HAR was the *sole* source of auth, the matrix saw only anonymous access and refused to run ("needs at least two identities") — so the authenticated surface the HAR unlocked was never exercised.

## Change
`authzIdentities()` now falls back to the scan's session auth (`httpclient.SessionAuthForContext(a.scanCtx.ID)`) as role A when `a.targetAuth` is empty. A configured operator account keeps **deterministic precedence**; the session is not double-added when both exist. Also updated the too-few-identities hint and the tool description to point at `ingest_har`.

Net effect: `ingest_har` -> session auth -> cross-identity access-control testing (IDOR/BOLA/auth-bypass) now works end-to-end from a HAR alone.

## Tests
- `authzIdentities` adopts the ingested session as role A (session-only scan).
- Operator auth takes precedence over an ingested session.
- End-to-end: `authz_matrix` runs with only an ingested session and flags a broken-access-control endpoint.

Build, gofmt, vet, lint, full agent + httpclient suites green. Base main (v4.6.12).