### PR TITLE
release: v4.6.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased] — Ingested session drives the authorization matrix
+## [v4.6.13](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.13) — Ingested session drives the authorization matrix (2026-09-01)
 
 ### Changed
 - **An ingested authenticated session now powers `authz_matrix` directly.** When a scan's credentials come from a logged-in HAR (`ingest_har`) rather than a separately configured operator account, `authz_matrix` now adopts that session as role A. Previously the HAR seeded IDOR/BOLA hypotheses but the matrix meant to test them saw only anonymous access and refused to run — so the authenticated surface never got exercised. Role A is the operator account when one is configured (unchanged, deterministic precedence) and otherwise the ingested session, closing the loop from `ingest_har` → session auth → cross-identity access-control testing.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.12
+VERSION=4.6.13
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.12"
+var version = "4.6.13"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.13 — Ingested session drives the authorization matrix.

Bumps version (main.go, Makefile) and promotes the CHANGELOG [Unreleased] section to v4.6.13.

Ships the fix from #505: authz_matrix now adopts an ingested HAR session (ingest_har) as role A when no separate operator account is configured, so an authenticated HAR actually drives IDOR/BOLA/auth-bypass testing.