### PR TITLE
Seed the hypothesis ledger from uploaded scan-context artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased] — Uploaded context seeds the hypothesis ledger
+
+### Changed
+- **Uploaded scan-context artifacts now seed the hypothesis ledger, not just a briefing.** When a scan starts with an OpenAPI/Swagger spec, HAR, Postman collection, or Burp export, Xalgorix already parsed it into a normalized endpoint surface and registered any captured session — but the endpoints only appeared as a passive text briefing. They now also become bounded, role-scoped authorization hypotheses (the prime IDOR/BOLA surface) in the shared ledger, so the operator-supplied surface directly drives `authz_matrix` and the evidence-driven specialists instead of relying on the model to re-derive targets from prose. Role is `authenticated` when the artifact carried a live session, otherwise `anonymous`. Seeding is deduplicated (by class/endpoint/parameter/role) and bounded, so it never floods the scheduler or double-counts across sub-agents. This mirrors what `ingest_har` does mid-scan, now applied to every context upload at scan start.
+
 ## [v4.6.13](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.13) — Ingested session drives the authorization matrix (2026-09-01)
 
 ### Changed

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1688,8 +1688,18 @@ func (a *Agent) prepareScanEnvironment() {
 					}
 				}
 			}
+			// Turn the parsed surface into schedulable ledger hypotheses so the
+			// uploaded context drives authz_matrix and the specialists, not just
+			// the text briefing. Idempotent (the ledger dedups), so sub-agents
+			// that also parse the context add nothing new.
+			seeded := a.seedLedgerFromSurface(res)
 			if a.scanContextBriefing != "" {
-				a.emit(Event{Type: "message", Content: fmt.Sprintf("🗺️ Attack surface seeded from context (%d endpoints).", len(res.Endpoints))})
+				msg := fmt.Sprintf("🗺️ Attack surface seeded from context (%d endpoints", len(res.Endpoints))
+				if seeded > 0 {
+					msg += fmt.Sprintf(", %d ledger hypotheses", seeded)
+				}
+				msg += ")."
+				a.emit(Event{Type: "message", Content: msg})
 			}
 		}
 	}

--- a/internal/agent/surface_seed.go
+++ b/internal/agent/surface_seed.go
@@ -1,0 +1,128 @@
+// Package agent — surface_seed.go turns a parsed scan-context artifact
+// (OpenAPI/Swagger, HAR, Postman, Burp) into schedulable ledger hypotheses.
+//
+// internal/attacksurface already parses those artifacts into a normalized,
+// deduplicated endpoint surface plus any captured session auth, and
+// prepareScanEnvironment already registers that auth and builds a text
+// briefing. But a briefing is passive: it does not, on its own, become
+// schedulable work in the evidence-driven loop. seedLedgerFromSurface closes
+// that gap — every endpoint the operator handed us becomes a role-scoped
+// authorization hypothesis (the prime IDOR/BOLA surface) that authz_matrix and
+// the specialists can pick up from the ledger, exactly as ingest_har does for a
+// HAR supplied mid-scan.
+package agent
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/xalgord/xalgorix/v4/internal/attacksurface"
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+)
+
+// maxSurfaceSeed bounds how many endpoints from an uploaded context artifact are
+// seeded into the ledger. The parser caps the merged surface at 500 endpoints;
+// seeding every one would swamp the scheduler and the LLM context window, so we
+// take the first N (the parser returns them sorted and deduplicated) and leave
+// the remainder described in the text briefing. The scheduler picks the
+// highest-confidence hypotheses first, so a bounded seed still surfaces the most
+// promising work.
+const maxSurfaceSeed = 40
+
+// seedLedgerFromSurface seeds the shared ledger with role-scoped authorization
+// hypotheses for the endpoints in a parsed attack surface. Role is
+// "authenticated" when the artifact carried a live session (so these are
+// post-auth IDOR/BOLA candidates), otherwise "anonymous". It returns the number
+// of NEW hypotheses inserted.
+//
+// Idempotent: the ledger deduplicates by (vuln_class, endpoint, parameter,
+// role), so calling this more than once for the same scan (root coordinator and
+// any sub-agents that also parse the context) never creates duplicates — the
+// repeat calls simply insert nothing new.
+func (a *Agent) seedLedgerFromSurface(res *attacksurface.Result) int {
+	if res == nil || a.scanCtx == nil {
+		return 0
+	}
+	l := a.ledger()
+	if l == nil {
+		return 0
+	}
+
+	role := "anonymous"
+	if len(res.AuthHeaders) > 0 {
+		role = "authenticated"
+	}
+
+	seeded := 0
+	for _, e := range res.Endpoints {
+		if seeded >= maxSurfaceSeed {
+			break
+		}
+		host, path := splitSurfaceEndpoint(e.Path, res.BaseURLs)
+		if path == "" {
+			continue
+		}
+		param := ""
+		if len(e.Params) > 0 {
+			param = e.Params[0]
+		}
+
+		title := "Endpoint"
+		if role == "authenticated" {
+			title = "Authenticated endpoint"
+		}
+		if m := strings.ToUpper(strings.TrimSpace(e.Method)); m != "" {
+			title += " " + m
+		}
+		title += " " + path
+
+		origin := "context"
+		if s := strings.TrimSpace(e.Source); s != "" {
+			origin = "context:" + s
+		}
+
+		before := l.Len()
+		l.Upsert(scanctx.Hypothesis{
+			Title:      title,
+			VulnClass:  "idor",
+			Target:     host,
+			Endpoint:   path,
+			Parameter:  param,
+			Role:       role,
+			Confidence: 0.4,
+			Status:     scanctx.HypothesisQueued,
+			Origin:     origin,
+			NextAction: "Probe this endpoint from the uploaded context; if it exposes an object/action by id, test cross-role access with authz_matrix (role A vs role B vs anonymous).",
+		})
+		if l.Len() > before {
+			seeded++
+		}
+	}
+	return seeded
+}
+
+// splitSurfaceEndpoint returns (host, path) for an attack-surface endpoint whose
+// Path may be a full URL or a bare path. For a bare path the host is taken from
+// the first usable base URL so the ledger entry still names a concrete host when
+// one is known. An empty path (which cannot be tested) yields ("", "").
+func splitSurfaceEndpoint(raw string, baseURLs []string) (host, path string) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", ""
+	}
+	if strings.HasPrefix(raw, "http://") || strings.HasPrefix(raw, "https://") {
+		if u, err := url.Parse(raw); err == nil && u.Host != "" {
+			p := u.Path
+			if p == "" {
+				p = "/"
+			}
+			return u.Host, p
+		}
+	}
+	for _, b := range baseURLs {
+		if u, err := url.Parse(strings.TrimSpace(b)); err == nil && u.Host != "" {
+			return u.Host, raw
+		}
+	}
+	return "", raw
+}

--- a/internal/agent/surface_seed_test.go
+++ b/internal/agent/surface_seed_test.go
@@ -1,0 +1,161 @@
+package agent
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/attacksurface"
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+)
+
+func newSurfaceAgent(t *testing.T) *Agent {
+	t.Helper()
+	return &Agent{scanCtx: scanctx.New("surface-"+t.Name(), "")}
+}
+
+// findHyp returns the first hypothesis with the given endpoint path.
+func findHyp(hyps []scanctx.Hypothesis, endpoint string) (scanctx.Hypothesis, bool) {
+	for _, h := range hyps {
+		if h.Endpoint == endpoint {
+			return h, true
+		}
+	}
+	return scanctx.Hypothesis{}, false
+}
+
+func TestSeedLedgerFromSurfaceAuthenticated(t *testing.T) {
+	res := &attacksurface.Result{
+		AuthHeaders: map[string]string{"Authorization": "Bearer X"},
+		BaseURLs:    []string{"https://app.example.com"},
+		Endpoints: []attacksurface.Endpoint{
+			{Method: "GET", Path: "https://app.example.com/api/orders", Params: []string{"id"}, Source: "openapi"},
+			{Method: "POST", Path: "/api/users", Params: []string{"role", "name"}, Source: "har"},
+		},
+	}
+	ag := newSurfaceAgent(t)
+
+	n := ag.seedLedgerFromSurface(res)
+	if n != 2 {
+		t.Fatalf("expected 2 hypotheses seeded, got %d", n)
+	}
+	l := ag.scanCtx.Ledger
+	if l.Len() != 2 {
+		t.Fatalf("expected ledger len 2, got %d", l.Len())
+	}
+	all := l.All()
+
+	h1, ok := findHyp(all, "/api/orders")
+	if !ok {
+		t.Fatalf("missing /api/orders hypothesis; got %+v", all)
+	}
+	if h1.Role != "authenticated" || h1.VulnClass != "idor" {
+		t.Fatalf("expected authenticated idor, got role=%q class=%q", h1.Role, h1.VulnClass)
+	}
+	if h1.Target != "app.example.com" {
+		t.Fatalf("expected host from full URL, got %q", h1.Target)
+	}
+	if h1.Parameter != "id" {
+		t.Fatalf("expected first param 'id', got %q", h1.Parameter)
+	}
+	if h1.Origin != "context:openapi" {
+		t.Fatalf("expected origin context:openapi, got %q", h1.Origin)
+	}
+	if h1.Status != scanctx.HypothesisQueued {
+		t.Fatalf("expected queued status, got %q", h1.Status)
+	}
+
+	h2, ok := findHyp(all, "/api/users")
+	if !ok {
+		t.Fatalf("missing /api/users hypothesis; got %+v", all)
+	}
+	if h2.Target != "app.example.com" {
+		t.Fatalf("expected host derived from base URL, got %q", h2.Target)
+	}
+	if h2.Parameter != "role" {
+		t.Fatalf("expected first param 'role', got %q", h2.Parameter)
+	}
+	if h2.Origin != "context:har" {
+		t.Fatalf("expected origin context:har, got %q", h2.Origin)
+	}
+}
+
+func TestSeedLedgerFromSurfaceAnonymous(t *testing.T) {
+	res := &attacksurface.Result{
+		Endpoints: []attacksurface.Endpoint{
+			{Method: "GET", Path: "https://api.example.com/status", Source: "openapi"},
+		},
+	}
+	ag := newSurfaceAgent(t)
+
+	if n := ag.seedLedgerFromSurface(res); n != 1 {
+		t.Fatalf("expected 1 seeded, got %d", n)
+	}
+	all := ag.scanCtx.Ledger.All()
+	if len(all) != 1 || all[0].Role != "anonymous" {
+		t.Fatalf("expected a single anonymous hypothesis, got %+v", all)
+	}
+}
+
+func TestSeedLedgerFromSurfaceIdempotent(t *testing.T) {
+	res := &attacksurface.Result{
+		AuthHeaders: map[string]string{"Cookie": "s=1"},
+		Endpoints: []attacksurface.Endpoint{
+			{Method: "GET", Path: "https://app.example.com/api/orders", Params: []string{"id"}, Source: "openapi"},
+		},
+	}
+	ag := newSurfaceAgent(t)
+
+	if n := ag.seedLedgerFromSurface(res); n != 1 {
+		t.Fatalf("first seed expected 1, got %d", n)
+	}
+	if n := ag.seedLedgerFromSurface(res); n != 0 {
+		t.Fatalf("second seed expected 0 (dedup), got %d", n)
+	}
+	if got := ag.scanCtx.Ledger.Len(); got != 1 {
+		t.Fatalf("expected ledger len 1 after re-seed, got %d", got)
+	}
+}
+
+func TestSeedLedgerFromSurfaceBounded(t *testing.T) {
+	res := &attacksurface.Result{}
+	for i := 0; i < maxSurfaceSeed+10; i++ {
+		res.Endpoints = append(res.Endpoints, attacksurface.Endpoint{
+			Method: "GET",
+			Path:   fmt.Sprintf("https://app.example.com/api/e%d", i),
+			Source: "openapi",
+		})
+	}
+	ag := newSurfaceAgent(t)
+
+	n := ag.seedLedgerFromSurface(res)
+	if n != maxSurfaceSeed {
+		t.Fatalf("expected seeding bounded to %d, got %d", maxSurfaceSeed, n)
+	}
+	if got := ag.scanCtx.Ledger.Len(); got != maxSurfaceSeed {
+		t.Fatalf("expected ledger len %d, got %d", maxSurfaceSeed, got)
+	}
+}
+
+func TestSplitSurfaceEndpoint(t *testing.T) {
+	cases := []struct {
+		name     string
+		raw      string
+		bases    []string
+		wantHost string
+		wantPath string
+	}{
+		{"full url", "https://app.example.com/api/orders", nil, "app.example.com", "/api/orders"},
+		{"full url no path", "https://app.example.com", nil, "app.example.com", "/"},
+		{"bare path with base", "/api/users", []string{"https://app.example.com"}, "app.example.com", "/api/users"},
+		{"bare path no base", "/api/users", nil, "", "/api/users"},
+		{"empty", "", nil, "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			host, path := splitSurfaceEndpoint(c.raw, c.bases)
+			if host != c.wantHost || path != c.wantPath {
+				t.Fatalf("splitSurfaceEndpoint(%q,%v) = (%q,%q), want (%q,%q)", c.raw, c.bases, host, path, c.wantHost, c.wantPath)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Builds on v4.6.12 (ingest_har) and v4.6.13 (ingested session drives authz_matrix).

## Problem
`internal/attacksurface` already parses an uploaded OpenAPI/Swagger spec, HAR, Postman collection, or Burp export into a normalized, deduplicated endpoint surface plus any captured session, and `prepareScanEnvironment` registers that auth and builds a text briefing. But the endpoints only ever appeared as **passive prose** — they never became schedulable hypotheses, so the evidence-driven loop (`authz_matrix` + specialists) had to re-derive targets from the briefing.

## Change
`seedLedgerFromSurface` turns `res.Endpoints` into bounded, role-scoped `idor` authorization hypotheses — the prime IDOR/BOLA surface — and is wired into `prepareScanEnvironment` right after auth registration.
- **Role**: `authenticated` when the artifact carried a live session, else `anonymous`.
- **Origin**: `context:<source>` (openapi/har/postman).
- **Idempotent**: ledger dedups by (class, endpoint, parameter, role), so sub-agents that also parse the context add nothing new.
- **Bounded** to 40 so a 500-endpoint surface never swamps the scheduler.

Net effect: every context upload now drives structured authorization testing, mirroring what `ingest_har` does mid-scan.

## Tests
authenticated vs anonymous role, host/path/param/origin mapping, idempotent re-seed (0 new), the bound, and `splitSurfaceEndpoint` table. Build, gofmt, vet, lint, full agent suite green. Base main (v4.6.13).