### PR TITLE
release: v4.6.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased] — Uploaded context seeds the hypothesis ledger
+## [v4.6.14](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.14) — Uploaded context seeds the hypothesis ledger (2026-09-01)
 
 ### Changed
 - **Uploaded scan-context artifacts now seed the hypothesis ledger, not just a briefing.** When a scan starts with an OpenAPI/Swagger spec, HAR, Postman collection, or Burp export, Xalgorix already parsed it into a normalized endpoint surface and registered any captured session — but the endpoints only appeared as a passive text briefing. They now also become bounded, role-scoped authorization hypotheses (the prime IDOR/BOLA surface) in the shared ledger, so the operator-supplied surface directly drives `authz_matrix` and the evidence-driven specialists instead of relying on the model to re-derive targets from prose. Role is `authenticated` when the artifact carried a live session, otherwise `anonymous`. Seeding is deduplicated (by class/endpoint/parameter/role) and bounded, so it never floods the scheduler or double-counts across sub-agents. This mirrors what `ingest_har` does mid-scan, now applied to every context upload at scan start.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.13
+VERSION=4.6.14
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.13"
+var version = "4.6.14"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.14 — Uploaded context seeds the hypothesis ledger.

Bumps version (main.go, Makefile) and promotes the CHANGELOG [Unreleased] section to v4.6.14.

Ships the fix from #507: uploaded OpenAPI/HAR/Postman/Burp context now seeds bounded, role-scoped authorization hypotheses into the ledger at scan start, so the operator-supplied surface directly drives authz_matrix and the evidence-driven specialists.