### PR TITLE
Two-account IDOR/BOLA from a second ingested session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased] — Two-account IDOR/BOLA from a second ingested session
+
+### Added
+- **`ingest_har` can now register a SECOND account (`role=b`) for true two-account IDOR/BOLA.** Proving broken object-level authorization needs two real identities: one user's session reaching another user's objects. Capture a HAR while logged in as a second user and run `ingest_har path=… role=b` — its session is registered as role B (a dedicated store that is deliberately *not* auto-applied to `http_request`, since role B is the "other user" identity used on purpose). `authz_matrix` then uses that ingested session as role B (when no operator second account is configured, mirroring how role A already falls back to an ingested session), replaying each request as role A, role B, and anonymous to flag any of role A's resources that role B can reach. Role-B ingestion registers credentials only — it does not seed the ledger, since role B is a comparison identity, not new attack surface.
+
 ## [v4.6.14](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.14) — Uploaded context seeds the hypothesis ledger (2026-09-01)
 
 ### Changed

--- a/internal/agent/authz_matrix.go
+++ b/internal/agent/authz_matrix.go
@@ -49,7 +49,7 @@ type authzResult struct {
 func (a *Agent) registerAuthzMatrixTool(reg *tools.Registry) {
 	reg.Register(&tools.Tool{
 		Name:        "authz_matrix",
-		Description: "Test access control by replaying ONE request as every configured identity — your primary session (role A; from configured target auth, or a logged-in HAR registered via ingest_har), a second account (role B) if the scan has one, and anonymous (no credentials) — then report the differential. This is the definitive check for IDOR/BOLA (a second user reading role A's object) and auth bypass/BFLA (anonymous reaching a protected resource). Point it at a resource that SHOULD be restricted to role A (e.g. role A's own object by id); if a lower identity gets the same successful response, that is broken access control. Positive signals are recorded as role-scoped hypotheses in the ledger with the differential as proof.",
+		Description: "Test access control by replaying ONE request as every configured identity — your primary session (role A; from configured target auth, or a logged-in HAR registered via ingest_har), a second account (role B) if the scan has one (configured, or a second logged-in HAR ingested via ingest_har role=b), and anonymous (no credentials) — then report the differential. This is the definitive check for IDOR/BOLA (a second user reading role A's object) and auth bypass/BFLA (anonymous reaching a protected resource). Point it at a resource that SHOULD be restricted to role A (e.g. role A's own object by id); if a lower identity gets the same successful response, that is broken access control. Positive signals are recorded as role-scoped hypotheses in the ledger with the differential as proof.",
 		Parameters: []tools.Parameter{
 			{Name: "url", Description: "URL of the object/action under test, ideally one owned by/authorized for role A (e.g. https://app/api/orders/1042).", Required: true},
 			{Name: "method", Description: "HTTP method (default GET).", Required: false},
@@ -137,7 +137,10 @@ func (a *Agent) authzMatrixTool(args map[string]string) (tools.Result, error) {
 // otherwise it falls back to the scan's authenticated session — the credentials
 // registered by ingest_har from a logged-in HAR. Without that fallback an
 // authenticated HAR would seed IDOR/BOLA hypotheses but the matrix meant to
-// test them would have only anonymous access and refuse to run.
+// test them would have only anonymous access and refuse to run. Role B follows
+// the same rule: the operator's second account (a.targetAuthB) when set, else a
+// second session ingested via ingest_har role=b — enabling true two-account
+// IDOR/BOLA proof from two logged-in HARs.
 func (a *Agent) authzIdentities() []authzIdentity {
 	var ids []authzIdentity
 	if hdrs := httpclient.ParseAuthHeaders(a.targetAuth); len(hdrs) > 0 {
@@ -147,6 +150,8 @@ func (a *Agent) authzIdentities() []authzIdentity {
 	}
 	if hdrs := httpclient.ParseAuthHeaders(a.targetAuthB); len(hdrs) > 0 {
 		ids = append(ids, authzIdentity{label: "second account (role B)", role: "role-b", headers: hdrs})
+	} else if hdrs := a.sessionAuthBHeaders(); len(hdrs) > 0 {
+		ids = append(ids, authzIdentity{label: "second account (role B, ingested)", role: "role-b", headers: hdrs})
 	}
 	ids = append(ids, authzIdentity{label: "anonymous", role: "anonymous", headers: nil})
 	return ids
@@ -161,6 +166,18 @@ func (a *Agent) sessionAuthHeaders() map[string]string {
 		return nil
 	}
 	return httpclient.SessionAuthForContext(a.scanCtx.ID)
+}
+
+// sessionAuthBHeaders returns the second-account (role B) headers registered for
+// this scan context (e.g. by ingest_har role=b), or nil when none. This lets
+// the authorization matrix use an ingested second session as role B — enabling
+// true two-account IDOR/BOLA testing — when the operator did not configure a
+// separate second account.
+func (a *Agent) sessionAuthBHeaders() map[string]string {
+	if a.scanCtx == nil {
+		return nil
+	}
+	return httpclient.SessionAuthBForContext(a.scanCtx.ID)
 }
 
 // analyzeAuthzMatrix compares each identity against the authorized baseline

--- a/internal/agent/authz_matrix_test.go
+++ b/internal/agent/authz_matrix_test.go
@@ -207,3 +207,77 @@ func TestAuthzMatrixRunsWithIngestedSession(t *testing.T) {
 		t.Fatalf("expected 1 recorded hypothesis (anonymous vs ingested role A), got %v", res.Metadata["recorded_hypotheses"])
 	}
 }
+
+// TestAuthzIdentitiesUsesIngestedSessionBAsRoleB verifies that a second session
+// registered via ingest_har role=b (SetSessionAuthB) becomes role B when no
+// operator second account is configured — enabling two-account IDOR/BOLA.
+func TestAuthzIdentitiesUsesIngestedSessionBAsRoleB(t *testing.T) {
+	ag := &Agent{scanCtx: scanctx.New("authz-bses-"+t.Name(), ""), ctx: context.Background()}
+	httpclient.SetSessionAuth(ag.scanCtx.ID, map[string]string{"Authorization": "Bearer A"})
+	httpclient.SetSessionAuthB(ag.scanCtx.ID, map[string]string{"Authorization": "Bearer B"})
+	defer httpclient.SetSessionAuth(ag.scanCtx.ID, nil)
+	defer httpclient.SetSessionAuthB(ag.scanCtx.ID, nil)
+
+	ids := ag.authzIdentities()
+	if len(ids) != 3 {
+		t.Fatalf("expected role-a + role-b (both ingested) + anonymous, got %d: %+v", len(ids), ids)
+	}
+	if ids[0].role != "role-a" || ids[0].headers["Authorization"] != "Bearer A" {
+		t.Fatalf("role A wrong: %+v", ids[0])
+	}
+	if ids[1].role != "role-b" || ids[1].headers["Authorization"] != "Bearer B" {
+		t.Fatalf("role B (ingested) wrong: %+v", ids[1])
+	}
+	if ids[2].role != "anonymous" {
+		t.Fatalf("expected anonymous last, got %+v", ids[2])
+	}
+}
+
+// TestAuthzIdentitiesPrefersOperatorAuthBOverSessionB verifies operator role-B
+// precedence over an ingested role-B session.
+func TestAuthzIdentitiesPrefersOperatorAuthBOverSessionB(t *testing.T) {
+	ag := &Agent{targetAuthB: "Authorization: Bearer OPB", scanCtx: scanctx.New("authz-bprec-"+t.Name(), ""), ctx: context.Background()}
+	httpclient.SetSessionAuthB(ag.scanCtx.ID, map[string]string{"Authorization": "Bearer SESB"})
+	defer httpclient.SetSessionAuthB(ag.scanCtx.ID, nil)
+
+	var rb *authzIdentity
+	ids := ag.authzIdentities()
+	for i := range ids {
+		if ids[i].role == "role-b" {
+			rb = &ids[i]
+		}
+	}
+	if rb == nil || rb.headers["Authorization"] != "Bearer OPB" {
+		t.Fatalf("expected role B to use the operator account, got %+v", rb)
+	}
+}
+
+// TestAuthzMatrixTwoIngestedAccounts is the end-to-end two-account proof: role A
+// and role B both come from ingested sessions, and the matrix flags /broken
+// (role B and anonymous both reach role A's owner record).
+func TestAuthzMatrixTwoIngestedAccounts(t *testing.T) {
+	srv := authzTestServer()
+	defer srv.Close()
+	ag := newAuthzAgent(t, true)
+	ag.targetAuth = ""
+	ag.targetAuthB = ""
+	httpclient.SetSessionAuth(ag.scanCtx.ID, map[string]string{"Authorization": "Bearer AAA"})
+	httpclient.SetSessionAuthB(ag.scanCtx.ID, map[string]string{"Authorization": "Bearer BBB"})
+	defer httpclient.SetSessionAuth(ag.scanCtx.ID, nil)
+	defer httpclient.SetSessionAuthB(ag.scanCtx.ID, nil)
+
+	res, err := ag.authzMatrixTool(map[string]string{"url": srv.URL + "/broken", "parameter": "id"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, _ := res.Metadata["recorded_hypotheses"].(int); got != 2 {
+		t.Fatalf("expected 2 recorded (role B + anonymous), got %v", res.Metadata["recorded_hypotheses"])
+	}
+	var roles []string
+	for _, h := range ag.scanCtx.Ledger.All() {
+		roles = append(roles, h.Role)
+	}
+	if !contains(roles, "role-b") {
+		t.Fatalf("expected a role-b hypothesis, got roles %v", roles)
+	}
+}

--- a/internal/agent/har_ingest.go
+++ b/internal/agent/har_ingest.go
@@ -40,10 +40,11 @@ type harIngestSummary struct {
 func (a *Agent) registerHARIngestTool(reg *tools.Registry) {
 	reg.Register(&tools.Tool{
 		Name:        "ingest_har",
-		Description: "Ingest a recorded, logged-in HAR file to start testing from a real authenticated session. Give it the path to a HAR captured while logged in and exercising the app. It (1) registers the session credentials (Authorization/Cookie/API-key headers) so your subsequent http_request and authz_matrix calls are authenticated, and (2) seeds the ledger with authenticated endpoints (the prime IDOR/BOLA surface) as role-scoped hypotheses for the authorization specialist. Use this at the start of an authenticated assessment when a HAR is available.",
+		Description: "Ingest a recorded, logged-in HAR file to test from a real authenticated session. Give it the path to a HAR captured while logged in and exercising the app. For the PRIMARY session (default, role=a) it (1) registers the session credentials (Authorization/Cookie/API-key headers) so your subsequent http_request and authz_matrix calls are authenticated, and (2) seeds the ledger with authenticated endpoints (the prime IDOR/BOLA surface) as role-scoped hypotheses. To prove IDOR/BOLA you also want a SECOND account: capture a HAR while logged in as a different user and ingest it with role=b — authz_matrix will then replay each request as BOTH accounts and flag any resource role B can reach that belongs to role A. Use at the start of an authenticated assessment.",
 		Parameters: []tools.Parameter{
 			{Name: "path", Description: "Filesystem path to the HAR file captured from the authenticated session.", Required: true},
 			{Name: "target", Description: "Optional target host to scope endpoints to (e.g. app.example.com). Endpoints on other hosts in the HAR are ignored. Omit to ingest all.", Required: false},
+			{Name: "role", Description: "Which identity this HAR is for: 'a' (default) = your primary session (registered + seeds the ledger); 'b' = a SECOND account used only as the cross-account identity for authz_matrix IDOR/BOLA testing (credentials registered, not auto-applied, no ledger seeding).", Required: false},
 		},
 		Execute: a.harIngestTool,
 	})
@@ -70,6 +71,10 @@ func (a *Agent) harIngestTool(args map[string]string) (tools.Result, error) {
 		return tools.Result{Error: err.Error()}, nil
 	}
 
+	if normalizeIngestRole(args["role"]) == "b" {
+		return a.ingestHARRoleB(h, strings.TrimSpace(args["target"])), nil
+	}
+
 	sum := a.seedFromHAR(h, strings.TrimSpace(args["target"]))
 
 	var b strings.Builder
@@ -83,6 +88,45 @@ func (a *Agent) harIngestTool(args map[string]string) (tools.Result, error) {
 		fmt.Fprintf(&b, "Seeded %d authorization hypotheses (role=%s) into the ledger. Use read_ledger(filter=schedulable) and authz_matrix to test cross-role access on these endpoints.", sum.Seeded, authRole)
 	}
 	return tools.Result{Output: b.String(), Metadata: map[string]any{"endpoints": sum.Endpoints, "seeded": sum.Seeded}}, nil
+}
+
+// normalizeIngestRole maps a free-form role argument to "a" (primary session)
+// or "b" (second account). Anything role-B-shaped selects B; everything else,
+// including an empty value, defaults to the primary session.
+func normalizeIngestRole(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "b", "role-b", "role_b", "roleb", "account-b", "second", "2":
+		return "b"
+	default:
+		return "a"
+	}
+}
+
+// ingestHARRoleB registers the HAR's session as the SECOND account (role B) for
+// cross-account authorization testing. It does NOT seed the ledger — role B is
+// a comparison identity, not new attack surface — and its credentials are not
+// auto-applied to http_request (only authz_matrix uses them, deliberately, as
+// the "other user").
+func (a *Agent) ingestHARRoleB(h *har.HAR, targetHost string) tools.Result {
+	endpoints := h.InScopeEndpoints(targetHost)
+	auth := h.AuthHeaders()
+	var names []string
+	if a.scanCtx != nil && len(auth) > 0 {
+		httpclient.SetSessionAuthB(a.scanCtx.ID, auth)
+		for name := range auth {
+			names = append(names, name)
+		}
+		sortStrings(names)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Ingested HAR as the SECOND account (role B): %d endpoint(s) seen.\n", len(endpoints))
+	if len(names) > 0 {
+		fmt.Fprintf(&b, "Role-B session registered (%s). Now run authz_matrix on role A's objects — it will replay each request as role B (this account) and flag any of role A's resources that role B can reach (IDOR/BOLA).\n", strings.Join(names, ", "))
+	} else {
+		b.WriteString("No session credentials found in this HAR — nothing was registered for role B. Re-capture it while logged in as the second account.\n")
+	}
+	return tools.Result{Output: b.String(), Metadata: map[string]any{"role": "b", "endpoints": len(endpoints), "auth_registered": len(names) > 0}}
 }
 
 // seedFromHAR registers the HAR's session auth and seeds the ledger with

--- a/internal/agent/har_ingest_test.go
+++ b/internal/agent/har_ingest_test.go
@@ -65,3 +65,47 @@ func TestHarIngestToolMissingPath(t *testing.T) {
 		t.Fatal("expected an error when the HAR file cannot be read")
 	}
 }
+
+func TestIngestHARRoleB(t *testing.T) {
+	ctxID := "har-roleb-" + t.Name()
+	ag := &Agent{scanCtx: scanctx.New(ctxID, "")}
+	defer httpclient.SetSessionAuthB(ctxID, nil)
+
+	h, err := har.Parse([]byte(harIngestSample))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	res := ag.ingestHARRoleB(h, "app.example.com")
+
+	// Role-B credentials registered (merged Authorization + Cookie).
+	b := httpclient.SessionAuthBForContext(ctxID)
+	if b["Authorization"] != "Bearer TOKEN" || b["Cookie"] != "session=abc" {
+		t.Fatalf("expected role-B session merged+registered, got %#v", b)
+	}
+	// Role B must NOT register a role-A session, and must NOT seed the ledger.
+	if httpclient.SessionAuthForContext(ctxID) != nil {
+		t.Fatal("role B ingestion must not register the role A session")
+	}
+	if n := ag.scanCtx.Ledger.Len(); n != 0 {
+		t.Fatalf("role B ingestion must not seed the ledger, got %d", n)
+	}
+	if role, _ := res.Metadata["role"].(string); role != "b" {
+		t.Fatalf("expected metadata role=b, got %v", res.Metadata["role"])
+	}
+	if ok, _ := res.Metadata["auth_registered"].(bool); !ok {
+		t.Fatal("expected auth_registered=true")
+	}
+}
+
+func TestNormalizeIngestRole(t *testing.T) {
+	for _, in := range []string{"b", "B", "role-b", "second", "2", " b "} {
+		if normalizeIngestRole(in) != "b" {
+			t.Fatalf("expected %q -> b", in)
+		}
+	}
+	for _, in := range []string{"", "a", "primary", "x"} {
+		if normalizeIngestRole(in) != "a" {
+			t.Fatalf("expected %q -> a", in)
+		}
+	}
+}

--- a/internal/tools/httpclient/sessionauth.go
+++ b/internal/tools/httpclient/sessionauth.go
@@ -15,6 +15,12 @@ import (
 var (
 	sessionAuthMu sync.RWMutex
 	sessionAuth   = map[string]map[string]string{} // contextID -> canonical header -> value
+	// sessionAuthB holds a SECOND account's credentials (role B) per scan
+	// context. Unlike sessionAuth (role A), it is deliberately NOT applied to
+	// http_request calls: role B is the "other user" identity used on purpose
+	// by the authorization matrix to prove cross-account access (IDOR/BOLA),
+	// not the session the scan should carry by default.
+	sessionAuthB = map[string]map[string]string{} // contextID -> canonical header -> value
 )
 
 // SetSessionAuth registers authenticated-session headers for a scan context.
@@ -42,6 +48,44 @@ func SetSessionAuth(contextID string, headers map[string]string) {
 // external source (e.g. HAR ingestion) and want to confirm what was applied.
 func SessionAuthForContext(contextID string) map[string]string {
 	return getSessionAuth(contextID)
+}
+
+// SetSessionAuthB registers a SECOND account's headers (role B) for a scan
+// context. Passing an empty map clears any existing role-B auth. Role B is used
+// by the authorization matrix as the cross-account identity for IDOR/BOLA
+// testing; it is never auto-applied to http_request (see sessionAuthB).
+func SetSessionAuthB(contextID string, headers map[string]string) {
+	sessionAuthMu.Lock()
+	defer sessionAuthMu.Unlock()
+	if len(headers) == 0 {
+		delete(sessionAuthB, contextID)
+		return
+	}
+	cp := make(map[string]string, len(headers))
+	for k, v := range headers {
+		k = strings.TrimSpace(k)
+		if k == "" {
+			continue
+		}
+		cp[k] = v
+	}
+	sessionAuthB[contextID] = cp
+}
+
+// SessionAuthBForContext returns a copy of the registered role-B headers for a
+// context (or nil).
+func SessionAuthBForContext(contextID string) map[string]string {
+	sessionAuthMu.RLock()
+	defer sessionAuthMu.RUnlock()
+	src := sessionAuthB[contextID]
+	if len(src) == 0 {
+		return nil
+	}
+	cp := make(map[string]string, len(src))
+	for k, v := range src {
+		cp[k] = v
+	}
+	return cp
 }
 
 // getSessionAuth returns a copy of the auth headers for a context (or nil).

--- a/internal/tools/httpclient/sessionauth_test.go
+++ b/internal/tools/httpclient/sessionauth_test.go
@@ -112,3 +112,41 @@ func TestSetSessionAuthClears(t *testing.T) {
 		t.Fatal("passing empty map must clear the context's auth")
 	}
 }
+
+func TestSetAndGetSessionAuthB(t *testing.T) {
+	const ctx = "scan-ctx-B"
+	// Role A and role B are independent stores.
+	SetSessionAuth(ctx, map[string]string{"Authorization": "Bearer A"})
+	SetSessionAuthB(ctx, map[string]string{"Authorization": "Bearer B", "": "drop"})
+	defer SetSessionAuth(ctx, nil)
+	defer SetSessionAuthB(ctx, nil)
+
+	b := SessionAuthBForContext(ctx)
+	if b == nil || b["Authorization"] != "Bearer B" {
+		t.Fatalf("role B not stored: %v", b)
+	}
+	if _, ok := b[""]; ok {
+		t.Fatal("blank header name must be dropped for role B")
+	}
+	// Role A store must be unaffected by a role-B write.
+	if a := SessionAuthForContext(ctx); a["Authorization"] != "Bearer A" {
+		t.Fatalf("role A store affected by role B write: %v", a)
+	}
+	// http_request applies only role A (getSessionAuth), never role B.
+	if getSessionAuth(ctx)["Authorization"] != "Bearer A" {
+		t.Fatal("getSessionAuth (the http_request path) must return role A")
+	}
+	// Returned map must be a defensive copy.
+	b["Authorization"] = "TAMPER"
+	if again := SessionAuthBForContext(ctx); again["Authorization"] != "Bearer B" {
+		t.Fatal("SessionAuthBForContext must return a defensive copy")
+	}
+	// Clearing role B must leave role A intact.
+	SetSessionAuthB(ctx, nil)
+	if SessionAuthBForContext(ctx) != nil {
+		t.Fatal("passing empty map must clear role B")
+	}
+	if SessionAuthForContext(ctx) == nil {
+		t.Fatal("clearing role B must not clear role A")
+	}
+}


### PR DESCRIPTION
Completes the authenticated-context arc (v4.6.12 ingest_har -> v4.6.13 session drives role A -> v4.6.14 uploads seed the ledger) with the piece IDOR/BOLA actually needs: a **second account**.

## Why
Broken object-level authorization is proven by one user's session reaching another user's objects. That requires two real identities. The scan could already ingest a primary logged-in HAR (role A); there was no way to supply a second account short of operator config.

## Change
- **httpclient**: a second per-context session store (`SetSessionAuthB` / `SessionAuthBForContext`), deliberately **not** auto-applied to `http_request` — role B is the "other user" used on purpose by the matrix, not the default session.
- **`ingest_har`**: optional `role` param. `role=b` registers the HAR's session as role B (credentials only — no ledger seeding, since role B is a comparison identity, not new surface). `role=a` unchanged.
- **`authz_matrix`**: role B falls back to the ingested role-B session when no operator second account is set (mirrors the role-A fallback from v4.6.13). Two logged-in HARs now drive a full three-way replay (role A / role B / anonymous).

## Tests
role-B store isolation + not-applied-by-http_request; `ingest_har role=b` (registers B, seeds nothing); authz identity fallback + operator precedence; end-to-end two-ingested-account matrix flags a broken endpoint. Build, gofmt, vet, lint, full agent + httpclient suites green. Base main (v4.6.14).