### PR TITLE
Dedup object-ID variants before verification (precision over volume)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased] — Precision: dedup object-ID variants before verification
+
+### Changed
+- **Findings that are the same bug across different object IDs are now recognized as one.** Duplicate detection compared endpoints literally, so `/orders/1042`, `/orders/2087`, and `/orders/<uuid>` looked like three distinct findings — each one paying for a full independent verification pass and landing as a separate report. Deduplication now templates opaque per-object id segments (pure numbers, UUIDs, long hex/ObjectIds) to a placeholder when comparing endpoints, so object-id variants of the same endpoint collapse into a single finding. The templating is conservative (version segments like `v1`/`v2` and named paths are never collapsed) and applies only to the duplicate-comparison key — the stored and reported endpoint keeps the real id so the PoC stays reproducible. Because every dedup path (report gates and child→parent merge) shares this logic, it also cuts redundant, expensive verifier runs — precision over volume.
+
 ## [v4.6.15](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.15) — Two-account IDOR/BOLA from a second ingested session (2026-09-01)
 
 ### Added

--- a/internal/tools/reporting/reporting.go
+++ b/internal/tools/reporting/reporting.go
@@ -735,13 +735,16 @@ func duplicateResult(existing Vulnerability, msg string) tools.Result {
 func findDuplicateVulnerability(existing []Vulnerability, title, description, target, endpoint string) (Vulnerability, string, bool) {
 	normalizedTitle := normalizeFindingText(title)
 	normalizedTarget := normalizeEndpoint(target)
-	normalizedEndpoint := normalizeEndpoint(endpoint)
+	// Endpoints use the templated key so object-ID variants of the same path
+	// (/orders/1042 vs /orders/2087) are recognized as one finding. Targets are
+	// hosts, not object paths, so they keep the plain normalization.
+	normalizedEndpoint := dedupEndpointKey(endpoint)
 	vulnType := extractVulnType(title, description)
 
 	for _, vuln := range existing {
 		existingTitle := normalizeFindingText(vuln.Title)
 		existingTarget := normalizeEndpoint(vuln.Target)
-		existingEndpoint := normalizeEndpoint(vuln.Endpoint)
+		existingEndpoint := dedupEndpointKey(vuln.Endpoint)
 		existingType := extractVulnType(vuln.Title, vuln.Description)
 		sameTarget := normalizedTarget == existingTarget
 
@@ -2577,6 +2580,57 @@ func normalizeEndpoint(endpoint string) string {
 	endpoint = strings.TrimRight(endpoint, "/")
 	// Lowercase for consistent comparison
 	return strings.ToLower(endpoint)
+}
+
+// idPathSegment matches a single path segment that is an opaque per-object
+// identifier — a pure number, a UUID, or a long hex string (e.g. a Mongo
+// ObjectId). These vary per object instance, so the SAME finding across many
+// IDs (/orders/1, /orders/2, /orders/9f3e…-uuid) would otherwise look like
+// distinct endpoints and each trigger a fresh, expensive verification plus a
+// separate stored finding.
+var (
+	uuidPathSegment = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+	hexPathSegment  = regexp.MustCompile(`^[0-9a-f]{16,}$`)
+	numPathSegment  = regexp.MustCompile(`^\d+$`)
+)
+
+// isIDPathSegment reports whether a path segment looks like an opaque object
+// identifier. It is deliberately conservative: version-like ("v1", "v2") and
+// named segments ("users", "api") never match, so distinct endpoints are not
+// collapsed — only object-ID variants of the same endpoint are.
+func isIDPathSegment(seg string) bool {
+	if seg == "" {
+		return false
+	}
+	if numPathSegment.MatchString(seg) {
+		return true
+	}
+	// normalizeEndpoint already lowercased, but be defensive for direct callers.
+	low := strings.ToLower(seg)
+	return uuidPathSegment.MatchString(low) || hexPathSegment.MatchString(low)
+}
+
+// templatePathParams collapses opaque per-object identifier segments in a path
+// to "{id}", so ID variants of the same endpoint share a key. It expects an
+// already query/fragment-stripped, lowercased path (see dedupEndpointKey).
+func templatePathParams(path string) string {
+	if path == "" || !strings.Contains(path, "/") {
+		return path
+	}
+	segs := strings.Split(path, "/")
+	for i, s := range segs {
+		if isIDPathSegment(s) {
+			segs[i] = "{id}"
+		}
+	}
+	return strings.Join(segs, "/")
+}
+
+// dedupEndpointKey is normalizeEndpoint plus path-parameter templating. It is
+// used ONLY for duplicate comparison — never for the stored or displayed
+// endpoint, which must keep the real object id for the PoC to be reproducible.
+func dedupEndpointKey(endpoint string) string {
+	return templatePathParams(normalizeEndpoint(endpoint))
 }
 
 func normalizeFindingText(value string) string {

--- a/internal/tools/reporting/reporting_test.go
+++ b/internal/tools/reporting/reporting_test.go
@@ -1901,3 +1901,84 @@ func TestReportVuln_OptionalParamsHandledByGates(t *testing.T) {
 		}
 	})
 }
+
+func TestTemplatePathParams(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"/orders/1042", "/orders/{id}"},
+		{"/users/9f3e1c2a-1111-2222-3333-444455556666", "/users/{id}"}, // UUID
+		{"/o/deadbeefdeadbeef12345678", "/o/{id}"},                     // 24-hex ObjectId
+		{"/api/v1/users", "/api/v1/users"},                             // version segment preserved
+		{"/api/v2/orders/55", "/api/v2/orders/{id}"},                   // only the id templated
+		{"/orders/1042/items/9", "/orders/{id}/items/{id}"},            // multiple ids
+		{"/users/abc", "/users/abc"},                                   // short named slug preserved
+		{"/files/0a1b2c3d", "/files/0a1b2c3d"},                         // short hex (<16) preserved
+		{"/search", "/search"},                                         // no id
+		{"", ""},                                                       // empty
+	}
+	for _, c := range cases {
+		if got := templatePathParams(c.in); got != c.want {
+			t.Errorf("templatePathParams(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestDedupEndpointKey_NormalizesThenTemplates(t *testing.T) {
+	// Uppercase + query + fragment + trailing slash, then id templating.
+	got := dedupEndpointKey("https://App.example.com/Orders/1042/Items/9?x=1#frag")
+	want := "https://app.example.com/orders/{id}/items/{id}"
+	if got != want {
+		t.Fatalf("dedupEndpointKey = %q, want %q", got, want)
+	}
+}
+
+func TestFindDuplicateVulnerability_IDVariantsDedup(t *testing.T) {
+	existing := []Vulnerability{{
+		ID: "XALG-1", Title: "IDOR on order", Description: "idor",
+		Target: "https://app.example.com", Endpoint: "/api/orders/1042",
+	}}
+	// Same class + same target, different object id in the path.
+	dup, _, isDup := findDuplicateVulnerability(existing, "IDOR on order 2087", "idor",
+		"https://app.example.com", "/api/orders/2087")
+	if !isDup {
+		t.Fatal("expected /api/orders/2087 to dedup against /api/orders/1042 (same IDOR endpoint)")
+	}
+	if dup.ID != "XALG-1" {
+		t.Fatalf("expected duplicate of XALG-1, got %q", dup.ID)
+	}
+}
+
+func TestFindDuplicateVulnerability_VersionNotMerged(t *testing.T) {
+	existing := []Vulnerability{{
+		ID: "XALG-1", Title: "IDOR", Description: "idor",
+		Target: "https://app.example.com", Endpoint: "/api/v1/users/1",
+	}}
+	// v1 vs v2 are distinct endpoints, not object-id variants → not a duplicate.
+	if _, _, isDup := findDuplicateVulnerability(existing, "IDOR", "idor",
+		"https://app.example.com", "/api/v2/users/1"); isDup {
+		t.Fatal("expected /api/v1 and /api/v2 to remain distinct endpoints")
+	}
+}
+
+func TestFindDuplicateVulnerability_DifferentClassNotMerged(t *testing.T) {
+	existing := []Vulnerability{{
+		ID: "XALG-1", Title: "IDOR on orders", Description: "idor",
+		Target: "https://app.example.com", Endpoint: "/api/orders/1",
+	}}
+	// Same templated endpoint but a different vuln class + different title.
+	if _, _, isDup := findDuplicateVulnerability(existing, "SQL injection in orders", "sql injection",
+		"https://app.example.com", "/api/orders/2"); isDup {
+		t.Fatal("templating must not merge different vuln classes on the same endpoint")
+	}
+}
+
+func TestFindDuplicateVulnerability_DifferentTargetNotMerged(t *testing.T) {
+	existing := []Vulnerability{{
+		ID: "XALG-1", Title: "IDOR on order", Description: "idor",
+		Target: "https://app.example.com", Endpoint: "/api/orders/1042",
+	}}
+	// Same templated endpoint + class but a DIFFERENT host → not a duplicate.
+	if _, _, isDup := findDuplicateVulnerability(existing, "IDOR on order", "idor",
+		"https://other.example.com", "/api/orders/2087"); isDup {
+		t.Fatal("findings on different hosts must not be merged")
+	}
+}


### PR DESCRIPTION
## Problem
Duplicate detection compared endpoints literally, so `/orders/1042`, `/orders/2087`, and `/orders/<uuid>` looked like three distinct findings — each paying for a full independent verifier pass (Gate 4.5, ~8 turns / 3 min) and landing as a **separate** report. Object-id variants of the same bug are the single biggest source of duplicate volume.

## Change
Deduplication now templates opaque per-object id path segments (pure numbers, UUIDs, long hex / ObjectIds) to `{id}` when comparing endpoints, so id variants of the same endpoint collapse into one finding.
- **Conservative**: version segments (`v1`/`v2`), named paths, and short hex (<16) are never collapsed → distinct endpoints stay distinct.
- **Comparison-only**: applied via a new `dedupEndpointKey` used inside `findDuplicateVulnerability`. `normalizeEndpoint` and the **stored/reported** endpoint are untouched, so the PoC keeps the real id and stays reproducible.
- **Propagates everywhere**: report Gate 0 / Gate 4 / final write-lock check and `MergeVulnsToContext` all route through `findDuplicateVulnerability`, so this also cuts redundant, expensive verifier runs — with no call-site churn.

## Tests
`templatePathParams` (ids templated; `v1`/`v2`/named/short-hex preserved), `dedupEndpointKey` (normalize then template), and `findDuplicateVulnerability` (id-variants dedup; version / different-class / different-host NOT merged). Build, gofmt, vet, lint, reporting suite green. Base main (v4.6.15).