### PR TITLE
release: v4.6.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased] — Precision: dedup object-ID variants before verification
+## [v4.6.16](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.16) — Precision: dedup object-ID variants before verification (2026-09-01)
 
 ### Changed
 - **Findings that are the same bug across different object IDs are now recognized as one.** Duplicate detection compared endpoints literally, so `/orders/1042`, `/orders/2087`, and `/orders/<uuid>` looked like three distinct findings — each one paying for a full independent verification pass and landing as a separate report. Deduplication now templates opaque per-object id segments (pure numbers, UUIDs, long hex/ObjectIds) to a placeholder when comparing endpoints, so object-id variants of the same endpoint collapse into a single finding. The templating is conservative (version segments like `v1`/`v2` and named paths are never collapsed) and applies only to the duplicate-comparison key — the stored and reported endpoint keeps the real id so the PoC stays reproducible. Because every dedup path (report gates and child→parent merge) shares this logic, it also cuts redundant, expensive verifier runs — precision over volume.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.15
+VERSION=4.6.16
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.15"
+var version = "4.6.16"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.16 — Precision: dedup object-ID variants before verification.

Bumps version (main.go, Makefile) and promotes the CHANGELOG [Unreleased] section to v4.6.16.

Ships the fix from #512: duplicate detection now templates opaque per-object id path segments (numbers/UUIDs/long hex) when comparing endpoints, so object-id variants of the same bug (/orders/1042 vs /orders/2087) collapse into one finding instead of each triggering a full verifier pass and a separate report. Comparison-only; stored/reported endpoints keep the real id.