### PR TITLE
claim_next_hypothesis: deterministic evidence-driven scheduling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased] — Deterministic claiming of the next hypothesis
+
+### Added
+- **`claim_next_hypothesis` turns the evidence ledger into a real work queue.** The shared ledger already ranked untested hypotheses by confidence, but picking and assigning one was left to free-form model choice — so an agent could skip the strongest lead, and two parallel specialists could grab the same target. The new tool atomically claims the highest-confidence *queued* hypothesis (optionally scoped to a `vuln_class` lane), assigns it to the calling agent, and moves it to `testing` in one locked step — then hands back its next action and baseline. Specialists are now directed to claim their lane with it instead of eyeballing the ledger, so scheduling is deterministic and collision-free, and the coordinator provably works the most promising leads first.
+
 ## [v4.6.16](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.16) — Precision: dedup object-ID variants before verification (2026-09-01)
 
 ### Changed

--- a/internal/agent/claim_hypothesis_test.go
+++ b/internal/agent/claim_hypothesis_test.go
@@ -1,0 +1,99 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+)
+
+func newClaimAgent(t *testing.T) *Agent {
+	t.Helper()
+	return &Agent{scanCtx: scanctx.New("claim-"+t.Name(), "")}
+}
+
+// seedQueued adds a queued hypothesis and returns its stored id.
+func seedQueued(l *scanctx.LedgerStore, class, endpoint string, conf float64) string {
+	h := l.Upsert(scanctx.Hypothesis{
+		VulnClass:  class,
+		Endpoint:   endpoint,
+		Confidence: conf,
+		Status:     scanctx.HypothesisQueued,
+		NextAction: "probe " + endpoint,
+	})
+	return h.ID
+}
+
+func TestClaimNextHypothesis_TopQueuedByConfidence(t *testing.T) {
+	ag := newClaimAgent(t)
+	l := ag.scanCtx.Ledger
+	seedQueued(l, "idor", "/a", 0.5)
+	topID := seedQueued(l, "sqli", "/b", 0.9)
+
+	res, err := ag.claimNextHypothesisTool(map[string]string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, _ := res.Metadata["hypothesis_id"].(string); got != topID {
+		t.Fatalf("expected to claim highest-confidence %s, got %v", topID, res.Metadata["hypothesis_id"])
+	}
+	if got, _ := res.Metadata["status"].(string); got != string(scanctx.HypothesisTesting) {
+		t.Fatalf("expected claimed status testing, got %v", res.Metadata["status"])
+	}
+	// Ownership + testing transition persisted.
+	h, _ := l.Get(topID)
+	if h.Status != scanctx.HypothesisTesting {
+		t.Fatalf("expected %s to be testing, got %q", topID, h.Status)
+	}
+	if h.AssignedTo != ag.ledgerOrigin() {
+		t.Fatalf("expected owner %q, got %q", ag.ledgerOrigin(), h.AssignedTo)
+	}
+}
+
+func TestClaimNextHypothesis_ClassFilter(t *testing.T) {
+	ag := newClaimAgent(t)
+	l := ag.scanCtx.Ledger
+	idorID := seedQueued(l, "idor", "/a", 0.5)
+	seedQueued(l, "sqli", "/b", 0.9) // higher confidence, different class
+
+	res, err := ag.claimNextHypothesisTool(map[string]string{"vuln_class": "idor"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, _ := res.Metadata["hypothesis_id"].(string); got != idorID {
+		t.Fatalf("expected class filter to claim the idor hypothesis %s, got %v", idorID, res.Metadata["hypothesis_id"])
+	}
+}
+
+func TestClaimNextHypothesis_SecondClaimExcludesFirst(t *testing.T) {
+	ag := newClaimAgent(t)
+	l := ag.scanCtx.Ledger
+	seedQueued(l, "idor", "/a", 0.9)
+	seedQueued(l, "sqli", "/b", 0.8)
+
+	first, _ := ag.claimNextHypothesisTool(map[string]string{})
+	second, _ := ag.claimNextHypothesisTool(map[string]string{})
+	id1, _ := first.Metadata["hypothesis_id"].(string)
+	id2, _ := second.Metadata["hypothesis_id"].(string)
+	if id1 == "" || id2 == "" || id1 == id2 {
+		t.Fatalf("expected two distinct claims, got %q and %q", id1, id2)
+	}
+}
+
+func TestClaimNextHypothesis_NothingClaimable(t *testing.T) {
+	ag := newClaimAgent(t)
+	// Empty ledger.
+	res, _ := ag.claimNextHypothesisTool(map[string]string{})
+	if res.Error != "" {
+		t.Fatalf("unexpected error: %s", res.Error)
+	}
+	if _, ok := res.Metadata["hypothesis_id"]; ok {
+		t.Fatal("expected no claim on an empty ledger")
+	}
+
+	// One queued but of a different class than the filter.
+	seedQueued(ag.scanCtx.Ledger, "sqli", "/b", 0.9)
+	res2, _ := ag.claimNextHypothesisTool(map[string]string{"vuln_class": "idor"})
+	if _, ok := res2.Metadata["hypothesis_id"]; ok {
+		t.Fatal("expected no claim when no queued hypothesis matches the class filter")
+	}
+}

--- a/internal/agent/ledger_hooks.go
+++ b/internal/agent/ledger_hooks.go
@@ -103,7 +103,7 @@ Specialist roles (use these exact roles and hold each to its evidence contract):
 	b.WriteString(`
 Drive the work from the shared hypothesis ledger so specialists never overlap:
 - Call read_ledger(filter=schedulable) to see the open hypotheses.
-- Give each specialist a DISJOINT set and mark ownership with update_hypothesis(assigned_to=<agent_id>).
+- Give each specialist a DISJOINT lane by vuln class, and have it call claim_next_hypothesis(vuln_class=<its class>) to atomically take the top hypothesis in its lane — this assigns ownership and moves it to testing in one step, so two specialists can never grab the same target. (Use update_hypothesis(assigned_to=...) only for manual overrides.)
 - Require each specialist to record findings as they go with add_hypothesis_evidence, and to set a final status: proven (with a linked finding via kind=finding_ref) or rejected (with the baseline that ruled it out).
 - Keep coordinating while they run: incorporate every result with wait_agent/check_agent, independently verify candidates, and do not finish with an uncollected delegation or a proven-but-unreported hypothesis.
 Do not delegate three generic scans or duplicate your own work.`)

--- a/internal/agent/ledger_tools.go
+++ b/internal/agent/ledger_tools.go
@@ -121,6 +121,20 @@ func (a *Agent) registerLedgerTools(reg *tools.Registry) {
 		},
 		Execute: a.readLedgerTool,
 	})
+
+	reg.Register(&tools.Tool{
+		Name: "claim_next_hypothesis",
+		Description: "Atomically claim the single highest-value untested hypothesis from the shared " +
+			"ledger to work next. This deterministically picks the top QUEUED hypothesis (highest " +
+			"confidence first), optionally filtered to your vuln_class, assigns it to you, and moves it " +
+			"to 'testing' so no other agent works the same target. Prefer this over eyeballing " +
+			"read_ledger: it guarantees you take the most promising lead and prevents two specialists " +
+			"from colliding. Returns the hypothesis and its next action; if nothing is claimable it says so.",
+		Parameters: []tools.Parameter{
+			{Name: "vuln_class", Description: "Optional: only claim a hypothesis of this class (e.g. idor, sqli, xss, ssrf). Omit to claim the top hypothesis of any class.", Required: false},
+		},
+		Execute: a.claimNextHypothesisTool,
+	})
 }
 
 func (a *Agent) recordHypothesisTool(args map[string]string) (tools.Result, error) {
@@ -295,6 +309,59 @@ func (a *Agent) readLedgerTool(args map[string]string) (tools.Result, error) {
 		}
 		return tools.Result{Output: out}, nil
 	}
+}
+
+func (a *Agent) claimNextHypothesisTool(args map[string]string) (tools.Result, error) {
+	l := a.ledger()
+	if l == nil {
+		return tools.Result{Error: "ledger unavailable in this context"}, nil
+	}
+	classFilter := strings.ToLower(strings.TrimSpace(args["vuln_class"]))
+
+	// Schedulable is already ranked (highest confidence first). We only
+	// auto-claim QUEUED hypotheses: "blocked" ones are waiting on a precondition
+	// and shouldn't be silently moved into testing. Assign() will flip the
+	// chosen one queued→testing atomically under the ledger lock.
+	var picked *scanctx.Hypothesis
+	for _, h := range l.Schedulable(0) {
+		if h.Status != scanctx.HypothesisQueued {
+			continue
+		}
+		if classFilter != "" && strings.ToLower(h.VulnClass) != classFilter {
+			continue
+		}
+		hh := h
+		picked = &hh
+		break
+	}
+	if picked == nil {
+		if classFilter != "" {
+			return tools.Result{Output: fmt.Sprintf("No queued %q hypotheses to claim. Use read_ledger(filter=schedulable) to see other classes, or record new ones from recon with record_hypothesis.", classFilter)}, nil
+		}
+		return tools.Result{Output: "No queued hypotheses to claim right now. Record new ones from recon with record_hypothesis, or the surface may be exhausted."}, nil
+	}
+
+	owner := a.ledgerOrigin()
+	l.Assign(picked.ID, owner)
+	got, ok := l.Get(picked.ID)
+	if !ok {
+		got = *picked
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Claimed %s — now [%s], owner %s: %s%s (confidence %.2f).\n",
+		got.ID, got.Status, owner, got.VulnClass, formatLoc(got), got.Confidence)
+	if got.NextAction != "" {
+		fmt.Fprintf(&b, "Next action: %s\n", got.NextAction)
+	}
+	if got.Baseline != "" {
+		fmt.Fprintf(&b, "Baseline/control: %s\n", got.Baseline)
+	}
+	b.WriteString("Work this hypothesis, record evidence with add_hypothesis_evidence, then set its final status with update_hypothesis: proven (link the finding via kind=finding_ref) or rejected (with the baseline that ruled it out).")
+	return tools.Result{
+		Output:   b.String(),
+		Metadata: map[string]any{"hypothesis_id": got.ID, "vuln_class": got.VulnClass, "status": string(got.Status)},
+	}, nil
 }
 
 // ledgerOrigin identifies the writing agent: the delegation ID for a specialist,


### PR DESCRIPTION
Closes the 'deterministic planning' gap the parity research flagged.

## Problem
The shared hypothesis ledger already ranks untested hypotheses by confidence (`Schedulable`) and can record ownership (`Assign`), but nothing drove them — picking and assigning the next hypothesis was left to free-form model choice. An agent could skip the strongest lead, and two parallel specialists could grab the same target.

## Change
`claim_next_hypothesis` atomically:
1. picks the highest-confidence **queued** hypothesis (optionally scoped to a `vuln_class` lane),
2. assigns it to the calling agent (`a.ledgerOrigin()`), and
3. moves it to `testing` — in one locked step,

then returns its next action + baseline as the task. Blocked hypotheses are left untouched (they await a precondition). The delegation nudge now directs each specialist to claim its lane with this tool instead of eyeballing `read_ledger`, so scheduling is deterministic and collision-free and the coordinator provably works the most promising leads first.

Uses only existing ledger primitives — **no ledger changes**.

## Tests
top-by-confidence claim, `vuln_class` filter, second-claim-excludes-first (no collision), and nothing-claimable messages. Build, gofmt, vet, lint, full agent suite green. Base main (v4.6.16).