### PR TITLE
release: v4.6.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased] — Deterministic claiming of the next hypothesis
+## [v4.6.17](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.17) — Deterministic claiming of the next hypothesis (2026-09-01)
 
 ### Added
 - **`claim_next_hypothesis` turns the evidence ledger into a real work queue.** The shared ledger already ranked untested hypotheses by confidence, but picking and assigning one was left to free-form model choice — so an agent could skip the strongest lead, and two parallel specialists could grab the same target. The new tool atomically claims the highest-confidence *queued* hypothesis (optionally scoped to a `vuln_class` lane), assigns it to the calling agent, and moves it to `testing` in one locked step — then hands back its next action and baseline. Specialists are now directed to claim their lane with it instead of eyeballing the ledger, so scheduling is deterministic and collision-free, and the coordinator provably works the most promising leads first.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.16
+VERSION=4.6.17
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.16"
+var version = "4.6.17"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.17 — Deterministic claiming of the next hypothesis.

Bumps version (main.go, Makefile) and promotes the CHANGELOG [Unreleased] section to v4.6.17.

Ships the feature from #514: claim_next_hypothesis atomically takes the highest-confidence queued ledger hypothesis (optionally by vuln_class), assigns it to the caller, and moves it to testing — making evidence-driven scheduling deterministic and collision-free.