### PR TITLE
CWE-aware duplicate detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased] — CWE-aware duplicate detection
+
+### Changed
+- **Duplicate detection now falls back to the CWE when a finding's title doesn't name its class.** The near-duplicate check keys on vulnerability class, which it inferred from title/description keywords — so a finding worded without the class name (e.g. "Unauthenticated contact creation" that is really stored XSS, tagged CWE-79) escaped class-based dedup and paid for its own full verification. When no keyword is present, the finding's CWE is now mapped to the class, so same-class findings on the same endpoint collapse as intended. The mapping is limited to high-confidence, common CWEs; an unmapped CWE with no keyword still yields no class, so the fallback never over-merges distinct findings.
+
 ## [v4.6.17](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.17) — Deterministic claiming of the next hypothesis (2026-09-01)
 
 ### Added

--- a/internal/tools/reporting/reporting.go
+++ b/internal/tools/reporting/reporting.go
@@ -337,7 +337,7 @@ func reportVulnWithContextIDAndVerifier(contextID string, verifier FindingVerifi
 	// This is repeated under the write lock just before append to close races.
 	store := getStoreByID(contextID)
 	store.mu.RLock()
-	if existing, msg, ok := findDuplicateVulnerability(store.vulns, title, args["description"], target, endpoint); ok {
+	if existing, msg, ok := findDuplicateVulnerability(store.vulns, title, args["description"], args["cwe_id"], target, endpoint); ok {
 		store.mu.RUnlock()
 		return duplicateResult(existing, msg), nil
 	}
@@ -464,7 +464,7 @@ If you cannot exploit it, downgrade severity to 'info' and report as information
 	// ── Gate 4: Smart Deduplication — same vuln type on same endpoint = duplicate ──
 	store = getStoreByID(contextID)
 	store.mu.RLock()
-	if existing, msg, ok := findDuplicateVulnerability(store.vulns, title, args["description"], target, endpoint); ok {
+	if existing, msg, ok := findDuplicateVulnerability(store.vulns, title, args["description"], args["cwe_id"], target, endpoint); ok {
 		store.mu.RUnlock()
 		return duplicateResult(existing, msg), nil
 	}
@@ -596,7 +596,7 @@ If you cannot exploit it, downgrade severity to 'info' and report as information
 
 	store = getStoreByID(contextID) // re-resolve in case of race
 	store.mu.Lock()
-	if existing, msg, ok := findDuplicateVulnerability(store.vulns, title, args["description"], target, endpoint); ok {
+	if existing, msg, ok := findDuplicateVulnerability(store.vulns, title, args["description"], args["cwe_id"], target, endpoint); ok {
 		store.mu.Unlock()
 		return duplicateResult(existing, msg), nil
 	}
@@ -732,20 +732,20 @@ func duplicateResult(existing Vulnerability, msg string) tools.Result {
 	}
 }
 
-func findDuplicateVulnerability(existing []Vulnerability, title, description, target, endpoint string) (Vulnerability, string, bool) {
+func findDuplicateVulnerability(existing []Vulnerability, title, description, cwe, target, endpoint string) (Vulnerability, string, bool) {
 	normalizedTitle := normalizeFindingText(title)
 	normalizedTarget := normalizeEndpoint(target)
 	// Endpoints use the templated key so object-ID variants of the same path
 	// (/orders/1042 vs /orders/2087) are recognized as one finding. Targets are
 	// hosts, not object paths, so they keep the plain normalization.
 	normalizedEndpoint := dedupEndpointKey(endpoint)
-	vulnType := extractVulnType(title, description)
+	vulnType := extractVulnTypeWithCWE(title, description, cwe)
 
 	for _, vuln := range existing {
 		existingTitle := normalizeFindingText(vuln.Title)
 		existingTarget := normalizeEndpoint(vuln.Target)
 		existingEndpoint := dedupEndpointKey(vuln.Endpoint)
-		existingType := extractVulnType(vuln.Title, vuln.Description)
+		existingType := extractVulnTypeWithCWE(vuln.Title, vuln.Description, vuln.CWE)
 		sameTarget := normalizedTarget == existingTarget
 
 		// Exact finding match after trimming/case normalization.
@@ -2019,7 +2019,7 @@ func PromoteToParent(childContextID, parentContextID, vulnID string) {
 		}
 	}
 	// Skip semantic duplicates too, mirroring MergeVulnsToContext's behavior.
-	if _, _, dup := findDuplicateVulnerability(dst.vulns, found.Title, found.Description, found.Target, found.Endpoint); dup {
+	if _, _, dup := findDuplicateVulnerability(dst.vulns, found.Title, found.Description, found.CWE, found.Target, found.Endpoint); dup {
 		return
 	}
 	dst.vulns = append(dst.vulns, *found)
@@ -2067,7 +2067,7 @@ func MergeVulnsToContext(srcContextID, dstContextID string) int {
 
 	added := 0
 	for _, v := range srcVulns {
-		if _, _, duplicate := findDuplicateVulnerability(dstStore.vulns, v.Title, v.Description, v.Target, v.Endpoint); duplicate {
+		if _, _, duplicate := findDuplicateVulnerability(dstStore.vulns, v.Title, v.Description, v.CWE, v.Target, v.Endpoint); duplicate {
 			continue
 		}
 		if seenIDs[v.ID] {
@@ -2558,6 +2558,67 @@ func extractVulnType(title, description string) string {
 		}
 	}
 	return ""
+}
+
+// cweDigitsRe pulls the numeric portion out of a CWE identifier so "CWE-79",
+// "cwe 79", and "79" all normalize to "79".
+var cweDigitsRe = regexp.MustCompile(`[0-9]+`)
+
+// cweToVulnType maps a CWE identifier to the same canonical class names
+// extractVulnType uses, so deduplication can still recognize a finding's class
+// when the title/description carry no class keyword but a CWE is set. Only
+// high-confidence, common mappings are included; anything unmapped yields "".
+func cweToVulnType(cwe string) string {
+	switch cweDigitsRe.FindString(cwe) {
+	case "79":
+		return "xss"
+	case "89":
+		return "sqli"
+	case "918":
+		return "ssrf"
+	case "22":
+		return "lfi"
+	case "98":
+		return "rfi"
+	case "77", "78", "94", "95":
+		return "rce"
+	case "352":
+		return "csrf"
+	case "611":
+		return "xxe"
+	case "601":
+		return "open_redirect"
+	case "287", "288", "305", "306":
+		return "auth_bypass"
+	case "200", "209", "532":
+		return "info_disclosure"
+	case "284", "285", "566", "639", "862", "863":
+		return "idor"
+	case "1021":
+		return "clickjacking"
+	case "942":
+		return "cors"
+	case "93", "113":
+		return "crlf"
+	case "1336":
+		return "ssti"
+	case "502":
+		return "deserialization"
+	default:
+		return ""
+	}
+}
+
+// extractVulnTypeWithCWE is extractVulnType with a CWE fallback: when the
+// title/description don't reveal a class, the finding's CWE (if any) is mapped
+// to one. This tightens dedup for findings whose titles omit the class keyword
+// (e.g. "Unauthenticated contact creation" with CWE-79) so they still collapse
+// onto the same-class report instead of each triggering a fresh verification.
+func extractVulnTypeWithCWE(title, description, cwe string) string {
+	if t := extractVulnType(title, description); t != "" {
+		return t
+	}
+	return cweToVulnType(cwe)
 }
 
 // normalizeEndpoint strips query params, fragments, and trailing slashes

--- a/internal/tools/reporting/reporting_test.go
+++ b/internal/tools/reporting/reporting_test.go
@@ -1937,7 +1937,7 @@ func TestFindDuplicateVulnerability_IDVariantsDedup(t *testing.T) {
 		Target: "https://app.example.com", Endpoint: "/api/orders/1042",
 	}}
 	// Same class + same target, different object id in the path.
-	dup, _, isDup := findDuplicateVulnerability(existing, "IDOR on order 2087", "idor",
+	dup, _, isDup := findDuplicateVulnerability(existing, "IDOR on order 2087", "idor", "",
 		"https://app.example.com", "/api/orders/2087")
 	if !isDup {
 		t.Fatal("expected /api/orders/2087 to dedup against /api/orders/1042 (same IDOR endpoint)")
@@ -1953,7 +1953,7 @@ func TestFindDuplicateVulnerability_VersionNotMerged(t *testing.T) {
 		Target: "https://app.example.com", Endpoint: "/api/v1/users/1",
 	}}
 	// v1 vs v2 are distinct endpoints, not object-id variants → not a duplicate.
-	if _, _, isDup := findDuplicateVulnerability(existing, "IDOR", "idor",
+	if _, _, isDup := findDuplicateVulnerability(existing, "IDOR", "idor", "",
 		"https://app.example.com", "/api/v2/users/1"); isDup {
 		t.Fatal("expected /api/v1 and /api/v2 to remain distinct endpoints")
 	}
@@ -1965,7 +1965,7 @@ func TestFindDuplicateVulnerability_DifferentClassNotMerged(t *testing.T) {
 		Target: "https://app.example.com", Endpoint: "/api/orders/1",
 	}}
 	// Same templated endpoint but a different vuln class + different title.
-	if _, _, isDup := findDuplicateVulnerability(existing, "SQL injection in orders", "sql injection",
+	if _, _, isDup := findDuplicateVulnerability(existing, "SQL injection in orders", "sql injection", "",
 		"https://app.example.com", "/api/orders/2"); isDup {
 		t.Fatal("templating must not merge different vuln classes on the same endpoint")
 	}
@@ -1977,8 +1977,61 @@ func TestFindDuplicateVulnerability_DifferentTargetNotMerged(t *testing.T) {
 		Target: "https://app.example.com", Endpoint: "/api/orders/1042",
 	}}
 	// Same templated endpoint + class but a DIFFERENT host → not a duplicate.
-	if _, _, isDup := findDuplicateVulnerability(existing, "IDOR on order", "idor",
+	if _, _, isDup := findDuplicateVulnerability(existing, "IDOR on order", "idor", "",
 		"https://other.example.com", "/api/orders/2087"); isDup {
 		t.Fatal("findings on different hosts must not be merged")
+	}
+}
+
+func TestExtractVulnTypeWithCWE(t *testing.T) {
+	cases := []struct {
+		name             string
+		title, desc, cwe string
+		want             string
+	}{
+		{"keyword wins over cwe", "Reflected XSS in search", "", "CWE-89", "xss"},
+		{"cwe fallback when no keyword", "Unauthenticated contact creation", "adds a record", "CWE-79", "xss"},
+		{"cwe fallback idor", "Access another account's order", "returns the record", "CWE-639", "idor"},
+		{"cwe format variants", "no class keyword here", "", "79", "xss"},
+		{"unmapped cwe → empty", "no class keyword here", "", "CWE-770", ""},
+		{"neither → empty", "no class keyword here", "", "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := extractVulnTypeWithCWE(c.title, c.desc, c.cwe); got != c.want {
+				t.Fatalf("extractVulnTypeWithCWE(%q,%q,%q) = %q, want %q", c.title, c.desc, c.cwe, got, c.want)
+			}
+		})
+	}
+}
+
+func TestFindDuplicateVulnerability_CWEFallbackDedup(t *testing.T) {
+	// Neither title nor description carries an XSS keyword, but both findings
+	// declare CWE-79 → the CWE fallback recognizes them as the same class on the
+	// same endpoint, so the second is a duplicate.
+	existing := []Vulnerability{{
+		ID: "XALG-1", Title: "Unauthenticated contact creation", Description: "creates a contact record",
+		CWE: "CWE-79", Target: "https://app.example.com", Endpoint: "/api/contacts",
+	}}
+	dup, _, isDup := findDuplicateVulnerability(existing, "Arbitrary contact addition", "adds a contact record",
+		"CWE-79", "https://app.example.com", "/api/contacts")
+	if !isDup {
+		t.Fatal("expected CWE-79 findings on the same endpoint to dedup via the CWE class fallback")
+	}
+	if dup.ID != "XALG-1" {
+		t.Fatalf("expected duplicate of XALG-1, got %q", dup.ID)
+	}
+}
+
+func TestFindDuplicateVulnerability_UnmappedCWENotMerged(t *testing.T) {
+	// An unmapped CWE and no class keyword → class stays "", so distinct titles
+	// on the same endpoint are NOT collapsed (the fallback never over-merges).
+	existing := []Vulnerability{{
+		ID: "XALG-1", Title: "Odd behavior A", Description: "something happens",
+		CWE: "CWE-770", Target: "https://app.example.com", Endpoint: "/api/x",
+	}}
+	if _, _, isDup := findDuplicateVulnerability(existing, "Odd behavior B", "something else happens",
+		"CWE-770", "https://app.example.com", "/api/x"); isDup {
+		t.Fatal("unmapped CWE + no keyword must not merge distinct findings")
 	}
 }


### PR DESCRIPTION
Follow-up to v4.6.16 (path-templated dedup), same precision-over-volume goal.

## Problem
Near-duplicate detection keys on vulnerability class, inferred only from title/description keywords. A finding worded without its class name — e.g. `Unauthenticated contact creation` that is really stored XSS (CWE-79) — yields class `""` and escapes the class-match rule, so it lands as a separate report and pays for its own full verifier pass.

## Change
`extractVulnTypeWithCWE` adds a CWE fallback: when no keyword is present, the finding's CWE maps to the same canonical class names `extractVulnType` uses. `findDuplicateVulnerability` now threads the incoming `cwe` (`args["cwe_id"]`) and compares against each existing finding's `CWE`.
- **Conservative**: only high-confidence, common CWEs are mapped; an unmapped CWE with no keyword still yields no class, so the fallback never over-merges distinct findings.
- All 5 call sites updated (report Gate 0/4/final + the two merge paths).

## Tests
`extractVulnTypeWithCWE` (keyword precedence, CWE fallback, unmapped/empty) and `findDuplicateVulnerability` (keyword-free same-CWE dedup; unmapped-CWE stays distinct). Build, gofmt, vet, lint, reporting suite green. Base main (v4.6.17).