### PR TITLE
release: v4.6.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased] — CWE-aware duplicate detection
+## [v4.6.18](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.18) — CWE-aware duplicate detection (2026-09-01)
 
 ### Changed
 - **Duplicate detection now falls back to the CWE when a finding's title doesn't name its class.** The near-duplicate check keys on vulnerability class, which it inferred from title/description keywords — so a finding worded without the class name (e.g. "Unauthenticated contact creation" that is really stored XSS, tagged CWE-79) escaped class-based dedup and paid for its own full verification. When no keyword is present, the finding's CWE is now mapped to the class, so same-class findings on the same endpoint collapse as intended. The mapping is limited to high-confidence, common CWEs; an unmapped CWE with no keyword still yields no class, so the fallback never over-merges distinct findings.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.17
+VERSION=4.6.18
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.17"
+var version = "4.6.18"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.18 — CWE-aware duplicate detection.

Bumps version (main.go, Makefile) and promotes the CHANGELOG [Unreleased] section to v4.6.18.

Ships the fix from #516: when a finding's title/description carry no class keyword, its CWE is mapped to the class so same-class findings on the same endpoint still dedup — conservative (unmapped CWE never over-merges).