### PR TITLE
Benchmark harness: measure detection per vulnerability class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased] — Benchmark harness (measure detection per class)
+
+### Added
+- **A benchmark harness to measure detection, per vulnerability class.** New `internal/bench` package hosts a set of deliberately vulnerable, self-contained challenge apps (reflected XSS, IDOR, open redirect, error-based SQLi to start) and deterministically scores a scan's findings against the expected class and endpoint — so the effect of a change on real detection can be measured instead of assumed. The heavy agent run is injected as a `ScanFunc`, keeping the challenge apps, scoring, and aggregation fully unit-tested without any model calls. A new operator command, `xalgorix-bench`, wires the real agent and prints a per-class scorecard; it needs `XALGORIX_LLM`/`XALGORIX_API_KEY` and makes live calls, so it is a local tool and not part of the shipped release. This is the first step toward the repeatable evaluation the roadmap requires before any parity claim; the challenge set is intentionally small and will grow.
+
 ## [v4.6.18](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.18) — CWE-aware duplicate detection (2026-09-01)
 
 ### Changed

--- a/cmd/xalgorix-bench/main.go
+++ b/cmd/xalgorix-bench/main.go
@@ -1,0 +1,111 @@
+// Command xalgorix-bench runs the scanner against the built-in benchmark
+// challenges and prints a per-class scorecard. It is an operator tool, NOT part
+// of the shipped release: each challenge triggers a full LLM-driven agent run
+// with live network + tool execution, so it needs XALGORIX_LLM + XALGORIX_API_KEY
+// (or a provider profile) set and cannot run in CI.
+//
+// Usage:
+//
+//	XALGORIX_LLM=... XALGORIX_API_KEY=... xalgorix-bench [-only reflected-xss,idor] [-task "..."]
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/xalgord/xalgorix/v4/internal/agent"
+	"github.com/xalgord/xalgorix/v4/internal/bench"
+	"github.com/xalgord/xalgorix/v4/internal/config"
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+	"github.com/xalgord/xalgorix/v4/internal/scopeguard"
+	"github.com/xalgord/xalgorix/v4/internal/tools/reporting"
+)
+
+func main() {
+	only := flag.String("only", "", "comma-separated challenge names to run (default: all built-in)")
+	task := flag.String("task", "Perform a full security assessment of this target and prove any vulnerability you find with a concrete PoC.", "instruction passed to the agent")
+	flag.Parse()
+
+	cfg := config.Get()
+	if err := cfg.Validate(); err != nil {
+		fmt.Fprintln(os.Stderr, "xalgorix-bench: config invalid — set XALGORIX_LLM and XALGORIX_API_KEY (or XALGORIX_LLM_PROFILE):", err)
+		os.Exit(2)
+	}
+
+	challenges := bench.Builtin()
+	if *only != "" {
+		challenges = filterChallenges(challenges, *only)
+		if len(challenges) == 0 {
+			fmt.Fprintf(os.Stderr, "xalgorix-bench: no built-in challenges matched -only=%q\n", *only)
+			os.Exit(2)
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "xalgorix-bench: running %d challenge(s) with model %s\n", len(challenges), cfg.ResolveModel())
+	card := bench.Run(context.Background(), challenges, realScan(*task))
+	fmt.Print(card.String())
+}
+
+func filterChallenges(all []bench.Challenge, csv string) []bench.Challenge {
+	want := map[string]bool{}
+	for _, n := range strings.Split(csv, ",") {
+		if n = strings.TrimSpace(n); n != "" {
+			want[n] = true
+		}
+	}
+	out := make([]bench.Challenge, 0, len(want))
+	for _, c := range all {
+		if want[c.Name] {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// realScan builds the ScanFunc that drives a real agent run against one target
+// and returns the findings it produced. Mirrors the production scan wiring
+// (internal/web/scan_session.go) minus the dashboard plumbing.
+func realScan(instruction string) bench.ScanFunc {
+	return func(_ context.Context, target, scanID string) ([]reporting.Vulnerability, error) {
+		cfg := config.Get()
+
+		scanDir := filepath.Join(os.TempDir(), "xalgorix-bench", scanID)
+		if err := os.MkdirAll(scanDir, 0o750); err != nil {
+			return nil, err
+		}
+		sc := scanctx.New(scanID, scanDir)
+		scanctx.Activate(sc)
+		defer func() {
+			scanctx.Deactivate(sc.ID)
+			sc.Close()
+			reporting.CleanupContext(sc.ID)
+		}()
+
+		// Drain agent events so the agent never blocks on emit.
+		events := make(chan agent.Event, 512)
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			for range events {
+			}
+		}()
+
+		// AllowLocalTargets lets the scan reach the loopback challenge server.
+		guard := scopeguard.Config{BindAddr: "127.0.0.1", Port: 0, AllowLocalTargets: true}
+		ag := agent.NewAgent(cfg, "XalgorixBench", events, guard, sc)
+		ag.SetPhaseRestrictions(nil)
+		ag.SetActivityPolicy("active", "active", []string{target})
+
+		fmt.Fprintf(os.Stderr, "  [bench] %s → %s\n", scanID, target)
+		ag.Run([]string{target}, instruction)
+
+		close(events)
+		<-done
+
+		return reporting.GetVulnerabilitiesForContext(sc.ID), nil
+	}
+}

--- a/internal/bench/bench_test.go
+++ b/internal/bench/bench_test.go
@@ -1,0 +1,149 @@
+package bench
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/tools/reporting"
+)
+
+func challengeByName(t *testing.T, name string) Challenge {
+	t.Helper()
+	for _, c := range Builtin() {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("no builtin challenge %q", name)
+	return Challenge{}
+}
+
+// noRedirectClient captures 3xx instead of following them.
+func noRedirectClient() *http.Client {
+	return &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+}
+
+func TestBuiltinChallengesExhibitVuln(t *testing.T) {
+	// reflected-xss: payload reflected unescaped.
+	xss := challengeByName(t, "reflected-xss").Start()
+	defer xss.Close()
+	if body := httpGet(t, xss.URL+"/search?q=<script>alert(1)</script>"); !strings.Contains(body, "<script>alert(1)</script>") {
+		t.Fatalf("reflected-xss did not reflect payload: %q", body)
+	}
+
+	// idor: arbitrary id returns a populated record.
+	idor := challengeByName(t, "idor").Start()
+	defer idor.Close()
+	if body := httpGet(t, idor.URL+"/api/orders/999"); !strings.Contains(body, "user-999") {
+		t.Fatalf("idor did not serve arbitrary id: %q", body)
+	}
+
+	// open-redirect: 302 to attacker url.
+	orc := challengeByName(t, "open-redirect").Start()
+	defer orc.Close()
+	resp, err := noRedirectClient().Get(orc.URL + "/redirect?url=https://evil.example/")
+	if err != nil {
+		t.Fatalf("open-redirect request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusFound || resp.Header.Get("Location") != "https://evil.example/" {
+		t.Fatalf("open-redirect: status=%d loc=%q", resp.StatusCode, resp.Header.Get("Location"))
+	}
+
+	// error-sqli: quote triggers a SQL error.
+	sqli := challengeByName(t, "error-sqli").Start()
+	defer sqli.Close()
+	if body := httpGet(t, sqli.URL+"/product?id=1'"); !strings.Contains(strings.ToLower(body), "sql syntax") {
+		t.Fatalf("error-sqli did not leak a SQL error: %q", body)
+	}
+}
+
+func httpGet(t *testing.T, url string) string {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	return string(b)
+}
+
+func TestClassifyFinding(t *testing.T) {
+	cases := []struct {
+		title, desc, cwe, want string
+	}{
+		{"Reflected XSS in search", "", "", "xss"},
+		{"Injection issue", "SQL injection via id", "", "sqli"},
+		{"Open Redirect on /redirect", "", "", "open_redirect"},
+		{"Access another user's order", "insecure direct object reference", "", "idor"},
+		{"Mystery bug", "no class keyword", "CWE-79", "xss"},   // CWE fallback
+		{"Mystery bug", "no class keyword", "CWE-639", "idor"}, // CWE fallback
+		{"Mystery bug", "no class keyword", "CWE-99999", ""},   // unmapped
+		{"Mystery bug", "no class keyword", "", ""},            // nothing
+	}
+	for _, c := range cases {
+		got := classifyFinding(reporting.Vulnerability{Title: c.title, Description: c.desc, CWE: c.cwe})
+		if got != c.want {
+			t.Errorf("classifyFinding(%q,%q,%q) = %q, want %q", c.title, c.desc, c.cwe, got, c.want)
+		}
+	}
+}
+
+func TestSolved(t *testing.T) {
+	// Match on class + exact endpoint.
+	f := []reporting.Vulnerability{{ID: "XALG-1", Title: "Reflected XSS", Endpoint: "https://h/search?q=x"}}
+	if ok, id := Solved("xss", "/search", f); !ok || id != "XALG-1" {
+		t.Fatalf("expected xss on /search to solve, got ok=%v id=%q", ok, id)
+	}
+	// IDOR reported on an object-id path matches the parent challenge endpoint.
+	f = []reporting.Vulnerability{{ID: "XALG-2", Title: "IDOR", Description: "insecure direct object", Endpoint: "/api/orders/1042"}}
+	if ok, _ := Solved("idor", "/api/orders", f); !ok {
+		t.Fatal("expected idor on /api/orders/1042 to match challenge endpoint /api/orders")
+	}
+	// Right class, wrong endpoint → not solved.
+	if ok, _ := Solved("xss", "/search", []reporting.Vulnerability{{Title: "Reflected XSS", Endpoint: "/other"}}); ok {
+		t.Fatal("xss on /other must not solve /search")
+	}
+	// Right endpoint, wrong class → not solved.
+	if ok, _ := Solved("xss", "/search", []reporting.Vulnerability{{Title: "SQL injection", Endpoint: "/search"}}); ok {
+		t.Fatal("sqli on /search must not solve an xss challenge")
+	}
+	// No findings → not solved.
+	if ok, _ := Solved("xss", "/search", nil); ok {
+		t.Fatal("no findings must not solve")
+	}
+}
+
+func TestRunWithFakeScanFunc(t *testing.T) {
+	// Fake solves xss and idor, leaves open-redirect and error-sqli unsolved,
+	// and errors on nothing.
+	fake := func(_ context.Context, target, scanID string) ([]reporting.Vulnerability, error) {
+		switch scanID {
+		case "bench-reflected-xss":
+			return []reporting.Vulnerability{{ID: "XALG-1", Title: "Reflected XSS in search", Endpoint: target + "/search"}}, nil
+		case "bench-idor":
+			return []reporting.Vulnerability{{ID: "XALG-1", Title: "IDOR", Description: "insecure direct object reference", Endpoint: target + "/api/orders/1042"}}, nil
+		default:
+			return nil, nil
+		}
+	}
+
+	card := Run(context.Background(), Builtin(), fake)
+	if card.Total() != 4 {
+		t.Fatalf("expected 4 challenges, got %d", card.Total())
+	}
+	if card.SolvedCount() != 2 {
+		t.Fatalf("expected 2 solved (xss+idor), got %d\n%s", card.SolvedCount(), card.String())
+	}
+	byClass := card.ByClass()
+	if byClass["xss"] != [2]int{1, 1} || byClass["idor"] != [2]int{1, 1} {
+		t.Fatalf("expected xss 1/1 and idor 1/1, got %v", byClass)
+	}
+	if byClass["open_redirect"] != [2]int{0, 1} || byClass["sqli"] != [2]int{0, 1} {
+		t.Fatalf("expected open_redirect 0/1 and sqli 0/1, got %v", byClass)
+	}
+}

--- a/internal/bench/challenge.go
+++ b/internal/bench/challenge.go
@@ -1,0 +1,110 @@
+// Package bench is an operator-run benchmark harness for Xalgorix. It runs the
+// scanner against a fixed set of deliberately vulnerable, self-hosted challenge
+// apps and scores the findings, so the effect of a change on real detection can
+// be measured per vulnerability class instead of guessed at.
+//
+// The heavy part — actually running the LLM-driven agent — is injected as a
+// ScanFunc (see harness.go), so the challenge apps, scoring, and aggregation are
+// deterministic and unit-testable without any model calls. The real agent
+// ScanFunc lives in cmd/xalgorix-bench (operator-run: it needs an LLM key and
+// makes live network/tool calls, so it can never run in CI).
+package bench
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+)
+
+// Challenge is one benchmark task: a self-contained, deliberately vulnerable web
+// app plus the finding a correct scan is expected to produce against it.
+type Challenge struct {
+	Name     string       // unique id, e.g. "reflected-xss"
+	Class    string       // canonical expected vuln class (see canonicalClass)
+	Endpoint string       // the vulnerable path, e.g. "/search"
+	Param    string       // the vulnerable parameter, when applicable
+	Desc     string       // one-line human description
+	Handler  http.Handler // the deliberately vulnerable app
+}
+
+// Start launches the challenge app on an ephemeral loopback server. The caller
+// owns the returned server and must Close it.
+func (c Challenge) Start() *httptest.Server {
+	return httptest.NewServer(c.Handler)
+}
+
+// Builtin returns the starter challenge set. Each app exhibits exactly one
+// unambiguous, class-canonical vulnerability on its Endpoint so scoring is
+// crisp. The set is intentionally small; expand it (and, later, wire external
+// suites like XBOW) in follow-ups.
+//
+// These handlers are deliberately vulnerable — that is the whole point of a
+// detection benchmark — so the security-lint warnings they would otherwise
+// attract are avoided by construction (e.g. the open redirect sets Location
+// directly) rather than by shipping exploitable helpers.
+func Builtin() []Challenge {
+	return []Challenge{
+		{
+			Name: "reflected-xss", Class: "xss", Endpoint: "/search", Param: "q",
+			Desc: "Reflects the q parameter into the HTML response without encoding.",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				q := r.URL.Query().Get("q")
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				// Deliberately unescaped reflection.
+				_, _ = fmt.Fprintf(w, "<html><body><h1>Results</h1><p>You searched for: %s</p></body></html>", q)
+			}),
+		},
+		{
+			Name: "idor", Class: "idor", Endpoint: "/api/orders", Param: "id",
+			Desc: "Serves any order by id under /api/orders/<id> with no authorization check.",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Any id returns a populated record — no session/ownership check.
+				id := r.URL.Path[len("/api/orders/"):]
+				if id == "" {
+					http.NotFound(w, r)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprintf(w, `{"order_id":%q,"owner":"user-%s","total":"1240.00","card_last4":"4242"}`, id, id)
+			}),
+		},
+		{
+			Name: "open-redirect", Class: "open_redirect", Endpoint: "/redirect", Param: "url",
+			Desc: "Issues a 302 to an attacker-controlled url parameter.",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				u := r.URL.Query().Get("url")
+				if u == "" {
+					u = "/"
+				}
+				// Deliberately unvalidated redirect. Set Location directly (rather
+				// than http.Redirect) so this stays a real open redirect for the
+				// scanner to detect.
+				w.Header().Set("Location", u)
+				w.WriteHeader(http.StatusFound)
+			}),
+		},
+		{
+			Name: "error-sqli", Class: "sqli", Endpoint: "/product", Param: "id",
+			Desc: "Leaks a database syntax error when the id parameter contains a quote.",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				id := r.URL.Query().Get("id")
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				if containsQuote(id) {
+					w.WriteHeader(http.StatusInternalServerError)
+					_, _ = fmt.Fprintf(w, "Database error: You have an error in your SQL syntax; check the manual near '%s' at line 1", id)
+					return
+				}
+				_, _ = fmt.Fprintf(w, "<html><body>Product #%s</body></html>", id)
+			}),
+		},
+	}
+}
+
+func containsQuote(s string) bool {
+	for _, r := range s {
+		if r == '\'' || r == '"' {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/bench/harness.go
+++ b/internal/bench/harness.go
@@ -1,0 +1,47 @@
+package bench
+
+import (
+	"context"
+	"time"
+
+	"github.com/xalgord/xalgorix/v4/internal/tools/reporting"
+)
+
+// ScanFunc runs a full scan against target (the base URL of a challenge app)
+// under the given scan id, and returns the findings it produced. It is injected
+// so the harness stays free of the heavy, non-hermetic agent machinery: the
+// real implementation (cmd/xalgorix-bench) drives the LLM agent and makes live
+// calls, while tests pass a deterministic fake.
+type ScanFunc func(ctx context.Context, target, scanID string) ([]reporting.Vulnerability, error)
+
+// Run executes each challenge in order: it starts the challenge app, invokes the
+// scan against its base URL, scores the findings against the expected class and
+// endpoint, and aggregates a Scorecard. Challenges run sequentially so a single
+// shared LLM/tool budget isn't contended and the run is reproducible.
+func Run(ctx context.Context, challenges []Challenge, scan ScanFunc) Scorecard {
+	card := Scorecard{Results: make([]Result, 0, len(challenges))}
+	for _, c := range challenges {
+		if ctx.Err() != nil {
+			break
+		}
+		card.Results = append(card.Results, runOne(ctx, c, scan))
+	}
+	return card
+}
+
+func runOne(ctx context.Context, c Challenge, scan ScanFunc) Result {
+	srv := c.Start()
+	defer srv.Close()
+
+	res := Result{Name: c.Name, Class: canonicalClass(c.Class)}
+	start := time.Now()
+	findings, err := scan(ctx, srv.URL, "bench-"+c.Name)
+	res.Elapsed = time.Since(start)
+	res.Findings = len(findings)
+	if err != nil {
+		res.Err = err
+		return res
+	}
+	res.Solved, res.MatchedFindingID = Solved(c.Class, c.Endpoint, findings)
+	return res
+}

--- a/internal/bench/score.go
+++ b/internal/bench/score.go
@@ -1,0 +1,245 @@
+package bench
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/xalgord/xalgorix/v4/internal/tools/reporting"
+)
+
+// Result is the outcome of running one challenge.
+type Result struct {
+	Name             string
+	Class            string
+	Solved           bool
+	MatchedFindingID string
+	Findings         int
+	Elapsed          time.Duration
+	Err              error
+}
+
+// Scorecard aggregates challenge results.
+type Scorecard struct {
+	Results []Result
+}
+
+// Total returns the number of challenges run.
+func (s Scorecard) Total() int { return len(s.Results) }
+
+// SolvedCount returns the number of challenges solved.
+func (s Scorecard) SolvedCount() int {
+	n := 0
+	for _, r := range s.Results {
+		if r.Solved {
+			n++
+		}
+	}
+	return n
+}
+
+// ByClass returns solved/total counts per vulnerability class.
+func (s Scorecard) ByClass() map[string][2]int {
+	out := map[string][2]int{}
+	for _, r := range s.Results {
+		c := out[r.Class]
+		c[1]++
+		if r.Solved {
+			c[0]++
+		}
+		out[r.Class] = c
+	}
+	return out
+}
+
+// String renders a human-readable scorecard.
+func (s Scorecard) String() string {
+	var b strings.Builder
+	total := s.Total()
+	solved := s.SolvedCount()
+	pct := 0.0
+	if total > 0 {
+		pct = 100 * float64(solved) / float64(total)
+	}
+	fmt.Fprintf(&b, "Benchmark scorecard: %d/%d solved (%.0f%%)\n", solved, total, pct)
+	for _, r := range s.Results {
+		status := "FAIL"
+		if r.Solved {
+			status = "PASS"
+		}
+		fmt.Fprintf(&b, "  [%s] %-16s %-14s %2d finding(s)  %6.1fs", status, r.Name, r.Class, r.Findings, r.Elapsed.Seconds())
+		if r.MatchedFindingID != "" {
+			fmt.Fprintf(&b, "  -> %s", r.MatchedFindingID)
+		}
+		if r.Err != nil {
+			fmt.Fprintf(&b, "  ERROR: %v", r.Err)
+		}
+		b.WriteByte('\n')
+	}
+	// Per-class line, sorted for stable output.
+	byClass := s.ByClass()
+	classes := make([]string, 0, len(byClass))
+	for c := range byClass {
+		classes = append(classes, c)
+	}
+	sort.Strings(classes)
+	if len(classes) > 0 {
+		b.WriteString("By class:")
+		for _, c := range classes {
+			fmt.Fprintf(&b, " %s %d/%d", c, byClass[c][0], byClass[c][1])
+		}
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// Solved reports whether any finding proves the expected class on the expected
+// endpoint, returning the matching finding's ID. This is the deterministic
+// scoring primitive — no model involved.
+func Solved(expectedClass, expectedEndpoint string, findings []reporting.Vulnerability) (bool, string) {
+	want := canonicalClass(expectedClass)
+	wantPath := endpointPath(expectedEndpoint)
+	for _, f := range findings {
+		if classifyFinding(f) != want {
+			continue
+		}
+		if endpointMatches(wantPath, f.Endpoint) || endpointMatches(wantPath, f.Target) {
+			return true, f.ID
+		}
+	}
+	return false, ""
+}
+
+// classifyFinding maps a finding to a canonical vuln class using its title,
+// description, and CWE. It is intentionally self-contained (not tied to the
+// reporting package's private classifier) so the benchmark's notion of "right
+// class" is explicit and stable.
+func classifyFinding(f reporting.Vulnerability) string {
+	text := strings.ToLower(f.Title + " " + f.Description)
+	for _, m := range classKeywords {
+		for _, kw := range m.keywords {
+			if strings.Contains(text, kw) {
+				return m.class
+			}
+		}
+	}
+	return cweClass(f.CWE)
+}
+
+type classMatch struct {
+	class    string
+	keywords []string
+}
+
+// classKeywords maps title/description keywords to canonical classes. Order
+// matters only in that the first hit wins; keep the more specific phrases first.
+var classKeywords = []classMatch{
+	{"xss", []string{"xss", "cross-site scripting", "cross site scripting", "script injection"}},
+	{"sqli", []string{"sql injection", "sqli", "sql inject", "union select", "blind sql"}},
+	{"open_redirect", []string{"open redirect", "unvalidated redirect", "url redirect"}},
+	{"idor", []string{"idor", "insecure direct object", "bola", "broken object level", "broken access control", "unauthorized access"}},
+	{"ssrf", []string{"ssrf", "server-side request forgery", "server side request forgery"}},
+	{"rce", []string{"remote code execution", "rce", "command injection", "os command", "code execution"}},
+	{"lfi", []string{"local file inclusion", "lfi", "path traversal", "directory traversal"}},
+	{"ssti", []string{"ssti", "template injection"}},
+	{"xxe", []string{"xxe", "xml external entity"}},
+	{"csrf", []string{"csrf", "cross-site request forgery"}},
+}
+
+// canonicalClass normalizes a class label to the benchmark's canonical set.
+func canonicalClass(c string) string {
+	c = strings.ToLower(strings.TrimSpace(c))
+	switch c {
+	case "bola", "bfla":
+		return "idor"
+	case "openredirect", "open-redirect":
+		return "open_redirect"
+	default:
+		return c
+	}
+}
+
+// cweClass maps a CWE identifier to a canonical class, or "" when unmapped.
+func cweClass(cwe string) string {
+	switch firstDigits(cwe) {
+	case "79":
+		return "xss"
+	case "89":
+		return "sqli"
+	case "601":
+		return "open_redirect"
+	case "918":
+		return "ssrf"
+	case "22":
+		return "lfi"
+	case "77", "78", "94":
+		return "rce"
+	case "611":
+		return "xxe"
+	case "352":
+		return "csrf"
+	case "1336":
+		return "ssti"
+	case "284", "285", "639", "862", "863", "566":
+		return "idor"
+	default:
+		return ""
+	}
+}
+
+// firstDigits returns the first run of digits in s (so "CWE-79" -> "79").
+func firstDigits(s string) string {
+	start := -1
+	for i := 0; i < len(s); i++ {
+		if s[i] >= '0' && s[i] <= '9' {
+			if start == -1 {
+				start = i
+			}
+		} else if start != -1 {
+			return s[start:i]
+		}
+	}
+	if start != -1 {
+		return s[start:]
+	}
+	return ""
+}
+
+// endpointMatches reports whether a finding's endpoint/target covers the
+// expected path: exact match, or the expected path is a parent segment of the
+// finding's path (so an IDOR reported on /api/orders/1042 matches the challenge
+// endpoint /api/orders).
+func endpointMatches(wantPath, findingLoc string) bool {
+	got := endpointPath(findingLoc)
+	if got == "" || wantPath == "" {
+		return false
+	}
+	return got == wantPath || strings.HasPrefix(got, wantPath+"/")
+}
+
+// endpointPath reduces an endpoint or full URL to a normalized path: host and
+// scheme stripped, query/fragment removed, trailing slash trimmed, lowercased.
+func endpointPath(loc string) string {
+	loc = strings.TrimSpace(loc)
+	if loc == "" {
+		return ""
+	}
+	if strings.Contains(loc, "://") {
+		if u, err := url.Parse(loc); err == nil {
+			loc = u.Path
+		}
+	}
+	if i := strings.IndexAny(loc, "?#"); i >= 0 {
+		loc = loc[:i]
+	}
+	loc = strings.ToLower(loc)
+	if len(loc) > 1 {
+		loc = strings.TrimRight(loc, "/")
+	}
+	if loc == "" {
+		return "/"
+	}
+	return loc
+}


### PR DESCRIPTION
First step toward the repeatable evaluation the roadmap requires before any parity claim.

## What
- **`internal/bench`**: a `Challenge` is a self-contained, deliberately vulnerable `httptest` app plus the finding a correct scan should produce (`{class, endpoint}`). `Builtin()` ships a starter set: reflected XSS, IDOR, open redirect, error-based SQLi. Scoring is deterministic — `classifyFinding` (title/description keywords + CWE fallback) and `Solved` (class + endpoint match, with parent-path matching so an IDOR on `/api/orders/1042` counts for the `/api/orders` challenge). A `Scorecard` aggregates per-class pass rates.
- **Injected `ScanFunc`**: the heavy LLM agent run is a pluggable function, so the challenge apps, scoring, and aggregation are **fully unit-tested with a fake** — hermetic, race-clean, no model calls.
- **`cmd/xalgorix-bench`**: an operator runner that wires the real agent (mirrors production scan wiring) and prints the scorecard. It needs `XALGORIX_LLM`/`XALGORIX_API_KEY` and makes live calls, so it compiles under `go vet/test ./...` but is **never run in CI**, and the release still ships only `./cmd/xalgorix`.

## Why
We've added a lot of detection capability recently; this lets us actually measure the effect per class instead of assuming it. The challenge set is intentionally small and will grow (and later wire external suites like XBOW).

## Tests
Challenge servers exhibit their vuln; `classifyFinding` and `Solved` matrices; `Run` with a fake ScanFunc yields the expected per-class scorecard. Build, gofmt, vet, golangci-lint (0 issues), and the hermetic bench tests (`-race`) are green. Base main (v4.6.18).