### PR TITLE
release: v4.6.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased] — Benchmark harness (measure detection per class)
+## [v4.6.19](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.19) — Benchmark harness (measure detection per class) (2026-09-01)
 
 ### Added
 - **A benchmark harness to measure detection, per vulnerability class.** New `internal/bench` package hosts a set of deliberately vulnerable, self-contained challenge apps (reflected XSS, IDOR, open redirect, error-based SQLi to start) and deterministically scores a scan's findings against the expected class and endpoint — so the effect of a change on real detection can be measured instead of assumed. The heavy agent run is injected as a `ScanFunc`, keeping the challenge apps, scoring, and aggregation fully unit-tested without any model calls. A new operator command, `xalgorix-bench`, wires the real agent and prints a per-class scorecard; it needs `XALGORIX_LLM`/`XALGORIX_API_KEY` and makes live calls, so it is a local tool and not part of the shipped release. This is the first step toward the repeatable evaluation the roadmap requires before any parity claim; the challenge set is intentionally small and will grow.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.18
+VERSION=4.6.19
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.18"
+var version = "4.6.19"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.19 — Benchmark harness (measure detection per class).

Bumps version (main.go, Makefile) and promotes the CHANGELOG [Unreleased] section to v4.6.19.

Ships the feature from #518: internal/bench (self-hosted vulnerable challenge apps + deterministic per-class scoring, unit-tested via an injected ScanFunc) and the operator-only cmd/xalgorix-bench runner. Shipped binary unchanged (release builds only ./cmd/xalgorix).