### PR TITLE
Benchmark: add SSRF, SSTI, LFI, and command-injection challenges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased] — More benchmark challenges (SSRF, SSTI, LFI, command injection)
+
+### Added
+- **Four more benchmark challenge classes.** The benchmark harness now covers SSRF (an internal-target fetch returns cloud-metadata-like secrets), SSTI (a `{{7*7}}` expression evaluates to `49`), LFI/path traversal (`../../etc/passwd` returns passwd-like content), and command injection (a shell metacharacter yields `uid=0(root)`), on top of the existing reflected XSS, IDOR, open redirect, and error-based SQLi. Each challenge simulates the dangerous outcome rather than performing a real fetch/exec/file-read, so the set stays hermetic and safe while presenting a crisp, detectable signal. All four map to existing scoring classes, so `xalgorix-bench` now measures eight classes.
+
 ## [v4.6.19](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.19) — Benchmark harness (measure detection per class) (2026-09-01)
 
 ### Added

--- a/internal/bench/bench_test.go
+++ b/internal/bench/bench_test.go
@@ -80,6 +80,10 @@ func TestClassifyFinding(t *testing.T) {
 		{"Injection issue", "SQL injection via id", "", "sqli"},
 		{"Open Redirect on /redirect", "", "", "open_redirect"},
 		{"Access another user's order", "insecure direct object reference", "", "idor"},
+		{"SSRF in the fetch endpoint", "", "", "ssrf"},
+		{"Server-Side Template Injection via name", "template injection", "", "ssti"},
+		{"Path traversal in download", "local file inclusion", "", "lfi"},
+		{"Command injection in ping", "os command executed", "", "rce"},
 		{"Mystery bug", "no class keyword", "CWE-79", "xss"},   // CWE fallback
 		{"Mystery bug", "no class keyword", "CWE-639", "idor"}, // CWE fallback
 		{"Mystery bug", "no class keyword", "CWE-99999", ""},   // unmapped
@@ -133,8 +137,8 @@ func TestRunWithFakeScanFunc(t *testing.T) {
 	}
 
 	card := Run(context.Background(), Builtin(), fake)
-	if card.Total() != 4 {
-		t.Fatalf("expected 4 challenges, got %d", card.Total())
+	if card.Total() != len(Builtin()) {
+		t.Fatalf("expected %d challenges, got %d", len(Builtin()), card.Total())
 	}
 	if card.SolvedCount() != 2 {
 		t.Fatalf("expected 2 solved (xss+idor), got %d\n%s", card.SolvedCount(), card.String())
@@ -143,7 +147,40 @@ func TestRunWithFakeScanFunc(t *testing.T) {
 	if byClass["xss"] != [2]int{1, 1} || byClass["idor"] != [2]int{1, 1} {
 		t.Fatalf("expected xss 1/1 and idor 1/1, got %v", byClass)
 	}
-	if byClass["open_redirect"] != [2]int{0, 1} || byClass["sqli"] != [2]int{0, 1} {
-		t.Fatalf("expected open_redirect 0/1 and sqli 0/1, got %v", byClass)
+	// Every other class is present but unsolved by this fake.
+	for _, c := range []string{"open_redirect", "sqli", "ssrf", "ssti", "lfi", "rce"} {
+		if byClass[c] != [2]int{0, 1} {
+			t.Fatalf("expected %s 0/1, got %v", c, byClass[c])
+		}
+	}
+}
+
+func TestNewBuiltinChallengesExhibitVuln(t *testing.T) {
+	// ssrf: an internal-target url returns metadata-like secret content.
+	ssrf := challengeByName(t, "ssrf").Start()
+	defer ssrf.Close()
+	if body := httpGet(t, ssrf.URL+"/fetch?url=http://169.254.169.254/latest/meta-data/"); !strings.Contains(body, "security-credentials") {
+		t.Fatalf("ssrf did not return internal metadata: %q", body)
+	}
+
+	// ssti: {{7*7}} evaluates to 49.
+	ssti := challengeByName(t, "ssti").Start()
+	defer ssti.Close()
+	if body := httpGet(t, ssti.URL+"/greet?name={{7*7}}"); !strings.Contains(body, "Hello, 49!") {
+		t.Fatalf("ssti did not evaluate the template expression: %q", body)
+	}
+
+	// lfi: path traversal to passwd returns fabricated passwd content.
+	lfi := challengeByName(t, "lfi").Start()
+	defer lfi.Close()
+	if body := httpGet(t, lfi.URL+"/download?file=../../../../etc/passwd"); !strings.Contains(body, "root:x:0:0:") {
+		t.Fatalf("lfi did not leak passwd content: %q", body)
+	}
+
+	// cmdi: a shell metacharacter yields command output.
+	cmdi := challengeByName(t, "cmdi").Start()
+	defer cmdi.Close()
+	if body := httpGet(t, cmdi.URL+"/ping?host=127.0.0.1%3Bid"); !strings.Contains(body, "uid=0(root)") {
+		t.Fatalf("cmdi did not execute the injected command: %q", body)
 	}
 }

--- a/internal/bench/challenge.go
+++ b/internal/bench/challenge.go
@@ -14,6 +14,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
 )
 
 // Challenge is one benchmark task: a self-contained, deliberately vulnerable web
@@ -39,9 +43,10 @@ func (c Challenge) Start() *httptest.Server {
 // suites like XBOW) in follow-ups.
 //
 // These handlers are deliberately vulnerable — that is the whole point of a
-// detection benchmark — so the security-lint warnings they would otherwise
-// attract are avoided by construction (e.g. the open redirect sets Location
-// directly) rather than by shipping exploitable helpers.
+// detection benchmark — but they SIMULATE the dangerous outcome (no real
+// outbound fetch, command execution, or filesystem read), so they exhibit a
+// crisp, detectable signal while staying hermetic and free of security-lint
+// findings.
 func Builtin() []Challenge {
 	return []Challenge{
 		{
@@ -97,6 +102,62 @@ func Builtin() []Challenge {
 				_, _ = fmt.Fprintf(w, "<html><body>Product #%s</body></html>", id)
 			}),
 		},
+		{
+			Name: "ssrf", Class: "ssrf", Endpoint: "/fetch", Param: "url",
+			Desc: "Fetches a user-supplied url; internal targets return cloud-metadata-like content.",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				raw := r.URL.Query().Get("url")
+				host := ""
+				if u, err := url.Parse(raw); err == nil {
+					host = strings.ToLower(u.Hostname())
+				}
+				w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+				if isInternalHost(host) {
+					// Simulated SSRF: the server reaches an internal-only resource
+					// and returns its (fabricated) secret content.
+					_, _ = fmt.Fprint(w, "ami-id: ami-0abc123\niam/security-credentials/admin: {\"AccessKeyId\":\"AKIAINTERNAL\",\"Token\":\"internal-metadata-token\"}\n")
+					return
+				}
+				_, _ = fmt.Fprintf(w, "fetched external url: %s\n", raw)
+			}),
+		},
+		{
+			Name: "ssti", Class: "ssti", Endpoint: "/greet", Param: "name",
+			Desc: "Evaluates a {{ a * b }} expression in the name parameter (template injection).",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				name := r.URL.Query().Get("name")
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				_, _ = fmt.Fprintf(w, "<html><body>Hello, %s!</body></html>", sstiRender(name))
+			}),
+		},
+		{
+			Name: "lfi", Class: "lfi", Endpoint: "/download", Param: "file",
+			Desc: "Path traversal in the file parameter returns system file contents.",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				file := r.URL.Query().Get("file")
+				w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+				if strings.Contains(file, "..") && strings.Contains(file, "passwd") {
+					// Simulated path traversal: return fabricated /etc/passwd content.
+					_, _ = fmt.Fprint(w, "root:x:0:0:root:/root:/bin/bash\ndaemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin\n")
+					return
+				}
+				_, _ = fmt.Fprintf(w, "file not found: %s\n", file)
+			}),
+		},
+		{
+			Name: "cmdi", Class: "rce", Endpoint: "/ping", Param: "host",
+			Desc: "Command injection in the host parameter (shell metacharacters execute).",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				host := r.URL.Query().Get("host")
+				w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+				out := fmt.Sprintf("PING %s: 56 data bytes\n64 bytes: icmp_seq=0 ttl=64 time=0.048 ms\n", host)
+				if hasShellMeta(host) {
+					// Simulated command execution of the injected command.
+					out += "uid=0(root) gid=0(root) groups=0(root)\n"
+				}
+				_, _ = fmt.Fprint(w, out)
+			}),
+		},
 	}
 }
 
@@ -107,4 +168,35 @@ func containsQuote(s string) bool {
 		}
 	}
 	return false
+}
+
+// isInternalHost reports whether a host points at loopback, link-local cloud
+// metadata, or private space — the targets that make a server-side fetch SSRF.
+func isInternalHost(host string) bool {
+	switch host {
+	case "127.0.0.1", "localhost", "0.0.0.0", "169.254.169.254", "metadata.google.internal", "metadata":
+		return true
+	}
+	return strings.HasPrefix(host, "10.") || strings.HasPrefix(host, "192.168.") || strings.HasSuffix(host, ".internal")
+}
+
+// sstiExpr matches a simple "{{ a * b }}" arithmetic template expression.
+var sstiExpr = regexp.MustCompile(`\{\{\s*(\d+)\s*\*\s*(\d+)\s*\}\}`)
+
+// sstiRender evaluates any {{ a * b }} expressions in s (returning the product),
+// simulating a template engine that evaluates attacker input — so the classic
+// {{7*7}} → 49 probe is confirmable.
+func sstiRender(s string) string {
+	return sstiExpr.ReplaceAllStringFunc(s, func(m string) string {
+		parts := sstiExpr.FindStringSubmatch(m)
+		a, _ := strconv.Atoi(parts[1])
+		b, _ := strconv.Atoi(parts[2])
+		return strconv.Itoa(a * b)
+	})
+}
+
+// hasShellMeta reports whether s carries a shell metacharacter that would chain
+// a command in a naive system() call.
+func hasShellMeta(s string) bool {
+	return strings.ContainsAny(s, ";|&`$\n")
 }


### PR DESCRIPTION
Follow-up to v4.6.19 (benchmark harness). Grows the challenge set from 4 to 8 classes.

## What
Four new self-hosted challenge apps in `internal/bench`:
- **ssrf** (`/fetch?url=`) — an internal-target url returns cloud-metadata-like secrets.
- **ssti** (`/greet?name=`) — `{{7*7}}` evaluates to `49`.
- **lfi** (`/download?file=`) — `../../etc/passwd` returns passwd-like content.
- **cmdi** (`/ping?host=`, class `rce`) — a shell metacharacter yields `uid=0(root)`.

Each handler **simulates** the dangerous outcome (no real fetch/exec/file-read), so the set stays hermetic and lint-clean while presenting a crisp, detectable signal. All four map to existing scoring classes — no scorer changes.

## Tests
Each new server's signal is exercised; classifier cases extended; the fake-scan scorecard updated to the larger set. gofmt, `build ./...`, vet, golangci-lint (0 issues), and the `-race` bench tests are green. Shipped binary unchanged (release builds only `./cmd/xalgorix`). Base main (v4.6.19).