### PR TITLE
release: v4.6.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased] — More benchmark challenges (SSRF, SSTI, LFI, command injection)
+## [v4.6.20](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.20) — More benchmark challenges (SSRF, SSTI, LFI, command injection) (2026-09-01)
 
 ### Added
 - **Four more benchmark challenge classes.** The benchmark harness now covers SSRF (an internal-target fetch returns cloud-metadata-like secrets), SSTI (a `{{7*7}}` expression evaluates to `49`), LFI/path traversal (`../../etc/passwd` returns passwd-like content), and command injection (a shell metacharacter yields `uid=0(root)`), on top of the existing reflected XSS, IDOR, open redirect, and error-based SQLi. Each challenge simulates the dangerous outcome rather than performing a real fetch/exec/file-read, so the set stays hermetic and safe while presenting a crisp, detectable signal. All four map to existing scoring classes, so `xalgorix-bench` now measures eight classes.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.19
+VERSION=4.6.20
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.19"
+var version = "4.6.20"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.20 — More benchmark challenges (SSRF, SSTI, LFI, command injection).

Bumps version (main.go, Makefile) and promotes the CHANGELOG [Unreleased] section to v4.6.20.

Ships the feature from #520: the benchmark challenge set grows from 4 to 8 classes (adds SSRF, SSTI, LFI/path-traversal, command injection), all simulated + hermetic. Shipped binary unchanged (release builds only ./cmd/xalgorix).