### PR TITLE
release: v4.6.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased] — Benchmark scoring, robustness, and a per-challenge timeout
+## [v4.6.21](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.21) — Benchmark scoring, robustness, and a per-challenge timeout (2026-09-01)
 
 ### Changed
 - **Benchmark scoring is now class-based.** Each challenge app hosts exactly one vulnerability, so a finding of the expected class against it counts as solved; the previous exact-endpoint requirement wrongly failed a correct detection when the agent proved the bug on a different path (e.g. reflected XSS confirmed at `/?q=` rather than a declared `/search`). Path precision is a separate concern from class detection, which is what the benchmark measures.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.20
+VERSION=4.6.21
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.20"
+var version = "4.6.21"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.21 — Benchmark scoring, robustness, and a per-challenge timeout.

Bumps version (main.go, Makefile) and promotes the CHANGELOG [Unreleased] section to v4.6.21.

Ships the fixes from #522 (surfaced by the first live baseline run): class-based benchmark scoring, a per-challenge wall-clock timeout (bench.RunWithTimeout + -timeout flag), and idor challenge panic-guard + discoverability. Shipped binary unchanged (release builds only ./cmd/xalgorix).