### PR TITLE
release: v4.6.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased] — Stop dropping browser-confirmed XSS as a false positive
+## [v4.6.22](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.22) — Stop dropping browser-confirmed XSS as a false positive (2026-09-01)
 
 ### Fixed
 - **The false-positive gate no longer rejects a browser-confirmed XSS as "reflection only."** When `verify_xss` proves execution in a real browser, it emits a machine-generated proof — `Browser-confirmed XSS: a dialog:alert dialog carrying the nonce "…" fired while loading …` — but that phrasing matched none of the gate's execution markers, while the reflected payload the agent includes (`<script>`, `onerror=`) tripped the reflection-only check, so a genuinely proven XSS was dropped (and had to be re-reported, sometimes landing as needs-manual-verification). The gate now recognizes the verifier's execution tokens (and dialog/console/DOM signal kinds), so a browser-confirmed XSS passes through to the independent verifier instead of being discarded. Surfaced by the first benchmark baseline run.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.21
+VERSION=4.6.22
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.21"
+var version = "4.6.22"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.22 — Stop dropping browser-confirmed XSS as a false positive.

Bumps version (main.go, Makefile) and promotes the CHANGELOG [Unreleased] section to v4.6.22.

Ships the fix from #524 (surfaced by the benchmark baseline): the false-positive gate now recognizes verify_xss's browser-confirmed execution proof, so a genuinely proven XSS is no longer dropped as reflection-only.