### PR TITLE
feat(agent): scan_source_sinks — bridge whitebox source to runtime hypotheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **`scan_source_sinks` bridges whitebox source to runtime exploitation.** Black-box recon finds routes; whitebox search finds the dangerous code behind them — but nothing connected the two automatically. The new tool sweeps the attached source tree for dangerous sinks (RCE/command injection, SQLi, SSRF, file I/O→LFI, template→SSTI, deserialization, open redirect) using the same curated patterns as `code_search`, then seeds each hit into the shared ledger as a source→sink hypothesis tagged with its `file:line` and a `source-sink:` data-flow note — the first automated populator of `Hypothesis.DataFlow`. Each sink class is mapped to its canonical vuln class (e.g. `cmdi`→`rce`, `fileio`→`lfi`, `template`→`ssti`); discovery-only classes (secrets, auth, crypto) are deliberately not seeded. Seeding is bounded (max 40 hypotheses per sweep) and idempotent (dedup by class + `file:line`, so re-running adds nothing), and when no source is configured the tool degrades to a black-box fallback message. Specialists can then `claim_next_hypothesis` and trace each sink back to a reachable route to prove it on the live target — the first step toward source-to-runtime exploitation.
+
 ## [v4.6.22](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.22) — Stop dropping browser-confirmed XSS as a false positive (2026-09-01)
 
 ### Fixed

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -374,6 +374,12 @@ func NewAgent(cfg *config.Config, name string, events chan Event, localGuard sco
 	// with authenticated-endpoint authorization hypotheses.
 	a.registerHARIngestTool(reg)
 
+	// Register the whitebox source-to-runtime bridge (scan_source_sinks): sweeps
+	// the attached source tree for dangerous sinks and seeds each as a
+	// source->sink hypothesis (Endpoint=file:line, Origin=source-sink) so the
+	// evidence-driven loop can trace it to a reachable route and exploit it.
+	a.registerScanSourceSinksTool(reg)
+
 	// Create cancellable context
 	a.ctx, a.cancel = context.WithCancel(a.ctx)
 	// Wire context to LLM client so cancel interrupts pending HTTP requests

--- a/internal/agent/scan_source_sinks.go
+++ b/internal/agent/scan_source_sinks.go
@@ -1,0 +1,161 @@
+// Package agent — scan_source_sinks.go implements scan_source_sinks: the first
+// source-to-runtime bridge. It deterministically sweeps the attached whitebox
+// source tree for dangerous sinks (reusing codesearch's curated patterns +
+// ripgrep/grep) and seeds each hit into the shared ledger as a source->sink
+// hypothesis — the first automated populator of Hypothesis.DataFlow.
+//
+// Why this matters: black-box recon finds routes; whitebox sink discovery finds
+// the DANGEROUS code behind them. Bridging the two — "here is a call to
+// os.system at handlers.py:42; find the route that reaches it and prove RCE on
+// the live target" — is how the agent lands the high-severity classes (RCE,
+// SQLi, SSTI, deserialization) that pure black-box testing misses. Each seeded
+// hypothesis carries the sink location (Endpoint=file:line) and a source->sink
+// DataFlow so a specialist can trace it back to a reachable HTTP route and
+// build a PoC against the running target.
+package agent
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+	"github.com/xalgord/xalgorix/v4/internal/tools"
+	"github.com/xalgord/xalgorix/v4/internal/tools/codesearch"
+)
+
+// maxSinkSeed caps how many hypotheses a single sink sweep seeds so a large
+// codebase cannot flood the ledger.
+const maxSinkSeed = 40
+
+// sinkClassToVuln maps a codesearch sink class to the canonical vuln class used
+// across the ledger/reporting. Only classes that map to a testable runtime
+// vulnerability are seeded; discovery-only classes (secrets, auth, crypto) are
+// intentionally omitted — a matched secret/auth/crypto line is a lead for a
+// human or a different tool, not a source->sink runtime hypothesis.
+var sinkClassToVuln = map[string]string{
+	"rce":             "rce",
+	"cmdi":            "rce",
+	"sqli":            "sqli",
+	"ssrf":            "ssrf",
+	"fileio":          "lfi",
+	"template":        "ssti",
+	"deserialization": "deserialization",
+	"redirect":        "open_redirect",
+}
+
+func (a *Agent) registerScanSourceSinksTool(reg *tools.Registry) {
+	reg.Register(&tools.Tool{
+		Name:        "scan_source_sinks",
+		Description: "Whitebox source-to-runtime bridge. Sweeps the target's attached source tree for dangerous sinks (RCE/command-injection, SQLi, SSRF, file I/O→LFI, template→SSTI, deserialization, open-redirect) and seeds each as a source→sink hypothesis in the shared ledger, tagged with its file:line so you can trace it to a reachable HTTP route and prove it against the LIVE target. Run this once at the start of a whitebox assessment (after source is configured), then use read_ledger(filter=schedulable) / claim_next_hypothesis to work the highest-value sinks. Only available when source is configured for the scan; otherwise fall back to black-box discovery.",
+		Parameters: []tools.Parameter{
+			{Name: "max_per_class", Description: "Max sink matches to seed per vuln class (default 20, hard cap 100).", Required: false},
+		},
+		Execute: a.scanSourceSinksTool,
+	})
+}
+
+func (a *Agent) scanSourceSinksTool(args map[string]string) (tools.Result, error) {
+	if a.scanCtx == nil {
+		return tools.Result{Error: "no scan context — scan_source_sinks needs a scan to seed hypotheses into"}, nil
+	}
+	if codesearch.GetSourceRoot(a.scanCtx.ID) == "" {
+		return tools.Result{Output: "❌ Whitebox source not configured for this scan (set XALGORIX_SOURCE_REPO to a git URL or local path). Fall back to black-box discovery: fetch and read client-side JS bundles and map routes with http_request/browser."}, nil
+	}
+
+	maxPerClass := 20
+	if raw := strings.TrimSpace(args["max_per_class"]); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			maxPerClass = n
+		}
+	}
+
+	found, err := codesearch.SinkScan(a.scanCtx.ID, maxPerClass)
+	if err != nil {
+		return tools.Result{Error: "scan_source_sinks: " + err.Error()}, nil
+	}
+	if len(found) == 0 {
+		return tools.Result{Output: "Swept the source for dangerous sinks and found none of the curated classes. The app may be small or use uncommon APIs — try code_search with a custom regex, or proceed with black-box testing."}, nil
+	}
+
+	seeded := a.seedSinks(found)
+
+	// Deterministic summary: classes sorted, counts and vuln mapping shown.
+	classes := make([]string, 0, len(found))
+	total := 0
+	for c, ms := range found {
+		classes = append(classes, c)
+		total += len(ms)
+	}
+	sort.Strings(classes)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Swept source for dangerous sinks: %d match(es) across %d class(es).\n", total, len(classes))
+	for _, c := range classes {
+		vuln, mapped := sinkClassToVuln[c]
+		note := ""
+		switch {
+		case !mapped:
+			note = " (discovery-only, not seeded)"
+		case vuln != c:
+			note = " → " + vuln
+		}
+		fmt.Fprintf(&b, "  • %s: %d%s\n", c, len(found[c]), note)
+	}
+	if seeded > 0 {
+		fmt.Fprintf(&b, "Seeded %d source→sink hypotheses into the ledger (origin=source-sink). Use read_ledger(filter=schedulable) or claim_next_hypothesis, then trace each sink back to a reachable route and prove it on the live target.", seeded)
+	} else {
+		b.WriteString("No new hypotheses seeded (these sinks are already in the ledger).")
+	}
+	return tools.Result{Output: b.String(), Metadata: map[string]any{"matches": total, "classes": len(classes), "seeded": seeded}}, nil
+}
+
+// seedSinks upserts bounded, deduplicated source->sink hypotheses from a sink
+// sweep and returns how many NEW hypotheses were created. It maps each sink
+// class to its canonical vuln class (skipping discovery-only classes), stamps
+// the sink location as Endpoint=file:line and a source->sink DataFlow, and caps
+// the total at maxSinkSeed. Idempotent: the ledger dedups by
+// vuln_class+endpoint, so re-seeding the same sinks merges onto the existing
+// hypotheses and a second call adds 0.
+func (a *Agent) seedSinks(found map[string][]codesearch.SinkMatch) int {
+	l := a.ledger()
+	if l == nil {
+		return 0
+	}
+	// Deterministic order: classes sorted, matches in scan order.
+	classes := make([]string, 0, len(found))
+	for c := range found {
+		classes = append(classes, c)
+	}
+	sort.Strings(classes)
+
+	seeded := 0
+	for _, class := range classes {
+		vuln, ok := sinkClassToVuln[class]
+		if !ok {
+			continue // discovery-only class (secrets/auth/crypto) — skip.
+		}
+		for _, m := range found[class] {
+			if seeded >= maxSinkSeed {
+				return seeded
+			}
+			loc := fmt.Sprintf("%s:%d", m.File, m.Line)
+			before := l.Len()
+			l.Upsert(scanctx.Hypothesis{
+				Title:      fmt.Sprintf("Source sink (%s) at %s", vuln, loc),
+				VulnClass:  vuln,
+				Endpoint:   loc,
+				DataFlow:   fmt.Sprintf("source-sink: %s — %s", loc, m.Text),
+				Confidence: 0.3,
+				Status:     scanctx.HypothesisQueued,
+				Origin:     "source-sink",
+				NextAction: "Trace this sink backward to the user-controlled input and the reachable HTTP route, then build a PoC against the live target.",
+			})
+			if l.Len() > before {
+				seeded++
+			}
+		}
+	}
+	return seeded
+}

--- a/internal/agent/scan_source_sinks_test.go
+++ b/internal/agent/scan_source_sinks_test.go
@@ -1,0 +1,135 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+	"github.com/xalgord/xalgorix/v4/internal/tools/codesearch"
+)
+
+// TestSeedSinksMapsClassesAndStampsFields verifies the sink-class → vuln-class
+// mapping, that discovery-only classes (secrets/auth/crypto) are skipped, and
+// that every seeded hypothesis carries the source-sink stamp (Endpoint=file:line,
+// DataFlow, Origin, queued status, confidence 0.3).
+func TestSeedSinksMapsClassesAndStampsFields(t *testing.T) {
+	ag := &Agent{scanCtx: scanctx.New("sink-map-"+t.Name(), "")}
+	found := map[string][]codesearch.SinkMatch{
+		"rce":             {{File: "a.py", Line: 1, Text: "os.system(cmd)"}},
+		"cmdi":            {{File: "b.py", Line: 2, Text: "subprocess.call(x)"}},
+		"sqli":            {{File: "c.py", Line: 3, Text: "cursor.execute(q)"}},
+		"ssrf":            {{File: "d.py", Line: 4, Text: "requests.get(u)"}},
+		"fileio":          {{File: "e.py", Line: 5, Text: "open(p)"}},
+		"template":        {{File: "f.py", Line: 6, Text: "render_template_string(t)"}},
+		"deserialization": {{File: "g.py", Line: 7, Text: "pickle.loads(b)"}},
+		"redirect":        {{File: "h.py", Line: 8, Text: "res.redirect(u)"}},
+		// Discovery-only classes must be skipped (no runtime source->sink):
+		"secrets": {{File: "s.py", Line: 9, Text: "api_key = 'x'"}},
+		"auth":    {{File: "au.py", Line: 10, Text: "is_admin == true"}},
+		"crypto":  {{File: "cr.py", Line: 11, Text: "MD5(x)"}},
+	}
+
+	seeded := ag.seedSinks(found)
+	if seeded != 8 {
+		t.Fatalf("expected 8 seeded (mapped classes only), got %d", seeded)
+	}
+	all := ag.scanCtx.Ledger.All()
+	if len(all) != 8 {
+		t.Fatalf("expected 8 ledger hypotheses, got %d", len(all))
+	}
+
+	// endpoint(file:line) -> expected canonical vuln class.
+	wantVuln := map[string]string{
+		"a.py:1": "rce",  // rce -> rce
+		"b.py:2": "rce",  // cmdi -> rce
+		"c.py:3": "sqli", // sqli -> sqli
+		"d.py:4": "ssrf", // ssrf -> ssrf
+		"e.py:5": "lfi",  // fileio -> lfi
+		"f.py:6": "ssti", // template -> ssti
+		"g.py:7": "deserialization",
+		"h.py:8": "open_redirect", // redirect -> open_redirect
+	}
+	for _, h := range all {
+		want, ok := wantVuln[h.Endpoint]
+		if !ok {
+			t.Fatalf("unexpected hypothesis (skipped class leaked?) endpoint=%q vuln=%q", h.Endpoint, h.VulnClass)
+		}
+		if h.VulnClass != want {
+			t.Fatalf("endpoint %s: vuln = %q, want %q", h.Endpoint, h.VulnClass, want)
+		}
+		if h.Origin != "source-sink" {
+			t.Fatalf("endpoint %s: origin = %q, want source-sink", h.Endpoint, h.Origin)
+		}
+		if h.Status != scanctx.HypothesisQueued {
+			t.Fatalf("endpoint %s: status = %q, want queued", h.Endpoint, h.Status)
+		}
+		if !strings.HasPrefix(h.DataFlow, "source-sink:") {
+			t.Fatalf("endpoint %s: DataFlow = %q, want a source-sink: prefix", h.Endpoint, h.DataFlow)
+		}
+		if h.Confidence != 0.3 {
+			t.Fatalf("endpoint %s: confidence = %v, want 0.3", h.Endpoint, h.Confidence)
+		}
+	}
+}
+
+// TestSeedSinksIdempotent verifies re-seeding the same sinks adds nothing (the
+// ledger dedups by vuln_class+endpoint).
+func TestSeedSinksIdempotent(t *testing.T) {
+	ag := &Agent{scanCtx: scanctx.New("sink-idem-"+t.Name(), "")}
+	found := map[string][]codesearch.SinkMatch{
+		"rce":  {{File: "a.py", Line: 1, Text: "os.system(cmd)"}},
+		"sqli": {{File: "c.py", Line: 3, Text: "cursor.execute(q)"}},
+	}
+	if n := ag.seedSinks(found); n != 2 {
+		t.Fatalf("first seed = %d, want 2", n)
+	}
+	if n := ag.seedSinks(found); n != 0 {
+		t.Fatalf("second seed must be idempotent (0 new), got %d", n)
+	}
+	if got := ag.scanCtx.Ledger.Len(); got != 2 {
+		t.Fatalf("ledger should still hold 2 hypotheses, got %d", got)
+	}
+}
+
+// TestSeedSinksBounded verifies a large sweep cannot flood the ledger past
+// maxSinkSeed.
+func TestSeedSinksBounded(t *testing.T) {
+	ag := &Agent{scanCtx: scanctx.New("sink-bound-"+t.Name(), "")}
+	matches := make([]codesearch.SinkMatch, 0, maxSinkSeed*2)
+	for i := 0; i < maxSinkSeed*2; i++ {
+		matches = append(matches, codesearch.SinkMatch{File: "big.py", Line: i + 1, Text: "os.system(x)"})
+	}
+	seeded := ag.seedSinks(map[string][]codesearch.SinkMatch{"rce": matches})
+	if seeded > maxSinkSeed {
+		t.Fatalf("seedSinks must cap at maxSinkSeed=%d, seeded %d", maxSinkSeed, seeded)
+	}
+	if got := ag.scanCtx.Ledger.Len(); got > maxSinkSeed {
+		t.Fatalf("ledger must not exceed maxSinkSeed=%d, got %d", maxSinkSeed, got)
+	}
+}
+
+// TestSeedSinksNilLedger verifies the helper is safe when there is no scan
+// context (some unit paths construct a bare Agent).
+func TestSeedSinksNilLedger(t *testing.T) {
+	ag := &Agent{}
+	if n := ag.seedSinks(map[string][]codesearch.SinkMatch{"rce": {{File: "a", Line: 1}}}); n != 0 {
+		t.Fatalf("nil ledger must seed 0, got %d", n)
+	}
+}
+
+// TestScanSourceSinksToolNoSource verifies the tool degrades gracefully to a
+// black-box fallback message (no error, no seeds) when whitebox source is not
+// configured for the scan.
+func TestScanSourceSinksToolNoSource(t *testing.T) {
+	ag := &Agent{scanCtx: scanctx.New("sink-tool-nosrc-"+t.Name(), "")}
+	res, err := ag.scanSourceSinksTool(map[string]string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(res.Output, "Whitebox source not configured") {
+		t.Fatalf("expected black-box fallback message, got: %s", res.Output)
+	}
+	if ag.scanCtx.Ledger.Len() != 0 {
+		t.Fatal("no source configured → nothing should be seeded")
+	}
+}

--- a/internal/tools/codesearch/codesearch.go
+++ b/internal/tools/codesearch/codesearch.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -182,6 +183,135 @@ func sinkClasses() []string {
 	}
 	sort.Strings(cs)
 	return cs
+}
+
+// SinkMatch is one dangerous-sink hit located in the target's source: a
+// source-root-relative file, a 1-based line number, and the (bounded) matched
+// source text. It is the structured unit the agent seeds into the ledger as a
+// source->sink hypothesis to trace back to a reachable HTTP route.
+type SinkMatch struct {
+	File string `json:"file"`
+	Line int    `json:"line"`
+	Text string `json:"text"`
+}
+
+// SinkScan runs every curated sink-class pattern over the scan's resolved
+// source root and returns the structured matches grouped by class (only classes
+// with at least one hit appear in the map). maxPerClass bounds matches returned
+// per class (defaults to 20, hard cap 100). It errors only when no whitebox
+// source is configured for the scan — the signal callers use to fall back to
+// black-box discovery.
+//
+// This is the programmatic, seed-the-ledger sibling of the code_search tool:
+// code_search renders a human-readable blob for one class on demand, whereas
+// SinkScan sweeps all classes at once and yields typed matches so the agent can
+// deterministically populate source->sink hypotheses. A single class whose
+// search times out is skipped rather than failing the whole sweep.
+func SinkScan(contextID string, maxPerClass int) (map[string][]SinkMatch, error) {
+	root := getSourceRoot(contextID)
+	if root == "" {
+		return nil, fmt.Errorf("whitebox source not configured for scan %q", contextID)
+	}
+	if maxPerClass <= 0 {
+		maxPerClass = 20
+	}
+	if maxPerClass > 100 {
+		maxPerClass = 100
+	}
+	results := make(map[string][]SinkMatch)
+	for _, class := range sinkClasses() {
+		pattern := sinkPatterns[class]
+		if pattern == "" {
+			continue
+		}
+		matches, err := searchSinkMatches(root, pattern, maxPerClass)
+		if err != nil {
+			continue // e.g. this class's search timed out; keep sweeping.
+		}
+		if len(matches) > 0 {
+			results[class] = matches
+		}
+	}
+	return results, nil
+}
+
+// searchSinkMatches runs one sink-class regex over dir and returns structured
+// matches (file:line:text), preferring ripgrep and falling back to grep -RnE.
+// It is the structured sibling of runSearch: instead of a display blob it
+// yields []SinkMatch for programmatic seeding, with source-root-relative paths
+// and bounded text. rg/grep exit 1 (no matches) is not treated as an error;
+// only a timeout is.
+func searchSinkMatches(dir, pattern string, max int) ([]SinkMatch, error) {
+	if max <= 0 {
+		max = 20
+	}
+	var cmd *exec.Cmd
+	if rg, err := exec.LookPath("rg"); err == nil {
+		cmd = exec.Command(rg, "--no-heading", "--line-number", "--color", "never", "-S",
+			"--max-count", strconv.Itoa(max), "-e", pattern, dir)
+	} else {
+		cmd = exec.Command("grep", "-RnE", "--color=never", pattern, dir)
+	}
+
+	done := make(chan struct{})
+	var out []byte
+	go func() {
+		out, _ = cmd.CombinedOutput() // exit 1 == no matches; tolerated
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(60 * time.Second):
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		return nil, fmt.Errorf("sink search timed out")
+	}
+
+	matches := make([]SinkMatch, 0, max)
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		m, ok := parseGrepLine(dir, line)
+		if !ok {
+			continue
+		}
+		matches = append(matches, m)
+		if len(matches) >= max {
+			break
+		}
+	}
+	return matches, nil
+}
+
+// parseGrepLine parses a single rg/grep "file:line:text" record into a
+// SinkMatch with a source-root-relative path and bounded text. It returns
+// ok=false for lines that don't carry a parseable line number (e.g. binary
+// notices or blank separators).
+func parseGrepLine(root, line string) (SinkMatch, bool) {
+	parts := strings.SplitN(line, ":", 3)
+	if len(parts) < 3 {
+		return SinkMatch{}, false
+	}
+	ln, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return SinkMatch{}, false
+	}
+	file := parts[0]
+	if rel, err := filepath.Rel(root, file); err == nil && !strings.HasPrefix(rel, "..") {
+		file = rel
+	}
+	return SinkMatch{File: file, Line: ln, Text: boundText(parts[2], 200)}, true
+}
+
+// boundText trims and length-bounds a matched source line for compact display.
+func boundText(s string, max int) string {
+	s = strings.TrimSpace(s)
+	if len(s) > max {
+		return s[:max] + "…"
+	}
+	return s
 }
 
 func parseIntSafe(s string) (int, error) {

--- a/internal/tools/codesearch/codesearch_test.go
+++ b/internal/tools/codesearch/codesearch_test.go
@@ -208,3 +208,77 @@ func TestRegister(t *testing.T) {
 		t.Fatal("code_search should declare parameters")
 	}
 }
+
+func TestSinkScanNoSource(t *testing.T) {
+	// No source root configured for this context → SinkScan must error so the
+	// caller can fall back to black-box discovery.
+	if _, err := SinkScan("ctx-sinkscan-missing", 20); err == nil {
+		t.Fatal("SinkScan must error when no source root is configured")
+	}
+}
+
+func TestSinkScanFindsRCESink(t *testing.T) {
+	const ctx = "ctx-sinkscan-rce"
+	dir := t.TempDir()
+	// A user-controlled command reaching os.system — the canonical RCE sink the
+	// curated 'rce' class must catch. grep-ERE-safe (no (?i)) so it passes with
+	// the grep fallback when ripgrep is absent (as in CI).
+	src := "import os\n\ndef handler(request):\n    cmd = request.args.get('cmd')\n    os.system(cmd)  # RCE sink\n"
+	if err := os.WriteFile(filepath.Join(dir, "vuln.py"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	SetSourceRoot(ctx, dir)
+	defer SetSourceRoot(ctx, "")
+
+	res, err := SinkScan(ctx, 20)
+	if err != nil {
+		t.Fatalf("SinkScan: %v", err)
+	}
+	rce := res["rce"]
+	if len(rce) == 0 {
+		t.Fatalf("expected >=1 rce sink match, got none; full result: %+v", res)
+	}
+	var found bool
+	for _, m := range rce {
+		// Structured fields must be populated: a source-root-relative file
+		// (never absolute), a 1-based line, and bounded text.
+		if m.File == "" || filepath.IsAbs(m.File) {
+			t.Fatalf("SinkMatch.File must be a source-root-relative path, got %q", m.File)
+		}
+		if m.Line <= 0 {
+			t.Fatalf("SinkMatch.Line must be 1-based, got %d", m.Line)
+		}
+		if strings.Contains(m.Text, "os.system") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected an os.system hit in rce matches, got: %+v", rce)
+	}
+	if rce[0].File != "vuln.py" {
+		t.Fatalf("expected match file 'vuln.py', got %q", rce[0].File)
+	}
+}
+
+func TestSinkScanBoundsPerClass(t *testing.T) {
+	const ctx = "ctx-sinkscan-bound"
+	dir := t.TempDir()
+	var sb strings.Builder
+	sb.WriteString("import os\n")
+	for i := 0; i < 5; i++ {
+		sb.WriteString("os.system('x')\n")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "many.py"), []byte(sb.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	SetSourceRoot(ctx, dir)
+	defer SetSourceRoot(ctx, "")
+
+	res, err := SinkScan(ctx, 2)
+	if err != nil {
+		t.Fatalf("SinkScan: %v", err)
+	}
+	if n := len(res["rce"]); n > 2 {
+		t.Fatalf("maxPerClass=2 must bound rce matches, got %d", n)
+	}
+}


### PR DESCRIPTION
## Summary
First source-to-runtime increment. `scan_source_sinks` sweeps the attached whitebox source tree for dangerous sinks (reusing `code_search`'s curated patterns + ripgrep/grep) and seeds each hit into the shared ledger as a source→sink hypothesis tagged with its `file:line` — the first automated populator of `Hypothesis.DataFlow`.

## Details
- **codesearch**: export `SinkMatch{File,Line,Text}` + `SinkScan(contextID, maxPerClass)` — the programmatic, all-classes sibling of `code_search`. Typed matches, source-root-relative paths, bounded text; errors only when no whitebox source is configured.
- **agent**: `scan_source_sinks` tool + `seedSinks` helper. Maps sink classes → canonical vuln classes (`cmdi`→`rce`, `fileio`→`lfi`, `template`→`ssti`, `redirect`→`open_redirect`, …); skips discovery-only classes (secrets/auth/crypto). Stamps `Endpoint=file:line`, a `source-sink:` `DataFlow`, `Origin=source-sink`, queued, confidence 0.3. Bounded (max 40/sweep) and idempotent (dedup by class+`file:line`). Degrades to a black-box fallback message when no source is configured. Registered in `NewAgent` next to `ingest_har`.

## Testing
- `go build ./...`, `go vet ./...` clean; gofmt clean.
- `go test -race ./internal/tools/codesearch/ ./internal/agent/` (new SinkScan + seedSinks/tool tests pass; regressions green).
- golangci-lint clean on changed files.