### PR TITLE
feat(agent): scan_source_routes — give source-discovered sinks a reachable HTTP path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **`scan_source_routes` completes the source-to-runtime bridge: it gives source-discovered sinks a reachable HTTP path.** `scan_source_sinks` (v4.6.23) finds the dangerous code (a sink at `file:line`), but a `file:line` is not something the runtime tools can request. The new tool extracts HTTP route declarations from the attached source across the common frameworks (Flask/FastAPI, Django, Express, Spring, Go routers, Rails) and seeds each into the shared ledger as a hypothesis with a **real, reachable path** — including internal/admin routes a black-box crawler never reaches. It then correlates routes with sinks by handler-file co-location: a route whose file also contains a dangerous sink is seeded **class-typed** (by the worst sink class present) at higher confidence with a data-flow note linking the two, turning "there is an rce sink somewhere" into "`POST /admin/exec` reaches it — attack it." Uncorrelated routes seed as authz/attack-surface (`idor`) leads. Seeding is bounded (max 40 per sweep) and idempotent (dedup by vuln class + path), and the tool degrades to a black-box fallback when no source is configured. Specialists `claim_next_hypothesis` and request the route on the live target to prove the vuln.
+
 ## [v4.6.23](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.23) — Bridge whitebox source to runtime (scan_source_sinks) (2026-09-02)
 
 ### Added

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -380,6 +380,13 @@ func NewAgent(cfg *config.Config, name string, events chan Event, localGuard sco
 	// evidence-driven loop can trace it to a reachable route and exploit it.
 	a.registerScanSourceSinksTool(reg)
 
+	// Register the second half of the bridge (scan_source_routes): extracts HTTP
+	// route declarations from the attached source and seeds each as a hypothesis
+	// with a REAL reachable path (Origin=source-route), correlating a route with
+	// dangerous sinks in the same handler file so the sink gets an attackable
+	// endpoint.
+	a.registerScanSourceRoutesTool(reg)
+
 	// Create cancellable context
 	a.ctx, a.cancel = context.WithCancel(a.ctx)
 	// Wire context to LLM client so cancel interrupts pending HTTP requests

--- a/internal/agent/scan_source_routes.go
+++ b/internal/agent/scan_source_routes.go
@@ -1,0 +1,224 @@
+// Package agent — scan_source_routes.go implements scan_source_routes: the
+// second half of the source-to-runtime bridge. scan_source_sinks finds the
+// dangerous CODE (a sink at file:line); scan_source_routes finds the HTTP
+// ROUTES declared in the same source and seeds each as a ledger hypothesis with
+// a REAL, reachable path — then correlates the two by co-location so a route
+// whose handler file contains a dangerous sink is seeded as a class-typed,
+// higher-confidence lead.
+//
+// Why this matters: a source-sink hypothesis carries a file:line, not something
+// the runtime tools can hit. A route hypothesis carries an actual HTTP path the
+// agent can request against the live target. Discovering routes from the SOURCE
+// (not just the crawlable UI) also surfaces internal/admin endpoints a
+// black-box crawler never reaches. Correlating route↔sink by same-file
+// proximity turns "there's an rce sink somewhere" into "POST /admin/exec is
+// declared in the file that has the rce sink — attack it" — the concrete
+// source→runtime lead the evidence loop needs.
+package agent
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+	"github.com/xalgord/xalgorix/v4/internal/tools"
+	"github.com/xalgord/xalgorix/v4/internal/tools/codesearch"
+)
+
+// maxRouteSeed caps how many route hypotheses a single sweep seeds so a large
+// codebase cannot flood the ledger.
+const maxRouteSeed = 40
+
+// routeVulnSeverity orders sink vuln classes most-dangerous-first, so a route
+// whose file contains several sink classes is typed by the worst one.
+var routeVulnSeverity = []string{"rce", "ssti", "deserialization", "sqli", "ssrf", "lfi", "open_redirect"}
+
+func (a *Agent) registerScanSourceRoutesTool(reg *tools.Registry) {
+	reg.Register(&tools.Tool{
+		Name:        "scan_source_routes",
+		Description: "Whitebox source-to-runtime bridge (part 2). Extracts HTTP route declarations from the target's attached source (Flask/FastAPI, Django, Express, Spring, Go routers, Rails) and seeds each as a ledger hypothesis with a REAL, reachable path — including internal/admin routes a black-box crawler can't reach. Routes whose handler file also contains a dangerous sink (see scan_source_sinks) are seeded class-typed and higher-confidence, turning 'there is an rce sink somewhere' into 'POST /admin/exec reaches it'. Run after source is configured; then use read_ledger(filter=schedulable) / claim_next_hypothesis and request each route on the live target. Only available when source is configured; otherwise fall back to black-box discovery.",
+		Parameters: []tools.Parameter{
+			{Name: "max", Description: "Max routes to seed (default 60, hard cap 300).", Required: false},
+		},
+		Execute: a.scanSourceRoutesTool,
+	})
+}
+
+func (a *Agent) scanSourceRoutesTool(args map[string]string) (tools.Result, error) {
+	if a.scanCtx == nil {
+		return tools.Result{Error: "no scan context — scan_source_routes needs a scan to seed hypotheses into"}, nil
+	}
+	if codesearch.GetSourceRoot(a.scanCtx.ID) == "" {
+		return tools.Result{Output: "❌ Whitebox source not configured for this scan (set XALGORIX_SOURCE_REPO to a git URL or local path). Fall back to black-box discovery: crawl the live target and read client-side JS bundles to map routes."}, nil
+	}
+
+	maxRoutes := 60
+	if raw := strings.TrimSpace(args["max"]); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			maxRoutes = n
+		}
+	}
+
+	routes, err := codesearch.RouteScan(a.scanCtx.ID, maxRoutes)
+	if err != nil {
+		return tools.Result{Error: "scan_source_routes: " + err.Error()}, nil
+	}
+	if len(routes) == 0 {
+		return tools.Result{Output: "Swept the source for HTTP route declarations and found none of the known framework patterns (Flask/FastAPI, Django, Express, Spring, Go routers, Rails). The app may use an uncommon router — try code_search with a custom regex, or map routes by crawling the live target."}, nil
+	}
+
+	// Correlate routes with dangerous sinks in the same file (best-effort: a
+	// sink-scan failure just means no correlation, not a hard error).
+	byFile := map[string][]string{}
+	if found, serr := codesearch.SinkScan(a.scanCtx.ID, 20); serr == nil {
+		byFile = sinkVulnsByFile(found)
+	}
+
+	seeded, correlated := a.seedRoutes(routes, byFile)
+
+	// Deterministic summary: routes grouped by framework.
+	frameworks := map[string]int{}
+	for _, r := range routes {
+		frameworks[r.Framework]++
+	}
+	fwNames := make([]string, 0, len(frameworks))
+	for f := range frameworks {
+		fwNames = append(fwNames, f)
+	}
+	sort.Strings(fwNames)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Discovered %d HTTP route(s) in source across %d framework(s):\n", len(routes), len(fwNames))
+	for _, f := range fwNames {
+		fmt.Fprintf(&b, "  • %s: %d\n", f, frameworks[f])
+	}
+	if seeded > 0 {
+		fmt.Fprintf(&b, "Seeded %d route hypotheses into the ledger (origin=source-route)", seeded)
+		if correlated > 0 {
+			fmt.Fprintf(&b, ", %d correlated with a same-file dangerous sink (class-typed, higher confidence)", correlated)
+		}
+		b.WriteString(". Use read_ledger(filter=schedulable) or claim_next_hypothesis, then request each route on the live target and prove the vuln.")
+	} else {
+		b.WriteString("No new route hypotheses seeded (these routes are already in the ledger).")
+	}
+	return tools.Result{Output: b.String(), Metadata: map[string]any{"routes": len(routes), "seeded": seeded, "correlated": correlated}}, nil
+}
+
+// sinkVulnsByFile inverts a SinkScan result into file -> sorted, deduplicated
+// canonical vuln classes, using the same sinkClassToVuln allowlist as
+// scan_source_sinks (discovery-only classes are skipped). It is the lookup
+// seedRoutes uses to type a route by the dangerous sinks in its handler file.
+func sinkVulnsByFile(found map[string][]codesearch.SinkMatch) map[string][]string {
+	byFile := map[string]map[string]bool{}
+	for class, matches := range found {
+		vuln, ok := sinkClassToVuln[class]
+		if !ok {
+			continue
+		}
+		for _, m := range matches {
+			if byFile[m.File] == nil {
+				byFile[m.File] = map[string]bool{}
+			}
+			byFile[m.File][vuln] = true
+		}
+	}
+	out := map[string][]string{}
+	for file, set := range byFile {
+		for v := range set {
+			out[file] = append(out[file], v)
+		}
+		sort.Strings(out[file])
+	}
+	return out
+}
+
+// highestSeverityVuln picks the most-dangerous vuln class present, falling back
+// to the lexically-first when none are in the severity list.
+func highestSeverityVuln(vulns []string) string {
+	set := map[string]bool{}
+	for _, v := range vulns {
+		set[v] = true
+	}
+	for _, v := range routeVulnSeverity {
+		if set[v] {
+			return v
+		}
+	}
+	if len(vulns) > 0 {
+		sorted := append([]string(nil), vulns...)
+		sort.Strings(sorted)
+		return sorted[0]
+	}
+	return ""
+}
+
+// seedRoutes upserts bounded, deduplicated route hypotheses from a route sweep
+// and returns how many NEW hypotheses were created and how many of those were
+// correlated with a same-file dangerous sink. Each hypothesis carries a REAL
+// HTTP path as Endpoint and Origin=source-route. A route whose handler file
+// contains a dangerous sink is typed by that sink's (worst) vuln class at
+// confidence 0.45; an uncorrelated route seeds as an authz/attack-surface
+// (idor) lead at confidence 0.3. Idempotent: the ledger dedups by
+// vuln_class+endpoint, so re-seeding the same routes adds nothing.
+func (a *Agent) seedRoutes(routes []codesearch.RouteMatch, sinkVulnsByFile map[string][]string) (seeded, correlated int) {
+	l := a.ledger()
+	if l == nil {
+		return 0, 0
+	}
+	for _, r := range routes {
+		if seeded >= maxRouteSeed {
+			break
+		}
+		path := strings.TrimSpace(r.Path)
+		if path == "" {
+			continue
+		}
+		loc := fmt.Sprintf("%s:%d", r.File, r.Line)
+		label := path
+		if r.Method != "" && r.Method != "ANY" {
+			label = r.Method + " " + path
+		}
+
+		vuln := ""
+		if vulns := sinkVulnsByFile[r.File]; len(vulns) > 0 {
+			vuln = highestSeverityVuln(vulns)
+		}
+
+		var h scanctx.Hypothesis
+		if vuln != "" {
+			h = scanctx.Hypothesis{
+				Title:      fmt.Sprintf("Source route %s → %s sink", label, vuln),
+				VulnClass:  vuln,
+				Endpoint:   path,
+				DataFlow:   fmt.Sprintf("source-route: %s %s @ %s → reaches a %s sink in the same file", r.Framework, label, loc, vuln),
+				Confidence: 0.45,
+				Status:     scanctx.HypothesisQueued,
+				Origin:     "source-route",
+				NextAction: fmt.Sprintf("Request %s on the live target; its handler file %s contains a %s sink — drive user input to it and prove %s.", label, r.File, vuln, vuln),
+			}
+		} else {
+			h = scanctx.Hypothesis{
+				Title:      "Source route " + label,
+				VulnClass:  "idor",
+				Endpoint:   path,
+				DataFlow:   fmt.Sprintf("source-route: %s %s @ %s", r.Framework, label, loc),
+				Confidence: 0.3,
+				Status:     scanctx.HypothesisQueued,
+				Origin:     "source-route",
+				NextAction: "Request this source-discovered route on the live target; probe for broken access control (IDOR/BOLA) and injection.",
+			}
+		}
+
+		before := l.Len()
+		l.Upsert(h)
+		if l.Len() > before {
+			seeded++
+			if vuln != "" {
+				correlated++
+			}
+		}
+	}
+	return seeded, correlated
+}

--- a/internal/agent/scan_source_routes_test.go
+++ b/internal/agent/scan_source_routes_test.go
@@ -1,0 +1,158 @@
+package agent
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+	"github.com/xalgord/xalgorix/v4/internal/tools/codesearch"
+)
+
+// TestSeedRoutesCorrelatedAndUncorrelated verifies a route whose file has a
+// dangerous sink is typed by that vuln class at confidence 0.45, while a route
+// with no co-located sink seeds as an idor/attack-surface lead at 0.3 — both
+// carrying a real HTTP path Endpoint, source-route Origin, and queued status.
+func TestSeedRoutesCorrelatedAndUncorrelated(t *testing.T) {
+	ag := &Agent{scanCtx: scanctx.New("routes-corr-"+t.Name(), "")}
+	routes := []codesearch.RouteMatch{
+		{Method: "POST", Path: "/admin/exec", File: "handlers.py", Line: 12, Framework: "flask"},
+		{Method: "GET", Path: "/profile", File: "views.py", Line: 3, Framework: "flask/fastapi"},
+	}
+	byFile := map[string][]string{
+		"handlers.py": {"rce"}, // correlated
+		// views.py has no sink -> uncorrelated
+	}
+
+	seeded, correlated := ag.seedRoutes(routes, byFile)
+	if seeded != 2 || correlated != 1 {
+		t.Fatalf("expected seeded=2 correlated=1, got seeded=%d correlated=%d", seeded, correlated)
+	}
+
+	byEndpoint := map[string]scanctx.Hypothesis{}
+	for _, h := range ag.scanCtx.Ledger.All() {
+		byEndpoint[h.Endpoint] = h
+		if h.Origin != "source-route" {
+			t.Fatalf("endpoint %s: origin=%q want source-route", h.Endpoint, h.Origin)
+		}
+		if h.Status != scanctx.HypothesisQueued {
+			t.Fatalf("endpoint %s: status=%q want queued", h.Endpoint, h.Status)
+		}
+		if !strings.HasPrefix(h.DataFlow, "source-route:") {
+			t.Fatalf("endpoint %s: DataFlow=%q want source-route: prefix", h.Endpoint, h.DataFlow)
+		}
+	}
+
+	exec, ok := byEndpoint["/admin/exec"]
+	if !ok {
+		t.Fatal("missing /admin/exec hypothesis")
+	}
+	if exec.VulnClass != "rce" {
+		t.Fatalf("/admin/exec vuln=%q want rce", exec.VulnClass)
+	}
+	if exec.Confidence != 0.45 {
+		t.Fatalf("/admin/exec confidence=%v want 0.45", exec.Confidence)
+	}
+	prof, ok := byEndpoint["/profile"]
+	if !ok {
+		t.Fatal("missing /profile hypothesis")
+	}
+	if prof.VulnClass != "idor" {
+		t.Fatalf("/profile vuln=%q want idor", prof.VulnClass)
+	}
+	if prof.Confidence != 0.3 {
+		t.Fatalf("/profile confidence=%v want 0.3", prof.Confidence)
+	}
+}
+
+// TestSeedRoutesHighestSeverity verifies a route whose file has several sink
+// classes is typed by the most-dangerous one.
+func TestSeedRoutesHighestSeverity(t *testing.T) {
+	ag := &Agent{scanCtx: scanctx.New("routes-sev-"+t.Name(), "")}
+	routes := []codesearch.RouteMatch{{Method: "GET", Path: "/x", File: "app.py", Line: 1, Framework: "flask"}}
+	byFile := map[string][]string{"app.py": {"sqli", "rce", "lfi"}}
+
+	if seeded, correlated := ag.seedRoutes(routes, byFile); seeded != 1 || correlated != 1 {
+		t.Fatalf("seeded=%d correlated=%d want 1,1", seeded, correlated)
+	}
+	all := ag.scanCtx.Ledger.All()
+	if len(all) != 1 || all[0].VulnClass != "rce" {
+		t.Fatalf("expected 1 hypothesis typed rce (highest severity), got %+v", all)
+	}
+}
+
+// TestSeedRoutesIdempotent verifies re-seeding the same routes adds nothing.
+func TestSeedRoutesIdempotent(t *testing.T) {
+	ag := &Agent{scanCtx: scanctx.New("routes-idem-"+t.Name(), "")}
+	routes := []codesearch.RouteMatch{
+		{Method: "POST", Path: "/a", File: "a.py", Line: 1, Framework: "flask"},
+		{Method: "GET", Path: "/b", File: "b.py", Line: 2, Framework: "flask"},
+	}
+	if s, _ := ag.seedRoutes(routes, nil); s != 2 {
+		t.Fatalf("first seed=%d want 2", s)
+	}
+	if s, _ := ag.seedRoutes(routes, nil); s != 0 {
+		t.Fatalf("second seed=%d want 0 (idempotent)", s)
+	}
+	if n := ag.scanCtx.Ledger.Len(); n != 2 {
+		t.Fatalf("ledger len=%d want 2", n)
+	}
+}
+
+// TestSeedRoutesBounded verifies a large sweep cannot flood the ledger past
+// maxRouteSeed.
+func TestSeedRoutesBounded(t *testing.T) {
+	ag := &Agent{scanCtx: scanctx.New("routes-bound-"+t.Name(), "")}
+	routes := make([]codesearch.RouteMatch, 0, maxRouteSeed*2)
+	for i := 0; i < maxRouteSeed*2; i++ {
+		routes = append(routes, codesearch.RouteMatch{Method: "GET", Path: "/r" + strconv.Itoa(i), File: "big.py", Line: i + 1, Framework: "flask"})
+	}
+	seeded, _ := ag.seedRoutes(routes, nil)
+	if seeded > maxRouteSeed {
+		t.Fatalf("seedRoutes must cap at maxRouteSeed=%d, seeded %d", maxRouteSeed, seeded)
+	}
+	if n := ag.scanCtx.Ledger.Len(); n > maxRouteSeed {
+		t.Fatalf("ledger must not exceed %d, got %d", maxRouteSeed, n)
+	}
+}
+
+// TestSeedRoutesNilLedger verifies the helper is safe with no scan context.
+func TestSeedRoutesNilLedger(t *testing.T) {
+	ag := &Agent{}
+	if s, c := ag.seedRoutes([]codesearch.RouteMatch{{Path: "/x", File: "a", Line: 1}}, nil); s != 0 || c != 0 {
+		t.Fatalf("nil ledger must seed 0,0; got %d,%d", s, c)
+	}
+}
+
+// TestSinkVulnsByFileSkipsDiscoveryOnly verifies the file->vuln inversion maps
+// via the sinkClassToVuln allowlist and skips discovery-only classes.
+func TestSinkVulnsByFileSkipsDiscoveryOnly(t *testing.T) {
+	found := map[string][]codesearch.SinkMatch{
+		"rce":    {{File: "a.py", Line: 1, Text: "os.system(x)"}},
+		"crypto": {{File: "a.py", Line: 2, Text: "MD5(x)"}}, // discovery-only, skipped
+		"sqli":   {{File: "b.py", Line: 3, Text: "cursor.execute(q)"}},
+	}
+	byFile := sinkVulnsByFile(found)
+	if got := byFile["a.py"]; len(got) != 1 || got[0] != "rce" {
+		t.Fatalf("a.py vulns=%v want [rce] (crypto skipped)", got)
+	}
+	if got := byFile["b.py"]; len(got) != 1 || got[0] != "sqli" {
+		t.Fatalf("b.py vulns=%v want [sqli]", got)
+	}
+}
+
+// TestScanSourceRoutesToolNoSource verifies the tool degrades to a black-box
+// fallback message (no error, no seeds) when whitebox source is not configured.
+func TestScanSourceRoutesToolNoSource(t *testing.T) {
+	ag := &Agent{scanCtx: scanctx.New("routes-tool-nosrc-"+t.Name(), "")}
+	res, err := ag.scanSourceRoutesTool(map[string]string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(res.Output, "Whitebox source not configured") {
+		t.Fatalf("expected black-box fallback message, got: %s", res.Output)
+	}
+	if ag.scanCtx.Ledger.Len() != 0 {
+		t.Fatal("no source configured -> nothing should be seeded")
+	}
+}

--- a/internal/tools/codesearch/codesearch.go
+++ b/internal/tools/codesearch/codesearch.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -312,6 +313,185 @@ func boundText(s string, max int) string {
 		return s[:max] + "…"
 	}
 	return s
+}
+
+// RouteMatch is one HTTP route declaration located in the target's source: the
+// method (uppercased, or "ANY" when the framework doesn't name it inline), the
+// declared path, the source-root-relative file, its 1-based line, and the
+// framework family that matched. It is the structured unit the agent turns into
+// a reachable-endpoint hypothesis and correlates with co-located sinks.
+type RouteMatch struct {
+	Method    string `json:"method"`
+	Path      string `json:"path"`
+	File      string `json:"file"`
+	Line      int    `json:"line"`
+	Framework string `json:"framework"`
+}
+
+// routePattern is a framework-specific route-declaration matcher. Its regex is
+// deliberately kept ERE-safe (plain capturing groups, no (?:...) or (?i)) and
+// RE2-valid so it works with both ripgrep and the grep -E fallback and can be
+// recompiled in Go to pull the method/path capture groups. methodGroup is 0
+// when the framework does not name the method inline (Flask @route, Django
+// path()), in which case the method is reported as "ANY".
+type routePattern struct {
+	framework   string
+	re          string
+	methodGroup int
+	pathGroup   int
+}
+
+// routePatterns covers the common web frameworks. Each regex captures the
+// declared path (and the method when it is named inline) so RouteScan can hand
+// back a concrete METHOD + path an operator can request against the live
+// target. These are DISCOVERY aids — the agent still confirms the route is live
+// and reachable.
+var routePatterns = []routePattern{
+	// Flask/FastAPI/Starlette method decorators: @app.get("/x"), @router.post('/y')
+	{"flask/fastapi", `@[A-Za-z_][A-Za-z0-9_]*\.(get|post|put|patch|delete|options|head)\(['"]([^'"]+)`, 1, 2},
+	// Flask/Blueprint generic route: @app.route("/x"), @bp.route('/y')
+	{"flask", `@[A-Za-z_][A-Za-z0-9_]*\.route\(['"]([^'"]+)`, 0, 1},
+	// Express/Koa/Fastify: app.get("/x"), router.post('/y')
+	{"express", `\b[A-Za-z_][A-Za-z0-9_]*\.(get|post|put|patch|delete|all)\(['"]([^'"]+)`, 1, 2},
+	// Django urls: path("x/", ...), re_path(r'^x$', ...), url(r'^x', ...)
+	{"django", `\b(path|re_path|url)\(\s*r?['"]([^'"]+)`, 0, 2},
+	// Spring: @GetMapping("/x"), @RequestMapping(value="/y")
+	{"spring", `@(Get|Post|Put|Patch|Delete|Request)Mapping\(\s*(value\s*=\s*)?['"]([^'"]+)`, 1, 3},
+	// Go routers (gin/echo/chi/mux/net-http): r.GET("/x"), e.POST('/y'), mux.HandleFunc("/z")
+	{"go-router", `\b[A-Za-z_][A-Za-z0-9_]*\.(GET|POST|PUT|PATCH|DELETE|Handle|HandleFunc)\(['"]([^'"]+)`, 1, 2},
+	// Rails routes.rb: get "x", post 'y'
+	{"rails", `\b(get|post|put|patch|delete)\s+['"]([^'"]+)`, 1, 2},
+}
+
+// RouteScan runs every framework route-declaration pattern over the scan's
+// resolved source root and returns the discovered routes, deduplicated by
+// method+path+file:line and bounded to max total (default 60, hard cap 300). It
+// errors only when no whitebox source is configured for the scan.
+//
+// Like SinkScan this is the programmatic sibling of code_search: it hands the
+// agent the target's HTTP attack surface straight from the code — including
+// internal/admin routes a black-box crawler can't reach — so each route becomes
+// a reachable endpoint to test and a correlation anchor for co-located sinks.
+func RouteScan(contextID string, max int) ([]RouteMatch, error) {
+	root := getSourceRoot(contextID)
+	if root == "" {
+		return nil, fmt.Errorf("whitebox source not configured for scan %q", contextID)
+	}
+	if max <= 0 {
+		max = 60
+	}
+	if max > 300 {
+		max = 300
+	}
+	var out []RouteMatch
+	seen := make(map[string]bool)
+	for _, rp := range routePatterns {
+		if len(out) >= max {
+			break
+		}
+		ms, err := searchRouteMatches(root, rp, max)
+		if err != nil {
+			continue // this framework's search timed out; keep sweeping.
+		}
+		for _, m := range ms {
+			key := m.Method + " " + m.Path + " " + m.File + ":" + strconv.Itoa(m.Line)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			out = append(out, m)
+			if len(out) >= max {
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+// searchRouteMatches runs one framework's route regex over dir and returns the
+// structured route declarations it finds, preferring ripgrep and falling back
+// to grep -RnE. It reuses parseGrepLine to get file:line:text, then recompiles
+// the pattern in Go to pull the method/path capture groups out of the matched
+// line. Only a timeout is treated as an error (rg/grep exit 1 == no matches).
+func searchRouteMatches(dir string, rp routePattern, max int) ([]RouteMatch, error) {
+	if max <= 0 {
+		max = 60
+	}
+	re, err := regexp.Compile(rp.re)
+	if err != nil {
+		return nil, err
+	}
+	var cmd *exec.Cmd
+	if rg, err := exec.LookPath("rg"); err == nil {
+		cmd = exec.Command(rg, "--no-heading", "--line-number", "--color", "never", "-S",
+			"--max-count", strconv.Itoa(max), "-e", rp.re, dir)
+	} else {
+		cmd = exec.Command("grep", "-RnE", "--color=never", rp.re, dir)
+	}
+
+	done := make(chan struct{})
+	var out []byte
+	go func() {
+		out, _ = cmd.CombinedOutput() // exit 1 == no matches; tolerated
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(60 * time.Second):
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		return nil, fmt.Errorf("route search timed out")
+	}
+
+	matches := make([]RouteMatch, 0, max)
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		loc, ok := parseGrepLine(dir, line)
+		if !ok {
+			continue
+		}
+		groups := re.FindStringSubmatch(loc.Text)
+		if groups == nil {
+			continue
+		}
+		path := ""
+		if rp.pathGroup < len(groups) {
+			path = strings.TrimSpace(groups[rp.pathGroup])
+		}
+		if path == "" {
+			continue
+		}
+		method := "ANY"
+		if rp.methodGroup > 0 && rp.methodGroup < len(groups) {
+			method = normalizeMethod(groups[rp.methodGroup])
+		}
+		matches = append(matches, RouteMatch{
+			Method:    method,
+			Path:      path,
+			File:      loc.File,
+			Line:      loc.Line,
+			Framework: rp.framework,
+		})
+		if len(matches) >= max {
+			break
+		}
+	}
+	return matches, nil
+}
+
+// normalizeMethod uppercases a captured HTTP method verb; framework tokens that
+// don't denote a single method (Flask route, Express "all", Spring
+// RequestMapping, Go Handle/HandleFunc) collapse to "ANY".
+func normalizeMethod(raw string) string {
+	switch m := strings.ToUpper(strings.TrimSpace(raw)); m {
+	case "GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD":
+		return m
+	default:
+		return "ANY"
+	}
 }
 
 func parseIntSafe(s string) (int, error) {

--- a/internal/tools/codesearch/codesearch_test.go
+++ b/internal/tools/codesearch/codesearch_test.go
@@ -282,3 +282,96 @@ func TestSinkScanBoundsPerClass(t *testing.T) {
 		t.Fatalf("maxPerClass=2 must bound rce matches, got %d", n)
 	}
 }
+
+func TestRoutePatternsAreValidRE2(t *testing.T) {
+	// Every framework route pattern must compile under Go's RE2 engine (it is
+	// recompiled in searchRouteMatches to extract method/path groups) and stay
+	// grep-ERE-safe so the grep fallback works when ripgrep is absent.
+	for _, rp := range routePatterns {
+		if _, err := regexp.Compile(rp.re); err != nil {
+			t.Errorf("route pattern %q does not compile: %v", rp.framework, err)
+		}
+	}
+}
+
+func TestRouteScanNoSource(t *testing.T) {
+	if _, err := RouteScan("ctx-routescan-missing", 60); err == nil {
+		t.Fatal("RouteScan must error when no source root is configured")
+	}
+}
+
+func TestRouteScanFindsRoutes(t *testing.T) {
+	const ctx = "ctx-routescan"
+	dir := t.TempDir()
+	// Flask: a generic @app.route (method ANY) and a @app.get method decorator.
+	flask := "from flask import Flask\napp = Flask(__name__)\n\n" +
+		"@app.route('/admin')\ndef admin():\n    return 'ok'\n\n" +
+		"@app.get('/users')\ndef users():\n    return 'ok'\n"
+	if err := os.WriteFile(filepath.Join(dir, "app.py"), []byte(flask), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Express: app.post method call (no decorator).
+	express := "const app = require('express')()\n" +
+		"app.post('/login', (req, res) => res.send('ok'))\n"
+	if err := os.WriteFile(filepath.Join(dir, "server.js"), []byte(express), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	SetSourceRoot(ctx, dir)
+	defer SetSourceRoot(ctx, "")
+
+	routes, err := RouteScan(ctx, 60)
+	if err != nil {
+		t.Fatalf("RouteScan: %v", err)
+	}
+	byPath := map[string]RouteMatch{}
+	for _, r := range routes {
+		byPath[r.Path] = r
+		if r.File == "" || filepath.IsAbs(r.File) {
+			t.Fatalf("RouteMatch.File must be source-root-relative, got %q", r.File)
+		}
+		if r.Line <= 0 {
+			t.Fatalf("RouteMatch.Line must be 1-based, got %d for %s", r.Line, r.Path)
+		}
+	}
+	admin, ok := byPath["/admin"]
+	if !ok {
+		t.Fatalf("expected /admin route, got %+v", routes)
+	}
+	if admin.File != "app.py" {
+		t.Fatalf("/admin should be in app.py, got %q", admin.File)
+	}
+	if users, ok := byPath["/users"]; !ok || users.Method != "GET" {
+		t.Fatalf("expected GET /users, got %+v (all: %+v)", users, routes)
+	}
+	login, ok := byPath["/login"]
+	if !ok || login.Method != "POST" {
+		t.Fatalf("expected POST /login, got %+v (all: %+v)", login, routes)
+	}
+	if login.File != "server.js" {
+		t.Fatalf("/login should be in server.js, got %q", login.File)
+	}
+}
+
+func TestRouteScanBounded(t *testing.T) {
+	const ctx = "ctx-routescan-bound"
+	dir := t.TempDir()
+	src := "from flask import Flask\napp = Flask(__name__)\n" +
+		"@app.get('/a')\ndef a():\n    return 1\n" +
+		"@app.get('/b')\ndef b():\n    return 1\n" +
+		"@app.get('/c')\ndef c():\n    return 1\n" +
+		"@app.get('/d')\ndef d():\n    return 1\n" +
+		"@app.get('/e')\ndef e():\n    return 1\n"
+	if err := os.WriteFile(filepath.Join(dir, "many.py"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	SetSourceRoot(ctx, dir)
+	defer SetSourceRoot(ctx, "")
+
+	routes, err := RouteScan(ctx, 2)
+	if err != nil {
+		t.Fatalf("RouteScan: %v", err)
+	}
+	if len(routes) > 2 {
+		t.Fatalf("max=2 must bound routes, got %d", len(routes))
+	}
+}


### PR DESCRIPTION
## Summary
Second half of the source-to-runtime bridge (follows #526 `scan_source_sinks`). `scan_source_sinks` finds the dangerous code at `file:line`, but that is not something the runtime tools can request. `scan_source_routes` extracts HTTP route declarations from the attached source and seeds each into the shared ledger as a hypothesis with a **real, reachable path**, then correlates routes with sinks by handler-file co-location so a sink gets an attackable endpoint.

## Details
- **codesearch**: export `RouteMatch{Method,Path,File,Line,Framework}` + `RouteScan(contextID, max)` — the route sibling of `SinkScan`. `routePatterns` cover Flask/FastAPI, Django, Express, Spring, Go routers, Rails (grep-ERE-safe capturing groups); `searchRouteMatches` reuses the rg/grep runner + `parseGrepLine` and recompiles the pattern in Go to pull method/path groups. Deduped by method+path+file:line, bounded (default 60, cap 300).
- **agent**: `scan_source_routes` tool + `seedRoutes`. Runs RouteScan, then a best-effort SinkScan to build a file→vuln map; a route whose handler file has a dangerous sink is seeded **class-typed** (worst sink class) at confidence 0.45 with a data-flow note linking route→sink; uncorrelated routes seed as `idor`/attack-surface at 0.3. `Endpoint`=real path, `Origin=source-route`, queued. Bounded (max 40), idempotent (dedup by class+path), black-box fallback when no source. Registered next to `scan_source_sinks`.

## Testing
- `go build ./...`, `go vet ./...` clean; gofmt clean.
- `go test -race ./internal/tools/codesearch/ ./internal/agent/` (new RouteScan + seedRoutes tests pass; regressions green).
- golangci-lint clean on changed files.