### PR TITLE
feat(agent): probe_hypothesis — touch the live target from a seeded hypothesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **`probe_hypothesis` closes the source-to-runtime loop: it touches the live target from a seeded hypothesis.** `scan_source_sinks` finds the dangerous code and `scan_source_routes` gives it a reachable path, but until now nothing acted on that path — the model had to hand-craft every request. The new tool takes a ledger hypothesis that carries a real HTTP path (a `source-route` hypothesis, or an ingested/authenticated endpoint), resolves it against the scan target, issues **one** baseline request, and records the response as evidence — turning a guessed route into a confirmed lead. A live `2xx` raises confidence and moves the hypothesis to `testing`; `401/403` flags it as a prime `authz_matrix` target; a `404`/connection failure marks it `blocked` so the scheduler stops spending budget on routes that aren't deployed. It uses the scan's session auth automatically (so authenticated routes are probed authenticated) and does not follow redirects (a `3xx` to `/login` is itself a signal). Safety: because the tool resolves the target host internally (the agent-loop scope gate keys off tool arguments and can't see it), it always scope-checks the resolved host with the same operator-machine guard `authz_matrix` uses and refuses loopback/RFC1918/the dashboard listener; it reuses the existing scope-agnostic request path, honors the scan's request-rate policy and cancellation, and is disabled in passive mode. Source-location (`file:line`) endpoints from `scan_source_sinks` are skipped — they carry no HTTP path.
+
 ## [v4.6.24](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.24) — Give source-discovered sinks a reachable HTTP path (scan_source_routes) (2026-09-02)
 
 ### Added

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -147,6 +147,7 @@ type Agent struct {
 	reconMode                  string    // active or passive reconnaissance
 	scanIntensity              string    // active or passive testing/scanning
 	activityHosts              []string  // normalized target hosts used by passive policy
+	targets                    []string  // raw scan targets from Run(), used to resolve a base URL for probe_hypothesis
 	passiveReconGuardActive    bool      // full scans with passive recon block direct access until passive evidence is collected
 	passiveReconGuardDone      bool
 	passiveReconPassiveLookups int
@@ -386,6 +387,14 @@ func NewAgent(cfg *config.Config, name string, events chan Event, localGuard sco
 	// dangerous sinks in the same handler file so the sink gets an attackable
 	// endpoint.
 	a.registerScanSourceRoutesTool(reg)
+
+	// Register the third part of the bridge (probe_hypothesis): issues ONE
+	// scope-gated baseline request against the live target for a ledger
+	// hypothesis that carries a real HTTP path (e.g. a source-route hypothesis)
+	// and records the response as evidence — turning a seeded path into a
+	// confirmed-reachable (or blocked) lead. Agent-bound: needs the scope
+	// config, session auth, the scan target, and the ledger.
+	a.registerProbeHypothesisTool(reg)
 
 	// Create cancellable context
 	a.ctx, a.cancel = context.WithCancel(a.ctx)
@@ -805,6 +814,7 @@ func (a *Agent) Run(targets []string, instruction string) {
 	if a.stopped.Load() {
 		return
 	}
+	a.targets = targets // remember the scan targets so probe_hypothesis can resolve a base URL for a bare path
 	a.scanStart = time.Now()
 	if a.scanBudget != nil {
 		a.scanBudget.start()

--- a/internal/agent/agent_guard.go
+++ b/internal/agent/agent_guard.go
@@ -325,7 +325,7 @@ func (a *Agent) shouldBlockForOutOfScope(toolName string, toolArgs map[string]st
 	lowerTool := strings.ToLower(toolName)
 	switch lowerTool {
 	case "terminal_execute", "python_action", "browser_action", "page_agent", "pageagent",
-		"report_vulnerability", "authz_matrix":
+		"report_vulnerability", "authz_matrix", "probe_hypothesis":
 		// gated
 	default:
 		return false, ""

--- a/internal/agent/probe_hypothesis.go
+++ b/internal/agent/probe_hypothesis.go
@@ -1,0 +1,301 @@
+// Package agent — probe_hypothesis.go implements probe_hypothesis: the third
+// part of the source-to-runtime bridge. scan_source_sinks finds the dangerous
+// code, scan_source_routes gives it a reachable HTTP path, and probe_hypothesis
+// takes that path and actually TOUCHES the live target — issuing one scope-gated
+// baseline request and recording the response as ledger evidence.
+//
+// This closes the loop: a seeded source→route hypothesis stops being a guess and
+// becomes a confirmed-reachable (2xx/redirect/protected/5xx) or blocked (404 /
+// connection failure) lead, with the real response attached as evidence and the
+// status/confidence nudged accordingly — so the evidence-driven scheduler works
+// the routes that actually exist first.
+//
+// Safety: the tool resolves the target host from the hypothesis/scan itself, so
+// the agent-loop scope gate (which keys off tool args) cannot see it. Therefore
+// this tool ALWAYS scope-checks the resolved host with scopeguard.IsLocalOrListener
+// and refuses the operator's own machine/listener, exactly as authz_matrix does
+// for defense-in-depth. It reuses httpclient.SendRaw (the same scope-agnostic
+// request path authz_matrix uses), honors the scan's request-rate policy and
+// cancellation, does not follow redirects, and is disabled in passive mode.
+package agent
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+	"github.com/xalgord/xalgorix/v4/internal/scopeguard"
+	"github.com/xalgord/xalgorix/v4/internal/tools"
+	"github.com/xalgord/xalgorix/v4/internal/tools/httpclient"
+)
+
+func (a *Agent) registerProbeHypothesisTool(reg *tools.Registry) {
+	reg.Register(&tools.Tool{
+		Name:        "probe_hypothesis",
+		Description: "Issue ONE scope-gated baseline HTTP request against the LIVE target for a ledger hypothesis that carries a real HTTP path (e.g. a source-route hypothesis from scan_source_routes, or an ingested/authenticated endpoint), and record the response as evidence. Turns a seeded path into a confirmed lead: a live 2xx raises confidence and moves it to testing; 401/403 flags it as an authz_matrix target; a 404/connection failure marks it blocked. Uses the scan's session auth automatically so authenticated routes are probed authenticated, and does not follow redirects (a 3xx to /login is itself a signal). Use it to triage which seeded routes actually exist before investing in exploitation. Skips hypotheses whose endpoint is a source location (file:line) rather than an HTTP path.",
+		Parameters: []tools.Parameter{
+			{Name: "hypothesis_id", Description: "The ledger hypothesis id to probe (e.g. H-7). Must carry an HTTP path endpoint (not a file:line source location).", Required: true},
+			{Name: "base_url", Description: "Optional base URL (scheme://host) to resolve a bare path against. Defaults to the hypothesis's target host, then the scan target.", Required: false},
+			{Name: "method", Description: "HTTP method for the baseline request (default GET).", Required: false},
+		},
+		Execute: a.probeHypothesisTool,
+	})
+}
+
+func (a *Agent) probeHypothesisTool(args map[string]string) (tools.Result, error) {
+	l := a.ledger()
+	if l == nil {
+		return tools.Result{Error: "ledger unavailable in this context"}, nil
+	}
+	// An active probe is disabled in passive scan mode.
+	if normalizeActivityMode(a.scanIntensity) == activityModePassive {
+		return tools.Result{Error: "probe_hypothesis issues a live request and is disabled in passive scan mode."}, nil
+	}
+
+	id := strings.TrimSpace(args["hypothesis_id"])
+	if id == "" {
+		return tools.Result{Error: "hypothesis_id is required"}, nil
+	}
+	h, ok := l.Get(id)
+	if !ok {
+		return tools.Result{Error: fmt.Sprintf("unknown hypothesis id %q — use read_ledger to list ids", id)}, nil
+	}
+
+	absURL, err := a.resolveProbeURL(h, strings.TrimSpace(args["base_url"]))
+	if err != nil {
+		return tools.Result{Error: "probe_hypothesis: " + err.Error()}, nil
+	}
+	u, perr := url.Parse(absURL)
+	if perr != nil || u.Host == "" {
+		return tools.Result{Error: fmt.Sprintf("probe_hypothesis: could not form a valid URL from %q", absURL)}, nil
+	}
+
+	// PRIMARY scope protection: the loop gate can't see this internally-resolved
+	// host, so refuse the operator's own machine/listener here.
+	if scopeguard.IsLocalOrListener(a.localGuard, u.Host) {
+		return tools.Result{Error: fmt.Sprintf("probe_hypothesis refused: %q resolves to the operator's own machine or local network, not the engagement target.", u.Host)}, nil
+	}
+
+	if a.ctx != nil && a.ctx.Err() != nil {
+		return tools.Result{Error: "probe_hypothesis: scan is shutting down"}, nil
+	}
+	if a.scanCtx != nil {
+		if d := a.scanCtx.RequestRatePolicy().Delay(); d > 0 {
+			time.Sleep(d)
+		}
+	}
+
+	method := strings.ToUpper(strings.TrimSpace(args["method"]))
+	if method == "" {
+		method = "GET"
+	}
+	headers := a.probeAuthHeaders()
+	authed := len(headers) > 0
+	reqLine := method + " " + u.String()
+
+	resp, sErr := httpclient.SendRaw(httpclient.RawRequest{
+		Method:          method,
+		URL:             u.String(),
+		Headers:         headers,
+		FollowRedirects: false, // a 3xx→login is itself a signal, not something to mask
+		TimeoutSec:      30,
+	})
+	if sErr != nil {
+		l.AddEvidence(id, scanctx.Evidence{
+			Kind:    "probe",
+			Summary: "Baseline probe could not connect: " + sErr.Error(),
+			Request: reqLine,
+			AgentID: a.ledgerOrigin(),
+		})
+		l.SetStatus(id, scanctx.HypothesisBlocked, "Route did not respond ("+sErr.Error()+"). Confirm the target host / base_url, or the route may not be deployed here.")
+		return tools.Result{Output: fmt.Sprintf("Probed %s → connection error: %v. Marked %s blocked.", reqLine, sErr, id)}, nil
+	}
+
+	summary, status, nextAction, conf := interpretProbe(resp, authed)
+	l.AddEvidence(id, scanctx.Evidence{
+		Kind:       "probe",
+		Summary:    summary,
+		Request:    reqLine,
+		Response:   probeResponseEvidence(resp),
+		Confidence: conf,
+		AgentID:    a.ledgerOrigin(),
+	})
+	if status != "" {
+		l.SetStatus(id, status, nextAction)
+	}
+	got, _ := l.Get(id)
+
+	authTag := ""
+	if authed {
+		authTag = " [authenticated]"
+	}
+	return tools.Result{
+		Output: fmt.Sprintf("Probed %s%s → %s (%d-byte body). %s\nHypothesis %s is now [%s], confidence %.2f. Next: %s",
+			reqLine, authTag, resp.Status, resp.BodyLen, summary, id, got.Status, got.Confidence, nextAction),
+		Metadata: map[string]any{"hypothesis_id": id, "status_code": resp.StatusCode, "http_status": resp.Status, "authenticated": authed},
+	}, nil
+}
+
+// resolveProbeURL turns a hypothesis endpoint into an absolute URL to probe. It
+// rejects source-location (file:line) endpoints, uses an absolute endpoint
+// as-is, and otherwise joins a path against the base URL (explicit override →
+// hypothesis Target host → scan target).
+func (a *Agent) resolveProbeURL(h scanctx.Hypothesis, baseOverride string) (string, error) {
+	ep := strings.TrimSpace(h.Endpoint)
+	if ep == "" {
+		return "", fmt.Errorf("hypothesis %s has no endpoint to probe", h.ID)
+	}
+	if h.Origin == "source-sink" || looksLikeSourceLocation(ep) {
+		return "", fmt.Errorf("hypothesis %s endpoint %q is a source location (file:line), not an HTTP path — probe a source-route or authenticated-endpoint hypothesis, or run scan_source_routes first", h.ID, ep)
+	}
+	if strings.HasPrefix(ep, "http://") || strings.HasPrefix(ep, "https://") {
+		return ep, nil
+	}
+	if !strings.HasPrefix(ep, "/") {
+		ep = "/" + ep
+	}
+
+	base := strings.TrimSpace(baseOverride)
+	if base == "" && strings.TrimSpace(h.Target) != "" {
+		base = strings.TrimSpace(h.Target)
+	}
+	if base == "" {
+		base = a.primaryTargetURL()
+	}
+	if base == "" {
+		return "", fmt.Errorf("no base URL to resolve path %q — pass base_url (scheme://host) or ensure the scan has a target", ep)
+	}
+	base = normalizeBaseURL(base)
+	bu, err := url.Parse(base)
+	if err != nil || bu.Host == "" {
+		return "", fmt.Errorf("invalid base URL %q", base)
+	}
+	ref, err := url.Parse(ep)
+	if err != nil {
+		return "", fmt.Errorf("invalid endpoint path %q", ep)
+	}
+	return bu.ResolveReference(ref).String(), nil
+}
+
+// primaryTargetURL returns the scan's first target normalized to a base URL, or
+// "" when Run has not recorded a target.
+func (a *Agent) primaryTargetURL() string {
+	for _, t := range a.targets {
+		if t = strings.TrimSpace(t); t != "" {
+			return normalizeBaseURL(t)
+		}
+	}
+	return ""
+}
+
+// probeAuthHeaders resolves the scan's role-A session headers (operator-configured
+// target auth first, else an ingested session), so an authenticated route is
+// probed authenticated. Empty when the scan has no session.
+func (a *Agent) probeAuthHeaders() map[string]string {
+	if hdrs := httpclient.ParseAuthHeaders(a.targetAuth); len(hdrs) > 0 {
+		return hdrs
+	}
+	return a.sessionAuthHeaders()
+}
+
+// normalizeBaseURL ensures a base URL carries a scheme (defaulting to https),
+// matching how http_request/authz_matrix/SendRaw treat schemeless targets.
+func normalizeBaseURL(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if !strings.HasPrefix(s, "http://") && !strings.HasPrefix(s, "https://") {
+		s = "https://" + s
+	}
+	return s
+}
+
+// looksLikeSourceLocation reports whether an endpoint is a "file:line" source
+// location (as seeded by scan_source_sinks) rather than an HTTP path/URL.
+func looksLikeSourceLocation(ep string) bool {
+	if strings.HasPrefix(ep, "/") || strings.HasPrefix(ep, "http://") || strings.HasPrefix(ep, "https://") {
+		return false
+	}
+	// e.g. "handlers.py:42": a trailing ":<digits>" with no path-separator prefix.
+	if i := strings.LastIndex(ep, ":"); i > 0 && i < len(ep)-1 {
+		for _, c := range ep[i+1:] {
+			if c < '0' || c > '9' {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// interpretProbe classifies a baseline response into an evidence summary, a
+// status transition, a next action, and an evidence confidence. AddEvidence
+// only raises confidence, so a 404 passes conf 0 and relies on the blocked
+// status transition to deprioritize the hypothesis.
+func interpretProbe(resp *httpclient.RawResponse, authed bool) (summary string, status scanctx.HypothesisStatus, nextAction string, conf float64) {
+	authNote := ""
+	if authed {
+		authNote = " (authenticated)"
+	}
+	switch code := resp.StatusCode; {
+	case code >= 200 && code < 300:
+		return fmt.Sprintf("Live%s: %s, %d-byte body — route is reachable and serves content.", authNote, resp.Status, resp.BodyLen),
+			scanctx.HypothesisTesting,
+			"Route confirmed live (2xx). Build the class-specific payload and attempt exploitation; for object/action endpoints use authz_matrix across role A/B/anonymous.",
+			0.6
+	case code == 401 || code == 403:
+		return fmt.Sprintf("Access-controlled%s: %s — endpoint exists but is protected.", authNote, resp.Status),
+			scanctx.HypothesisTesting,
+			"Endpoint exists but is access-controlled — prime target for authz_matrix (role A vs role B vs anonymous) and auth-bypass checks.",
+			0.5
+	case code == 404 || code == 410:
+		return fmt.Sprintf("Not found: %s — route not deployed at this path on the live target.", resp.Status),
+			scanctx.HypothesisBlocked,
+			"Route returned 404/410 — it may not be deployed here, the base path differs, or it needs path parameters. Verify the route or pass base_url.",
+			0
+	case code == 405:
+		return fmt.Sprintf("Method not allowed: %s — endpoint exists but rejects this method.", resp.Status),
+			scanctx.HypothesisTesting,
+			"Endpoint exists but rejects this method; retry with the route's declared method (POST/PUT/PATCH).",
+			0.45
+	case code >= 500:
+		return fmt.Sprintf("Server error%s: %s — handler is reachable and erroring.", authNote, resp.Status),
+			scanctx.HypothesisTesting,
+			"Server error (5xx) — the handler is reachable and failing; probe for injection (the error may leak a stack trace or query).",
+			0.55
+	case code >= 300 && code < 400:
+		return fmt.Sprintf("Redirect: %s → %s.", resp.Status, resp.Header.Get("Location")),
+			scanctx.HypothesisTesting,
+			"Redirects (often to login/SSO). If unauthenticated, register a session (ingest_har) or configure target auth, then re-probe; the redirect target itself may be an open-redirect sink.",
+			0.4
+	default:
+		return fmt.Sprintf("Response: %s (%d-byte body).", resp.Status, resp.BodyLen),
+			scanctx.HypothesisTesting,
+			"Endpoint responded; analyze the response and craft the class-specific test.",
+			0.4
+	}
+}
+
+// probeResponseEvidence renders a compact response record (status line, a few
+// telling headers, a bounded body slice) for the ledger. The ledger re-bounds
+// the stored string, so this only needs to stay reasonable.
+func probeResponseEvidence(resp *httpclient.RawResponse) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s %s\n", resp.Proto, resp.Status)
+	for _, name := range []string{"Location", "Content-Type", "WWW-Authenticate", "Server", "Set-Cookie"} {
+		if v := resp.Header.Get(name); v != "" {
+			fmt.Fprintf(&b, "%s: %s\n", name, v)
+		}
+	}
+	if body := strings.TrimSpace(string(resp.Body)); body != "" {
+		if len(body) > 800 {
+			body = body[:800] + "…"
+		}
+		b.WriteString("\n")
+		b.WriteString(body)
+	}
+	return b.String()
+}

--- a/internal/agent/probe_hypothesis_test.go
+++ b/internal/agent/probe_hypothesis_test.go
@@ -1,0 +1,202 @@
+package agent
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+	"github.com/xalgord/xalgorix/v4/internal/scopeguard"
+)
+
+// probeTestServer serves /live (200), /secure (200 only with Bearer AAA, else
+// 403), and returns 404 for anything else (unregistered on the mux).
+func probeTestServer() *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/live", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("hello world body padding padding padding"))
+	})
+	mux.HandleFunc("/secure", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "Bearer AAA" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("owner data"))
+			return
+		}
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("forbidden"))
+	})
+	return httptest.NewServer(mux)
+}
+
+func newProbeAgent(t *testing.T, targetURL string, allowLocal bool) *Agent {
+	t.Helper()
+	return &Agent{
+		localGuard: scopeguard.Config{AllowLocalTargets: allowLocal},
+		scanCtx:    scanctx.New("probe-test-"+t.Name(), ""),
+		ctx:        context.Background(),
+		targets:    []string{targetURL},
+	}
+}
+
+func seedProbeHypothesis(ag *Agent, endpoint, origin, vuln string) string {
+	h := ag.scanCtx.Ledger.Upsert(scanctx.Hypothesis{
+		VulnClass:  vuln,
+		Endpoint:   endpoint,
+		Origin:     origin,
+		Status:     scanctx.HypothesisQueued,
+		Confidence: 0.3,
+	})
+	return h.ID
+}
+
+func lastEvidence(h scanctx.Hypothesis) scanctx.Evidence {
+	if len(h.Evidence) == 0 {
+		return scanctx.Evidence{}
+	}
+	return h.Evidence[len(h.Evidence)-1]
+}
+
+func TestProbeHypothesisLiveRoute(t *testing.T) {
+	srv := probeTestServer()
+	defer srv.Close()
+	ag := newProbeAgent(t, srv.URL, true)
+	id := seedProbeHypothesis(ag, "/live", "source-route", "rce")
+
+	res, err := ag.probeHypothesisTool(map[string]string{"hypothesis_id": id})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Error != "" {
+		t.Fatalf("unexpected tool error: %s", res.Error)
+	}
+	if code, _ := res.Metadata["status_code"].(int); code != 200 {
+		t.Fatalf("expected status_code 200, got %v", res.Metadata["status_code"])
+	}
+	h, _ := ag.scanCtx.Ledger.Get(id)
+	if h.Status != scanctx.HypothesisTesting {
+		t.Fatalf("expected status testing, got %s", h.Status)
+	}
+	if lastEvidence(h).Kind != "probe" {
+		t.Fatalf("expected a probe evidence record, got %q", lastEvidence(h).Kind)
+	}
+	if h.Confidence < 0.6 {
+		t.Fatalf("expected confidence raised to >=0.6 for a live route, got %.2f", h.Confidence)
+	}
+}
+
+func TestProbeHypothesisNotFoundBlocks(t *testing.T) {
+	srv := probeTestServer()
+	defer srv.Close()
+	ag := newProbeAgent(t, srv.URL, true)
+	id := seedProbeHypothesis(ag, "/missing", "source-route", "idor")
+
+	res, err := ag.probeHypothesisTool(map[string]string{"hypothesis_id": id})
+	if err != nil || res.Error != "" {
+		t.Fatalf("unexpected: err=%v toolError=%s", err, res.Error)
+	}
+	if code, _ := res.Metadata["status_code"].(int); code != 404 {
+		t.Fatalf("expected 404, got %v", res.Metadata["status_code"])
+	}
+	h, _ := ag.scanCtx.Ledger.Get(id)
+	if h.Status != scanctx.HypothesisBlocked {
+		t.Fatalf("expected status blocked for 404, got %s", h.Status)
+	}
+}
+
+func TestProbeHypothesisProtectedFlagsAuthz(t *testing.T) {
+	srv := probeTestServer()
+	defer srv.Close()
+	ag := newProbeAgent(t, srv.URL, true) // no auth configured -> /secure returns 403
+	id := seedProbeHypothesis(ag, "/secure", "source-route", "idor")
+
+	res, _ := ag.probeHypothesisTool(map[string]string{"hypothesis_id": id})
+	if code, _ := res.Metadata["status_code"].(int); code != 403 {
+		t.Fatalf("expected 403, got %v", res.Metadata["status_code"])
+	}
+	h, _ := ag.scanCtx.Ledger.Get(id)
+	if h.Status != scanctx.HypothesisTesting {
+		t.Fatalf("expected status testing for a protected route, got %s", h.Status)
+	}
+	if !strings.Contains(strings.ToLower(lastEvidence(h).Summary), "access-controlled") {
+		t.Fatalf("expected access-controlled evidence, got %q", lastEvidence(h).Summary)
+	}
+}
+
+func TestProbeHypothesisUsesTargetAuth(t *testing.T) {
+	srv := probeTestServer()
+	defer srv.Close()
+	ag := newProbeAgent(t, srv.URL, true)
+	ag.targetAuth = "Authorization: Bearer AAA"
+	id := seedProbeHypothesis(ag, "/secure", "source-route", "idor")
+
+	res, err := ag.probeHypothesisTool(map[string]string{"hypothesis_id": id})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code, _ := res.Metadata["status_code"].(int); code != 200 {
+		t.Fatalf("authenticated probe should get 200 from /secure, got %v", res.Metadata["status_code"])
+	}
+	if authed, _ := res.Metadata["authenticated"].(bool); !authed {
+		t.Fatal("expected authenticated=true when target auth is configured")
+	}
+}
+
+func TestProbeHypothesisSkipsSourceLocation(t *testing.T) {
+	srv := probeTestServer()
+	defer srv.Close()
+	ag := newProbeAgent(t, srv.URL, true)
+	id := seedProbeHypothesis(ag, "handlers.py:42", "source-sink", "rce")
+
+	res, err := ag.probeHypothesisTool(map[string]string{"hypothesis_id": id})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Error == "" || !strings.Contains(res.Error, "source location") {
+		t.Fatalf("expected a source-location refusal, got error=%q output=%q", res.Error, res.Output)
+	}
+	h, _ := ag.scanCtx.Ledger.Get(id)
+	if h.Status != scanctx.HypothesisQueued {
+		t.Fatalf("expected status unchanged (queued), got %s", h.Status)
+	}
+	if len(h.Evidence) != 0 {
+		t.Fatal("no request should have been made for a source-location endpoint")
+	}
+}
+
+func TestProbeHypothesisRefusesOperatorMachine(t *testing.T) {
+	srv := probeTestServer()
+	defer srv.Close()
+	ag := newProbeAgent(t, srv.URL, false) // allowLocal=false -> loopback refused
+	id := seedProbeHypothesis(ag, "/live", "source-route", "rce")
+
+	res, err := ag.probeHypothesisTool(map[string]string{"hypothesis_id": id})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Error == "" || !strings.Contains(res.Error, "operator") {
+		t.Fatalf("expected a scope refusal for the operator's machine, got error=%q", res.Error)
+	}
+	h, _ := ag.scanCtx.Ledger.Get(id)
+	if len(h.Evidence) != 0 {
+		t.Fatal("no request should have been made when scope-refused")
+	}
+}
+
+func TestProbeHypothesisUnknownID(t *testing.T) {
+	ag := newProbeAgent(t, "https://example.com", true)
+	if res, _ := ag.probeHypothesisTool(map[string]string{"hypothesis_id": "H-999"}); res.Error == "" {
+		t.Fatal("expected an error for an unknown hypothesis id")
+	}
+}
+
+func TestProbeHypothesisPassiveDisabled(t *testing.T) {
+	ag := newProbeAgent(t, "https://example.com", true)
+	ag.scanIntensity = "passive"
+	res, _ := ag.probeHypothesisTool(map[string]string{"hypothesis_id": "H-1"})
+	if res.Error == "" || !strings.Contains(res.Error, "passive") {
+		t.Fatalf("expected a passive-mode refusal, got %q", res.Error)
+	}
+}


### PR DESCRIPTION
## Summary
Third part of the source-to-runtime bridge (follows #526 scan_source_sinks and #528 scan_source_routes). `scan_source_sinks` finds the dangerous code, `scan_source_routes` gives it a reachable path, and `probe_hypothesis` finally acts on that path: it takes a ledger hypothesis carrying a real HTTP endpoint, resolves it against the scan target, issues ONE baseline request, and records the response as evidence — turning a guessed route into a confirmed lead.

## Behavior
- Live `2xx` → confidence up, status `testing`. `401/403` → `testing`, flagged as a prime `authz_matrix` target. `404`/connection failure → `blocked` (scheduler stops spending budget). `3xx/5xx/405` recorded with tailored next actions.
- Uses the scan's role-A session auth automatically (so authenticated routes are probed authenticated). Does not follow redirects (a `3xx`→`/login` is a signal).

## Safety
- The tool resolves the target host internally, which the agent-loop scope gate (keyed off tool args) can't see — so it ALWAYS scope-checks the resolved host with `scopeguard.IsLocalOrListener` and refuses the operator's own machine/listener, exactly as `authz_matrix` does. Reuses `httpclient.SendRaw` (same scope-agnostic path), honors the request-rate policy + cancellation, is disabled in passive mode, and skips `file:line` source-location endpoints.

## Testing
- `go build ./...`, `go vet ./...` clean; gofmt clean.
- `go test -race ./internal/agent/`: live/404/403/auth/source-location/loopback-refusal/unknown-id/passive cases pass; regressions green.
- golangci-lint clean on changed files.