### PR TITLE
feat(agent): auto-seed the ledger from whitebox source at scan start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- **Whitebox source now auto-seeds the ledger at scan start — the source-to-runtime bridge fires from iteration 1.** The three whitebox tools (`scan_source_sinks`, `scan_source_routes`, `probe_hypothesis`) only ran if the model chose to call them, so a scan with source attached could spend early iterations black-box-crawling before the code was ever examined. Now, as soon as the source is resolved, the scan sweeps it for dangerous sinks and HTTP routes and seeds the ledger with the resulting hypotheses — dangerous sinks (`file:line`), reachable routes (real HTTP paths), and the route↔sink correlations (a route whose handler file has a dangerous sink is seeded class-typed and higher-confidence) — exactly as an uploaded OpenAPI/HAR context already auto-seeds the surface. The specialists get concrete, source-derived leads to `probe_hypothesis` and exploit from the first iteration instead of rediscovering them. Deterministic, bounded (per-sweep caps), and idempotent (the ledger dedups), so it never floods or duplicates; a no-op when no source is configured.
+
 ## [v4.6.25](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.25) — Touch the live target from a seeded hypothesis (probe_hypothesis) (2026-09-02)
 
 ### Added

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1690,6 +1690,15 @@ func (a *Agent) prepareScanEnvironment() {
 			codesearch.SetSourceRoot(a.scanCtx.ID, root)
 			a.emit(Event{Type: "message", Content: "📦 Whitebox source ready — use code_search to hunt sinks."})
 			log.Printf("[agent] whitebox source ready at %s", root)
+			// Auto-seed the ledger from source so the source-to-runtime bridge
+			// starts populated (mirrors seedLedgerFromSurface for uploaded
+			// artifacts): dangerous sinks + reachable routes become schedulable
+			// hypotheses from iteration 1, without waiting for the model to call
+			// scan_source_sinks / scan_source_routes.
+			if s := a.seedLedgerFromSource(); s.SinkHypotheses+s.RouteHypotheses > 0 {
+				a.emit(Event{Type: "message", Content: fmt.Sprintf("🔎 Seeded %d source→sink and %d route hypotheses from source (%d route↔sink correlated) — use read_ledger and probe_hypothesis to confirm reachability.", s.SinkHypotheses, s.RouteHypotheses, s.Correlated)})
+				log.Printf("[agent] source seeding: %d sink, %d route hypotheses (%d correlated)", s.SinkHypotheses, s.RouteHypotheses, s.Correlated)
+			}
 		}
 	}
 	// Attack-surface seeding (OpenAPI / HAR / Postman). Parse the operator's

--- a/internal/agent/scan_source_routes.go
+++ b/internal/agent/scan_source_routes.go
@@ -222,3 +222,39 @@ func (a *Agent) seedRoutes(routes []codesearch.RouteMatch, sinkVulnsByFile map[s
 	}
 	return seeded, correlated
 }
+
+// sourceSeedSummary is the outcome of auto-seeding the ledger from whitebox
+// source at scan start.
+type sourceSeedSummary struct {
+	SinkHypotheses  int
+	RouteHypotheses int
+	Correlated      int
+}
+
+// seedLedgerFromSource runs the deterministic sink + route sweeps over the
+// scan's resolved whitebox source and seeds the ledger, so the source-to-runtime
+// bridge populates schedulable hypotheses at scan start instead of waiting for
+// the model to call scan_source_sinks / scan_source_routes. Routes are
+// correlated with the sinks found in the same handler file (a route whose file
+// has a dangerous sink is seeded class-typed and higher-confidence). It is a
+// no-op when no source is configured, bounded by the per-sweep caps, and
+// idempotent (the ledger dedups), so it is safe to call once per scan alongside
+// seedLedgerFromSurface's artifact seeding.
+func (a *Agent) seedLedgerFromSource() sourceSeedSummary {
+	var sum sourceSeedSummary
+	if a.scanCtx == nil || codesearch.GetSourceRoot(a.scanCtx.ID) == "" {
+		return sum
+	}
+	// Sinks first: file-scoped dangerous-sink hypotheses, plus the file→vuln map
+	// used to type co-located routes.
+	byFile := map[string][]string{}
+	if sinkFound, err := codesearch.SinkScan(a.scanCtx.ID, 20); err == nil {
+		sum.SinkHypotheses = a.seedSinks(sinkFound)
+		byFile = sinkVulnsByFile(sinkFound)
+	}
+	// Routes next: reachable-path hypotheses, correlated with the sinks above.
+	if routes, err := codesearch.RouteScan(a.scanCtx.ID, 60); err == nil {
+		sum.RouteHypotheses, sum.Correlated = a.seedRoutes(routes, byFile)
+	}
+	return sum
+}

--- a/internal/agent/source_seed_auto_test.go
+++ b/internal/agent/source_seed_auto_test.go
@@ -1,0 +1,64 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+	"github.com/xalgord/xalgorix/v4/internal/tools/codesearch"
+)
+
+// TestSeedLedgerFromSource exercises the full whitebox bridge end-to-end: a
+// Flask app whose handler file declares a route AND contains an rce sink should
+// auto-seed both a source-sink hypothesis and a route hypothesis, with the
+// route correlated to the co-located sink.
+func TestSeedLedgerFromSource(t *testing.T) {
+	ag := &Agent{scanCtx: scanctx.New("src-seed-"+t.Name(), "")}
+	dir := t.TempDir()
+	src := "from flask import Flask, request\n" +
+		"import os\n" +
+		"app = Flask(__name__)\n\n" +
+		"@app.route('/run')\n" +
+		"def run():\n" +
+		"    os.system(request.args.get('cmd'))\n" +
+		"    return 'ok'\n"
+	if err := os.WriteFile(filepath.Join(dir, "app.py"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	codesearch.SetSourceRoot(ag.scanCtx.ID, dir)
+	defer codesearch.SetSourceRoot(ag.scanCtx.ID, "")
+
+	sum := ag.seedLedgerFromSource()
+	if sum.SinkHypotheses == 0 {
+		t.Fatalf("expected source-sink hypotheses seeded, got 0")
+	}
+	if sum.RouteHypotheses == 0 {
+		t.Fatalf("expected route hypotheses seeded, got 0")
+	}
+	if sum.Correlated == 0 {
+		t.Fatalf("expected the /run route to correlate with the rce sink in app.py, got 0")
+	}
+
+	var haveSink, haveRoute bool
+	for _, h := range ag.scanCtx.Ledger.All() {
+		switch h.Origin {
+		case "source-sink":
+			haveSink = true
+		case "source-route":
+			haveRoute = true
+		}
+	}
+	if !haveSink || !haveRoute {
+		t.Fatalf("expected both source-sink and source-route hypotheses in the ledger, sink=%v route=%v", haveSink, haveRoute)
+	}
+}
+
+// TestSeedLedgerFromSourceNoSource verifies the auto-seed is a no-op when no
+// whitebox source is configured for the scan.
+func TestSeedLedgerFromSourceNoSource(t *testing.T) {
+	ag := &Agent{scanCtx: scanctx.New("src-seed-nosrc-"+t.Name(), "")}
+	if sum := ag.seedLedgerFromSource(); sum.SinkHypotheses != 0 || sum.RouteHypotheses != 0 {
+		t.Fatalf("no source configured must seed nothing, got %+v", sum)
+	}
+}


### PR DESCRIPTION
## Summary
The three whitebox tools (`scan_source_sinks`, `scan_source_routes`, `probe_hypothesis`) only ran if the model chose to call them, so a scan with source attached could spend early iterations black-box-crawling before the code was examined. Now, as soon as the source is resolved in `prepareScanEnvironment`, the scan sweeps it for dangerous sinks and HTTP routes and seeds the ledger — sinks (`file:line`), reachable routes (real paths), and the route↔sink correlations — exactly as an uploaded OpenAPI/HAR context already auto-seeds via `seedLedgerFromSurface`. Specialists get concrete source-derived leads to `probe_hypothesis` and exploit from iteration 1.

## Details
- New `Agent.seedLedgerFromSource()` (+ `sourceSeedSummary`) reuses the shipped `SinkScan`/`seedSinks` and `RouteScan`/`seedRoutes`/`sinkVulnsByFile` helpers: sinks first (for the file→vuln map), then routes correlated against them. No-op when no source; bounded by per-sweep caps; idempotent (ledger dedups). Wired in right after `codesearch.SetSourceRoot` succeeds, with a one-line emit.

## Testing
- `go build ./...`, `go vet ./...` clean; gofmt clean.
- `go test -race ./internal/agent/`: full end-to-end bridge on a temp Flask app (route + os.system sink in one file) seeds both a source-sink and a source-route hypothesis, route correlated; no-source is a no-op. Regressions green.
- golangci-lint clean on changed files.