### PR TITLE
release: v4.6.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [v4.6.26](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.26) — Auto-seed the ledger from whitebox source at scan start (2026-09-02)
 
 ### Changed
 - **Whitebox source now auto-seeds the ledger at scan start — the source-to-runtime bridge fires from iteration 1.** The three whitebox tools (`scan_source_sinks`, `scan_source_routes`, `probe_hypothesis`) only ran if the model chose to call them, so a scan with source attached could spend early iterations black-box-crawling before the code was ever examined. Now, as soon as the source is resolved, the scan sweeps it for dangerous sinks and HTTP routes and seeds the ledger with the resulting hypotheses — dangerous sinks (`file:line`), reachable routes (real HTTP paths), and the route↔sink correlations (a route whose handler file has a dangerous sink is seeded class-typed and higher-confidence) — exactly as an uploaded OpenAPI/HAR context already auto-seeds the surface. The specialists get concrete, source-derived leads to `probe_hypothesis` and exploit from the first iteration instead of rediscovering them. Deterministic, bounded (per-sweep caps), and idempotent (the ledger dedups), so it never floods or duplicates; a no-op when no source is configured.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.25
+VERSION=4.6.26
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.25"
+var version = "4.6.26"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.26 — Auto-seed the ledger from whitebox source at scan start.

Bumps version (main.go, Makefile) and promotes the CHANGELOG [Unreleased] section to v4.6.26.

Ships the change from #532: when source is configured, the scan now sweeps it for dangerous sinks and HTTP routes and seeds the ledger with source→sink, reachable-route, and route↔sink-correlated hypotheses as soon as the source resolves — so the source-to-runtime bridge (scan_source_sinks #526 -> scan_source_routes #528 -> probe_hypothesis #530) fires from iteration 1 instead of waiting for the model to call the tools, exactly as an uploaded OpenAPI/HAR context already auto-seeds the surface. Deterministic, bounded, idempotent; a no-op when no source is configured.