### PR TITLE
feat(bench): whitebox benchmark challenge exercising the source-to-runtime bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **A whitebox benchmark challenge that measures the source-to-runtime bridge end-to-end.** The benchmark harness could only measure black-box detection; the whitebox capability shipped over the last four releases (`scan_source_sinks`, `scan_source_routes`, `probe_hypothesis`, and auto-seeding at scan start) had no benchmark to prove it works. A `Challenge` can now carry a `SourceFiles` source tree, which the harness materializes to a temp directory and hands to the scan as the target's source repo (the real runner wires it via `SetSourceRepo`). The new `whitebox-cmdi` challenge is a small app whose command-injectable route is **not linked from any page** — black-box crawling cannot reach it, so solving it (class RCE) genuinely requires the bridge: scan the source, discover the route and the `os.popen` sink in the same file, probe it live, then exploit it. This is operator-only benchmark tooling; the shipped binary is unchanged (releases build only `./cmd/xalgorix`).
+
 ## [v4.6.26](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.26) — Auto-seed the ledger from whitebox source at scan start (2026-09-02)
 
 ### Changed

--- a/cmd/xalgorix-bench/main.go
+++ b/cmd/xalgorix-bench/main.go
@@ -71,7 +71,7 @@ func filterChallenges(all []bench.Challenge, csv string) []bench.Challenge {
 // and returns the findings it produced. Mirrors the production scan wiring
 // (internal/web/scan_session.go) minus the dashboard plumbing.
 func realScan(instruction string) bench.ScanFunc {
-	return func(ctx context.Context, target, scanID string) ([]reporting.Vulnerability, error) {
+	return func(ctx context.Context, target, sourceDir, scanID string) ([]reporting.Vulnerability, error) {
 		cfg := config.Get()
 
 		scanDir := filepath.Join(os.TempDir(), "xalgorix-bench", scanID)
@@ -100,6 +100,13 @@ func realScan(instruction string) bench.ScanFunc {
 		ag := agent.NewAgent(cfg, "XalgorixBench", events, guard, sc)
 		ag.SetPhaseRestrictions(nil)
 		ag.SetActivityPolicy("active", "active", []string{target})
+		// Whitebox challenge: wire the materialized source tree so the scan can
+		// use the source-to-runtime bridge (auto-seed + scan_source_sinks/routes
+		// + probe_hypothesis), mirroring production's per-scan source repo.
+		if sourceDir != "" {
+			ag.SetSourceRepo(sourceDir)
+			fmt.Fprintf(os.Stderr, "  [bench] %s → source %s\n", scanID, sourceDir)
+		}
 
 		fmt.Fprintf(os.Stderr, "  [bench] %s → %s\n", scanID, target)
 		// Run the (blocking) scan in a goroutine so the harness's per-challenge

--- a/internal/bench/bench_test.go
+++ b/internal/bench/bench_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -121,7 +123,7 @@ func TestSolved(t *testing.T) {
 func TestRunWithFakeScanFunc(t *testing.T) {
 	// Fake solves xss and idor, leaves open-redirect and error-sqli unsolved,
 	// and errors on nothing.
-	fake := func(_ context.Context, target, scanID string) ([]reporting.Vulnerability, error) {
+	fake := func(_ context.Context, target, _, scanID string) ([]reporting.Vulnerability, error) {
 		switch scanID {
 		case "bench-reflected-xss":
 			return []reporting.Vulnerability{{ID: "XALG-1", Title: "Reflected XSS in search", Endpoint: target + "/search"}}, nil
@@ -143,11 +145,15 @@ func TestRunWithFakeScanFunc(t *testing.T) {
 	if byClass["xss"] != [2]int{1, 1} || byClass["idor"] != [2]int{1, 1} {
 		t.Fatalf("expected xss 1/1 and idor 1/1, got %v", byClass)
 	}
-	// Every other class is present but unsolved by this fake.
-	for _, c := range []string{"open_redirect", "sqli", "ssrf", "ssti", "lfi", "rce"} {
+	// Every other single-challenge class is present but unsolved by this fake.
+	for _, c := range []string{"open_redirect", "sqli", "ssrf", "ssti", "lfi"} {
 		if byClass[c] != [2]int{0, 1} {
 			t.Fatalf("expected %s 0/1, got %v", c, byClass[c])
 		}
+	}
+	// rce now has two challenges (cmdi + whitebox-cmdi), both unsolved here.
+	if byClass["rce"] != [2]int{0, 2} {
+		t.Fatalf("expected rce 0/2, got %v", byClass["rce"])
 	}
 }
 
@@ -184,7 +190,7 @@ func TestNewBuiltinChallengesExhibitVuln(t *testing.T) {
 func TestRunWithTimeoutMarksTimedOut(t *testing.T) {
 	// A scan that blocks past the per-challenge deadline is stopped and marked
 	// timed out (and, with no findings, not solved).
-	blocking := func(ctx context.Context, _, _ string) ([]reporting.Vulnerability, error) {
+	blocking := func(ctx context.Context, _, _, _ string) ([]reporting.Vulnerability, error) {
 		<-ctx.Done()
 		return nil, ctx.Err()
 	}
@@ -197,5 +203,64 @@ func TestRunWithTimeoutMarksTimedOut(t *testing.T) {
 	}
 	if card.Results[0].Solved {
 		t.Fatal("a timed-out scan with no findings must not be solved")
+	}
+}
+
+func TestWhiteboxChallengeExhibitsVuln(t *testing.T) {
+	wb := challengeByName(t, "whitebox-cmdi")
+
+	// The whitebox source carries the sink and the (unlinked) vulnerable route
+	// in the same file, so the source→route↔sink bridge can find it.
+	src, ok := wb.SourceFiles["app.py"]
+	if !ok {
+		t.Fatal("whitebox-cmdi must ship app.py source")
+	}
+	if !strings.Contains(src, "os.popen") || !strings.Contains(src, "/internal/run-check") {
+		t.Fatalf("app.py must contain the os.popen sink and the /internal/run-check route:\n%s", src)
+	}
+
+	srv := wb.Start()
+	defer srv.Close()
+
+	// The vulnerable route executes injected commands (shell metacharacter).
+	if body := httpGet(t, srv.URL+"/internal/run-check?host=127.0.0.1%3Bid"); !strings.Contains(body, "uid=0(root)") {
+		t.Fatalf("whitebox route did not execute the injected command: %q", body)
+	}
+	// A benign host does not.
+	if body := httpGet(t, srv.URL+"/internal/run-check?host=127.0.0.1"); strings.Contains(body, "uid=0(root)") {
+		t.Fatalf("benign host must not yield command output: %q", body)
+	}
+	// Health endpoint is benign.
+	if body := httpGet(t, srv.URL+"/healthz"); !strings.Contains(body, "ok") {
+		t.Fatalf("healthz should return ok, got %q", body)
+	}
+	// The index must NOT link the vulnerable route — black-box crawling can't
+	// reach it, so the win genuinely requires whitebox source discovery.
+	if body := httpGet(t, srv.URL+"/"); strings.Contains(body, "/internal/run-check") {
+		t.Fatalf("index must not link the vulnerable route (whitebox-only), got %q", body)
+	}
+}
+
+func TestHarnessMaterializesSourceFiles(t *testing.T) {
+	// Capture the sourceDir handed to each challenge's scan.
+	seen := map[string]string{}
+	fake := func(_ context.Context, _, sourceDir, scanID string) ([]reporting.Vulnerability, error) {
+		seen[scanID] = sourceDir
+		// While the scan runs, a whitebox challenge's source must exist on disk.
+		if sourceDir != "" {
+			if _, err := os.Stat(filepath.Join(sourceDir, "app.py")); err != nil {
+				t.Errorf("expected app.py in materialized source dir %q: %v", sourceDir, err)
+			}
+		}
+		return nil, nil
+	}
+
+	Run(context.Background(), Builtin(), fake)
+
+	if seen["bench-whitebox-cmdi"] == "" {
+		t.Fatal("whitebox-cmdi must receive a non-empty, materialized source dir")
+	}
+	if seen["bench-reflected-xss"] != "" {
+		t.Fatalf("a black-box challenge must receive an empty source dir, got %q", seen["bench-reflected-xss"])
 	}
 }

--- a/internal/bench/challenge.go
+++ b/internal/bench/challenge.go
@@ -29,6 +29,13 @@ type Challenge struct {
 	Param    string       // the vulnerable parameter, when applicable
 	Desc     string       // one-line human description
 	Handler  http.Handler // the deliberately vulnerable app
+
+	// SourceFiles is the whitebox source tree for the app, as relative path →
+	// file content. When set, the harness materializes it to a temp directory
+	// and hands that directory to the scan as the target's source repo, so the
+	// scan can use the source-to-runtime bridge (scan_source_sinks /
+	// scan_source_routes / probe_hypothesis). Nil for pure black-box challenges.
+	SourceFiles map[string]string
 }
 
 // Start launches the challenge app on an ephemeral loopback server. The caller
@@ -164,6 +171,56 @@ func Builtin() []Challenge {
 					out += "uid=0(root) gid=0(root) groups=0(root)\n"
 				}
 				_, _ = fmt.Fprint(w, out)
+			}),
+		},
+		{
+			// Whitebox challenge: the command-injectable route is NOT linked from
+			// any page, so black-box crawling cannot find it. Solving it requires
+			// the source-to-runtime bridge — scan the attached source, discover
+			// the route + the os.popen sink in the same file, probe it live, then
+			// exploit it. Class rce, so it scores on the existing scale.
+			Name: "whitebox-cmdi", Class: "rce", Endpoint: "/internal/run-check", Param: "host",
+			Desc: "Command injection on an UNLINKED route, discoverable only via the attached source.",
+			SourceFiles: map[string]string{
+				"app.py": "from flask import Flask, request\n" +
+					"import os\n\n" +
+					"app = Flask(__name__)\n\n\n" +
+					"@app.route('/')\n" +
+					"def index():\n" +
+					"    return '<html><body>Service</body></html>'\n\n\n" +
+					"@app.route('/healthz')\n" +
+					"def healthz():\n" +
+					"    return 'ok'\n\n\n" +
+					"# Internal diagnostics endpoint - intentionally not linked from any page.\n" +
+					"@app.route('/internal/run-check')\n" +
+					"def run_check():\n" +
+					"    host = request.args.get('host', '')\n" +
+					"    # Vulnerable: user input flows into a shell command.\n" +
+					"    return os.popen('ping -c1 ' + host).read()\n",
+			},
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/healthz":
+					w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+					_, _ = fmt.Fprint(w, "ok")
+				case "/internal/run-check":
+					host := r.URL.Query().Get("host")
+					w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+					out := fmt.Sprintf("PING %s: 56 data bytes\n64 bytes: icmp_seq=0 ttl=64 time=0.041 ms\n", host)
+					if hasShellMeta(host) {
+						// Simulated command execution of the injected command.
+						out += "uid=0(root) gid=0(root) groups=0(root)\n"
+					}
+					_, _ = fmt.Fprint(w, out)
+				case "/":
+					// Index links only to /healthz — the vulnerable route is NOT
+					// linked, so black-box crawling can't find it; only whitebox
+					// source discovery can.
+					w.Header().Set("Content-Type", "text/html; charset=utf-8")
+					_, _ = fmt.Fprint(w, `<html><body><h1>Service</h1><p>See <a href="/healthz">health</a>.</p></body></html>`)
+				default:
+					http.NotFound(w, r)
+				}
 			}),
 		},
 	}

--- a/internal/bench/harness.go
+++ b/internal/bench/harness.go
@@ -2,17 +2,21 @@ package bench
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/xalgord/xalgorix/v4/internal/tools/reporting"
 )
 
 // ScanFunc runs a full scan against target (the base URL of a challenge app)
-// under the given scan id, and returns the findings it produced. It is injected
+// under the given scan id, and returns the findings it produced. sourceDir is
+// the challenge's materialized whitebox source tree (the scan wires it as the
+// target's source repo), or "" for a pure black-box challenge. It is injected
 // so the harness stays free of the heavy, non-hermetic agent machinery: the
 // real implementation (cmd/xalgorix-bench) drives the LLM agent and makes live
 // calls, while tests pass a deterministic fake.
-type ScanFunc func(ctx context.Context, target, scanID string) ([]reporting.Vulnerability, error)
+type ScanFunc func(ctx context.Context, target, sourceDir, scanID string) ([]reporting.Vulnerability, error)
 
 // DefaultChallengeTimeout bounds how long a single challenge scan may run. A
 // scan against a trivial challenge app should finish quickly; without a bound a
@@ -44,6 +48,16 @@ func runOne(parent context.Context, c Challenge, scan ScanFunc, timeout time.Dur
 	srv := c.Start()
 	defer srv.Close()
 
+	// Materialize the whitebox source tree (if any) to a temp dir the scan can
+	// point its source repo at, and clean it up afterward.
+	sourceDir := ""
+	if len(c.SourceFiles) > 0 {
+		if dir, err := writeSourceFiles(c.SourceFiles); err == nil {
+			sourceDir = dir
+			defer func() { _ = os.RemoveAll(dir) }()
+		}
+	}
+
 	ctx := parent
 	if timeout > 0 {
 		var cancel context.CancelFunc
@@ -53,7 +67,7 @@ func runOne(parent context.Context, c Challenge, scan ScanFunc, timeout time.Dur
 
 	res := Result{Name: c.Name, Class: canonicalClass(c.Class)}
 	start := time.Now()
-	findings, err := scan(ctx, srv.URL, "bench-"+c.Name)
+	findings, err := scan(ctx, srv.URL, sourceDir, "bench-"+c.Name)
 	res.Elapsed = time.Since(start)
 	res.Findings = len(findings)
 	if ctx.Err() == context.DeadlineExceeded {
@@ -66,4 +80,25 @@ func runOne(parent context.Context, c Challenge, scan ScanFunc, timeout time.Dur
 	// have reported the vulnerability before the deadline.
 	res.Solved, res.MatchedFindingID = Solved(c.Class, findings)
 	return res
+}
+
+// writeSourceFiles materializes a challenge's whitebox source tree (relative
+// path → content) into a fresh temp directory, creating parent directories as
+// needed, and returns its path. The caller owns the directory and should remove
+// it when done.
+func writeSourceFiles(files map[string]string) (string, error) {
+	dir, err := os.MkdirTemp("", "xalgorix-bench-src-")
+	if err != nil {
+		return "", err
+	}
+	for rel, content := range files {
+		p := filepath.Join(dir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
+			return dir, err
+		}
+		if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+			return dir, err
+		}
+	}
+	return dir, nil
 }


### PR DESCRIPTION
## Summary
The benchmark harness could only measure black-box detection; the whitebox capability shipped over the last four releases (`scan_source_sinks` #526, `scan_source_routes` #528, `probe_hypothesis` #530, auto-seed #532) had no benchmark to prove it works end-to-end. This adds one.

## Details
- `Challenge` gains `SourceFiles` (relative path → content). The harness materializes it to a temp dir and threads a `sourceDir` through `ScanFunc`; the real `xalgorix-bench` runner wires it via `ag.SetSourceRepo`, mirroring production's per-scan source repo. Cleaned up after each challenge.
- New `whitebox-cmdi` challenge (class RCE): the command-injectable route (`/internal/run-check`, `os.popen` sink) is **not linked from any page**, so black-box crawling cannot reach it. Solving it genuinely requires the bridge — scan the source, discover the route + the co-located sink, probe it live, then exploit it.
- Operator-only tooling; the **shipped binary is unchanged** (releases build only `./cmd/xalgorix`).

## Testing
- `go build ./...`, `go vet ./...` clean; gofmt clean; golangci-lint clean on changed files.
- `go test -race ./internal/bench/`: whitebox challenge exhibits the vuln (injected command → uid=0(root); benign host does not; index does NOT link the vuln route); harness materializes SourceFiles and passes empty sourceDir for black-box; updated fakes + rce class count.