### PR TITLE
release: v4.6.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [v4.6.27](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.27) — Whitebox benchmark challenge for the source-to-runtime bridge (2026-09-02)
 
 ### Added
 - **A whitebox benchmark challenge that measures the source-to-runtime bridge end-to-end.** The benchmark harness could only measure black-box detection; the whitebox capability shipped over the last four releases (`scan_source_sinks`, `scan_source_routes`, `probe_hypothesis`, and auto-seeding at scan start) had no benchmark to prove it works. A `Challenge` can now carry a `SourceFiles` source tree, which the harness materializes to a temp directory and hands to the scan as the target's source repo (the real runner wires it via `SetSourceRepo`). The new `whitebox-cmdi` challenge is a small app whose command-injectable route is **not linked from any page** — black-box crawling cannot reach it, so solving it (class RCE) genuinely requires the bridge: scan the source, discover the route and the `os.popen` sink in the same file, probe it live, then exploit it. This is operator-only benchmark tooling; the shipped binary is unchanged (releases build only `./cmd/xalgorix`).

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.26
+VERSION=4.6.27
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.26"
+var version = "4.6.27"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.27 — Whitebox benchmark challenge for the source-to-runtime bridge.

Bumps version (main.go, Makefile) and promotes the CHANGELOG [Unreleased] section to v4.6.27.

Ships the change from #534: the benchmark harness can now carry a whitebox source tree per challenge (Challenge.SourceFiles), materialized to a temp dir and wired into the scan via SetSourceRepo. The new whitebox-cmdi challenge exposes a command-injectable route that is NOT linked from any page, so solving it (class rce) genuinely requires the source-to-runtime bridge (scan_source_sinks/routes + auto-seed + probe_hypothesis). Operator-only benchmark tooling; the shipped binary is unchanged (releases build only ./cmd/xalgorix).