### PR TITLE
fix(codesearch): stop route discovery matching non-router .get()/.post() calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **Source route discovery no longer mistakes ordinary `.get()`/`.post()` calls for HTTP routes.** The Express/Koa route pattern matched `<anything>.get("…")`, so common non-router calls — `request.args.get('host')`, `dict.get('key')`, `session.get('token')` — were scooped up as bogus route hypotheses (the first whitebox benchmark run seeded 4 routes for a 3-route app; the extra one was a "route" named `host` harvested from `request.args.get('host')`). The receiver is now restricted to router-like names (`app`, `router`, `routes`, `route`, `api`, `srv`, `server`, `mux`, `koa`, `fastify`), so only real route declarations are seeded — keeping the ledger and `probe_hypothesis` focused on genuine attack surface. Gin/Echo routers, which use upper-case method calls (`r.GET(...)`), are matched by the separate Go-router pattern and are unaffected. Surfaced by the v4.6.27 whitebox benchmark.
+
 ## [v4.6.27](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.27) — Whitebox benchmark challenge for the source-to-runtime bridge (2026-09-02)
 
 ### Added

--- a/internal/tools/codesearch/codesearch.go
+++ b/internal/tools/codesearch/codesearch.go
@@ -351,8 +351,10 @@ var routePatterns = []routePattern{
 	{"flask/fastapi", `@[A-Za-z_][A-Za-z0-9_]*\.(get|post|put|patch|delete|options|head)\(['"]([^'"]+)`, 1, 2},
 	// Flask/Blueprint generic route: @app.route("/x"), @bp.route('/y')
 	{"flask", `@[A-Za-z_][A-Za-z0-9_]*\.route\(['"]([^'"]+)`, 0, 1},
-	// Express/Koa/Fastify: app.get("/x"), router.post('/y')
-	{"express", `\b[A-Za-z_][A-Za-z0-9_]*\.(get|post|put|patch|delete|all)\(['"]([^'"]+)`, 1, 2},
+	// Express/Koa/Fastify: app.get("/x"), router.post('/y'). The receiver is
+	// restricted to router-like names so this does NOT match unrelated .get()
+	// calls such as request.args.get('host'), dict.get('k'), or session.get(...).
+	{"express", `\b(app|router|routes|route|api|srv|server|mux|koa|fastify)\.(get|post|put|patch|delete|all)\(['"]([^'"]+)`, 2, 3},
 	// Django urls: path("x/", ...), re_path(r'^x$', ...), url(r'^x', ...)
 	{"django", `\b(path|re_path|url)\(\s*r?['"]([^'"]+)`, 0, 2},
 	// Spring: @GetMapping("/x"), @RequestMapping(value="/y")

--- a/internal/tools/codesearch/codesearch_test.go
+++ b/internal/tools/codesearch/codesearch_test.go
@@ -375,3 +375,42 @@ func TestRouteScanBounded(t *testing.T) {
 		t.Fatalf("max=2 must bound routes, got %d", len(routes))
 	}
 }
+
+func TestRouteScanIgnoresNonRouterGetCalls(t *testing.T) {
+	// Regression: the express pattern must not treat arbitrary .get()/.post()
+	// calls (request.args.get, dict.get, session.get) as HTTP routes — only
+	// router-like receivers (app, router, …) declare routes.
+	const ctx = "ctx-routescan-fp"
+	dir := t.TempDir()
+	src := "from flask import request\n" +
+		"def handler():\n" +
+		"    host = request.args.get('host', '')\n" +
+		"    k = data.get('secret_key')\n" +
+		"    v = session.get('token')\n" +
+		"    app.get('/users')\n" +
+		"    router.post('/login')\n"
+	if err := os.WriteFile(filepath.Join(dir, "app.py"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	SetSourceRoot(ctx, dir)
+	defer SetSourceRoot(ctx, "")
+
+	routes, err := RouteScan(ctx, 60)
+	if err != nil {
+		t.Fatalf("RouteScan: %v", err)
+	}
+	paths := map[string]bool{}
+	for _, r := range routes {
+		paths[r.Path] = true
+	}
+	// Real router route declarations are still found.
+	if !paths["/users"] || !paths["/login"] {
+		t.Fatalf("expected /users and /login routes, got %+v", routes)
+	}
+	// Non-router .get() argument strings must NOT be seeded as routes.
+	for _, bogus := range []string{"host", "secret_key", "token"} {
+		if paths[bogus] {
+			t.Fatalf("non-router .get() call must not yield a route %q; got %+v", bogus, routes)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
The first whitebox benchmark run (#534, v4.6.27) surfaced a false positive in source route discovery: the Express/Koa pattern matched `<anything>.get("…")`, so `request.args.get('host')`, `dict.get('key')`, and `session.get('token')` were harvested as bogus route hypotheses (4 routes seeded for a 3-route app — the extra being a route named `host`).

## Fix
Restrict the receiver to router-like names (`app|router|routes|route|api|srv|server|mux|koa|fastify`), so only real route declarations are seeded — keeping the ledger and `probe_hypothesis` focused on genuine attack surface. Gin/Echo (upper-case `r.GET(...)`) are matched by the separate Go-router pattern and are unaffected. The pattern stays ERE-safe/RE2-valid; method/path capture groups shift to 2/3.

## Testing
- `go build ./...`, `go vet ./...` clean; gofmt clean; golangci-lint clean on changed files.
- `go test -race ./internal/tools/codesearch/`: new regression test asserts `request.args.get`/`dict.get`/`session.get` yield no routes while `app.get('/users')`/`router.post('/login')` still do; existing route/sink tests green.