### PR TITLE
feat(agent): attribute source sinks to the enclosing route handler, not the file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- **Source route↔sink correlation now attributes a sink to its enclosing handler, not the whole file.** When source auto-seeding types a route by a co-located dangerous sink, it previously matched *any* sink anywhere in the same file — so in a multi-route file every route was typed with the same (often unrelated) vuln class. The first whitebox benchmark run showed this: all three routes in the challenge's `app.py` were typed `rce` even though only `/internal/run-check` actually contains the `os.popen` sink. Correlation now uses the route's handler span — a sink at line L is attributed to the route whose declaration is the nearest one at or above L (bounded by the next route declaration below it) — so only the route that genuinely reaches a sink is class-typed and prioritized; the others seed as ordinary attack-surface (`idor`) leads. This keeps `probe_hypothesis` and exploitation focused on the route that actually reaches the dangerous code.
+
 ## [v4.6.28](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.28) — Route-discovery precision fix (2026-09-02)
 
 ### Fixed

--- a/internal/agent/scan_source_routes.go
+++ b/internal/agent/scan_source_routes.go
@@ -69,11 +69,12 @@ func (a *Agent) scanSourceRoutesTool(args map[string]string) (tools.Result, erro
 		return tools.Result{Output: "Swept the source for HTTP route declarations and found none of the known framework patterns (Flask/FastAPI, Django, Express, Spring, Go routers, Rails). The app may use an uncommon router — try code_search with a custom regex, or map routes by crawling the live target."}, nil
 	}
 
-	// Correlate routes with dangerous sinks in the same file (best-effort: a
-	// sink-scan failure just means no correlation, not a hard error).
-	byFile := map[string][]string{}
+	// Correlate routes with dangerous sinks inside each route's handler
+	// (best-effort: a sink-scan failure just means no correlation, not a hard
+	// error).
+	byFile := map[string][]fileSink{}
 	if found, serr := codesearch.SinkScan(a.scanCtx.ID, 20); serr == nil {
-		byFile = sinkVulnsByFile(found)
+		byFile = sinksByFileWithLines(found)
 	}
 
 	seeded, correlated := a.seedRoutes(routes, byFile)
@@ -97,7 +98,7 @@ func (a *Agent) scanSourceRoutesTool(args map[string]string) (tools.Result, erro
 	if seeded > 0 {
 		fmt.Fprintf(&b, "Seeded %d route hypotheses into the ledger (origin=source-route)", seeded)
 		if correlated > 0 {
-			fmt.Fprintf(&b, ", %d correlated with a same-file dangerous sink (class-typed, higher confidence)", correlated)
+			fmt.Fprintf(&b, ", %d whose handler reaches a dangerous sink (class-typed, higher confidence)", correlated)
 		}
 		b.WriteString(". Use read_ledger(filter=schedulable) or claim_next_hypothesis, then request each route on the live target and prove the vuln.")
 	} else {
@@ -106,32 +107,53 @@ func (a *Agent) scanSourceRoutesTool(args map[string]string) (tools.Result, erro
 	return tools.Result{Output: b.String(), Metadata: map[string]any{"routes": len(routes), "seeded": seeded, "correlated": correlated}}, nil
 }
 
-// sinkVulnsByFile inverts a SinkScan result into file -> sorted, deduplicated
-// canonical vuln classes, using the same sinkClassToVuln allowlist as
-// scan_source_sinks (discovery-only classes are skipped). It is the lookup
-// seedRoutes uses to type a route by the dangerous sinks in its handler file.
-func sinkVulnsByFile(found map[string][]codesearch.SinkMatch) map[string][]string {
-	byFile := map[string]map[string]bool{}
+// fileSink is a dangerous sink located at a specific line in a source file,
+// tagged with its canonical vuln class. Carrying the line lets seedRoutes
+// attribute a sink to the ENCLOSING route handler rather than the whole file.
+type fileSink struct {
+	line int
+	vuln string
+}
+
+// sinksByFileWithLines inverts a SinkScan result into file -> sinks (line +
+// canonical vuln), using the same sinkClassToVuln allowlist as scan_source_sinks
+// (discovery-only classes are skipped). It is the lookup seedRoutes uses to type
+// a route by the dangerous sinks that fall inside its handler span.
+func sinksByFileWithLines(found map[string][]codesearch.SinkMatch) map[string][]fileSink {
+	out := map[string][]fileSink{}
 	for class, matches := range found {
 		vuln, ok := sinkClassToVuln[class]
 		if !ok {
 			continue
 		}
 		for _, m := range matches {
-			if byFile[m.File] == nil {
-				byFile[m.File] = map[string]bool{}
-			}
-			byFile[m.File][vuln] = true
+			out[m.File] = append(out[m.File], fileSink{line: m.Line, vuln: vuln})
 		}
-	}
-	out := map[string][]string{}
-	for file, set := range byFile {
-		for v := range set {
-			out[file] = append(out[file], v)
-		}
-		sort.Strings(out[file])
 	}
 	return out
+}
+
+// enclosingRouteVuln returns the worst vuln class among the sinks that fall
+// within route r's handler span — the lines from r's declaration up to (but not
+// including) the next route declaration in the same file. sameFileRouteLines
+// must be the sorted decl lines of every route in r.File. Returns "" when no
+// dangerous sink is enclosed (the route is then seeded as an attack-surface
+// lead, not class-typed).
+func enclosingRouteVuln(r codesearch.RouteMatch, sameFileRouteLines []int, sinks []fileSink) string {
+	// The handler span ends at the next route declaration strictly below r.
+	nextLine := int(^uint(0) >> 1) // max int
+	for _, ln := range sameFileRouteLines {
+		if ln > r.Line && ln < nextLine {
+			nextLine = ln
+		}
+	}
+	var enclosed []string
+	for _, s := range sinks {
+		if s.line >= r.Line && s.line < nextLine {
+			enclosed = append(enclosed, s.vuln)
+		}
+	}
+	return highestSeverityVuln(enclosed)
 }
 
 // highestSeverityVuln picks the most-dangerous vuln class present, falling back
@@ -156,17 +178,30 @@ func highestSeverityVuln(vulns []string) string {
 
 // seedRoutes upserts bounded, deduplicated route hypotheses from a route sweep
 // and returns how many NEW hypotheses were created and how many of those were
-// correlated with a same-file dangerous sink. Each hypothesis carries a REAL
-// HTTP path as Endpoint and Origin=source-route. A route whose handler file
-// contains a dangerous sink is typed by that sink's (worst) vuln class at
-// confidence 0.45; an uncorrelated route seeds as an authz/attack-surface
-// (idor) lead at confidence 0.3. Idempotent: the ledger dedups by
-// vuln_class+endpoint, so re-seeding the same routes adds nothing.
-func (a *Agent) seedRoutes(routes []codesearch.RouteMatch, sinkVulnsByFile map[string][]string) (seeded, correlated int) {
+// correlated with a dangerous sink INSIDE the route's handler. Each hypothesis
+// carries a REAL HTTP path as Endpoint and Origin=source-route. A route whose
+// handler span (its declaration up to the next route in the same file) encloses
+// a dangerous sink is typed by that sink's (worst) vuln class at confidence
+// 0.45; a route with no enclosed sink seeds as an authz/attack-surface (idor)
+// lead at confidence 0.3. Attributing sinks by handler span (not whole file)
+// avoids typing every route in a multi-route file with an unrelated sink.
+// Idempotent: the ledger dedups by vuln_class+endpoint, so re-seeding the same
+// routes adds nothing.
+func (a *Agent) seedRoutes(routes []codesearch.RouteMatch, sinksByFile map[string][]fileSink) (seeded, correlated int) {
 	l := a.ledger()
 	if l == nil {
 		return 0, 0
 	}
+	// Per-file sorted route declaration lines, so each route's handler span can
+	// be bounded by the next route declaration below it.
+	routeLinesByFile := map[string][]int{}
+	for _, r := range routes {
+		routeLinesByFile[r.File] = append(routeLinesByFile[r.File], r.Line)
+	}
+	for f := range routeLinesByFile {
+		sort.Ints(routeLinesByFile[f])
+	}
+
 	for _, r := range routes {
 		if seeded >= maxRouteSeed {
 			break
@@ -181,10 +216,7 @@ func (a *Agent) seedRoutes(routes []codesearch.RouteMatch, sinkVulnsByFile map[s
 			label = r.Method + " " + path
 		}
 
-		vuln := ""
-		if vulns := sinkVulnsByFile[r.File]; len(vulns) > 0 {
-			vuln = highestSeverityVuln(vulns)
-		}
+		vuln := enclosingRouteVuln(r, routeLinesByFile[r.File], sinksByFile[r.File])
 
 		var h scanctx.Hypothesis
 		if vuln != "" {
@@ -192,11 +224,11 @@ func (a *Agent) seedRoutes(routes []codesearch.RouteMatch, sinkVulnsByFile map[s
 				Title:      fmt.Sprintf("Source route %s → %s sink", label, vuln),
 				VulnClass:  vuln,
 				Endpoint:   path,
-				DataFlow:   fmt.Sprintf("source-route: %s %s @ %s → reaches a %s sink in the same file", r.Framework, label, loc, vuln),
+				DataFlow:   fmt.Sprintf("source-route: %s %s @ %s → its handler reaches a %s sink", r.Framework, label, loc, vuln),
 				Confidence: 0.45,
 				Status:     scanctx.HypothesisQueued,
 				Origin:     "source-route",
-				NextAction: fmt.Sprintf("Request %s on the live target; its handler file %s contains a %s sink — drive user input to it and prove %s.", label, r.File, vuln, vuln),
+				NextAction: fmt.Sprintf("Request %s on the live target; its handler (in %s) reaches a %s sink — drive user input to it and prove %s.", label, r.File, vuln, vuln),
 			}
 		} else {
 			h = scanctx.Hypothesis{
@@ -245,12 +277,12 @@ func (a *Agent) seedLedgerFromSource() sourceSeedSummary {
 	if a.scanCtx == nil || codesearch.GetSourceRoot(a.scanCtx.ID) == "" {
 		return sum
 	}
-	// Sinks first: file-scoped dangerous-sink hypotheses, plus the file→vuln map
-	// used to type co-located routes.
-	byFile := map[string][]string{}
+	// Sinks first: file-scoped dangerous-sink hypotheses, plus the per-file
+	// sink lines used to attribute sinks to their enclosing route handler.
+	byFile := map[string][]fileSink{}
 	if sinkFound, err := codesearch.SinkScan(a.scanCtx.ID, 20); err == nil {
 		sum.SinkHypotheses = a.seedSinks(sinkFound)
-		byFile = sinkVulnsByFile(sinkFound)
+		byFile = sinksByFileWithLines(sinkFound)
 	}
 	// Routes next: reachable-path hypotheses, correlated with the sinks above.
 	if routes, err := codesearch.RouteScan(a.scanCtx.ID, 60); err == nil {

--- a/internal/agent/scan_source_routes_test.go
+++ b/internal/agent/scan_source_routes_test.go
@@ -9,18 +9,18 @@ import (
 	"github.com/xalgord/xalgorix/v4/internal/tools/codesearch"
 )
 
-// TestSeedRoutesCorrelatedAndUncorrelated verifies a route whose file has a
-// dangerous sink is typed by that vuln class at confidence 0.45, while a route
-// with no co-located sink seeds as an idor/attack-surface lead at 0.3 — both
-// carrying a real HTTP path Endpoint, source-route Origin, and queued status.
+// TestSeedRoutesCorrelatedAndUncorrelated verifies a route whose handler
+// encloses a dangerous sink is typed by that vuln class at confidence 0.45,
+// while a route with no enclosed sink seeds as an idor/attack-surface lead at
+// 0.3 — both carrying a real HTTP path Endpoint, source-route Origin, queued.
 func TestSeedRoutesCorrelatedAndUncorrelated(t *testing.T) {
 	ag := &Agent{scanCtx: scanctx.New("routes-corr-"+t.Name(), "")}
 	routes := []codesearch.RouteMatch{
 		{Method: "POST", Path: "/admin/exec", File: "handlers.py", Line: 12, Framework: "flask"},
 		{Method: "GET", Path: "/profile", File: "views.py", Line: 3, Framework: "flask/fastapi"},
 	}
-	byFile := map[string][]string{
-		"handlers.py": {"rce"}, // correlated
+	byFile := map[string][]fileSink{
+		"handlers.py": {{line: 14, vuln: "rce"}}, // sink inside /admin/exec's handler span
 		// views.py has no sink -> uncorrelated
 	}
 
@@ -65,12 +65,12 @@ func TestSeedRoutesCorrelatedAndUncorrelated(t *testing.T) {
 	}
 }
 
-// TestSeedRoutesHighestSeverity verifies a route whose file has several sink
-// classes is typed by the most-dangerous one.
+// TestSeedRoutesHighestSeverity verifies a route whose handler encloses several
+// sink classes is typed by the most-dangerous one.
 func TestSeedRoutesHighestSeverity(t *testing.T) {
 	ag := &Agent{scanCtx: scanctx.New("routes-sev-"+t.Name(), "")}
 	routes := []codesearch.RouteMatch{{Method: "GET", Path: "/x", File: "app.py", Line: 1, Framework: "flask"}}
-	byFile := map[string][]string{"app.py": {"sqli", "rce", "lfi"}}
+	byFile := map[string][]fileSink{"app.py": {{line: 5, vuln: "sqli"}, {line: 6, vuln: "rce"}, {line: 7, vuln: "lfi"}}}
 
 	if seeded, correlated := ag.seedRoutes(routes, byFile); seeded != 1 || correlated != 1 {
 		t.Fatalf("seeded=%d correlated=%d want 1,1", seeded, correlated)
@@ -124,20 +124,50 @@ func TestSeedRoutesNilLedger(t *testing.T) {
 	}
 }
 
-// TestSinkVulnsByFileSkipsDiscoveryOnly verifies the file->vuln inversion maps
-// via the sinkClassToVuln allowlist and skips discovery-only classes.
-func TestSinkVulnsByFileSkipsDiscoveryOnly(t *testing.T) {
+// TestSinksByFileWithLinesSkipsDiscoveryOnly verifies the file->sinks inversion
+// keeps sink lines + canonical vuln and skips discovery-only classes.
+func TestSinksByFileWithLinesSkipsDiscoveryOnly(t *testing.T) {
 	found := map[string][]codesearch.SinkMatch{
 		"rce":    {{File: "a.py", Line: 1, Text: "os.system(x)"}},
 		"crypto": {{File: "a.py", Line: 2, Text: "MD5(x)"}}, // discovery-only, skipped
 		"sqli":   {{File: "b.py", Line: 3, Text: "cursor.execute(q)"}},
 	}
-	byFile := sinkVulnsByFile(found)
-	if got := byFile["a.py"]; len(got) != 1 || got[0] != "rce" {
-		t.Fatalf("a.py vulns=%v want [rce] (crypto skipped)", got)
+	byFile := sinksByFileWithLines(found)
+	if got := byFile["a.py"]; len(got) != 1 || got[0].vuln != "rce" || got[0].line != 1 {
+		t.Fatalf("a.py sinks=%v want [{1 rce}] (crypto skipped)", got)
 	}
-	if got := byFile["b.py"]; len(got) != 1 || got[0] != "sqli" {
-		t.Fatalf("b.py vulns=%v want [sqli]", got)
+	if got := byFile["b.py"]; len(got) != 1 || got[0].vuln != "sqli" || got[0].line != 3 {
+		t.Fatalf("b.py sinks=%v want [{3 sqli}]", got)
+	}
+}
+
+// TestSeedRoutesHandlerSpanAttribution verifies a sink is attributed only to the
+// route whose handler span encloses it, not every route in the file. Two routes
+// share app.py; the os.popen sink lives inside the second route's handler, so
+// only the second is class-typed rce — the first stays an idor lead.
+func TestSeedRoutesHandlerSpanAttribution(t *testing.T) {
+	ag := &Agent{scanCtx: scanctx.New("routes-span-"+t.Name(), "")}
+	routes := []codesearch.RouteMatch{
+		{Method: "GET", Path: "/healthz", File: "app.py", Line: 5, Framework: "flask"},
+		{Method: "GET", Path: "/run", File: "app.py", Line: 14, Framework: "flask"},
+	}
+	byFile := map[string][]fileSink{
+		// Sink at line 18: inside /run's span [14, ∞), NOT /healthz's span [5, 14).
+		"app.py": {{line: 18, vuln: "rce"}},
+	}
+
+	if seeded, correlated := ag.seedRoutes(routes, byFile); seeded != 2 || correlated != 1 {
+		t.Fatalf("expected seeded=2 correlated=1, got seeded=%d correlated=%d", seeded, correlated)
+	}
+	byEndpoint := map[string]scanctx.Hypothesis{}
+	for _, h := range ag.scanCtx.Ledger.All() {
+		byEndpoint[h.Endpoint] = h
+	}
+	if got := byEndpoint["/run"]; got.VulnClass != "rce" || got.Confidence != 0.45 {
+		t.Fatalf("/run should be rce@0.45 (encloses the sink), got %q @ %v", got.VulnClass, got.Confidence)
+	}
+	if got := byEndpoint["/healthz"]; got.VulnClass != "idor" || got.Confidence != 0.3 {
+		t.Fatalf("/healthz should be idor@0.3 (no enclosed sink), got %q @ %v", got.VulnClass, got.Confidence)
 	}
 }
 


### PR DESCRIPTION
## Summary
The first whitebox benchmark run (#534, v4.6.27) showed route↔sink correlation over-correlating: all three routes in the challenge's `app.py` were typed `rce` because the heuristic matched any sink anywhere in the file, even though only `/internal/run-check` contains the `os.popen` sink.

## Fix
Correlation now uses the route's **handler span**: a sink at line L is attributed to the route whose declaration is the nearest one at/above L, bounded by the next route declaration below it. Only the route that genuinely reaches a sink is class-typed (confidence 0.45); the others seed as ordinary attack-surface (`idor`) leads (0.3) — keeping `probe_hypothesis` and exploitation focused on the route that reaches the dangerous code.

- Replace `sinkVulnsByFile` (whole-file vuln set) with `sinksByFileWithLines` (sink line + vuln) + `enclosingRouteVuln` (handler-span attribution). `seedRoutes` now takes `map[string][]fileSink` and sorts per-file route decl lines to bound each span.

## Testing
- `go build ./...`, `go vet ./...` clean; gofmt clean; golangci-lint clean on changed files.
- `go test -race ./internal/agent/`: new handler-span attribution test (two routes in one file; sink only in the 2nd's span -> only the 2nd is rce, 1st stays idor); reworked correlated/uncorrelated + highest-severity; end-to-end auto-seed test green.