### PR TITLE
feat(bench): add whitebox-sqli challenge to widen source-to-runtime validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **Second whitebox benchmark challenge (`whitebox-sqli`) widens source-to-runtime validation to a second injection class.** The `whitebox-cmdi` challenge (v4.6.27) proved the source-to-runtime bridge end-to-end for command injection; this adds an equivalent SQL-injection challenge so the bridge is exercised across classes rather than one. Its vulnerable reporting route (`/internal/report`, which concatenates a user parameter straight into a raw `SELECT`) is **not linked from any page**, so — as with `whitebox-cmdi` — black-box crawling can't reach it and solving it requires the bridge: scan the source, discover the route and the co-located SQLi sink, attribute the sink to that handler, probe the route live, then prove the injection. Operator-only benchmark tooling; the shipped binary is unchanged (releases build only `./cmd/xalgorix`).
+
 ## [v4.6.29](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.29) — Handler-span route↔sink correlation (2026-09-02)
 
 ### Changed

--- a/internal/bench/bench_test.go
+++ b/internal/bench/bench_test.go
@@ -146,14 +146,18 @@ func TestRunWithFakeScanFunc(t *testing.T) {
 		t.Fatalf("expected xss 1/1 and idor 1/1, got %v", byClass)
 	}
 	// Every other single-challenge class is present but unsolved by this fake.
-	for _, c := range []string{"open_redirect", "sqli", "ssrf", "ssti", "lfi"} {
+	for _, c := range []string{"open_redirect", "ssrf", "ssti", "lfi"} {
 		if byClass[c] != [2]int{0, 1} {
 			t.Fatalf("expected %s 0/1, got %v", c, byClass[c])
 		}
 	}
-	// rce now has two challenges (cmdi + whitebox-cmdi), both unsolved here.
+	// rce (cmdi + whitebox-cmdi) and sqli (error-sqli + whitebox-sqli) each have
+	// two challenges, both unsolved by this fake.
 	if byClass["rce"] != [2]int{0, 2} {
 		t.Fatalf("expected rce 0/2, got %v", byClass["rce"])
+	}
+	if byClass["sqli"] != [2]int{0, 2} {
+		t.Fatalf("expected sqli 0/2, got %v", byClass["sqli"])
 	}
 }
 
@@ -262,5 +266,39 @@ func TestHarnessMaterializesSourceFiles(t *testing.T) {
 	}
 	if seen["bench-reflected-xss"] != "" {
 		t.Fatalf("a black-box challenge must receive an empty source dir, got %q", seen["bench-reflected-xss"])
+	}
+}
+
+func TestWhiteboxSqliChallengeExhibitsVuln(t *testing.T) {
+	wb := challengeByName(t, "whitebox-sqli")
+
+	// The whitebox source carries the sqli sink (a raw SELECT built by string
+	// concatenation) inside the unlinked reporting route's handler.
+	src, ok := wb.SourceFiles["app.py"]
+	if !ok {
+		t.Fatal("whitebox-sqli must ship app.py source")
+	}
+	if !strings.Contains(src, "/internal/report") || !strings.Contains(src, "SELECT id, name FROM users") {
+		t.Fatalf("app.py must contain the /internal/report route and the raw SELECT sink:\n%s", src)
+	}
+
+	srv := wb.Start()
+	defer srv.Close()
+
+	// A quote in uid triggers a SQL syntax error (injectable).
+	if body := httpGet(t, srv.URL+"/internal/report?uid=1%27"); !strings.Contains(strings.ToLower(body), "sql syntax") {
+		t.Fatalf("whitebox-sqli did not leak a SQL error on quote injection: %q", body)
+	}
+	// A benign uid does not.
+	if body := httpGet(t, srv.URL+"/internal/report?uid=1"); strings.Contains(strings.ToLower(body), "sql syntax") {
+		t.Fatalf("benign uid must not yield a SQL error: %q", body)
+	}
+	// Health endpoint is benign.
+	if body := httpGet(t, srv.URL+"/healthz"); !strings.Contains(body, "ok") {
+		t.Fatalf("healthz should return ok, got %q", body)
+	}
+	// The index must NOT link the vulnerable route (whitebox-only discovery).
+	if body := httpGet(t, srv.URL+"/"); strings.Contains(body, "/internal/report") {
+		t.Fatalf("index must not link the vulnerable route (whitebox-only), got %q", body)
 	}
 }

--- a/internal/bench/challenge.go
+++ b/internal/bench/challenge.go
@@ -223,6 +223,57 @@ func Builtin() []Challenge {
 				}
 			}),
 		},
+		{
+			// Whitebox challenge (SQLi): the vulnerable reporting route is not
+			// linked from any page, so it is discoverable only via the attached
+			// source. Solving it exercises the source-to-runtime bridge for a
+			// second injection class — the sqli sink (a raw SELECT built by
+			// string concatenation) lives inside the /internal/report handler.
+			Name: "whitebox-sqli", Class: "sqli", Endpoint: "/internal/report", Param: "uid",
+			Desc: "SQL injection on an UNLINKED route, discoverable only via the attached source.",
+			SourceFiles: map[string]string{
+				"app.py": "from flask import Flask, request\n" +
+					"import sqlite3\n\n" +
+					"app = Flask(__name__)\n" +
+					"db = sqlite3.connect(':memory:', check_same_thread=False)\n\n\n" +
+					"@app.route('/')\n" +
+					"def index():\n" +
+					"    return '<html><body>Reports service</body></html>'\n\n\n" +
+					"@app.route('/healthz')\n" +
+					"def healthz():\n" +
+					"    return 'ok'\n\n\n" +
+					"# Internal reporting endpoint - intentionally not linked from any page.\n" +
+					"@app.route('/internal/report')\n" +
+					"def report():\n" +
+					"    uid = request.args.get('uid', '')\n" +
+					"    # Vulnerable: user input concatenated into a raw SQL query.\n" +
+					"    query = \"SELECT id, name FROM users WHERE id = '\" + uid + \"'\"\n" +
+					"    return str(db.execute(query).fetchall())\n",
+			},
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/healthz":
+					w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+					_, _ = fmt.Fprint(w, "ok")
+				case "/internal/report":
+					uid := r.URL.Query().Get("uid")
+					w.Header().Set("Content-Type", "text/html; charset=utf-8")
+					if containsQuote(uid) {
+						// Simulated SQL error revealing injectability.
+						w.WriteHeader(http.StatusInternalServerError)
+						_, _ = fmt.Fprintf(w, "Database error: You have an error in your SQL syntax; check the manual near '%s' at line 1", uid)
+						return
+					}
+					_, _ = fmt.Fprintf(w, "<html><body>report for uid %s</body></html>", uid)
+				case "/":
+					// Index does NOT link the vulnerable reporting route.
+					w.Header().Set("Content-Type", "text/html; charset=utf-8")
+					_, _ = fmt.Fprint(w, `<html><body><h1>Reports</h1><p>See <a href="/healthz">health</a>.</p></body></html>`)
+				default:
+					http.NotFound(w, r)
+				}
+			}),
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary
`whitebox-cmdi` (#534, v4.6.27) proved the source-to-runtime bridge end-to-end for command injection. This adds an equivalent SQL-injection challenge so the bridge is exercised across classes, not one.

## Details
The vulnerable reporting route (`/internal/report`, which concatenates a user parameter straight into a raw `SELECT`) is **not linked from any page** — so, like `whitebox-cmdi`, black-box crawling can't reach it and solving it requires the full bridge: scan the source, discover the route + the co-located SQLi sink, attribute the sink to that handler (handler-span correlation, v4.6.29), probe the route live, then prove the injection. The live app returns a SQL syntax error on quote injection. Operator-only tooling; the shipped binary is unchanged.

## Testing
- `go build ./...`, `go vet ./...` clean; gofmt clean; golangci-lint 0 issues on changed files.
- `go test -race ./internal/bench/`: whitebox-sqli exhibits the vuln (uid=1' -> SQL syntax error; benign uid does not; /healthz benign; index does NOT link the vuln route); updated fake-scan class counts (sqli 0/2).