### PR TITLE
release: v4.6.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [v4.6.30](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.30) — Second whitebox benchmark challenge (SQLi) (2026-09-02)
 
 ### Added
 - **Second whitebox benchmark challenge (`whitebox-sqli`) widens source-to-runtime validation to a second injection class.** The `whitebox-cmdi` challenge (v4.6.27) proved the source-to-runtime bridge end-to-end for command injection; this adds an equivalent SQL-injection challenge so the bridge is exercised across classes rather than one. Its vulnerable reporting route (`/internal/report`, which concatenates a user parameter straight into a raw `SELECT`) is **not linked from any page**, so — as with `whitebox-cmdi` — black-box crawling can't reach it and solving it requires the bridge: scan the source, discover the route and the co-located SQLi sink, attribute the sink to that handler, probe the route live, then prove the injection. Operator-only benchmark tooling; the shipped binary is unchanged (releases build only `./cmd/xalgorix`).

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.29
+VERSION=4.6.30
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.29"
+var version = "4.6.30"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.30 — Second whitebox benchmark challenge (SQLi).

Bumps version (main.go, Makefile) and promotes the CHANGELOG [Unreleased] section to v4.6.30.

Ships the change from #540: a whitebox-sqli benchmark challenge (an UNLINKED /internal/report route that concatenates a user param into a raw SELECT) widens source-to-runtime bridge validation to a second injection class — solving it requires source discovery + handler-span sink correlation + probe + exploit, like whitebox-cmdi. Operator-only benchmark tooling; the shipped binary is unchanged (releases build only ./cmd/xalgorix).