### PR TITLE
fix: recognize error-based SQL injection as valid High proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v4.6.31](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.31) — Error-based SQL injection recognized as valid High proof (2026-09-02)
+
+### Fixed
+- **A reflected DBMS error is now treated as valid proof of error-based SQL injection instead of being silently dropped.** The `whitebox-sqli` benchmark (v4.6.30) surfaced a false negative: an agent could inject a quote, get back a database error that proves the injection point (`You have an error in your SQL syntax`, `ORA-#####`, `SQLSTATE`, `PG::…SyntaxError`, `SQLite error`), and still never file the finding. Three things conspired against it. (1) The agent prompt contradicted itself — one rule accepted a DB error as SQLi proof while the evidence standard listed "an error string" as *not* an outcome and the depth-first checklist omitted DB errors entirely, so the agent judged its own proof insufficient. (2) The reporting `checkClaimConsistency` C:H gate rejected a High/`C:H` error-based finding because a lone DB error carries no data-obtained marker. (3) The DBMS-error signatures were absent from the concrete-impact indicators, so error-based SQLi was auto-downgraded and never tagged exploit-proven. All three are fixed: the prompt now names a provoked DBMS error as a concrete error-based SQLi outcome (CWE-89) to report as High without extracting data; the C:H gate is SQLi-aware (a SQLi finding whose proof carries a native SQLi/DBMS-error signal satisfies C:H); and the DBMS-error signatures are recognized as concrete impact so the finding is tagged exploit-proven and the verifier can auto-confirm. A proven injection point is reported as High even when the PoC only triggered a database error rather than dumping rows. The SQLi carve-out is scoped to SQLi findings, so other classes still require real data-obtained evidence for C:H.
+
 ## [v4.6.30](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.30) — Second whitebox benchmark challenge (SQLi) (2026-09-02)
 
 ### Added

--- a/internal/agent/agent_prompt.go
+++ b/internal/agent/agent_prompt.go
@@ -100,7 +100,7 @@ When you stumble onto a related-but-not-authorized host while doing recon:
 Breadth is a trap. Running one payload against twenty endpoints finds nothing; fully exploiting ONE real weakness wins the bounty. Empirically, successful assessments are FAST and FOCUSED — they lock onto a promising signal and drive it all the way to a working proof-of-concept. Failed ones sprawl across many tools without ever landing an exploit.
 
 - After recon, RANK the attack surface by exploitability and pick the single most promising lead (an anomaly: odd error, reflected value, auth boundary, id you can tamper, a parser that behaves strangely). Go DEEP on it before moving on.
-- Push one lead to a CONCRETE OUTCOME (extracted data, an oob_callback hit, a state change, code execution) before starting the next. A half-tested endpoint is worth nothing.
+- Push one lead to a CONCRETE OUTCOME (extracted data, a DBMS error provoked by injection, an oob_callback hit, a state change, code execution) before starting the next. A half-tested endpoint is worth nothing.
 - Prefer precise, hand-crafted requests (http_request / curl / python) over spraying automated scanners. Scanners are for surface mapping, not for winning.
 - Blind class? Confirm it out-of-band with the oob_callback tool — do NOT report it unproven; the pipeline will drop unproven findings.
 - If a lead is truly dead after a genuine, multi-technique effort, drop it and move to the next-ranked lead. Don't thrash on the same failed idea.
@@ -174,7 +174,7 @@ A finding is only real when the EVIDENCE matches the CLAIM. Detection ≠ proof.
    - Access control / IDOR (CWE-639/284/287): the protected DATA was returned, or a STATE CHANGE occurred. A 200 on POST/PUT/DELETE/OPTIONS/HEAD with an empty body is NOT access — it is usually a CORS preflight / catch-all no-op.
    - Info disclosure (CWE-200): an actual secret VALUE leaked. Field/parameter NAMES, public API specs (OpenAPI/Swagger), and by-design data are NOT disclosure.
 
-2. PROOF IS A CONCRETE OUTCOME — paste the actual extracted data / command output / callback hit / returned record. A status code (200/401), the reflected payload echoed back, an error string, or "the server responded" are NOT outcomes.
+2. PROOF IS A CONCRETE OUTCOME — paste the actual extracted data / command output / callback hit / returned record. A status code (200/401), the reflected payload echoed back, a generic error string, or "the server responded" are NOT outcomes. EXCEPTION: a DBMS error provoked by an injected quote/syntax — "You have an error in your SQL syntax", ORA-#####, SQLSTATE, PG::…SyntaxError, SQLite error, "unclosed quotation mark" — IS a concrete error-based SQLi outcome (CWE-89): it proves an exploitable injection point, so report it as High immediately; you need NOT extract data to report it (paste the exact error).
 
 3. CVSS MATCHES IMPACT — only claim C:H if you actually obtained sensitive data; only claim I:H if you actually changed state; only claim A:H if you actually caused unavailability. Do not inflate the vector.
 
@@ -245,6 +245,7 @@ Components:
 Common vectors:
 - RCE (unauthenticated): CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H → 9.8 Critical
 - SQLi with data extraction: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N → 7.5 High
+- SQLi (error-based, injection proven by a DBMS error): CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N → 7.5 High (the DBMS error proves an exploitable injection point — report it; full data extraction not required)
 - Stored XSS: CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N → 5.4 Medium (or 7.1 High if session hijack proven)
 - Reflected XSS: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N → 6.1 Medium
 - CSRF: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N → 4.3 Medium

--- a/internal/tools/reporting/reporting.go
+++ b/internal/tools/reporting/reporting.go
@@ -918,8 +918,17 @@ func checkClaimConsistency(title, cwe, method, cvssVector, severity, description
 	// 3) CVSS High Confidentiality (C:H) requires sensitive data actually obtained.
 	//    Command execution / RCE inherently grants confidentiality, so its markers
 	//    satisfy this check too (an RCE proof shows `uid=`, not "extracted data").
+	//    A proven SQL-injection point ALSO satisfies C:H: a native SQLi signal
+	//    (UNION / error-based DBMS error / blind) demonstrates the injection is
+	//    exploitable to read arbitrary data, even when the PoC only triggered a
+	//    database error rather than dumping rows.
 	if strings.Contains(vec, "C:H") {
-		if !anyContains(lp, "extracted", "extraction", "dumped", "leaked", "exfiltrat", "retrieved",
+		sqliClaim := cweL == "cwe-89" || strings.Contains(strings.ToLower(title), "sql injection") ||
+			strings.Contains(strings.ToLower(title), "sqli")
+		sqliProof := sqliClaim && anyContains(lp, "sql syntax", "you have an error in your sql",
+			"syntax error", "sqlstate", "ora-0", "extractvalue", "updatexml", "union select",
+			"information_schema", "sqlmap", "unclosed quotation mark", "quoted string not properly")
+		if !sqliProof && !anyContains(lp, "extracted", "extraction", "dumped", "leaked", "exfiltrat", "retrieved",
 			"read /etc", "/etc/passwd", "password", "credential", "token", "api key", "secret",
 			"pii", "ssn", "credit card", "information_schema", "union select", "another user",
 			"other user", "private key", "169.254", "/latest/meta-data", "internal", "session",
@@ -1840,6 +1849,16 @@ var concreteImpactIndicators = []string{
 	"windows ip configuration", "microsoft windows [version",
 	// SQL data extraction
 	"union select", "information_schema", "@@version", "sqlmap",
+	// Error-based SQLi: a DBMS error provoked by an injected quote/syntax proves
+	// an exploitable injection point. These strings are emitted by database
+	// engines (not benign web responses) when a broken query reaches the server:
+	//   MySQL → "you have an error in your sql", "sql syntax", "warning: mysql";
+	//   generic → "sqlstate";  Oracle → "ora-0";  Postgres → "psqlexception";
+	//   SQLite → "sqlite3::";  MSSQL → "unclosed quotation mark after the character string";
+	//   Postgres/others → "quoted string not properly terminated".
+	"you have an error in your sql", "sql syntax", "sqlstate", "ora-0",
+	"psqlexception", "sqlite3::", "unclosed quotation mark after the character string",
+	"quoted string not properly terminated", "warning: mysql",
 	// Credential / session theft (concrete)
 	"set-cookie:", "document.cookie", "session_id=", "access_token", "refresh_token",
 	// SSRF / internal access (concrete targets/content)
@@ -1865,6 +1884,11 @@ var reproducedImpactIndicators = []string{
 	"gnu/linux", "load average", "nt authority\\", "volume serial number",
 	"windows ip configuration", "microsoft windows [version",
 	"union select", "information_schema", "@@version", "sqlmap",
+	// Error-based SQLi DBMS errors (see concreteImpactIndicators for rationale):
+	// distinctive engine-emitted strings that prove an exploitable injection point.
+	"you have an error in your sql", "sql syntax", "sqlstate", "ora-0",
+	"psqlexception", "sqlite3::", "unclosed quotation mark after the character string",
+	"quoted string not properly terminated", "warning: mysql",
 	"169.254.169.254", "/latest/meta-data", "metadata.google.internal",
 	"callback received", "dns query", "burp collaborator",
 	"interact.sh", "interactsh", "oast", "http request received", "pingback",

--- a/internal/tools/reporting/reporting_test.go
+++ b/internal/tools/reporting/reporting_test.go
@@ -961,6 +961,24 @@ func TestCheckClaimConsistency(t *testing.T) {
 			"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
 			"high", "dumped users table via union select from information_schema", false,
 		},
+		// Error-based SQLi: C:H proven by a reflected DBMS error, no data dumped
+		// → accepted. A provoked SQL syntax error proves an exploitable injection
+		// point, which is confidentiality-impacting even without extraction.
+		{
+			"error-based sqli c:h via dbms error",
+			"SQL injection", "CWE-89", "manual_verified",
+			"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+			"high", "injecting a single quote (uid=1') returned: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version", false,
+		},
+		// Guard: a NON-SQLi finding claiming C:H with only a 'syntax error'
+		// string (no data obtained) is still rejected — the SQLi carve-out must
+		// not leak to other classes.
+		{
+			"non-sqli c:h with syntax error still rejected",
+			"Information exposure", "CWE-200", "manual_verified",
+			"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+			"high", "the response contained a generic syntax error message", true,
+		},
 		// Info severity → gate does not apply.
 		{
 			"info severity skipped",
@@ -1816,6 +1834,8 @@ func TestHasConcreteImpact(t *testing.T) {
 		"dumped 42 rows including password hash values",
 		"interactsh callback received from target IP",
 		"union select confirmed data extraction",
+		// Error-based SQLi: a provoked DBMS error is a concrete injection outcome.
+		"HTTP/1.1 500\nYou have an error in your SQL syntax; check the manual near '''",
 	} {
 		if !HasConcreteImpact(s) {
 			t.Errorf("expected concrete impact for %q", s)


### PR DESCRIPTION
## Summary
Fixes the error-based SQL injection false negative surfaced by the `whitebox-sqli` benchmark (v4.6.30). An agent could inject a quote, receive a DBMS error that proves the injection point, and still never file the finding. Three causes, all fixed:

1. **Prompt self-contradiction (`agent_prompt.go`)** — one rule accepted a DB error as SQLi proof while the EVIDENCE STANDARD listed "an error string" as *not* an outcome and the depth-first checklist omitted DB errors, so the agent judged its own proof insufficient. The prompt now names a provoked DBMS error (`You have an error in your SQL syntax`, `ORA-#####`, `SQLSTATE`, `PG::…SyntaxError`, `SQLite error`) a concrete error-based SQLi outcome (CWE-89) to report as High without extracting data, and the CVSS template carries an error-based SQLi `C:H` → 7.5 High line.
2. **C:H claim-consistency gate (`reporting.go`)** — rejected High/`C:H` error-based findings because a lone DB error has no data-obtained marker. The gate is now SQLi-aware: a SQLi finding (CWE-89 / title) whose proof carries a native SQLi/DBMS-error signal satisfies `C:H`. Non-SQLi findings still require real data-obtained evidence.
3. **Missing impact signatures (`reporting.go`)** — DBMS-error strings were absent from `concreteImpactIndicators` and `reproducedImpactIndicators`, so error-based SQLi was auto-downgraded and never tagged exploit-proven. Added the distinctive engine-emitted strings to both, so `HasConcreteImpact`/`hasStrongEvidence` are true and the verifier can auto-confirm.

## Tests
- `TestCheckClaimConsistency` +2 cases: error-based C:H accepted (`You have an error in your SQL syntax`); non-SQLi C:H with only `syntax error` still rejected (guards the SQLi-scoping).
- `TestHasConcreteImpact` +1 true case (DBMS error).
- gofmt clean; `go build ./...` OK; `go vet` OK; `go test -race ./internal/tools/reporting/ ./internal/agent/` both pass; golangci-lint shows only the pre-existing `planner_test.go` SA5011 (unrelated).