### PR TITLE
release: v4.6.31

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.30
+VERSION=4.6.31
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.30"
+var version = "4.6.31"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.31 — Error-based SQL injection recognized as valid High proof.

Bumps `main.version` and `Makefile` VERSION to 4.6.31. CHANGELOG entry landed with the fix (#542).

See the [v4.6.31] CHANGELOG entry for details: a reflected DBMS error is now treated as valid proof of error-based SQL injection (prompt, C:H claim-consistency gate, and concrete-impact indicators all updated), scoped to SQLi so other classes still require data-obtained evidence for C:H.