### PR TITLE
release: v4.6.32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.31
+VERSION=4.6.32
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.31"
+var version = "4.6.32"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.32 — Deterministic error-based SQL injection confirmer (verify_sqli).

Bumps `main.version` and `Makefile` VERSION to 4.6.32. CHANGELOG entry landed with the feature (#544).

Adds `verify_sqli`, the SQLi counterpart of `verify_xss`: given a ledger hypothesis or a url + parameter, it sends a benign baseline, a single-quote (broken) and a doubled-quote (balanced) request, and confirms error-based SQLi when a DBMS error appears on the broken request but not on the benign baseline — recording exploit-proven evidence in the ledger for the agent to report as High CWE-89. DBMS-error detection is shared with the reporting impact-gate via `reporting.LooksLikeSQLError`.