### PR TITLE
feat: whitebox guidance teaches the source-to-runtime bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v4.6.33](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.33) — Whitebox guidance teaches the source-to-runtime bridge (2026-09-02)
+
+### Changed
+- **The whitebox methodology briefing now drives the agent through the source-to-runtime bridge instead of describing the old hand-crafted flow.** The bridge shipped over v4.6.23–v4.6.32 (`scan_source_sinks`, `scan_source_routes`, `probe_hypothesis`, auto-seeding at scan start, and the `verify_sqli`/`verify_xss`/`verify_oob` confirmers) was fully built, but the whitebox briefing the agent reads at scan start still described the pre-bridge methodology — `code_search` a sink, trace it by hand, then hand-craft an exploit — and never mentioned the auto-seeded ledger or the new tools. A benchmark diagnostic showed the cost: with the correlated source→route hypothesis already sitting in the ledger from iteration 1, the agent spent its early budget black-box crawling (chasing a reflected XSS) and only reached the seeded SQL-injection route late, missing an 8-minute deadline it clears comfortably when it works the seeded lead first. The live-target modes (whitebox, and provision-and-DAST) now tell the agent to WORK THE SEEDED LEDGER FIRST: `claim_next_hypothesis` the top correlated source→route lead, `probe_hypothesis` it to confirm it is live, then CONFIRM the class deterministically with `verify_sqli` (error-based SQLi), `verify_xss` (browser-executed XSS), or `verify_oob` (blind RCE/SQLi/SSRF/XXE) — widening to broad black-box crawling only after the seeded leads are worked. The source-review mode (no live target) is unchanged. The guidance text was also refactored behind a pure `whiteboxGuidanceText` helper so it is unit-tested directly.
+
 ## [v4.6.32](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.32) — Deterministic error-based SQL injection confirmer (verify_sqli) (2026-09-02)
 
 ### Added

--- a/internal/agent/agent_prompt.go
+++ b/internal/agent/agent_prompt.go
@@ -1550,8 +1550,23 @@ func (a *Agent) whiteboxGuidance() string {
 	if root == "" {
 		return ""
 	}
+	hostport := ""
+	if a.codeScanMode == CodeScanProvision {
+		bind := "127.0.0.1"
+		hostport = bind
+		if len(a.activityHosts) > 0 {
+			if port := portFromTarget(a.activityHosts[0]); port > 0 {
+				hostport = fmt.Sprintf("%s:%d", bind, port)
+			}
+		}
+	}
+	return whiteboxGuidanceText(a.codeScanMode, root, hostport)
+}
 
-	switch a.codeScanMode {
+// whiteboxGuidanceText renders the source-assisted methodology briefing for a
+// given code-scan mode. Pure (takes no Agent state) so it is unit-testable.
+func whiteboxGuidanceText(mode CodeScanMode, root, hostport string) string {
+	switch mode {
 	case CodeScanReview:
 		// Option 1 — source review / SAST with NO live target. Findings are
 		// statically verified: proven reachable in code, not runtime-exploited.
@@ -1568,21 +1583,12 @@ When you report_vulnerability, set the PoC to the concrete source-level data-flo
 
 	case CodeScanProvision:
 		// Option 2 — build & run from source, then DAST the running instance.
-		port := 0
-		if len(a.activityHosts) > 0 {
-			port = portFromTarget(a.activityHosts[0])
-		}
-		bind := "127.0.0.1"
-		hostport := bind
-		if port > 0 {
-			hostport = fmt.Sprintf("%s:%d", bind, port)
-		}
 		return fmt.Sprintf(`
 ## PROVISION + DAST MODE — build the target from source (at %s), run it, then pentest it
 You have the source AND you must stand the app up locally, then attack the RUNNING instance for exploit-verified findings. Methodology:
 1. INSPECT: read README, Dockerfile/compose, package manifest, and start scripts to learn how to build and run this app.
 2. BUILD & RUN: use terminal_execute to install dependencies and start the app. BIND IT TO %s (this exact loopback host:port is the only one you are permitted to reach). Prefer Docker/compose when present; otherwise the native run command. Run it in the background and confirm it's listening (curl -sI http://%s).
-3. WHITEBOX-GUIDED DAST: use code_search to find sinks (sinks=rce|cmdi|sqli|deserialization|ssrf|fileio|template|secrets|auth|redirect|crypto), trace each to a reachable route, then EXPLOIT it against http://%s and prove impact (extracted data, oob_callback hit, state change, command output).
+3. WHITEBOX-GUIDED DAST — WORK THE SEEDED LEDGER FIRST: the start-of-scan source sweep already seeded the hypothesis ledger with the sinks and the routes that reach them (a route whose handler holds a sink is seeded class-typed). claim_next_hypothesis to take the top correlated source→route lead, probe_hypothesis it against http://%s to confirm it is live, then CONFIRM the class deterministically — verify_sqli (error-based SQLi), verify_xss (browser-executed XSS), verify_oob (blind RCE/SQLi/SSRF/XXE) — each records exploit-proven evidence. Use code_search + manual exploitation only for what is not already seeded; prove impact (extracted data, oob_callback hit, state change, command output).
 4. If the app cannot be built/run after reasonable effort, fall back to SOURCE REVIEW: report source-verified findings from the data-flow trace and say runtime provisioning failed.
 Report findings with a working PoC against the running instance (the verifier will re-test). Source proves the bug EXISTS; the live PoC proves it's EXPLOITABLE — get both when the app runs.
 `, root, hostport, hostport, hostport)
@@ -1590,12 +1596,14 @@ Report findings with a working PoC against the running instance (the verifier wi
 
 	return fmt.Sprintf(`
 ## WHITEBOX MODE — you have the target's SOURCE CODE (at %s)
-This is your biggest advantage: you can SEE the vulnerable code, not just guess from responses. Methodology:
-1. MAP: identify the framework, routing, and how user input enters (route handlers, params, body, headers).
-2. HUNT SINKS: use the code_search tool (sinks=rce|cmdi|sqli|deserialization|ssrf|fileio|template|secrets|auth|redirect|crypto) to locate dangerous calls, and grep for hardcoded secrets/keys.
-3. TRACE REACHABILITY: for each sink, trace BACKWARD to a user-reachable HTTP route and confirm the tainted input reaches it without sanitization. Note the exact route + parameter.
-4. EXPLOIT ON THE LIVE TARGET: build a concrete PoC against the running target and prove impact (extracted data, oob_callback hit, state change, command output). Source proves the bug EXISTS; the live PoC proves it's EXPLOITABLE — you need both.
-5. Prioritize: RCE / command & template injection / insecure deserialization / hardcoded secrets / SSRF / auth bypass — the classes source access finds that black-box misses.
+This is your biggest advantage: you can SEE the vulnerable code, not just guess from responses.
+
+WORK THE SEEDED LEDGER FIRST. At scan start the source was swept and the hypothesis ledger was AUTO-SEEDED with the dangerous sinks and the HTTP routes that reach them; a route whose handler contains a sink is seeded CLASS-TYPED (rce/sqli/ssrf/…) at high confidence. These correlated source→route hypotheses are your highest-value leads — pursue them BEFORE any black-box crawling:
+1. CLAIM: claim_next_hypothesis (optionally vuln_class=…) takes the top correlated lead and marks it yours; read_ledger lists them all. If the ledger looks empty, run scan_source_sinks then scan_source_routes to (re)seed it from the code.
+2. PROBE: probe_hypothesis the lead to confirm the route is live and reachable on the target (it reuses the scan session, so authenticated routes are probed authenticated).
+3. CONFIRM DETERMINISTICALLY — do not hand-craft payloads when a confirmer exists: verify_sqli proves error-based SQL injection (it sends a benign/single-quote/balanced trio and reads the DBMS error), verify_xss proves browser-EXECUTED XSS, verify_oob proves blind RCE/SQLi/SSRF/XXE via an out-of-band callback. Each records exploit-proven evidence for you.
+4. REPORT with that proof (the verifier re-tests). Source proves the bug EXISTS; the live PoC proves it is EXPLOITABLE — get both.
+Only once the seeded correlated leads are worked should you widen to broad black-box crawling and manual code_search. Prioritize RCE / command & template injection / insecure deserialization / SQLi / SSRF / auth bypass — the classes source access finds that black-box misses.
 Report findings ONLY with a working live-target PoC (the verifier will re-test).
 `, root)
 }

--- a/internal/agent/agent_prompt_test.go
+++ b/internal/agent/agent_prompt_test.go
@@ -45,3 +45,41 @@ func TestSystemPromptIncludesCollectableMultiAgentWorkflow(t *testing.T) {
 		t.Fatalf("prompt contains fmt diagnostic, likely a placeholder/argument mismatch")
 	}
 }
+
+// TestWhiteboxGuidanceText verifies the live-target whitebox modes teach the
+// source-to-runtime bridge (work the auto-seeded ledger first, then confirm
+// deterministically), while the source-review mode — which has no live target —
+// does not push live-only tools.
+func TestWhiteboxGuidanceText(t *testing.T) {
+	const root = "/tmp/src"
+
+	bridge := []string{"claim_next_hypothesis", "probe_hypothesis", "verify_sqli", "verify_xss", "verify_oob", "seeded"}
+	for _, mode := range []CodeScanMode{CodeScanNone, CodeScanProvision} {
+		g := whiteboxGuidanceText(mode, root, "127.0.0.1:8080")
+		if !strings.Contains(g, root) {
+			t.Errorf("mode %d: guidance should mention the source root %q", mode, root)
+		}
+		for _, want := range bridge {
+			if !strings.Contains(g, want) {
+				t.Errorf("mode %d: guidance must mention %q", mode, want)
+			}
+		}
+	}
+
+	// Provision mode must embed the loopback bind host:port for build-and-run.
+	if prov := whiteboxGuidanceText(CodeScanProvision, root, "127.0.0.1:8080"); !strings.Contains(prov, "127.0.0.1:8080") {
+		t.Errorf("provision guidance must embed the bind host:port")
+	}
+
+	// Source-review mode has NO live target: it must NOT push live-only tools,
+	// but should retain the static code_search methodology.
+	rev := whiteboxGuidanceText(CodeScanReview, root, "")
+	for _, unwanted := range []string{"probe_hypothesis", "verify_sqli", "verify_xss", "verify_oob"} {
+		if strings.Contains(rev, unwanted) {
+			t.Errorf("source-review guidance must NOT mention live-only tool %q", unwanted)
+		}
+	}
+	if !strings.Contains(rev, "code_search") {
+		t.Errorf("source-review guidance should retain the code_search methodology")
+	}
+}


### PR DESCRIPTION
## Summary
Updates the whitebox methodology briefing (read by the agent at scan start) to drive it through the source-to-runtime bridge shipped over v4.6.23–v4.6.32, instead of the pre-bridge flow it still described.

The bridge — `scan_source_sinks`, `scan_source_routes`, `probe_hypothesis`, auto-seeding at scan start, and the `verify_sqli`/`verify_xss`/`verify_oob` confirmers — was fully built, but `whiteboxGuidance` still said: `code_search` a sink, trace it by hand, hand-craft an exploit. It never mentioned the auto-seeded ledger or the new tools.

## Why
A benchmark diagnostic showed the cost: with the correlated source→route hypothesis already in the ledger from iteration 1, the agent spent its early budget black-box crawling (chasing a reflected XSS) and only reached the seeded SQL-injection route late — missing an 8-minute deadline it clears comfortably when it works the seeded lead first.

## Change
The live-target modes (whitebox, and provision-and-DAST) now tell the agent to **WORK THE SEEDED LEDGER FIRST**:
1. `claim_next_hypothesis` the top correlated source→route lead (`read_ledger` lists them; `scan_source_sinks`/`scan_source_routes` re-seed).
2. `probe_hypothesis` it to confirm the route is live.
3. Confirm the class deterministically: `verify_sqli` (error-based SQLi), `verify_xss` (browser-executed XSS), `verify_oob` (blind RCE/SQLi/SSRF/XXE).
4. Report with that proof; widen to broad black-box crawling only after the seeded leads are worked.

Source-review mode (no live target) is unchanged. The guidance text was refactored behind a pure `whiteboxGuidanceText(mode, root, hostport)` helper so it is unit-tested directly.

## Tests
- `TestWhiteboxGuidanceText`: the two live-target modes mention `claim_next_hypothesis`/`probe_hypothesis`/`verify_sqli`/`verify_xss`/`verify_oob`/`seeded` and the source root; provision embeds the bind host:port; source-review retains `code_search` but does NOT push the live-only tools.
- gofmt clean; `go build ./...` OK; `go vet` OK; `go test -race ./internal/agent/` passes; golangci-lint clean on changed files (only the pre-existing `planner_test.go` SA5011 remains).