### PR TITLE
release: v4.6.33

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.32
+VERSION=4.6.33
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.32"
+var version = "4.6.33"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.33 — Whitebox guidance teaches the source-to-runtime bridge.

Bumps `main.version` and `Makefile` VERSION to 4.6.33. CHANGELOG entry landed with the feature (#546).

The whitebox methodology briefing now drives the agent to work the auto-seeded correlated source→route hypotheses FIRST (claim_next_hypothesis → probe_hypothesis → verify_sqli/verify_xss/verify_oob) before black-box crawling, instead of the stale pre-bridge flow. Source-review mode (no live target) is unchanged.