### PR TITLE
feat(bench): add whitebox-ssti challenge (third injection class)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v4.6.34](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.34) — Third whitebox benchmark challenge (SSTI) (2026-09-02)
+
+### Added
+- **A third whitebox benchmark challenge (`whitebox-ssti`) widens source-to-runtime validation to server-side template injection.** With `whitebox-cmdi` (RCE) and `whitebox-sqli` now solving within the standard benchmark deadline, this adds an equivalent SSTI challenge so the source-to-runtime bridge is exercised across a third injection class. Its vulnerable preview route (`/internal/preview`, which renders a concatenated user parameter through `render_template_string`) is **not linked from any page**, so black-box crawling cannot reach it and solving it requires the bridge: scan the source, discover the route and the co-located template sink (which the code scanner types as a template sink → SSTI), attribute the sink to that handler, probe the route live, then prove the injection with the classic `{{7*7}}` → `49` evaluation. Operator-only benchmark tooling; the shipped binary is unchanged (releases build only `./cmd/xalgorix`).
+
 ## [v4.6.33](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.33) — Whitebox guidance teaches the source-to-runtime bridge (2026-09-02)
 
 ### Changed

--- a/internal/bench/bench_test.go
+++ b/internal/bench/bench_test.go
@@ -146,18 +146,21 @@ func TestRunWithFakeScanFunc(t *testing.T) {
 		t.Fatalf("expected xss 1/1 and idor 1/1, got %v", byClass)
 	}
 	// Every other single-challenge class is present but unsolved by this fake.
-	for _, c := range []string{"open_redirect", "ssrf", "ssti", "lfi"} {
+	for _, c := range []string{"open_redirect", "ssrf", "lfi"} {
 		if byClass[c] != [2]int{0, 1} {
 			t.Fatalf("expected %s 0/1, got %v", c, byClass[c])
 		}
 	}
-	// rce (cmdi + whitebox-cmdi) and sqli (error-sqli + whitebox-sqli) each have
-	// two challenges, both unsolved by this fake.
+	// rce (cmdi + whitebox-cmdi), sqli (error-sqli + whitebox-sqli), and ssti
+	// (ssti + whitebox-ssti) each have two challenges, all unsolved by this fake.
 	if byClass["rce"] != [2]int{0, 2} {
 		t.Fatalf("expected rce 0/2, got %v", byClass["rce"])
 	}
 	if byClass["sqli"] != [2]int{0, 2} {
 		t.Fatalf("expected sqli 0/2, got %v", byClass["sqli"])
+	}
+	if byClass["ssti"] != [2]int{0, 2} {
+		t.Fatalf("expected ssti 0/2, got %v", byClass["ssti"])
 	}
 }
 
@@ -299,6 +302,40 @@ func TestWhiteboxSqliChallengeExhibitsVuln(t *testing.T) {
 	}
 	// The index must NOT link the vulnerable route (whitebox-only discovery).
 	if body := httpGet(t, srv.URL+"/"); strings.Contains(body, "/internal/report") {
+		t.Fatalf("index must not link the vulnerable route (whitebox-only), got %q", body)
+	}
+}
+
+func TestWhiteboxSstiChallengeExhibitsVuln(t *testing.T) {
+	wb := challengeByName(t, "whitebox-ssti")
+
+	// The whitebox source carries the template sink (render_template_string over
+	// concatenated user input) inside the unlinked preview route's handler.
+	src, ok := wb.SourceFiles["app.py"]
+	if !ok {
+		t.Fatal("whitebox-ssti must ship app.py source")
+	}
+	if !strings.Contains(src, "/internal/preview") || !strings.Contains(src, "render_template_string") {
+		t.Fatalf("app.py must contain the /internal/preview route and the render_template_string sink:\n%s", src)
+	}
+
+	srv := wb.Start()
+	defer srv.Close()
+
+	// A {{7*7}} expression is evaluated server-side to 49 (template injection).
+	if body := httpGet(t, srv.URL+"/internal/preview?name=%7B%7B7*7%7D%7D"); !strings.Contains(body, "49") {
+		t.Fatalf("whitebox-ssti did not evaluate the template expression to 49: %q", body)
+	}
+	// A benign name is echoed literally, not evaluated.
+	if body := httpGet(t, srv.URL+"/internal/preview?name=alice"); !strings.Contains(body, "alice") || strings.Contains(body, "49") {
+		t.Fatalf("benign name must be echoed literally, not evaluated: %q", body)
+	}
+	// Health endpoint is benign.
+	if body := httpGet(t, srv.URL+"/healthz"); !strings.Contains(body, "ok") {
+		t.Fatalf("healthz should return ok, got %q", body)
+	}
+	// The index must NOT link the vulnerable route (whitebox-only discovery).
+	if body := httpGet(t, srv.URL+"/"); strings.Contains(body, "/internal/preview") {
 		t.Fatalf("index must not link the vulnerable route (whitebox-only), got %q", body)
 	}
 }

--- a/internal/bench/challenge.go
+++ b/internal/bench/challenge.go
@@ -274,6 +274,51 @@ func Builtin() []Challenge {
 				}
 			}),
 		},
+		{
+			// Whitebox challenge (SSTI): the vulnerable preview route is not
+			// linked from any page, so it is discoverable only via the attached
+			// source. Solving it exercises the source-to-runtime bridge for a
+			// third injection class — the template sink (render_template_string
+			// over concatenated user input) lives inside the /internal/preview
+			// handler, which codesearch types as a template sink (→ ssti).
+			Name: "whitebox-ssti", Class: "ssti", Endpoint: "/internal/preview", Param: "name",
+			Desc: "Server-side template injection on an UNLINKED route, discoverable only via the attached source.",
+			SourceFiles: map[string]string{
+				"app.py": "from flask import Flask, request, render_template_string\n\n" +
+					"app = Flask(__name__)\n\n\n" +
+					"@app.route('/')\n" +
+					"def index():\n" +
+					"    return '<html><body>Preview service</body></html>'\n\n\n" +
+					"@app.route('/healthz')\n" +
+					"def healthz():\n" +
+					"    return 'ok'\n\n\n" +
+					"# Internal preview endpoint - intentionally not linked from any page.\n" +
+					"@app.route('/internal/preview')\n" +
+					"def preview():\n" +
+					"    name = request.args.get('name', '')\n" +
+					"    # Vulnerable: user input rendered as a Jinja2 template.\n" +
+					"    return render_template_string('<h1>Hello ' + name + '</h1>')\n",
+			},
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/healthz":
+					w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+					_, _ = fmt.Fprint(w, "ok")
+				case "/internal/preview":
+					name := r.URL.Query().Get("name")
+					w.Header().Set("Content-Type", "text/html; charset=utf-8")
+					// Simulated Jinja2 render: a {{ a * b }} expression is
+					// evaluated (so {{7*7}} → 49), proving template injection.
+					_, _ = fmt.Fprintf(w, "<html><body><h1>Hello %s</h1></body></html>", sstiRender(name))
+				case "/":
+					// Index does NOT link the vulnerable preview route.
+					w.Header().Set("Content-Type", "text/html; charset=utf-8")
+					_, _ = fmt.Fprint(w, `<html><body><h1>Preview</h1><p>See <a href="/healthz">health</a>.</p></body></html>`)
+				default:
+					http.NotFound(w, r)
+				}
+			}),
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary
Adds a third whitebox benchmark challenge, `whitebox-ssti`, widening source-to-runtime validation to server-side template injection. With `whitebox-cmdi` (RCE) and `whitebox-sqli` both now solving within the standard 8-minute deadline, this exercises the bridge across a third injection class.

## The challenge
`whitebox-ssti` (class `ssti`) ships a Flask source tree with an **UNLINKED** `/internal/preview` route that renders a concatenated user parameter through `render_template_string` — a template sink the code scanner types as `template` → `ssti`. The matching live app evaluates a `{{ a * b }}` expression, so the classic `{{7*7}}` → `49` probe confirms injection. Because the route is not linked from any page, black-box crawling can't reach it; solving it requires the full bridge: scan the source, discover the route + co-located template sink, attribute the sink to that handler, probe the route live, then prove SSTI.

## Notes
- Operator-only benchmark tooling; the shipped binary is unchanged (releases build only `./cmd/xalgorix`).
- Reuses the existing `sstiRender` helper. Bench now has 11 challenges; `ssti` has 2 (black-box + whitebox).

## Tests
- `TestWhiteboxSstiChallengeExhibitsVuln`: source `app.py` contains `render_template_string` + `/internal/preview`; live `?name={{7*7}}` → `49`; benign `name=alice` echoed literally; `/healthz` → ok; index does not link the vulnerable route.
- `TestRunWithFakeScanFunc` updated: `ssti` now a 2-challenge class (`{0,2}`).
- gofmt clean; `go build ./...` OK; `go vet` OK; `go test -race ./internal/bench/` passes; golangci-lint 0 issues.