### PR TITLE
release: v4.6.34

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.33
+VERSION=4.6.34
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.33"
+var version = "4.6.34"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.34 — Third whitebox benchmark challenge (SSTI).

Bumps main.version and Makefile VERSION to 4.6.34. CHANGELOG entry landed with the feature (#548).

Adds whitebox-ssti: an UNLINKED /internal/preview route that renders a concatenated user parameter via render_template_string (template sink → ssti), with a live app that evaluates {{7*7}} → 49. Widens source-to-runtime validation to a third injection class. Operator-only benchmark tooling; shipped binary unchanged.