### PR TITLE
release: v4.6.35

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.34
+VERSION=4.6.35
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.34"
+var version = "4.6.35"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.35 — Deterministic server-side template injection confirmer (verify_ssti).

Bumps main.version and Makefile VERSION to 4.6.35. CHANGELOG entry landed with the feature (#550).

Adds verify_ssti (SSTI sibling of verify_sqli): sends a benign baseline plus {{a*b}} / ${a*b} payloads with randomized operands and confirms injection when the evaluated product appears in the probe response but not the baseline, recording exploit-proven evidence for the agent to report as High CWE-1336. Closes the SSTI exploitation gap the whitebox-ssti benchmark surfaced.