### PR TITLE
fix(bench): classify findings by CWE before description keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v4.6.36](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.36) — Benchmark classifier prefers the CWE over description keywords (2026-09-02)
+
+### Fixed
+- **The benchmark's finding classifier now trusts the CWE over description keywords, so a genuine SSTI finding is no longer scored as a miss.** A `whitebox-ssti` run confirmed the `verify_ssti` tool works end-to-end — the agent reported an exploit-proven `Server-Side Template Injection (SSTI) … CWE-1336` on the correct route — yet the scorecard marked the challenge `[FAIL]`. The cause was in the benchmark scorer, not the agent: `classifyFinding` matched title/description keywords **before** falling back to the CWE, and the broad `rce` keywords (`remote code execution`, `code execution`, `command injection`) precede `ssti` in the keyword list. Because a proper SSTI report describes the remote code execution it can be escalated to (exactly what the `verify_ssti` guidance recommends), the finding matched `rce` first and was classified as the wrong class, so it did not count as solving the SSTI challenge. `classifyFinding` now prefers the authoritative, structured CWE (`CWE-1336` → `ssti`) when it maps to a known class, and only falls back to title/description keywords for findings that carry no (or an unmapped) CWE. This makes the benchmark's per-class scoring accurate for classes whose impact overlaps another class's keywords (SSTI/XXE/SQLi that escalate to RCE). Operator-only benchmark tooling; the shipped binary is unchanged (releases build only `./cmd/xalgorix`).
+
 ## [v4.6.35](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.35) — Deterministic server-side template injection confirmer (verify_ssti) (2026-09-02)
 
 ### Added

--- a/internal/bench/bench_test.go
+++ b/internal/bench/bench_test.go
@@ -91,6 +91,12 @@ func TestClassifyFinding(t *testing.T) {
 		{"Mystery bug", "no class keyword", "CWE-639", "idor"}, // CWE fallback
 		{"Mystery bug", "no class keyword", "CWE-99999", ""},   // unmapped
 		{"Mystery bug", "no class keyword", "", ""},            // nothing
+		// An SSTI finding whose description mentions the RCE it can escalate to
+		// must classify as ssti via its CWE, not rce via the "remote code
+		// execution" keyword (which precedes ssti in classKeywords).
+		{"Server-Side Template Injection via name", "confirmed {{7*7}}=49; can be escalated to remote code execution", "CWE-1336", "ssti"},
+		// CWE wins over a conflicting description keyword generally.
+		{"Template injection", "the payload triggers command injection style impact", "CWE-1336", "ssti"},
 	}
 	for _, c := range cases {
 		got := classifyFinding(reporting.Vulnerability{Title: c.title, Description: c.desc, CWE: c.cwe})

--- a/internal/bench/score.go
+++ b/internal/bench/score.go
@@ -122,6 +122,15 @@ func Solved(expectedClass string, findings []reporting.Vulnerability) (bool, str
 // reporting package's private classifier) so the benchmark's notion of "right
 // class" is explicit and stable.
 func classifyFinding(f reporting.Vulnerability) string {
+	// Prefer the CWE: it is the authoritative, structured class signal. A finding
+	// tagged CWE-1336 is SSTI even when its description also mentions the remote
+	// code execution it can escalate to — which would otherwise match the broader
+	// "rce" keyword (which precedes "ssti" in classKeywords) and misclassify the
+	// finding. Title/description keywords are the fallback for findings that carry
+	// no (or an unmapped) CWE.
+	if c := cweClass(f.CWE); c != "" {
+		return c
+	}
 	text := strings.ToLower(f.Title + " " + f.Description)
 	for _, m := range classKeywords {
 		for _, kw := range m.keywords {
@@ -130,7 +139,7 @@ func classifyFinding(f reporting.Vulnerability) string {
 			}
 		}
 	}
-	return cweClass(f.CWE)
+	return ""
 }
 
 type classMatch struct {


### PR DESCRIPTION
## Summary
Fixes the benchmark scorer so a genuine SSTI finding is credited. A `whitebox-ssti` run confirmed `verify_ssti` works end-to-end — the agent reported an exploit-proven `Server-Side Template Injection (SSTI) … CWE-1336` on the correct route — yet the scorecard marked the challenge `[FAIL]` (`ssti 0/1`).

## Root cause (scorer, not agent)
`classifyFinding` matched title/description keywords **before** the CWE fallback, and the broad `rce` keywords (`remote code execution`, `code execution`, `command injection`) precede `ssti` in `classKeywords`. A proper SSTI report describes the remote code execution it can be escalated to (exactly what the `verify_ssti` guidance recommends), so the finding matched `rce` first and was classified as the wrong class — not counting as solving the SSTI challenge.

## Fix
`classifyFinding` now prefers the authoritative, structured CWE (`CWE-1336` → `ssti`) when it maps to a known class, and only falls back to title/description keywords for findings that carry no (or an unmapped) CWE. This makes per-class scoring accurate for classes whose impact overlaps another class's keywords (SSTI/XXE/SQLi that escalate to RCE).

Operator-only benchmark tooling; the shipped binary is unchanged (releases build only `./cmd/xalgorix`).

## Tests
- `TestClassifyFinding` +2 cases: SSTI with `CWE-1336` and a description mentioning RCE escalation / command-injection impact → classifies `ssti` (guards the regression). Existing empty-CWE keyword cases stay green.
- gofmt clean; `go build ./...` OK; `go vet` OK; `go test -race ./internal/bench/` passes; golangci-lint 0 issues.