### PR TITLE
release: v4.6.36

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.35
+VERSION=4.6.36
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.35"
+var version = "4.6.36"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.36 — Benchmark classifier prefers the CWE over description keywords.

Bumps main.version and Makefile VERSION to 4.6.36. CHANGELOG entry landed with the fix (#552).

classifyFinding now prefers the authoritative CWE (CWE-1336 -> ssti) over title/description keywords, so a genuine SSTI finding that mentions the RCE it can escalate to is no longer misclassified as rce and mis-scored. Operator-only bench tooling; shipped binary unchanged.