### PR TITLE
feat(bench): add whitebox-lfi challenge (fourth class)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v4.6.37](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.37) — Fourth whitebox benchmark challenge (LFI / path traversal) (2026-09-02)
+
+### Added
+- **A fourth whitebox benchmark challenge (`whitebox-lfi`) widens source-to-runtime validation to local file inclusion / path traversal.** With `whitebox-cmdi` (RCE), `whitebox-sqli`, and `whitebox-ssti` all solving within the standard benchmark deadline, this adds an equivalent LFI challenge so the source-to-runtime bridge is exercised across a fourth class. Its vulnerable log-viewer route (`/internal/logs`, which concatenates a user-supplied `file` parameter onto a base directory and `open()`s it) is **not linked from any page**, so black-box crawling cannot reach it and solving it requires the bridge: scan the source, discover the route and the co-located file-read sink (which the code scanner types as a `fileio` sink → LFI), attribute the sink to that handler, probe the route live, then prove the traversal with the classic `?file=../../../../etc/passwd` → `root:x:0:0:…` read. Operator-only benchmark tooling; the shipped binary is unchanged (releases build only `./cmd/xalgorix`).
+
 ## [v4.6.36](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.36) — Benchmark classifier prefers the CWE over description keywords (2026-09-02)
 
 ### Fixed

--- a/internal/bench/bench_test.go
+++ b/internal/bench/bench_test.go
@@ -152,13 +152,14 @@ func TestRunWithFakeScanFunc(t *testing.T) {
 		t.Fatalf("expected xss 1/1 and idor 1/1, got %v", byClass)
 	}
 	// Every other single-challenge class is present but unsolved by this fake.
-	for _, c := range []string{"open_redirect", "ssrf", "lfi"} {
+	for _, c := range []string{"open_redirect", "ssrf"} {
 		if byClass[c] != [2]int{0, 1} {
 			t.Fatalf("expected %s 0/1, got %v", c, byClass[c])
 		}
 	}
-	// rce (cmdi + whitebox-cmdi), sqli (error-sqli + whitebox-sqli), and ssti
-	// (ssti + whitebox-ssti) each have two challenges, all unsolved by this fake.
+	// rce (cmdi + whitebox-cmdi), sqli (error-sqli + whitebox-sqli), ssti
+	// (ssti + whitebox-ssti), and lfi (lfi + whitebox-lfi) each have two
+	// challenges, all unsolved by this fake.
 	if byClass["rce"] != [2]int{0, 2} {
 		t.Fatalf("expected rce 0/2, got %v", byClass["rce"])
 	}
@@ -167,6 +168,9 @@ func TestRunWithFakeScanFunc(t *testing.T) {
 	}
 	if byClass["ssti"] != [2]int{0, 2} {
 		t.Fatalf("expected ssti 0/2, got %v", byClass["ssti"])
+	}
+	if byClass["lfi"] != [2]int{0, 2} {
+		t.Fatalf("expected lfi 0/2, got %v", byClass["lfi"])
 	}
 }
 
@@ -342,6 +346,40 @@ func TestWhiteboxSstiChallengeExhibitsVuln(t *testing.T) {
 	}
 	// The index must NOT link the vulnerable route (whitebox-only discovery).
 	if body := httpGet(t, srv.URL+"/"); strings.Contains(body, "/internal/preview") {
+		t.Fatalf("index must not link the vulnerable route (whitebox-only), got %q", body)
+	}
+}
+
+func TestWhiteboxLfiChallengeExhibitsVuln(t *testing.T) {
+	wb := challengeByName(t, "whitebox-lfi")
+
+	// The whitebox source carries the file-read sink (open() over a concatenated
+	// user path) inside the unlinked log-viewer route's handler.
+	src, ok := wb.SourceFiles["app.py"]
+	if !ok {
+		t.Fatal("whitebox-lfi must ship app.py source")
+	}
+	if !strings.Contains(src, "/internal/logs") || !strings.Contains(src, "open('/var/log/app/'") {
+		t.Fatalf("app.py must contain the /internal/logs route and the open() file-read sink:\n%s", src)
+	}
+
+	srv := wb.Start()
+	defer srv.Close()
+
+	// A ../ traversal to /etc/passwd leaks the passwd file (path traversal).
+	if body := httpGet(t, srv.URL+"/internal/logs?file=../../../../etc/passwd"); !strings.Contains(body, "root:") {
+		t.Fatalf("whitebox-lfi did not leak /etc/passwd on traversal: %q", body)
+	}
+	// A benign file name returns ordinary log lines, not passwd.
+	if body := httpGet(t, srv.URL+"/internal/logs?file=app.log"); strings.Contains(body, "root:") {
+		t.Fatalf("benign file must not leak passwd: %q", body)
+	}
+	// Health endpoint is benign.
+	if body := httpGet(t, srv.URL+"/healthz"); !strings.Contains(body, "ok") {
+		t.Fatalf("healthz should return ok, got %q", body)
+	}
+	// The index must NOT link the vulnerable route (whitebox-only discovery).
+	if body := httpGet(t, srv.URL+"/"); strings.Contains(body, "/internal/logs") {
 		t.Fatalf("index must not link the vulnerable route (whitebox-only), got %q", body)
 	}
 }

--- a/internal/bench/challenge.go
+++ b/internal/bench/challenge.go
@@ -319,7 +319,64 @@ func Builtin() []Challenge {
 				}
 			}),
 		},
+		{
+			// Whitebox challenge (LFI): the vulnerable log-viewer route is not
+			// linked from any page, so it is discoverable only via the attached
+			// source. Solving it exercises the source-to-runtime bridge for a
+			// fourth class — the file-read sink (open() over a concatenated user
+			// path) lives inside the /internal/logs handler, which codesearch
+			// types as a fileio sink (→ lfi).
+			Name: "whitebox-lfi", Class: "lfi", Endpoint: "/internal/logs", Param: "file",
+			Desc: "Local file inclusion / path traversal on an UNLINKED route, discoverable only via the attached source.",
+			SourceFiles: map[string]string{
+				"app.py": "from flask import Flask, request\n\n" +
+					"app = Flask(__name__)\n\n\n" +
+					"@app.route('/')\n" +
+					"def index():\n" +
+					"    return '<html><body>Logs service</body></html>'\n\n\n" +
+					"@app.route('/healthz')\n" +
+					"def healthz():\n" +
+					"    return 'ok'\n\n\n" +
+					"# Internal log viewer - intentionally not linked from any page.\n" +
+					"@app.route('/internal/logs')\n" +
+					"def logs():\n" +
+					"    name = request.args.get('file', 'app.log')\n" +
+					"    # Vulnerable: user input concatenated into a filesystem path.\n" +
+					"    return open('/var/log/app/' + name).read()\n",
+			},
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/healthz":
+					w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+					_, _ = fmt.Fprint(w, "ok")
+				case "/internal/logs":
+					file := r.URL.Query().Get("file")
+					w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+					if looksLikePasswdTraversal(file) {
+						// Simulated path traversal reading /etc/passwd.
+						_, _ = fmt.Fprint(w, "root:x:0:0:root:/root:/bin/bash\ndaemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin\n")
+						return
+					}
+					_, _ = fmt.Fprint(w, "2026-09-03 12:00:00 INFO app started\n2026-09-03 12:00:01 INFO request served\n")
+				case "/":
+					// Index does NOT link the vulnerable log-viewer route.
+					w.Header().Set("Content-Type", "text/html; charset=utf-8")
+					_, _ = fmt.Fprint(w, `<html><body><h1>Logs</h1><p>See <a href="/healthz">health</a>.</p></body></html>`)
+				default:
+					http.NotFound(w, r)
+				}
+			}),
+		},
 	}
+}
+
+// looksLikePasswdTraversal reports whether a file parameter uses ../ traversal to
+// reach /etc/passwd — the classic LFI probe this challenge is designed to catch
+// (the sink concatenates the value onto /var/log/app/, so only traversal escapes
+// to a sensitive file).
+func looksLikePasswdTraversal(file string) bool {
+	f := strings.ToLower(file)
+	return strings.Contains(f, "..") && strings.Contains(f, "etc/passwd")
 }
 
 func containsQuote(s string) bool {


### PR DESCRIPTION
## Summary
Adds a fourth whitebox benchmark challenge, `whitebox-lfi`, widening source-to-runtime validation to local file inclusion / path traversal. With `whitebox-cmdi` (RCE), `whitebox-sqli`, and `whitebox-ssti` all solving within the standard 8-minute deadline, this exercises the bridge across a fourth class.

## The challenge
`whitebox-lfi` (class `lfi`) ships a Flask source tree with an **UNLINKED** `/internal/logs` route that concatenates a user-supplied `file` parameter onto a base directory and `open()`s it — a `fileio` sink the code scanner types as `fileio` → `lfi`. The matching live app returns simulated `/etc/passwd` content on a `../` traversal to `etc/passwd`, so the classic `?file=../../../../etc/passwd` → `root:x:0:0:…` probe confirms it. Because the route is not linked from any page, black-box crawling can't reach it; solving it requires the full bridge.

## Notes
- Operator-only benchmark tooling; the shipped binary is unchanged (releases build only `./cmd/xalgorix`).
- Bench now has 12 challenges; `lfi` has 2 (black-box + whitebox).

## Tests
- `TestWhiteboxLfiChallengeExhibitsVuln`: source `app.py` has the `open()` sink + `/internal/logs`; live `?file=../../../../etc/passwd` → `root:`; benign `?file=app.log` → no `root:`; `/healthz` → ok; index does not link the vulnerable route.
- `TestRunWithFakeScanFunc` updated: `lfi` now a 2-challenge class (`{0,2}`).
- gofmt clean; `go build ./...` OK; `go vet` OK; `go test -race ./internal/bench/` passes; golangci-lint 0 issues.