### PR TITLE
release: v4.6.37

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.36
+VERSION=4.6.37
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.36"
+var version = "4.6.37"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.37 — Fourth whitebox benchmark challenge (LFI / path traversal).

Bumps main.version and Makefile VERSION to 4.6.37. CHANGELOG entry landed with the feature (#554).

Adds whitebox-lfi: an UNLINKED /internal/logs route that open()s a concatenated user path (fileio sink -> lfi), with a live app returning /etc/passwd on a ../ traversal. Widens source-to-runtime validation to a fourth class. Operator-only bench tooling; shipped binary unchanged.