### PR TITLE
feat(bench): cross-language whitebox challenge (Node/Express RCE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v4.6.38](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.38) — Cross-language whitebox benchmark challenge (Node/Express RCE) (2026-09-02)
+
+### Added
+- **A Node/Express whitebox benchmark challenge (`whitebox-node-rce`) validates the source-to-runtime bridge on a second source language.** The four existing whitebox challenges are all Python/Flask, so the bridge — source-sink discovery, route extraction, and route↔sink correlation — was only exercised for one language. This adds an equivalent command-injection challenge whose source is JavaScript: an `app.js` with an **UNLINKED** `app.get('/internal/ping')` Express route whose handler calls `child_process` `exec('ping -c1 ' + host)`. Solving it requires the bridge to work across languages: the code scanner must recognize the JS command-exec sink and the Express route declaration (`app.get(...)`, distinct from Flask's `@app.route` decorator), correlate the sink to that handler, probe the route live, and prove RCE via the injected command's output. The route is not linked from any page, so black-box crawling cannot reach it. Operator-only benchmark tooling; the shipped binary is unchanged (releases build only `./cmd/xalgorix`).
+
 ## [v4.6.37](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.37) — Fourth whitebox benchmark challenge (LFI / path traversal) (2026-09-02)
 
 ### Added

--- a/internal/bench/bench_test.go
+++ b/internal/bench/bench_test.go
@@ -157,11 +157,11 @@ func TestRunWithFakeScanFunc(t *testing.T) {
 			t.Fatalf("expected %s 0/1, got %v", c, byClass[c])
 		}
 	}
-	// rce (cmdi + whitebox-cmdi), sqli (error-sqli + whitebox-sqli), ssti
-	// (ssti + whitebox-ssti), and lfi (lfi + whitebox-lfi) each have two
-	// challenges, all unsolved by this fake.
-	if byClass["rce"] != [2]int{0, 2} {
-		t.Fatalf("expected rce 0/2, got %v", byClass["rce"])
+	// rce has three challenges (cmdi + whitebox-cmdi + whitebox-node-rce); sqli
+	// (error-sqli + whitebox-sqli), ssti (ssti + whitebox-ssti), and lfi
+	// (lfi + whitebox-lfi) each have two — all unsolved by this fake.
+	if byClass["rce"] != [2]int{0, 3} {
+		t.Fatalf("expected rce 0/3, got %v", byClass["rce"])
 	}
 	if byClass["sqli"] != [2]int{0, 2} {
 		t.Fatalf("expected sqli 0/2, got %v", byClass["sqli"])
@@ -263,10 +263,20 @@ func TestHarnessMaterializesSourceFiles(t *testing.T) {
 	seen := map[string]string{}
 	fake := func(_ context.Context, _, sourceDir, scanID string) ([]reporting.Vulnerability, error) {
 		seen[scanID] = sourceDir
-		// While the scan runs, a whitebox challenge's source must exist on disk.
+		// While the scan runs, each of the challenge's OWN declared source files
+		// must exist on disk (language-agnostic: app.py for Flask, app.js for
+		// Express, etc.).
 		if sourceDir != "" {
-			if _, err := os.Stat(filepath.Join(sourceDir, "app.py")); err != nil {
-				t.Errorf("expected app.py in materialized source dir %q: %v", sourceDir, err)
+			name := strings.TrimPrefix(scanID, "bench-")
+			for _, c := range Builtin() {
+				if c.Name != name {
+					continue
+				}
+				for f := range c.SourceFiles {
+					if _, err := os.Stat(filepath.Join(sourceDir, f)); err != nil {
+						t.Errorf("expected %s in materialized source dir %q: %v", f, sourceDir, err)
+					}
+				}
 			}
 		}
 		return nil, nil
@@ -380,6 +390,41 @@ func TestWhiteboxLfiChallengeExhibitsVuln(t *testing.T) {
 	}
 	// The index must NOT link the vulnerable route (whitebox-only discovery).
 	if body := httpGet(t, srv.URL+"/"); strings.Contains(body, "/internal/logs") {
+		t.Fatalf("index must not link the vulnerable route (whitebox-only), got %q", body)
+	}
+}
+
+func TestWhiteboxNodeRceChallengeExhibitsVuln(t *testing.T) {
+	wb := challengeByName(t, "whitebox-node-rce")
+
+	// The whitebox source is a Node/Express app: the command-exec sink
+	// (child_process exec over concatenated user input) lives inside the unlinked
+	// diagnostics route's handler, discovered via the Express route pattern.
+	src, ok := wb.SourceFiles["app.js"]
+	if !ok {
+		t.Fatal("whitebox-node-rce must ship app.js source")
+	}
+	if !strings.Contains(src, "child_process") || !strings.Contains(src, "app.get('/internal/ping'") {
+		t.Fatalf("app.js must contain the Express /internal/ping route and the child_process exec sink:\n%s", src)
+	}
+
+	srv := wb.Start()
+	defer srv.Close()
+
+	// A shell metacharacter in host triggers simulated command execution.
+	if body := httpGet(t, srv.URL+"/internal/ping?host=127.0.0.1%3Bid"); !strings.Contains(body, "uid=0") {
+		t.Fatalf("whitebox-node-rce did not execute the injected command: %q", body)
+	}
+	// A benign host does not.
+	if body := httpGet(t, srv.URL+"/internal/ping?host=localhost"); strings.Contains(body, "uid=0") {
+		t.Fatalf("benign host must not yield command output: %q", body)
+	}
+	// Health endpoint is benign.
+	if body := httpGet(t, srv.URL+"/healthz"); !strings.Contains(body, "ok") {
+		t.Fatalf("healthz should return ok, got %q", body)
+	}
+	// The index must NOT link the vulnerable route (whitebox-only discovery).
+	if body := httpGet(t, srv.URL+"/"); strings.Contains(body, "/internal/ping") {
 		t.Fatalf("index must not link the vulnerable route (whitebox-only), got %q", body)
 	}
 }

--- a/internal/bench/challenge.go
+++ b/internal/bench/challenge.go
@@ -367,6 +367,59 @@ func Builtin() []Challenge {
 				}
 			}),
 		},
+		{
+			// Whitebox challenge (RCE, Node/Express source): validates the
+			// source-to-runtime bridge on a SECOND language. The vulnerable
+			// diagnostics route is not linked from any page, so it is discoverable
+			// only via the attached JS source — the command-exec sink
+			// (child_process exec over concatenated user input) lives inside the
+			// app.get('/internal/ping') handler, which codesearch types as an rce
+			// sink and the Express route pattern discovers.
+			Name: "whitebox-node-rce", Class: "rce", Endpoint: "/internal/ping", Param: "host",
+			Desc: "Command injection on an UNLINKED Express route, discoverable only via the attached Node source.",
+			SourceFiles: map[string]string{
+				"app.js": "const express = require('express');\n" +
+					"const { exec } = require('child_process');\n" +
+					"const app = express();\n\n" +
+					"app.get('/', (req, res) => {\n" +
+					"  res.send('<html><body>Service</body></html>');\n" +
+					"});\n\n" +
+					"app.get('/healthz', (req, res) => {\n" +
+					"  res.send('ok');\n" +
+					"});\n\n" +
+					"// Internal diagnostics endpoint - intentionally not linked from any page.\n" +
+					"app.get('/internal/ping', (req, res) => {\n" +
+					"  const host = req.query.host || '';\n" +
+					"  // Vulnerable: user input flows into a shell command.\n" +
+					"  exec('ping -c1 ' + host, (err, stdout) => {\n" +
+					"    res.type('text/plain').send(stdout);\n" +
+					"  });\n" +
+					"});\n\n" +
+					"app.listen(3000);\n",
+			},
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/healthz":
+					w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+					_, _ = fmt.Fprint(w, "ok")
+				case "/internal/ping":
+					host := r.URL.Query().Get("host")
+					w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+					out := fmt.Sprintf("PING %s: 56 data bytes\n64 bytes: icmp_seq=0 ttl=64 time=0.041 ms\n", host)
+					if hasShellMeta(host) {
+						// Simulated command execution of the injected command.
+						out += "uid=0(root) gid=0(root) groups=0(root)\n"
+					}
+					_, _ = fmt.Fprint(w, out)
+				case "/":
+					// Index does NOT link the vulnerable diagnostics route.
+					w.Header().Set("Content-Type", "text/html; charset=utf-8")
+					_, _ = fmt.Fprint(w, `<html><body><h1>Service</h1><p>See <a href="/healthz">health</a>.</p></body></html>`)
+				default:
+					http.NotFound(w, r)
+				}
+			}),
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary
Adds `whitebox-node-rce`, a whitebox benchmark challenge whose source is **JavaScript (Node/Express)**, validating the source-to-runtime bridge on a second language. The four existing whitebox challenges are all Python/Flask, so source-sink discovery, route extraction, and route↔sink correlation were only exercised for one language.

## The challenge
`app.js` declares an **UNLINKED** `app.get('/internal/ping')` Express route whose handler calls `child_process` `exec('ping -c1 ' + host)`. Solving it requires the bridge to work across languages:
- the code scanner recognizes the JS command-exec sink (`child_process`/`exec`),
- the Express route pattern `(app|router|…).(get|post|…)('…')` discovers the route (distinct from Flask's `@app.route` decorator),
- correlation attributes the sink to that handler,
- the agent probes the route live and proves RCE via the injected command's output.

The route is not linked from any page, so black-box crawling can't reach it. Class `rce` (solves via the distinctive command-output signature — no verifier needed, as already shown for cmdi/lfi).

## Notes
- Operator-only benchmark tooling; the shipped binary is unchanged (releases build only `./cmd/xalgorix`). Bench now has 13 challenges; `rce` has 3.
- `TestHarnessMaterializesSourceFiles` is now language-agnostic (checks each challenge's own declared files, not a hardcoded `app.py`).

## Tests
- `TestWhiteboxNodeRceChallengeExhibitsVuln`: `app.js` has the Express `/internal/ping` route + `child_process` sink; live `?host=127.0.0.1%3Bid` → `uid=0`; benign host → none; `/healthz` → ok; index does not link the route.
- `TestRunWithFakeScanFunc` updated: `rce` now a 3-challenge class.
- gofmt clean; `go build ./...` OK; `go vet` OK; `go test -race ./internal/bench/` passes; golangci-lint 0 issues.