### PR TITLE
release: v4.6.38

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.37
+VERSION=4.6.38
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.37"
+var version = "4.6.38"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.38 — Cross-language whitebox benchmark challenge (Node/Express RCE).

Bumps main.version and Makefile VERSION to 4.6.38. CHANGELOG entry landed with the feature (#556).

Adds whitebox-node-rce: a JavaScript (Node/Express) source with an UNLINKED app.get('/internal/ping') route whose handler calls child_process exec over concatenated user input. Validates the source-to-runtime bridge (JS route + rce sink detection + correlation) on a second language. Operator-only bench tooling; shipped binary unchanged.