### PR TITLE
release: v4.6.39

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.38
+VERSION=4.6.39
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.38"
+var version = "4.6.39"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.39 — Lock in the source scanner's multi-language route/sink detection.

Bumps main.version and Makefile VERSION to 4.6.39. CHANGELOG entry landed with the change (#558).

Adds deterministic regression coverage (TestRouteScanCrossLanguage + TestSinkScanCrossLanguage) confirming the bridge detects routes and command-exec sinks across Go, Spring, Django, Rails, Java, and PHP — previously only Flask/Express were tested. Test-only; shipped binary unchanged.