### PR TITLE
feat(bench): make black-box challenges crawler-discoverable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v4.6.40](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.40) — Black-box benchmark challenges are now crawler-discoverable (2026-09-02)
+
+### Changed
+- **The black-box benchmark challenges now expose their vulnerable endpoint (and parameter) from a realistic index, so the benchmark measures crawl-then-detect rather than parameter-name guessing.** Only the `idor` challenge previously linked its endpoint from a landing page; the other seven (`reflected-xss`, `open-redirect`, `error-sqli`, `ssrf`, `ssti`, `lfi`, `cmdi`) served their vulnerable behavior at a fixed path with nothing advertising the path or the parameter name — so a scan could fail purely because it never guessed `?q=`/`?url=`/`?file=`/etc., not because it couldn't detect the bug. Each now serves a realistic `/` index (a form and/or an example link, e.g. a search form for `reflected-xss`, a catalog of `/product?id=` links for `error-sqli`, a link-preview form for `ssrf`) that exposes the endpoint path and parameter the way a real app would, so the scanner's crawler discovers the attack surface and the benchmark isolates detection ability. The vulnerable behavior is unchanged and still served on the endpoint paths. Operator-only benchmark tooling; the shipped binary is unchanged (releases build only `./cmd/xalgorix`).
+
 ## [v4.6.39](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.39) — Lock in the source scanner's multi-language route/sink detection (2026-09-02)
 
 ### Changed

--- a/internal/bench/bench_test.go
+++ b/internal/bench/bench_test.go
@@ -428,3 +428,30 @@ func TestWhiteboxNodeRceChallengeExhibitsVuln(t *testing.T) {
 		t.Fatalf("index must not link the vulnerable route (whitebox-only), got %q", body)
 	}
 }
+
+// TestBlackboxChallengesDiscoverable verifies every black-box challenge exposes
+// its vulnerable endpoint (and, for query-parameter bugs, the parameter name)
+// from its "/" index, so a crawling scanner can discover the attack surface the
+// way it would on a real app — the benchmark measures crawl-then-detect, not
+// parameter-name guessing. Whitebox challenges are exempt (discovered via source).
+func TestBlackboxChallengesDiscoverable(t *testing.T) {
+	for _, c := range Builtin() {
+		if c.SourceFiles != nil {
+			continue
+		}
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			srv := c.Start()
+			defer srv.Close()
+			body := httpGet(t, srv.URL+"/")
+			if !strings.Contains(body, c.Endpoint) {
+				t.Errorf("index must link endpoint %q so a crawler finds it; got %q", c.Endpoint, body)
+			}
+			// idor's object id is a path segment, not a query parameter, so it is
+			// exempt from the parameter-name check.
+			if c.Name != "idor" && c.Param != "" && !strings.Contains(body, c.Param) {
+				t.Errorf("index must expose parameter %q (form/link); got %q", c.Param, body)
+			}
+		})
+	}
+}

--- a/internal/bench/challenge.go
+++ b/internal/bench/challenge.go
@@ -60,8 +60,14 @@ func Builtin() []Challenge {
 			Name: "reflected-xss", Class: "xss", Endpoint: "/search", Param: "q",
 			Desc: "Reflects the q parameter into the HTML response without encoding.",
 			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				q := r.URL.Query().Get("q")
 				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				if r.URL.Path == "/" {
+					// Realistic index: a search form + example link so a crawler
+					// discovers the vulnerable endpoint and its parameter.
+					_, _ = fmt.Fprint(w, `<html><body><h1>Search</h1><form action="/search" method="get"><input name="q" placeholder="query"><button>Search</button></form><p><a href="/search?q=example">recent search</a></p></body></html>`)
+					return
+				}
+				q := r.URL.Query().Get("q")
 				// Deliberately unescaped reflection.
 				_, _ = fmt.Fprintf(w, "<html><body><h1>Results</h1><p>You searched for: %s</p></body></html>", q)
 			}),
@@ -92,6 +98,13 @@ func Builtin() []Challenge {
 			Name: "open-redirect", Class: "open_redirect", Endpoint: "/redirect", Param: "url",
 			Desc: "Issues a 302 to an attacker-controlled url parameter.",
 			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/" {
+					// Realistic index: a "continue to partner site" link exposes
+					// the redirect endpoint + url parameter to a crawler.
+					w.Header().Set("Content-Type", "text/html; charset=utf-8")
+					_, _ = fmt.Fprint(w, `<html><body><h1>Home</h1><p><a href="/redirect?url=https://example.com/welcome">continue to partner site</a></p></body></html>`)
+					return
+				}
 				u := r.URL.Query().Get("url")
 				if u == "" {
 					u = "/"
@@ -107,8 +120,14 @@ func Builtin() []Challenge {
 			Name: "error-sqli", Class: "sqli", Endpoint: "/product", Param: "id",
 			Desc: "Leaks a database syntax error when the id parameter contains a quote.",
 			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				id := r.URL.Query().Get("id")
 				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				if r.URL.Path == "/" {
+					// Realistic catalog index linking product detail pages, so a
+					// crawler discovers /product?id=.
+					_, _ = fmt.Fprint(w, `<html><body><h1>Catalog</h1><ul><li><a href="/product?id=1">Product #1</a></li><li><a href="/product?id=2">Product #2</a></li></ul></body></html>`)
+					return
+				}
+				id := r.URL.Query().Get("id")
 				if containsQuote(id) {
 					w.WriteHeader(http.StatusInternalServerError)
 					_, _ = fmt.Fprintf(w, "Database error: You have an error in your SQL syntax; check the manual near '%s' at line 1", id)
@@ -121,6 +140,13 @@ func Builtin() []Challenge {
 			Name: "ssrf", Class: "ssrf", Endpoint: "/fetch", Param: "url",
 			Desc: "Fetches a user-supplied url; internal targets return cloud-metadata-like content.",
 			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/" {
+					// Realistic link-preview index: a form + example link exposes
+					// the fetch endpoint + url parameter to a crawler.
+					w.Header().Set("Content-Type", "text/html; charset=utf-8")
+					_, _ = fmt.Fprint(w, `<html><body><h1>Link Preview</h1><form action="/fetch" method="get"><input name="url" placeholder="https://..."><button>Preview</button></form><p><a href="/fetch?url=https://example.com/logo.png">preview example</a></p></body></html>`)
+					return
+				}
 				raw := r.URL.Query().Get("url")
 				host := ""
 				if u, err := url.Parse(raw); err == nil {
@@ -140,8 +166,14 @@ func Builtin() []Challenge {
 			Name: "ssti", Class: "ssti", Endpoint: "/greet", Param: "name",
 			Desc: "Evaluates a {{ a * b }} expression in the name parameter (template injection).",
 			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				name := r.URL.Query().Get("name")
 				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				if r.URL.Path == "/" {
+					// Realistic greeter index: a form + example link exposes the
+					// greet endpoint + name parameter to a crawler.
+					_, _ = fmt.Fprint(w, `<html><body><h1>Greeter</h1><form action="/greet" method="get"><input name="name" placeholder="your name"><button>Greet</button></form><p><a href="/greet?name=friend">say hi</a></p></body></html>`)
+					return
+				}
+				name := r.URL.Query().Get("name")
 				_, _ = fmt.Fprintf(w, "<html><body>Hello, %s!</body></html>", sstiRender(name))
 			}),
 		},
@@ -149,6 +181,13 @@ func Builtin() []Challenge {
 			Name: "lfi", Class: "lfi", Endpoint: "/download", Param: "file",
 			Desc: "Path traversal in the file parameter returns system file contents.",
 			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/" {
+					// Realistic documents index linking downloadable files, so a
+					// crawler discovers /download?file=.
+					w.Header().Set("Content-Type", "text/html; charset=utf-8")
+					_, _ = fmt.Fprint(w, `<html><body><h1>Documents</h1><ul><li><a href="/download?file=report.pdf">report.pdf</a></li><li><a href="/download?file=invoice.txt">invoice.txt</a></li></ul></body></html>`)
+					return
+				}
 				file := r.URL.Query().Get("file")
 				w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 				if strings.Contains(file, "..") && strings.Contains(file, "passwd") {
@@ -163,6 +202,13 @@ func Builtin() []Challenge {
 			Name: "cmdi", Class: "rce", Endpoint: "/ping", Param: "host",
 			Desc: "Command injection in the host parameter (shell metacharacters execute).",
 			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/" {
+					// Realistic network-tools index: a form + example link exposes
+					// the ping endpoint + host parameter to a crawler.
+					w.Header().Set("Content-Type", "text/html; charset=utf-8")
+					_, _ = fmt.Fprint(w, `<html><body><h1>Network Tools</h1><form action="/ping" method="get"><input name="host" placeholder="host"><button>Ping</button></form><p><a href="/ping?host=example.com">ping example.com</a></p></body></html>`)
+					return
+				}
 				host := r.URL.Query().Get("host")
 				w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 				out := fmt.Sprintf("PING %s: 56 data bytes\n64 bytes: icmp_seq=0 ttl=64 time=0.048 ms\n", host)


### PR DESCRIPTION
## Summary
Makes the black-box benchmark measure **crawl-then-detect** instead of parameter-name guessing. Only the `idor` challenge previously linked its endpoint from a landing page; the other seven (`reflected-xss`, `open-redirect`, `error-sqli`, `ssrf`, `ssti`, `lfi`, `cmdi`) served their vulnerable behavior at a fixed path with nothing advertising the path or the parameter — so a scan could fail purely because it never guessed `?q=`/`?url=`/`?file=`/etc.

## Change
Each of the seven now serves a realistic `/` index — a form and/or an example link — that exposes the endpoint path and parameter the way a real app would (a search form for `reflected-xss`, a catalog of `/product?id=` links for `error-sqli`, a link-preview form for `ssrf`, a documents list for `lfi`, etc.). The scanner's crawler discovers the attack surface, so the benchmark isolates detection ability. The vulnerable behavior is unchanged and still served on the endpoint paths.

## Notes
- Operator-only benchmark tooling; the shipped binary is unchanged.

## Tests
- `TestBlackboxChallengesDiscoverable`: every black-box challenge's `/` index links its endpoint (and exposes the query parameter, except `idor`'s path-segment id).
- Existing endpoint-specific exhibit tests still pass (behavior unchanged on the endpoints).
- gofmt clean; `go build ./...` OK; `go vet` OK; `go test -race ./internal/bench/` passes; golangci-lint 0 issues.