### PR TITLE
release: v4.6.40

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.39
+VERSION=4.6.40
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.39"
+var version = "4.6.40"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.40 — Black-box benchmark challenges are now crawler-discoverable.

Bumps main.version and Makefile VERSION to 4.6.40. CHANGELOG entry landed with the feature (#560).

Each black-box challenge now serves a realistic "/" index (form + example link) exposing its endpoint path and parameter, so the benchmark measures crawl-then-detect instead of parameter-name guessing. Vulnerable behavior unchanged on the endpoints. Operator-only bench tooling; shipped binary unchanged.