### PR TITLE
feat(bench): measure precision via negative-control challenges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v4.6.41](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.41) — Black-box benchmark now measures precision (negative controls) (2026-09-02)
+
+### Added
+- **The benchmark now measures false-positive rate, not just recall, via negative-control challenges.** Every challenge so far was vulnerable, so the benchmark only rewarded finding bugs — a scanner that over-reports (the failure mode all the reporting gates and verifiers exist to prevent) would still score perfectly. A `Challenge` can now be flagged `Negative`: the app handles the same kind of input as a positive challenge but SECURELY, so the correct outcome is NO finding of that class, and scoring inverts (a negative control is "solved" only when the class is correctly NOT reported; reporting it is a false positive). Four negative controls ship: `safe-search` (reflects input but HTML-escapes it — no XSS), `safe-redirect` (only relative same-origin redirects — no open redirect), `safe-sqli` (parameterized; a bad id returns a generic 400 with no database error — no SQLi), and `safe-fetch` (an allowlist refuses internal/metadata hosts with 403 — no SSRF). The scorecard reports a `Precision: N/M negative controls clean, K false positive(s)` line and marks each false positive with the offending finding id, so a change's effect on precision is measured alongside recall. Operator-only benchmark tooling; the shipped binary is unchanged (releases build only `./cmd/xalgorix`).
+
 ## [v4.6.40](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.40) — Black-box benchmark challenges are now crawler-discoverable (2026-09-02)
 
 ### Changed

--- a/internal/bench/bench_test.go
+++ b/internal/bench/bench_test.go
@@ -144,27 +144,35 @@ func TestRunWithFakeScanFunc(t *testing.T) {
 	if card.Total() != len(Builtin()) {
 		t.Fatalf("expected %d challenges, got %d", len(Builtin()), card.Total())
 	}
-	if card.SolvedCount() != 2 {
-		t.Fatalf("expected 2 solved (xss+idor), got %d\n%s", card.SolvedCount(), card.String())
+	// Solved = 2 positives (reflected-xss + idor) + every negative control
+	// (all correctly clean, since the fake reports nothing on them).
+	negatives := card.NegativeCount()
+	if want := 2 + negatives; card.SolvedCount() != want {
+		t.Fatalf("expected %d solved (xss+idor+%d clean negatives), got %d\n%s", want, negatives, card.SolvedCount(), card.String())
+	}
+	if card.FalsePositives() != 0 {
+		t.Fatalf("expected 0 false positives (fake reports nothing on negatives), got %d\n%s", card.FalsePositives(), card.String())
 	}
 	byClass := card.ByClass()
-	if byClass["xss"] != [2]int{1, 1} || byClass["idor"] != [2]int{1, 1} {
-		t.Fatalf("expected xss 1/1 and idor 1/1, got %v", byClass)
+	// xss = reflected-xss (positive, solved) + safe-search (negative, clean) = 2/2.
+	if byClass["xss"] != [2]int{2, 2} || byClass["idor"] != [2]int{1, 1} {
+		t.Fatalf("expected xss 2/2 and idor 1/1, got %v", byClass)
 	}
-	// Every other single-challenge class is present but unsolved by this fake.
+	// open_redirect and ssrf each have a positive (unsolved by this fake) plus a
+	// negative control (correctly clean) => 1/2.
 	for _, c := range []string{"open_redirect", "ssrf"} {
-		if byClass[c] != [2]int{0, 1} {
-			t.Fatalf("expected %s 0/1, got %v", c, byClass[c])
+		if byClass[c] != [2]int{1, 2} {
+			t.Fatalf("expected %s 1/2, got %v", c, byClass[c])
 		}
 	}
-	// rce has three challenges (cmdi + whitebox-cmdi + whitebox-node-rce); sqli
-	// (error-sqli + whitebox-sqli), ssti (ssti + whitebox-ssti), and lfi
-	// (lfi + whitebox-lfi) each have two — all unsolved by this fake.
+	// rce = cmdi + whitebox-cmdi + whitebox-node-rce (0/3). sqli = error-sqli +
+	// whitebox-sqli (positives, unsolved) + safe-sqli (negative, clean) => 1/3.
+	// ssti and lfi each have two positives, unsolved by this fake.
 	if byClass["rce"] != [2]int{0, 3} {
 		t.Fatalf("expected rce 0/3, got %v", byClass["rce"])
 	}
-	if byClass["sqli"] != [2]int{0, 2} {
-		t.Fatalf("expected sqli 0/2, got %v", byClass["sqli"])
+	if byClass["sqli"] != [2]int{1, 3} {
+		t.Fatalf("expected sqli 1/3, got %v", byClass["sqli"])
 	}
 	if byClass["ssti"] != [2]int{0, 2} {
 		t.Fatalf("expected ssti 0/2, got %v", byClass["ssti"])
@@ -453,5 +461,92 @@ func TestBlackboxChallengesDiscoverable(t *testing.T) {
 				t.Errorf("index must expose parameter %q (form/link); got %q", c.Param, body)
 			}
 		})
+	}
+}
+
+// TestNegativeControlsScoring verifies the precision scoring: reporting a class
+// on a negative control is a false positive (that challenge FAILs and is
+// counted), while reporting nothing keeps every negative control clean.
+func TestNegativeControlsScoring(t *testing.T) {
+	// A scan that (wrongly) reports XSS on the safe-search negative control.
+	fpFake := func(_ context.Context, target, _, scanID string) ([]reporting.Vulnerability, error) {
+		if scanID == "bench-safe-search" {
+			return []reporting.Vulnerability{{ID: "XALG-9", Title: "Reflected XSS", CWE: "CWE-79", Endpoint: target + "/search"}}, nil
+		}
+		return nil, nil
+	}
+	card := Run(context.Background(), Builtin(), fpFake)
+	if card.FalsePositives() < 1 {
+		t.Fatalf("expected >=1 false positive on safe-search, got %d\n%s", card.FalsePositives(), card.String())
+	}
+	var ss Result
+	for _, r := range card.Results {
+		if r.Name == "safe-search" {
+			ss = r
+		}
+	}
+	if !ss.Negative {
+		t.Fatal("safe-search must be a negative control")
+	}
+	if ss.Solved {
+		t.Fatal("safe-search must FAIL (false positive) when the scan reports XSS on it")
+	}
+
+	// A scan that reports nothing keeps every negative control clean.
+	cleanFake := func(context.Context, string, string, string) ([]reporting.Vulnerability, error) {
+		return nil, nil
+	}
+	clean := Run(context.Background(), Builtin(), cleanFake)
+	if clean.FalsePositives() != 0 {
+		t.Fatalf("expected 0 false positives when nothing is reported, got %d", clean.FalsePositives())
+	}
+	if clean.NegativeCount() < 4 {
+		t.Fatalf("expected at least 4 negative controls, got %d", clean.NegativeCount())
+	}
+}
+
+// TestNegativeControlsAreSafe confirms each negative-control app actually
+// handles its input securely — so a finding of its class really would be a
+// false positive, not a genuine bug the benchmark mislabeled.
+func TestNegativeControlsAreSafe(t *testing.T) {
+	// safe-search: reflection is HTML-escaped (no raw <script>).
+	ss := challengeByName(t, "safe-search").Start()
+	defer ss.Close()
+	if body := httpGet(t, ss.URL+"/search?q=<script>alert(1)</script>"); strings.Contains(body, "<script>alert(1)</script>") {
+		t.Fatalf("safe-search must escape the payload, got %q", body)
+	}
+
+	// safe-redirect: an external absolute URL is rejected; a relative path is allowed.
+	sr := challengeByName(t, "safe-redirect").Start()
+	defer sr.Close()
+	respExt, err := noRedirectClient().Get(sr.URL + "/redirect?url=https://evil.example/")
+	if err != nil {
+		t.Fatalf("safe-redirect request: %v", err)
+	}
+	defer respExt.Body.Close()
+	if respExt.StatusCode == http.StatusFound && respExt.Header.Get("Location") == "https://evil.example/" {
+		t.Fatal("safe-redirect must not redirect to an external URL")
+	}
+	respRel, err := noRedirectClient().Get(sr.URL + "/redirect?url=/welcome")
+	if err != nil {
+		t.Fatalf("safe-redirect relative request: %v", err)
+	}
+	defer respRel.Body.Close()
+	if respRel.StatusCode != http.StatusFound || respRel.Header.Get("Location") != "/welcome" {
+		t.Fatalf("safe-redirect must allow a relative path, got status=%d loc=%q", respRel.StatusCode, respRel.Header.Get("Location"))
+	}
+
+	// safe-sqli: a quote yields a generic error, NOT a SQL error string.
+	sq := challengeByName(t, "safe-sqli").Start()
+	defer sq.Close()
+	if body := httpGet(t, sq.URL+"/product?id=1'"); strings.Contains(strings.ToLower(body), "sql syntax") {
+		t.Fatalf("safe-sqli must not leak a SQL error, got %q", body)
+	}
+
+	// safe-fetch: an internal metadata host is blocked (no metadata content).
+	sf := challengeByName(t, "safe-fetch").Start()
+	defer sf.Close()
+	if body := httpGet(t, sf.URL+"/fetch?url=http://169.254.169.254/latest/meta-data/"); strings.Contains(body, "security-credentials") {
+		t.Fatalf("safe-fetch must block internal metadata, got %q", body)
 	}
 }

--- a/internal/bench/challenge.go
+++ b/internal/bench/challenge.go
@@ -12,6 +12,7 @@ package bench
 
 import (
 	"fmt"
+	"html"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -36,6 +37,13 @@ type Challenge struct {
 	// scan can use the source-to-runtime bridge (scan_source_sinks /
 	// scan_source_routes / probe_hypothesis). Nil for pure black-box challenges.
 	SourceFiles map[string]string
+
+	// Negative marks a NEGATIVE CONTROL: the app handles the same kind of input
+	// as a matching positive challenge but SECURELY, so a correct scan reports
+	// NO finding of Class. These measure the false-positive rate — a scanner
+	// that over-reports fails them. Scoring inverts for negatives (see runOne):
+	// "solved" means the class was correctly NOT reported.
+	Negative bool
 }
 
 // Start launches the challenge app on an ephemeral loopback server. The caller
@@ -464,6 +472,93 @@ func Builtin() []Challenge {
 				default:
 					http.NotFound(w, r)
 				}
+			}),
+		},
+		{
+			// NEGATIVE CONTROL (xss): reflects q but HTML-escapes it, so there is
+			// no XSS to report. A precise scanner reports nothing here.
+			Name: "safe-search", Class: "xss", Endpoint: "/search", Param: "q", Negative: true,
+			Desc: "NEGATIVE CONTROL: reflects q but HTML-escapes it (no XSS).",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				if r.URL.Path == "/" {
+					_, _ = fmt.Fprint(w, `<html><body><h1>Search</h1><form action="/search" method="get"><input name="q" placeholder="query"><button>Search</button></form><p><a href="/search?q=example">recent search</a></p></body></html>`)
+					return
+				}
+				q := r.URL.Query().Get("q")
+				// SAFE: user input is HTML-escaped before reflection.
+				_, _ = fmt.Fprintf(w, "<html><body><h1>Results</h1><p>You searched for: %s</p></body></html>", html.EscapeString(q))
+			}),
+		},
+		{
+			// NEGATIVE CONTROL (open_redirect): only relative same-origin targets
+			// are honored; absolute/scheme-relative URLs are rejected.
+			Name: "safe-redirect", Class: "open_redirect", Endpoint: "/redirect", Param: "url", Negative: true,
+			Desc: "NEGATIVE CONTROL: only redirects to relative same-origin paths (no open redirect).",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/" {
+					w.Header().Set("Content-Type", "text/html; charset=utf-8")
+					_, _ = fmt.Fprint(w, `<html><body><h1>Home</h1><p><a href="/redirect?url=/welcome">continue</a></p></body></html>`)
+					return
+				}
+				u := r.URL.Query().Get("url")
+				// SAFE: allow only relative, same-origin paths. Reject absolute
+				// URLs and scheme-relative ("//host") targets.
+				if !strings.HasPrefix(u, "/") || strings.HasPrefix(u, "//") {
+					w.WriteHeader(http.StatusBadRequest)
+					_, _ = fmt.Fprint(w, "invalid redirect target")
+					return
+				}
+				w.Header().Set("Location", u)
+				w.WriteHeader(http.StatusFound)
+			}),
+		},
+		{
+			// NEGATIVE CONTROL (sqli): parameterized; a non-numeric id yields a
+			// generic 400 with no database error text, so there is no SQLi signal.
+			Name: "safe-sqli", Class: "sqli", Endpoint: "/product", Param: "id", Negative: true,
+			Desc: "NEGATIVE CONTROL: parameterized query; invalid id -> generic 400, no DB error (no SQLi).",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				if r.URL.Path == "/" {
+					_, _ = fmt.Fprint(w, `<html><body><h1>Catalog</h1><ul><li><a href="/product?id=1">Product #1</a></li><li><a href="/product?id=2">Product #2</a></li></ul></body></html>`)
+					return
+				}
+				id := r.URL.Query().Get("id")
+				// SAFE: parameterized. Non-numeric ids are rejected generically —
+				// no SQL string is built and no DBMS error is ever leaked.
+				if _, err := strconv.Atoi(strings.TrimSpace(id)); err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					_, _ = fmt.Fprint(w, "invalid product id")
+					return
+				}
+				_, _ = fmt.Fprintf(w, "<html><body>Product #%s</body></html>", id)
+			}),
+		},
+		{
+			// NEGATIVE CONTROL (ssrf): an allowlist refuses internal/link-local/
+			// metadata hosts with 403, so no internal resource is ever reached.
+			Name: "safe-fetch", Class: "ssrf", Endpoint: "/fetch", Param: "url", Negative: true,
+			Desc: "NEGATIVE CONTROL: SSRF allowlist blocks internal/metadata hosts (403); only external fetches succeed.",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/" {
+					w.Header().Set("Content-Type", "text/html; charset=utf-8")
+					_, _ = fmt.Fprint(w, `<html><body><h1>Link Preview</h1><form action="/fetch" method="get"><input name="url" placeholder="https://..."><button>Preview</button></form><p><a href="/fetch?url=https://example.com/logo.png">preview example</a></p></body></html>`)
+					return
+				}
+				raw := r.URL.Query().Get("url")
+				host := ""
+				if u, err := url.Parse(raw); err == nil {
+					host = strings.ToLower(u.Hostname())
+				}
+				w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+				// SAFE: refuse internal/metadata destinations.
+				if isInternalHost(host) {
+					w.WriteHeader(http.StatusForbidden)
+					_, _ = fmt.Fprint(w, "blocked: destination not allowed")
+					return
+				}
+				_, _ = fmt.Fprintf(w, "fetched external url: %s\n", raw)
 			}),
 		},
 	}

--- a/internal/bench/harness.go
+++ b/internal/bench/harness.go
@@ -65,7 +65,7 @@ func runOne(parent context.Context, c Challenge, scan ScanFunc, timeout time.Dur
 		defer cancel()
 	}
 
-	res := Result{Name: c.Name, Class: canonicalClass(c.Class)}
+	res := Result{Name: c.Name, Class: canonicalClass(c.Class), Negative: c.Negative}
 	start := time.Now()
 	findings, err := scan(ctx, srv.URL, sourceDir, "bench-"+c.Name)
 	res.Elapsed = time.Since(start)
@@ -77,8 +77,17 @@ func runOne(parent context.Context, c Challenge, scan ScanFunc, timeout time.Dur
 		res.Err = err
 	}
 	// Score whatever findings were gathered — a scan that timed out may still
-	// have reported the vulnerability before the deadline.
-	res.Solved, res.MatchedFindingID = Solved(c.Class, findings)
+	// have reported the vulnerability before the deadline. For a negative
+	// control the scoring inverts: reporting the class is a false positive, so
+	// "solved" means the class was correctly NOT reported. MatchedFindingID
+	// holds the offending finding id when a negative control false-positives.
+	reported, id := Solved(c.Class, findings)
+	res.MatchedFindingID = id
+	if c.Negative {
+		res.Solved = !reported
+	} else {
+		res.Solved = reported
+	}
 	return res
 }
 

--- a/internal/bench/score.go
+++ b/internal/bench/score.go
@@ -13,7 +13,8 @@ import (
 type Result struct {
 	Name             string
 	Class            string
-	Solved           bool
+	Negative         bool // negative control: correct outcome is NO finding of Class
+	Solved           bool // handled correctly (positive: found; negative: correctly avoided)
 	MatchedFindingID string
 	Findings         int
 	Elapsed          time.Duration
@@ -34,6 +35,30 @@ func (s Scorecard) SolvedCount() int {
 	n := 0
 	for _, r := range s.Results {
 		if r.Solved {
+			n++
+		}
+	}
+	return n
+}
+
+// NegativeCount returns the number of negative-control challenges.
+func (s Scorecard) NegativeCount() int {
+	n := 0
+	for _, r := range s.Results {
+		if r.Negative {
+			n++
+		}
+	}
+	return n
+}
+
+// FalsePositives returns the number of negative-control challenges the scan
+// mishandled by reporting the class it was supposed to stay silent on. This is
+// the benchmark's precision signal: a scanner that over-reports fails these.
+func (s Scorecard) FalsePositives() int {
+	n := 0
+	for _, r := range s.Results {
+		if r.Negative && !r.Solved {
 			n++
 		}
 	}
@@ -70,7 +95,12 @@ func (s Scorecard) String() string {
 			status = "PASS"
 		}
 		fmt.Fprintf(&b, "  [%s] %-16s %-14s %2d finding(s)  %6.1fs", status, r.Name, r.Class, r.Findings, r.Elapsed.Seconds())
-		if r.MatchedFindingID != "" {
+		switch {
+		case r.Negative && r.Solved:
+			b.WriteString("  (negative: no FP)")
+		case r.Negative && !r.Solved:
+			fmt.Fprintf(&b, "  FALSE POSITIVE -> %s", r.MatchedFindingID)
+		case r.MatchedFindingID != "":
 			fmt.Fprintf(&b, "  -> %s", r.MatchedFindingID)
 		}
 		if r.TimedOut {
@@ -94,6 +124,9 @@ func (s Scorecard) String() string {
 			fmt.Fprintf(&b, " %s %d/%d", c, byClass[c][0], byClass[c][1])
 		}
 		b.WriteByte('\n')
+	}
+	if neg := s.NegativeCount(); neg > 0 {
+		fmt.Fprintf(&b, "Precision: %d/%d negative controls clean, %d false positive(s)\n", neg-s.FalsePositives(), neg, s.FalsePositives())
 	}
 	return b.String()
 }


### PR DESCRIPTION
## Summary
The benchmark now measures **false-positive rate, not just recall**. Every challenge so far was vulnerable, so a scanner that over-reports (the failure mode all the reporting gates and verifiers exist to prevent) would still score perfectly.

## Change
A `Challenge` can now be flagged `Negative`: the app handles the same kind of input as a positive challenge but **securely**, so the correct outcome is NO finding of that class. Scoring inverts — a negative control is "solved" only when the class is correctly NOT reported; reporting it is a false positive. The scorecard adds a `Precision: N/M negative controls clean, K false positive(s)` line and marks each false positive with the offending finding id.

Four negative controls ship:
- `safe-search` — reflects input but HTML-escapes it → no XSS
- `safe-redirect` — only relative same-origin redirects → no open redirect
- `safe-sqli` — parameterized; a bad id returns a generic 400 with no DB error → no SQLi
- `safe-fetch` — an allowlist refuses internal/metadata hosts with 403 → no SSRF

## Notes
- Operator-only benchmark tooling; the shipped binary is unchanged. Bench now has 17 challenges (13 positive + 4 negative).

## Tests
- `TestNegativeControlsScoring`: reporting XSS on `safe-search` fails it and counts as a false positive; reporting nothing keeps all negatives clean.
- `TestNegativeControlsAreSafe`: each safe app truly doesn't emit its class's signal (escaped reflection, relative-only redirect, no SQL error, 403 on internal host).
- `TestRunWithFakeScanFunc` updated for the new counts.
- gofmt clean; `go build ./...` OK; `go vet` OK; `go test -race ./internal/bench/` passes; golangci-lint 0 issues.