### PR TITLE
release: v4.6.41

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.40
+VERSION=4.6.41
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.40"
+var version = "4.6.41"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.41 — Black-box benchmark now measures precision (negative controls).

Bumps main.version and Makefile VERSION to 4.6.41. CHANGELOG entry landed with the feature (#562).

Adds Challenge.Negative + 4 negative-control challenges (safe-search, safe-redirect, safe-sqli, safe-fetch) so the benchmark measures false-positive rate, not just recall; the scorecard reports a Precision line. Operator-only bench tooling; shipped binary unchanged.