### PR TITLE
feat(bench): a negative control for every black-box class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v4.6.42](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.42) — Complete precision coverage: a negative control for every black-box class (2026-09-02)
+
+### Added
+- **Every black-box class now has a matched positive + negative control, so precision is measured uniformly, not just for four classes.** v4.6.41 introduced negative controls for XSS, open redirect, SQLi, and SSRF; this adds the remaining four so a false positive is caught on any class: `safe-lfi` (rejects `..`/path separators — no path traversal), `safe-cmdi` (refuses shell metacharacters in `host` — no command injection), `safe-ssti` (renders `name` as literal HTML-escaped text, never evaluating it — a `{{7*7}}` probe stays literal), and `safe-idor` (enforces object ownership — every `/api/orders/<id>` returns 403 with no record). The benchmark now runs 21 challenges (13 positive + 8 negative), one negative control per black-box class, so a change's effect on the false-positive rate is visible across the whole class set. Operator-only benchmark tooling; the shipped binary is unchanged (releases build only `./cmd/xalgorix`).
+
 ## [v4.6.41](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.41) — Black-box benchmark now measures precision (negative controls) (2026-09-02)
 
 ### Added

--- a/internal/bench/bench_test.go
+++ b/internal/bench/bench_test.go
@@ -154,9 +154,11 @@ func TestRunWithFakeScanFunc(t *testing.T) {
 		t.Fatalf("expected 0 false positives (fake reports nothing on negatives), got %d\n%s", card.FalsePositives(), card.String())
 	}
 	byClass := card.ByClass()
-	// xss = reflected-xss (positive, solved) + safe-search (negative, clean) = 2/2.
-	if byClass["xss"] != [2]int{2, 2} || byClass["idor"] != [2]int{1, 1} {
-		t.Fatalf("expected xss 2/2 and idor 1/1, got %v", byClass)
+	// Each class now pairs its positive challenge(s) with a negative control.
+	// xss = reflected-xss (solved) + safe-search (clean) = 2/2. idor = idor
+	// (solved) + safe-idor (clean) = 2/2.
+	if byClass["xss"] != [2]int{2, 2} || byClass["idor"] != [2]int{2, 2} {
+		t.Fatalf("expected xss 2/2 and idor 2/2, got %v", byClass)
 	}
 	// open_redirect and ssrf each have a positive (unsolved by this fake) plus a
 	// negative control (correctly clean) => 1/2.
@@ -165,20 +167,22 @@ func TestRunWithFakeScanFunc(t *testing.T) {
 			t.Fatalf("expected %s 1/2, got %v", c, byClass[c])
 		}
 	}
-	// rce = cmdi + whitebox-cmdi + whitebox-node-rce (0/3). sqli = error-sqli +
-	// whitebox-sqli (positives, unsolved) + safe-sqli (negative, clean) => 1/3.
-	// ssti and lfi each have two positives, unsolved by this fake.
-	if byClass["rce"] != [2]int{0, 3} {
-		t.Fatalf("expected rce 0/3, got %v", byClass["rce"])
+	// rce = cmdi + whitebox-cmdi + whitebox-node-rce (positives) + safe-cmdi
+	// (clean) => 1/4. sqli = error-sqli + whitebox-sqli (positives) + safe-sqli
+	// (clean) => 1/3. ssti = ssti + whitebox-ssti + safe-ssti => 1/3. lfi = lfi
+	// + whitebox-lfi + safe-lfi => 1/3. The one "solved" in each is the clean
+	// negative control (this fake finds none of these positives).
+	if byClass["rce"] != [2]int{1, 4} {
+		t.Fatalf("expected rce 1/4, got %v", byClass["rce"])
 	}
 	if byClass["sqli"] != [2]int{1, 3} {
 		t.Fatalf("expected sqli 1/3, got %v", byClass["sqli"])
 	}
-	if byClass["ssti"] != [2]int{0, 2} {
-		t.Fatalf("expected ssti 0/2, got %v", byClass["ssti"])
+	if byClass["ssti"] != [2]int{1, 3} {
+		t.Fatalf("expected ssti 1/3, got %v", byClass["ssti"])
 	}
-	if byClass["lfi"] != [2]int{0, 2} {
-		t.Fatalf("expected lfi 0/2, got %v", byClass["lfi"])
+	if byClass["lfi"] != [2]int{1, 3} {
+		t.Fatalf("expected lfi 1/3, got %v", byClass["lfi"])
 	}
 }
 
@@ -455,9 +459,10 @@ func TestBlackboxChallengesDiscoverable(t *testing.T) {
 			if !strings.Contains(body, c.Endpoint) {
 				t.Errorf("index must link endpoint %q so a crawler finds it; got %q", c.Endpoint, body)
 			}
-			// idor's object id is a path segment, not a query parameter, so it is
-			// exempt from the parameter-name check.
-			if c.Name != "idor" && c.Param != "" && !strings.Contains(body, c.Param) {
+			// The IDOR challenges' object id is a path segment (/api/orders/1042),
+			// not a query parameter, so they are exempt from the param-name check
+			// (the index still links the object, exposing the surface).
+			if c.Name != "idor" && c.Name != "safe-idor" && c.Param != "" && !strings.Contains(body, c.Param) {
 				t.Errorf("index must expose parameter %q (form/link); got %q", c.Param, body)
 			}
 		})
@@ -548,5 +553,33 @@ func TestNegativeControlsAreSafe(t *testing.T) {
 	defer sf.Close()
 	if body := httpGet(t, sf.URL+"/fetch?url=http://169.254.169.254/latest/meta-data/"); strings.Contains(body, "security-credentials") {
 		t.Fatalf("safe-fetch must block internal metadata, got %q", body)
+	}
+
+	// safe-lfi: a traversal payload is rejected (no passwd content).
+	sl := challengeByName(t, "safe-lfi").Start()
+	defer sl.Close()
+	if body := httpGet(t, sl.URL+"/download?file=../../../../etc/passwd"); strings.Contains(body, "root:") {
+		t.Fatalf("safe-lfi must reject traversal, got %q", body)
+	}
+
+	// safe-cmdi: a shell metacharacter is rejected (no command output).
+	sc := challengeByName(t, "safe-cmdi").Start()
+	defer sc.Close()
+	if body := httpGet(t, sc.URL+"/ping?host=127.0.0.1%3Bid"); strings.Contains(body, "uid=0") {
+		t.Fatalf("safe-cmdi must reject shell metacharacters, got %q", body)
+	}
+
+	// safe-ssti: a template expression is echoed literally, never evaluated.
+	st := challengeByName(t, "safe-ssti").Start()
+	defer st.Close()
+	if body := httpGet(t, st.URL+"/greet?name=%7B%7B7*7%7D%7D"); strings.Contains(body, "49") {
+		t.Fatalf("safe-ssti must not evaluate the template, got %q", body)
+	}
+
+	// safe-idor: any order object is forbidden (no card/owner record leaked).
+	si := challengeByName(t, "safe-idor").Start()
+	defer si.Close()
+	if body := httpGet(t, si.URL+"/api/orders/1042"); strings.Contains(body, "card_last4") || strings.Contains(body, `"owner"`) {
+		t.Fatalf("safe-idor must not return an order record, got %q", body)
 	}
 }

--- a/internal/bench/challenge.go
+++ b/internal/bench/challenge.go
@@ -561,6 +561,88 @@ func Builtin() []Challenge {
 				_, _ = fmt.Fprintf(w, "fetched external url: %s\n", raw)
 			}),
 		},
+		{
+			// NEGATIVE CONTROL (lfi): rejects path traversal; only plain
+			// filenames are served, so /etc/passwd is never reachable.
+			Name: "safe-lfi", Class: "lfi", Endpoint: "/download", Param: "file", Negative: true,
+			Desc: "NEGATIVE CONTROL: rejects '..' and path separators (no path traversal).",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/" {
+					w.Header().Set("Content-Type", "text/html; charset=utf-8")
+					_, _ = fmt.Fprint(w, `<html><body><h1>Documents</h1><ul><li><a href="/download?file=report.pdf">report.pdf</a></li><li><a href="/download?file=invoice.txt">invoice.txt</a></li></ul></body></html>`)
+					return
+				}
+				file := r.URL.Query().Get("file")
+				w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+				// SAFE: reject traversal and any path separators; only a plain
+				// filename from the fixed documents directory is served.
+				if strings.ContainsAny(file, "/\\") || strings.Contains(file, "..") {
+					w.WriteHeader(http.StatusBadRequest)
+					_, _ = fmt.Fprint(w, "invalid file name")
+					return
+				}
+				_, _ = fmt.Fprintf(w, "contents of document %q\n", file)
+			}),
+		},
+		{
+			// NEGATIVE CONTROL (rce): validates the host and refuses shell
+			// metacharacters, so no injected command ever runs.
+			Name: "safe-cmdi", Class: "rce", Endpoint: "/ping", Param: "host", Negative: true,
+			Desc: "NEGATIVE CONTROL: rejects shell metacharacters in host (no command injection).",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/" {
+					w.Header().Set("Content-Type", "text/html; charset=utf-8")
+					_, _ = fmt.Fprint(w, `<html><body><h1>Network Tools</h1><form action="/ping" method="get"><input name="host" placeholder="host"><button>Ping</button></form><p><a href="/ping?host=example.com">ping example.com</a></p></body></html>`)
+					return
+				}
+				host := r.URL.Query().Get("host")
+				w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+				// SAFE: refuse shell metacharacters — the value is never handed to
+				// a shell, so nothing executes.
+				if hasShellMeta(host) {
+					w.WriteHeader(http.StatusBadRequest)
+					_, _ = fmt.Fprint(w, "invalid host")
+					return
+				}
+				_, _ = fmt.Fprintf(w, "PING %s: 56 data bytes\n64 bytes: icmp_seq=0 ttl=64 time=0.050 ms\n", host)
+			}),
+		},
+		{
+			// NEGATIVE CONTROL (ssti): the name is inserted as literal (HTML-
+			// escaped) text, never evaluated, so {{7*7}} stays {{7*7}} (never 49).
+			Name: "safe-ssti", Class: "ssti", Endpoint: "/greet", Param: "name", Negative: true,
+			Desc: "NEGATIVE CONTROL: name is rendered as literal text, not evaluated (no template injection).",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				if r.URL.Path == "/" {
+					_, _ = fmt.Fprint(w, `<html><body><h1>Greeter</h1><form action="/greet" method="get"><input name="name" placeholder="your name"><button>Greet</button></form><p><a href="/greet?name=friend">say hi</a></p></body></html>`)
+					return
+				}
+				name := r.URL.Query().Get("name")
+				// SAFE: literal, HTML-escaped text — the template engine never
+				// evaluates it, so a {{7*7}} probe is echoed as-is.
+				_, _ = fmt.Fprintf(w, "<html><body>Hello, %s!</body></html>", html.EscapeString(name))
+			}),
+		},
+		{
+			// NEGATIVE CONTROL (idor): ownership is enforced, so every order
+			// object is forbidden without the owner's session — no cross-object read.
+			Name: "safe-idor", Class: "idor", Endpoint: "/api/orders", Param: "id", Negative: true,
+			Desc: "NEGATIVE CONTROL: object access is authorized; other users' orders return 403 (no IDOR).",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				const prefix = "/api/orders/"
+				if !strings.HasPrefix(r.URL.Path, prefix) {
+					w.Header().Set("Content-Type", "text/html; charset=utf-8")
+					_, _ = fmt.Fprint(w, `<html><body><h1>Orders</h1><a href="/api/orders/1042">view order 1042</a></body></html>`)
+					return
+				}
+				// SAFE: the caller has no session establishing ownership of this
+				// object, so access is refused — no record (no card/owner data) is
+				// ever returned.
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = fmt.Fprint(w, "forbidden: not your order")
+			}),
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary
Completes precision coverage. v4.6.41 added negative controls for XSS, open redirect, SQLi, and SSRF; this adds the remaining four so a false positive is caught on any black-box class:

- `safe-lfi` — rejects `..`/path separators (no path traversal)
- `safe-cmdi` — refuses shell metacharacters in `host` (no command injection)
- `safe-ssti` — renders `name` as literal HTML-escaped text; a `{{7*7}}` probe stays literal (never `49`)
- `safe-idor` — enforces object ownership; every `/api/orders/<id>` returns 403 with no record

The benchmark now runs 21 challenges (13 positive + 8 negative), one negative control per black-box class, so a change's effect on the false-positive rate is visible across the whole class set.

## Notes
- Operator-only benchmark tooling; the shipped binary is unchanged.

## Tests
- `TestNegativeControlsAreSafe` extended: safe-lfi rejects traversal, safe-cmdi refuses shell metacharacters, safe-ssti echoes `{{7*7}}` literally, safe-idor returns 403 with no record.
- `TestRunWithFakeScanFunc` counts updated (idor 2/2, rce 1/4, ssti 1/3, lfi 1/3; SolvedCount = 2 + NegativeCount).
- `TestBlackboxChallengesDiscoverable` exempts safe-idor (path-segment id) like idor.
- gofmt clean; `go build ./...` OK; `go vet` OK; `go test -race ./internal/bench/` passes; golangci-lint 0 issues.