### PR TITLE
release: v4.6.42

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.41
+VERSION=4.6.42
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.41"
+var version = "4.6.42"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.42 — Complete precision coverage: a negative control for every black-box class.

Bumps main.version and Makefile VERSION to 4.6.42. CHANGELOG entry landed with the feature (#564).

Adds safe-lfi, safe-cmdi, safe-ssti, safe-idor so every black-box class has a matched positive+negative pair (21 challenges: 13 positive + 8 negative). Operator-only bench tooling; shipped binary unchanged.