### PR TITLE
feat(llm): native Z.AI (Zhipu GLM) provider support (#511)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v4.6.43](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.43) — Native Z.AI (Zhipu GLM) provider support (2026-09-03)
+
+### Added
+- **Native support for Z.AI (Zhipu GLM), including the GLM Coding Plan (#511).** Two catalog entries ship: `Z.AI (standard API)` (base `https://api.z.ai/api/paas/v4`) and `Z.AI Coding Plan` (base `https://api.z.ai/api/coding/paas/v4`), both offered in first-run setup and the Settings → LLM provider list and keyed by API key. `glm-*` model ids now route to Z.AI automatically, and a GLM id is accepted in either case — a `GLM-5.3` selection is sent as the canonical `glm-5.3` — so a newly released model id is not rejected as Z.AI's catalog evolves.
+
+### Fixed
+- **Z.AI chat requests no longer hit a malformed `/v4/v1/chat/completions` URL (which Z.AI rejects with `401 token expired or incorrect`).** The OpenAI-compatible URL builder now treats an explicit API-version segment already present in a provider's base (Z.AI's `/v4`, OpenAI's `/v1`, …) as authoritative and only inserts `/v1` when the base carries no version at all. The fix is applied uniformly across every endpoint builder — the legacy single-call resolver, the composite resolver, the multi-provider router, and model discovery — so `https://api.z.ai/api/coding/paas/v4` resolves to `…/v4/chat/completions`. Existing providers are unaffected (MiniMax and OpenAI still resolve to `…/v1/chat/completions`).
+
 ## [v4.6.42](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.42) — Complete precision coverage: a negative control for every black-box class (2026-09-02)
 
 ### Added

--- a/cmd/xalgorix/setup.go
+++ b/cmd/xalgorix/setup.go
@@ -25,6 +25,8 @@ var setupProviders = []setupProvider{
 	{id: "anthropic", name: "Anthropic (Claude)", defaultModel: "claude-fable-5", needsAPIKey: true},
 	{id: "google", name: "Google Gemini", defaultModel: "gemini-3.5-flash", needsAPIKey: true},
 	{id: "minimax", name: "MiniMax", defaultModel: "MiniMax-M3", needsAPIKey: true},
+	{id: "zai", name: "Z.AI (standard API)", defaultModel: "glm-5.3", needsAPIKey: true},
+	{id: "zai-coding-plan", name: "Z.AI Coding Plan", defaultModel: "glm-5.3", needsAPIKey: true},
 	{id: "ollama", name: "Ollama (local, no API key)", defaultModel: "llama3.3"},
 	{id: "custom", name: "Custom OpenAI-compatible endpoint", needsAPIKey: true},
 }

--- a/internal/llm/build_endpoint_test.go
+++ b/internal/llm/build_endpoint_test.go
@@ -153,3 +153,37 @@ func TestBuildCatalogEndpoint_CustomProviderFallbackBase(t *testing.T) {
 		t.Errorf("error type = %T, want *ConfigError", err)
 	}
 }
+
+func TestBuildCatalogEndpoint_ZAICodingPlanPreservesV4(t *testing.T) {
+	entry, ok := providers.LookupBuiltin("zai-coding-plan")
+	if !ok {
+		t.Fatal("Z.AI Coding Plan provider is missing")
+	}
+	prof := auth.Profile{
+		Provider:  "zai-coding-plan",
+		ProfileID: "default",
+		Type:      auth.APIKey,
+		APIKey:    "zai-key",
+	}
+	ep, err := BuildCatalogEndpoint(entry, prof, "GLM-5.3", "")
+	if err != nil {
+		t.Fatalf("BuildCatalogEndpoint: %v", err)
+	}
+	if ep.URL != "https://api.z.ai/api/coding/paas/v4/chat/completions" {
+		t.Fatalf("URL = %q, want Z.AI /v4/chat/completions without injected /v1", ep.URL)
+	}
+	if ep.Model != "glm-5.3" || ep.APIKey != "zai-key" || ep.HeaderStyle != "openai" {
+		t.Fatalf("endpoint = %+v", ep)
+	}
+}
+
+func TestNormalizeEndpointModelRecognizesLegacyCustomZAIConfig(t *testing.T) {
+	got := normalizeEndpointModel(
+		"custom",
+		"https://api.z.ai/api/coding/paas/v4/chat/completions",
+		"Glm-5.3-Flash",
+	)
+	if got != "glm-5.3-flash" {
+		t.Fatalf("normalized model = %q, want glm-5.3-flash", got)
+	}
+}

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -20,6 +20,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/xalgord/xalgorix/v4/internal/config"
+	"github.com/xalgord/xalgorix/v4/internal/providers"
 	"github.com/xalgord/xalgorix/v4/internal/resources"
 	"github.com/xalgord/xalgorix/v4/internal/safe"
 )
@@ -308,9 +309,19 @@ type anthropicResponse struct {
 // Validates: Requirements 2.2, 2.3, 11.2.
 func (c *Client) resolveRequestEndpoint(ctx context.Context) (Endpoint, error) {
 	if c.resolver != nil {
-		return c.resolver.Resolve(ctx)
+		ep, err := c.resolver.Resolve(ctx)
+		if err != nil {
+			return Endpoint{}, err
+		}
+		ep.Model = normalizeEndpointModel(c.cfg.LLMProvider, ep.URL, ep.Model)
+		return ep, nil
 	}
 	url, model := c.resolveEndpoint()
+	providerID := strings.TrimSpace(c.cfg.LLMProvider)
+	if providerID == "" {
+		providerID = c.provider
+	}
+	model = normalizeEndpointModel(providerID, url, model)
 	hs := "openai"
 	switch {
 	case c.usesGeminiAPI(url):
@@ -418,7 +429,8 @@ func applyAuthHeaders(req *http.Request, ep Endpoint) {
 
 // resolveEndpoint returns the full chat completions URL and clean model name.
 // Handles provider prefixes like "minimax/", "openai/", "anthropic/", etc.
-// Auto-appends /v1/chat/completions if the base doesn't already contain /v1.
+// Appends the OpenAI-compatible chat path while preserving an explicit API
+// version already present in the base (for example Z.AI's /v4).
 // Also supports custom providers - just set XALGORIX_API_BASE to your endpoint.
 //
 // This is the legacy single-call resolver kept on the Client so
@@ -438,12 +450,14 @@ func (c *Client) resolveEndpoint() (string, string) {
 	// Provider prefix in model name is the source of truth for API base.
 	// However, if a non-empty API base was explicitly set (e.g., from web UI), use it.
 	providerBases := map[string]string{
-		"openai":    "https://api.openai.com/v1",
-		"anthropic": "https://api.anthropic.com",
-		"minimax":   "https://api.minimax.io/v1",
-		"deepseek":  "https://api.deepseek.com/v1",
-		"groq":      "https://api.groq.com/openai/v1",
-		"ollama":    "http://localhost:11434/v1",
+		"openai":          "https://api.openai.com/v1",
+		"anthropic":       "https://api.anthropic.com",
+		"minimax":         "https://api.minimax.io/v1",
+		"deepseek":        "https://api.deepseek.com/v1",
+		"groq":            "https://api.groq.com/openai/v1",
+		"ollama":          "http://localhost:11434/v1",
+		"zai":             "https://api.z.ai/api/paas/v4",
+		"zai-coding-plan": "https://api.z.ai/api/coding/paas/v4",
 		// Google's chat endpoint is /v1beta/models/MODEL:generateContent — we
 		// store the bare host here and append the version segment below.
 		"google": "https://generativelanguage.googleapis.com",
@@ -479,12 +493,7 @@ func (c *Client) resolveEndpoint() (string, string) {
 		url = strings.TrimSuffix(url, "/v1")
 		url += "/v1beta/models/" + model + ":generateContent"
 	} else {
-		if !strings.HasSuffix(strings.ToLower(url), "/chat/completions") {
-			if !strings.HasSuffix(apiBase, "/v1") && !strings.Contains(apiBase, "/v1/") {
-				url += "/v1"
-			}
-			url += "/chat/completions"
-		}
+		url = providers.OpenAICompatibleURL(apiBase, "chat/completions")
 	}
 
 	return url, model

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -358,6 +358,12 @@ func TestResolveEndpoint_ProviderDefaultsAndCustomBases(t *testing.T) {
 			wantModel: "deepseek-v4-pro",
 		},
 		{
+			name:      "zai coding plan default",
+			cfg:       config.Config{LLM: "zai-coding-plan/Glm-5.3", APIKey: "k"},
+			wantURL:   "https://api.z.ai/api/coding/paas/v4/chat/completions",
+			wantModel: "Glm-5.3",
+		},
+		{
 			name:      "gemini default",
 			cfg:       config.Config{LLM: "google/gemini-3.1-pro-preview", APIKey: "k"},
 			wantURL:   "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:generateContent",
@@ -380,6 +386,12 @@ func TestResolveEndpoint_ProviderDefaultsAndCustomBases(t *testing.T) {
 			cfg:       config.Config{LLM: "custom/my-model", APIBase: "https://llm.example/v1/chat/completions", APIKey: "k"},
 			wantURL:   "https://llm.example/v1/chat/completions",
 			wantModel: "my-model",
+		},
+		{
+			name:      "custom versioned v4 base",
+			cfg:       config.Config{LLM: "custom/Glm-5.3", APIBase: "https://api.z.ai/api/coding/paas/v4", APIKey: "k"},
+			wantURL:   "https://api.z.ai/api/coding/paas/v4/chat/completions",
+			wantModel: "Glm-5.3",
 		},
 	}
 

--- a/internal/llm/legacy.go
+++ b/internal/llm/legacy.go
@@ -15,7 +15,7 @@ func LegacyProviderShape(xalgorixLLM string) bool {
 	}
 	switch s {
 	case "openai", "anthropic", "minimax", "deepseek",
-		"groq", "ollama", "google", "gemini":
+		"groq", "ollama", "google", "gemini", "zai", "zai-coding-plan":
 		return true
 	}
 	return false

--- a/internal/llm/models.go
+++ b/internal/llm/models.go
@@ -54,6 +54,7 @@ var canonicalProviders = map[string]bool{
 	"minimax":   true,
 	"nvidia":    true,
 	"cohere":    true,
+	"zai":       true,
 }
 
 // initModelIndex builds the exact-match index and pattern rules
@@ -139,6 +140,8 @@ func initModelIndex() {
 		{"kimi-", "moonshot"},
 		// MiniMax
 		{"minimax-", "minimax"},
+		// Z.AI / Zhipu GLM
+		{"glm-", "zai"},
 		// NVIDIA-hosted model ids
 		{"nvidia/", "nvidia"},
 		{"meta/llama-", "nvidia"},

--- a/internal/llm/models_test.go
+++ b/internal/llm/models_test.go
@@ -17,6 +17,8 @@ func TestResolveProvider_ExplicitPrefix(t *testing.T) {
 		{"deepseek/deepseek-chat", "deepseek", "deepseek-chat", true},
 		{"groq/llama-3.3-70b-versatile", "groq", "llama-3.3-70b-versatile", true},
 		{"xai/grok-3", "xai", "grok-3", true},
+		{"zai/glm-5.3", "zai", "glm-5.3", true},
+		{"zai-coding-plan/glm-5.3", "zai-coding-plan", "glm-5.3", true},
 	}
 
 	for _, tt := range tests {
@@ -88,6 +90,7 @@ func TestResolveProvider_PatternMatch(t *testing.T) {
 		{"open-mistral-nemo", "mistral", true},
 		// Qwen patterns
 		{"qwen-max-1201", "qwen", true},
+		{"glm-5.3", "zai", true},
 		// Unknown model → no match
 		{"my-custom-model", "", false},
 		{"", "", false},

--- a/internal/llm/provider_model.go
+++ b/internal/llm/provider_model.go
@@ -1,0 +1,53 @@
+package llm
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/xalgord/xalgorix/v4/internal/providers"
+)
+
+// normalizeProviderModel applies provider-specific normalization without
+// freezing a remote provider's model catalog into the binary. Z.AI publishes
+// lowercase GLM model IDs, while its product pages often render them as
+// uppercase names. Accept either form and send the canonical lowercase ID.
+func normalizeProviderModel(entry providers.Entry, model string) string {
+	model = strings.TrimSpace(model)
+	if entry.ID != "zai" && entry.ID != "zai-coding-plan" {
+		return model
+	}
+	if strings.HasPrefix(strings.ToLower(model), "glm-") {
+		return strings.ToLower(model)
+	}
+	return model
+}
+
+// normalizeEndpointModel also recognizes an explicitly configured Z.AI URL.
+// This matters for existing installations that selected "Custom Provider"
+// before native Z.AI support existed: their provider ID remains "custom", but
+// the /api/(coding/)paas/v4 URL still identifies the target unambiguously.
+func normalizeEndpointModel(providerID, endpointURL, model string) string {
+	if inferred := zaiProviderFromURL(endpointURL); inferred != "" {
+		providerID = inferred
+	}
+	entry, ok := providers.LookupBuiltin(providerID)
+	if !ok {
+		return strings.TrimSpace(model)
+	}
+	return normalizeProviderModel(entry, model)
+}
+
+func zaiProviderFromURL(rawURL string) string {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || !strings.EqualFold(u.Hostname(), "api.z.ai") {
+		return ""
+	}
+	path := strings.ToLower(u.Path)
+	if strings.Contains(path, "/api/coding/paas/v4") {
+		return "zai-coding-plan"
+	}
+	if strings.Contains(path, "/api/paas/v4") {
+		return "zai"
+	}
+	return ""
+}

--- a/internal/llm/resolver.go
+++ b/internal/llm/resolver.go
@@ -55,14 +55,16 @@ func (e *ConfigError) Error() string { return e.Msg }
 // the v4.4.21 client.resolveEndpoint so the legacy resolver
 // produces byte-identical URL results to the pre-feature path.
 var legacyProviderBases = map[string]string{
-	"openai":    "https://api.openai.com/v1",
-	"anthropic": "https://api.anthropic.com",
-	"minimax":   "https://api.minimax.io/v1",
-	"deepseek":  "https://api.deepseek.com/v1",
-	"groq":      "https://api.groq.com/openai/v1",
-	"ollama":    "http://localhost:11434/v1",
-	"google":    "https://generativelanguage.googleapis.com",
-	"gemini":    "https://generativelanguage.googleapis.com",
+	"openai":          "https://api.openai.com/v1",
+	"anthropic":       "https://api.anthropic.com",
+	"minimax":         "https://api.minimax.io/v1",
+	"deepseek":        "https://api.deepseek.com/v1",
+	"groq":            "https://api.groq.com/openai/v1",
+	"ollama":          "http://localhost:11434/v1",
+	"google":          "https://generativelanguage.googleapis.com",
+	"gemini":          "https://generativelanguage.googleapis.com",
+	"zai":             "https://api.z.ai/api/paas/v4",
+	"zai-coding-plan": "https://api.z.ai/api/coding/paas/v4",
 }
 
 // LegacyProviderBaseURL returns the canonical legacy API base URL
@@ -293,7 +295,6 @@ func (l *legacyResolver) Resolve(ctx context.Context) (Endpoint, error) {
 		provider = strings.ToLower(model[:idx])
 		model = model[idx+1:]
 	}
-
 	if apiBase == "" {
 		if knownBase, ok := legacyProviderBases[provider]; ok {
 			apiBase = knownBase
@@ -316,13 +317,9 @@ func (l *legacyResolver) Resolve(ctx context.Context) (Endpoint, error) {
 		url = strings.TrimSuffix(url, "/v1")
 		url += "/v1beta/models/" + model + ":generateContent"
 	default:
-		if !strings.HasSuffix(strings.ToLower(url), "/chat/completions") {
-			if !strings.HasSuffix(apiBase, "/v1") && !strings.Contains(apiBase, "/v1/") {
-				url += "/v1"
-			}
-			url += "/chat/completions"
-		}
+		url = providers.OpenAICompatibleURL(apiBase, "chat/completions")
 	}
+	model = normalizeEndpointModel(provider, url, model)
 
 	return Endpoint{
 		URL:         url,
@@ -337,7 +334,7 @@ func (l *legacyResolver) Resolve(ctx context.Context) (Endpoint, error) {
 // three values the LLM client switch dispatches on.
 func legacyHeaderStyle(provider, apiBase string) string {
 	switch provider {
-	case "openai", "minimax", "deepseek", "groq", "ollama":
+	case "openai", "minimax", "deepseek", "groq", "ollama", "zai", "zai-coding-plan":
 		return "openai"
 	case "anthropic":
 		return "anthropic"
@@ -410,7 +407,6 @@ func BuildCatalogEndpoint(entry providers.Entry, prof auth.Profile, preferModel,
 	if model == "" && len(entry.Models) > 0 {
 		model = entry.Models[0]
 	}
-
 	apiBase := entry.BaseURL
 	if prof.Type == auth.APIKey && prof.APIBaseOverride != "" {
 		apiBase = prof.APIBaseOverride
@@ -437,12 +433,7 @@ func BuildCatalogEndpoint(entry providers.Entry, prof auth.Profile, preferModel,
 		url = strings.TrimSuffix(url, "/v1")
 		url += "/v1beta/models/" + model + ":generateContent"
 	case "openai":
-		if !strings.HasSuffix(strings.ToLower(url), "/chat/completions") {
-			if !strings.HasSuffix(apiBase, "/v1") && !strings.Contains(apiBase, "/v1/") {
-				url += "/v1"
-			}
-			url += "/chat/completions"
-		}
+		url = providers.OpenAICompatibleURL(apiBase, "chat/completions")
 	case "openai_responses":
 		// OpenAI Responses API (Codex / ChatGPT subscription backend).
 		// The base URL already encodes the backend root (e.g.
@@ -456,6 +447,7 @@ func BuildCatalogEndpoint(entry providers.Entry, prof auth.Profile, preferModel,
 			Msg: "catalog resolver: unsupported headerStyle " + entry.HeaderStyle + " for entry " + entry.ID,
 		}
 	}
+	model = normalizeEndpointModel(entry.ID, url, model)
 
 	// Fail fast when the assembled URL is not absolute (missing
 	// scheme or host). This is the deterministic config bug behind

--- a/internal/llm/router.go
+++ b/internal/llm/router.go
@@ -70,6 +70,7 @@ func (r *Router) TestRoute(model string) (RouteResult, error) {
 	if !entryOK {
 		return RouteResult{}, fmt.Errorf("provider %q not found in catalog", providerID)
 	}
+	bareModel = normalizeProviderModel(entry, bareModel)
 
 	hasKey := r.keys.HasKey(providerID)
 
@@ -116,6 +117,7 @@ func (r *Router) Route(ctx context.Context, model string) (Endpoint, error) {
 			Msg: fmt.Sprintf("router: provider %q not in catalog", providerID),
 		}
 	}
+	bareModel = normalizeProviderModel(entry, bareModel)
 
 	// Step 3: Get API key
 	pk, hasKey := r.keys.Get(providerID)
@@ -150,20 +152,10 @@ func (r *Router) Route(ctx context.Context, model string) (Endpoint, error) {
 		url = strings.TrimSuffix(url, "/v1")
 		url += "/v1beta/models/" + bareModel + ":generateContent"
 	case "openai":
-		if !strings.HasSuffix(strings.ToLower(url), "/chat/completions") {
-			if !strings.HasSuffix(apiBase, "/v1") && !strings.Contains(apiBase, "/v1/") {
-				url += "/v1"
-			}
-			url += "/chat/completions"
-		}
+		url = providers.OpenAICompatibleURL(apiBase, "chat/completions")
 	default:
 		// Fallback to OpenAI-compatible format
-		if !strings.HasSuffix(strings.ToLower(url), "/chat/completions") {
-			if !strings.HasSuffix(apiBase, "/v1") && !strings.Contains(apiBase, "/v1/") {
-				url += "/v1"
-			}
-			url += "/chat/completions"
-		}
+		url = providers.OpenAICompatibleURL(apiBase, "chat/completions")
 	}
 
 	return Endpoint{

--- a/internal/llm/router_test.go
+++ b/internal/llm/router_test.go
@@ -180,6 +180,33 @@ func TestRouter_Route(t *testing.T) {
 	}
 }
 
+func TestRouter_Route_ZAICodingPlanPreservesV4(t *testing.T) {
+	dir := t.TempDir()
+	ks, err := NewKeyStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	if err := ks.Set(ctx, ProviderKey{
+		ProviderID: "zai-coding-plan",
+		APIKey:     "zai-key",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	router := NewRouter(providers.NewService(), ks)
+	ep, err := router.Route(ctx, "zai-coding-plan/Glm-5.3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ep.URL != "https://api.z.ai/api/coding/paas/v4/chat/completions" {
+		t.Fatalf("URL = %q, want Z.AI /v4/chat/completions", ep.URL)
+	}
+	if ep.Model != "glm-5.3" || ep.APIKey != "zai-key" {
+		t.Fatalf("endpoint = %+v", ep)
+	}
+}
+
 func TestRouter_Route_NoKey(t *testing.T) {
 	dir := t.TempDir()
 	ks, err := NewKeyStore(dir)

--- a/internal/providers/builtin.go
+++ b/internal/providers/builtin.go
@@ -4,7 +4,7 @@
 // operator-editable catalog file, no openclaw importer, and no
 // startup catalog write.
 //
-// The 45 entries are sorted alphabetically by ID and end with the
+// The entries are sorted alphabetically by ID and end with the
 // "custom" sentinel so the LLM tab dropdown ordering matches the
 // data ordering one-to-one ("custom" is alphabetically last by
 // design — it represents user-supplied endpoints rather than a
@@ -20,7 +20,7 @@
 //   - OAuth-capable entries have Flow set; for the four flows we
 //     wired fully (anthropic, google, copilot, xai) the endpoint
 //     fields are populated from public docs. Other OAuth-capable
-//     entries (codex, opencode, openai, opencode, qwen, zai,
+//     entries (codex, opencode, openai, opencode, qwen,
 //     huggingface) keep the OAuth fields empty and document the
 //     beta status via Notes — the existing PKCE / device-code
 //     drivers surface "endpoint not configured" errors to the
@@ -397,12 +397,19 @@ var builtinList = []Entry{
 	},
 	{
 		ID:          "zai",
-		DisplayName: "Z.AI",
-		BaseURL:     "",
+		DisplayName: "Z.AI (standard API)",
+		BaseURL:     "https://api.z.ai/api/paas/v4",
 		HeaderStyle: "openai",
-		AuthMethods: []string{"api_key", "oauth"},
-		Flow:        "pkce",
-		Notes:       "OAuth flow is beta — Z.AI OAuth client metadata is not publicly stable yet; API key path is fully tested.",
+		AuthMethods: []string{"api_key"},
+		Notes:       "Standard usage-based Z.AI API. For a GLM Coding Plan subscription, select Z.AI Coding Plan instead. Recommended model: glm-5.3.",
+	},
+	{
+		ID:          "zai-coding-plan",
+		DisplayName: "Z.AI Coding Plan",
+		BaseURL:     "https://api.z.ai/api/coding/paas/v4",
+		HeaderStyle: "openai",
+		AuthMethods: []string{"api_key"},
+		Notes:       "GLM Coding Plan subscription endpoint. Use the API key from the subscribed Z.AI account. Current models include glm-5.3 and glm-5.3-flash; usage remains subject to Z.AI's supported-tool policy.",
 	},
 	// Custom is the explicit "operator-supplied endpoint" entry.
 	// Always last in the LLM tab dropdown.

--- a/internal/providers/openai_url.go
+++ b/internal/providers/openai_url.go
@@ -1,0 +1,50 @@
+package providers
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+var apiVersionSegmentPattern = regexp.MustCompile(`(?i)^v[0-9]+(?:[a-z][a-z0-9._-]*)?$`)
+
+// OpenAICompatibleURL appends an OpenAI-compatible resource path to apiBase.
+//
+// Most providers publish a host/root and expect Xalgorix to insert /v1, while
+// others already include their API version in the base path. Z.AI is one such
+// provider: its Coding Plan base ends in /v4 and chat requests must go to
+// /v4/chat/completions, not /v4/v1/chat/completions. Treat any explicit
+// version path segment (v1, v1beta, v4, ...) as authoritative and only insert
+// /v1 when the base contains no version at all.
+func OpenAICompatibleURL(apiBase, resource string) string {
+	base := strings.TrimRight(strings.TrimSpace(apiBase), "/")
+	resource = strings.Trim(strings.TrimSpace(resource), "/")
+	if resource == "" {
+		return base
+	}
+
+	u, err := url.Parse(base)
+	if err != nil {
+		return strings.TrimRight(base, "/") + "/" + resource
+	}
+
+	path := strings.TrimRight(u.Path, "/")
+	wantedSuffix := "/" + resource
+	if strings.HasSuffix(strings.ToLower(path), strings.ToLower(wantedSuffix)) {
+		return u.String()
+	}
+	if !hasAPIVersionSegment(path) {
+		path += "/v1"
+	}
+	u.Path = strings.TrimRight(path, "/") + wantedSuffix
+	return u.String()
+}
+
+func hasAPIVersionSegment(path string) bool {
+	for _, segment := range strings.Split(strings.Trim(path, "/"), "/") {
+		if apiVersionSegmentPattern.MatchString(segment) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/providers/openai_url_test.go
+++ b/internal/providers/openai_url_test.go
@@ -1,0 +1,57 @@
+package providers
+
+import "testing"
+
+func TestOpenAICompatibleURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     string
+		resource string
+		want     string
+	}{
+		{
+			name:     "unversioned base receives v1",
+			base:     "https://llm.example/api",
+			resource: "chat/completions",
+			want:     "https://llm.example/api/v1/chat/completions",
+		},
+		{
+			name:     "openai v1 base is preserved",
+			base:     "https://api.openai.com/v1",
+			resource: "chat/completions",
+			want:     "https://api.openai.com/v1/chat/completions",
+		},
+		{
+			name:     "zai coding v4 base is preserved",
+			base:     "https://api.z.ai/api/coding/paas/v4",
+			resource: "chat/completions",
+			want:     "https://api.z.ai/api/coding/paas/v4/chat/completions",
+		},
+		{
+			name:     "zai models use v4 directly",
+			base:     "https://api.z.ai/api/coding/paas/v4/",
+			resource: "models",
+			want:     "https://api.z.ai/api/coding/paas/v4/models",
+		},
+		{
+			name:     "existing resource is not duplicated",
+			base:     "https://api.z.ai/api/paas/v4/chat/completions",
+			resource: "chat/completions",
+			want:     "https://api.z.ai/api/paas/v4/chat/completions",
+		},
+		{
+			name:     "version segment before provider path is respected",
+			base:     "https://llm.example/v2/openai",
+			resource: "chat/completions",
+			want:     "https://llm.example/v2/openai/chat/completions",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := OpenAICompatibleURL(tt.base, tt.resource); got != tt.want {
+				t.Fatalf("OpenAICompatibleURL(%q, %q) = %q, want %q", tt.base, tt.resource, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/providers/service_test.go
+++ b/internal/providers/service_test.go
@@ -122,6 +122,33 @@ func TestBuiltin_NovitaConfiguration(t *testing.T) {
 	}
 }
 
+func TestBuiltin_ZAIConfigurations(t *testing.T) {
+	tests := []struct {
+		id      string
+		baseURL string
+	}{
+		{"zai", "https://api.z.ai/api/paas/v4"},
+		{"zai-coding-plan", "https://api.z.ai/api/coding/paas/v4"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.id, func(t *testing.T) {
+			entry, ok := LookupBuiltin(tt.id)
+			if !ok {
+				t.Fatalf("%s provider is missing from the built-in catalog", tt.id)
+			}
+			if entry.BaseURL != tt.baseURL {
+				t.Errorf("BaseURL = %q, want %q", entry.BaseURL, tt.baseURL)
+			}
+			if entry.HeaderStyle != "openai" {
+				t.Errorf("HeaderStyle = %q, want openai", entry.HeaderStyle)
+			}
+			if len(entry.AuthMethods) != 1 || entry.AuthMethods[0] != "api_key" {
+				t.Errorf("AuthMethods = %v, want [api_key]", entry.AuthMethods)
+			}
+		})
+	}
+}
+
 // TestService_GetUnknown asserts an unknown id returns
 // (zero, false, nil) without an error so callers can branch
 // cleanly.

--- a/internal/web/handlers_provider_models.go
+++ b/internal/web/handlers_provider_models.go
@@ -182,6 +182,9 @@ func providerModelsURLs(entry providers.Entry) ([]string, error) {
 	for _, suffix := range []string{"/chat/completions", "/responses", "/messages", "/models"} {
 		base = strings.TrimSuffix(base, suffix)
 	}
+	if entry.HeaderStyle == "openai" {
+		base = providers.OpenAICompatibleURL(base, "models")
+	}
 	u, err := url.Parse(base)
 	if err != nil || u.Scheme == "" || u.Host == "" {
 		return nil, fmt.Errorf("provider has no valid model discovery URL")
@@ -189,13 +192,12 @@ func providerModelsURLs(entry providers.Entry) ([]string, error) {
 	if entry.HeaderStyle == "anthropic" && !strings.HasSuffix(u.Path, "/v1") {
 		u.Path = strings.TrimRight(u.Path, "/") + "/v1"
 	}
-	if entry.HeaderStyle == "openai" && !strings.HasSuffix(u.Path, "/v1") && !strings.Contains(u.Path, "/v1/") {
-		u.Path = strings.TrimRight(u.Path, "/") + "/v1"
-	}
 	if entry.HeaderStyle == "gemini" && !strings.HasSuffix(u.Path, "/v1beta") && !strings.Contains(u.Path, "/v1beta/") {
 		u.Path = strings.TrimRight(u.Path, "/") + "/v1beta"
 	}
-	u.Path = strings.TrimRight(u.Path, "/") + "/models"
+	if entry.HeaderStyle != "openai" {
+		u.Path = strings.TrimRight(u.Path, "/") + "/models"
+	}
 	if entry.HeaderStyle == "openai_responses" {
 		query := u.Query()
 		query.Set("client_version", codexModelsClientVersion)

--- a/internal/web/handlers_provider_models_test.go
+++ b/internal/web/handlers_provider_models_test.go
@@ -103,6 +103,19 @@ func TestProviderModelsURLsUsesCodexCatalogProtocol(t *testing.T) {
 	}
 }
 
+func TestProviderModelsURLsPreservesZAIV4(t *testing.T) {
+	urls, err := providerModelsURLs(providers.Entry{
+		ID: "zai-coding-plan", BaseURL: "https://api.z.ai/api/coding/paas/v4", HeaderStyle: "openai",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"https://api.z.ai/api/coding/paas/v4/models"}
+	if !reflect.DeepEqual(urls, want) {
+		t.Fatalf("URLs = %v, want %v", urls, want)
+	}
+}
+
 func TestModelDiscoveryConfigMatchesActiveProviderByLLMProvider(t *testing.T) {
 	// Providers routed via XALGORIX_LLM_PROVIDER (for example DeepSeek) persist a
 	// bare, provider-native model name with no "<provider>/" prefix on XALGORIX_LLM

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -3703,6 +3703,10 @@ func llmProviderLabel(model, apiBase string) string {
 		return "Groq"
 	case "ollama":
 		return "Ollama"
+	case "zai":
+		return "Z.AI"
+	case "zai-coding-plan":
+		return "Z.AI Coding Plan"
 	case "":
 		return "Not configured"
 	default:
@@ -3741,6 +3745,10 @@ func llmProviderKey(model, apiBase string) string {
 		return "openai"
 	case strings.Contains(apiBase, "ollama") || strings.Contains(apiBase, "localhost:11434"):
 		return "ollama"
+	case strings.Contains(apiBase, "api.z.ai/api/coding/"):
+		return "zai-coding-plan"
+	case strings.Contains(apiBase, "api.z.ai"):
+		return "zai"
 	case model != "":
 		return model
 	default:


### PR DESCRIPTION
## Summary

Adds native **Z.AI (Zhipu GLM)** support and fixes the concrete failure reported in #511, where Z.AI chat requests were sent to a malformed `.../v4/v1/chat/completions` URL and rejected with `401 token expired or incorrect`.

## What changed

**Native provider (Added)**
- Two catalog entries: `Z.AI (standard API)` (`https://api.z.ai/api/paas/v4`) and `Z.AI Coding Plan` (`https://api.z.ai/api/coding/paas/v4`).
- Both offered in first-run setup and the Settings → LLM provider list; API-key auth.
- `glm-*` model ids route to Z.AI automatically; GLM ids are accepted in any case and sent as the canonical lowercase id (`GLM-5.3` → `glm-5.3`), so a newly released id is not rejected as Z.AI's catalog evolves.

**URL builder (Fixed)**
- New `providers.OpenAICompatibleURL(base, resource)` treats an explicit API-version path segment already present in the base (`/v4`, `/v1`, …) as authoritative and only inserts `/v1` when the base has no version at all.
- Applied uniformly across **every** endpoint builder: the legacy single-call resolver, the composite resolver, the multi-provider router, and model discovery.
- `https://api.z.ai/api/coding/paas/v4` now resolves to `…/v4/chat/completions`.

## Compatibility

Existing providers are unaffected — MiniMax and OpenAI still resolve to `…/v1/chat/completions` (covered by tests). Legacy installs that selected "Custom" with an `api.z.ai` URL also get GLM case canonicalization via URL inference.

## Tests

Unit tests added for the URL builder, both catalog entries, provider/model resolution (`glm-` pattern + explicit prefixes), model discovery (`…/v4/models`), and GLM case canonicalization.

Closes #511
