### PR TITLE
feat(bench): add XXE challenge (positive + negative control)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v4.6.44](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.44) — Benchmark now covers XXE (positive + negative) (2026-09-03)
+
+### Added
+- **The black-box benchmark now exercises XXE detection — a class the finding classifier already recognized but no challenge tested.** Adds an `xxe` positive challenge: a `/import` endpoint that accepts a POSTed XML document and, when the document declares an external entity pointing at a local file (a `DOCTYPE` with a `SYSTEM` `file://` identifier), resolves it and reflects the file content in the import result (a simulated `/etc/passwd` read). A matching `safe-import` negative control exposes the same endpoint but with external-entity resolution disabled, so a `DOCTYPE` is ignored and no file content is ever returned — reporting XXE there is a false positive. Both advertise the XML import endpoint from a crawlable `/` index. The benchmark now covers XXE alongside the existing classes (23 challenges: 14 positive + 9 negative). Operator-only benchmark tooling; the shipped binary is unchanged (releases build only `./cmd/xalgorix`).
+
 ## [v4.6.43](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.43) — Native Z.AI (Zhipu GLM) provider support (2026-09-03)
 
 ### Added

--- a/internal/bench/bench_test.go
+++ b/internal/bench/bench_test.go
@@ -184,6 +184,10 @@ func TestRunWithFakeScanFunc(t *testing.T) {
 	if byClass["lfi"] != [2]int{1, 3} {
 		t.Fatalf("expected lfi 1/3, got %v", byClass["lfi"])
 	}
+	// xxe = xxe (positive, unsolved by this fake) + safe-import (negative, clean) => 1/2.
+	if byClass["xxe"] != [2]int{1, 2} {
+		t.Fatalf("expected xxe 1/2, got %v", byClass["xxe"])
+	}
 }
 
 func TestNewBuiltinChallengesExhibitVuln(t *testing.T) {
@@ -581,5 +585,44 @@ func TestNegativeControlsAreSafe(t *testing.T) {
 	defer si.Close()
 	if body := httpGet(t, si.URL+"/api/orders/1042"); strings.Contains(body, "card_last4") || strings.Contains(body, `"owner"`) {
 		t.Fatalf("safe-idor must not return an order record, got %q", body)
+	}
+
+	// safe-import: an XXE payload does not resolve any external entity (no file content).
+	simp := challengeByName(t, "safe-import").Start()
+	defer simp.Close()
+	xxePayload := `<?xml version="1.0"?><!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]><foo>&xxe;</foo>`
+	if body := httpPost(t, simp.URL+"/import", xxePayload); strings.Contains(body, "root:") {
+		t.Fatalf("safe-import must not resolve external entities, got %q", body)
+	}
+}
+
+// httpPost sends an XML body to url and returns the response body as a string.
+func httpPost(t *testing.T, url, body string) string {
+	t.Helper()
+	resp, err := http.Post(url, "application/xml", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	return string(b)
+}
+
+func TestXxeChallengeExhibitsVuln(t *testing.T) {
+	xxe := challengeByName(t, "xxe").Start()
+	defer xxe.Close()
+
+	// An external-entity payload resolves the referenced local file.
+	payload := `<?xml version="1.0"?><!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]><foo>&xxe;</foo>`
+	if body := httpPost(t, xxe.URL+"/import", payload); !strings.Contains(body, "root:") {
+		t.Fatalf("xxe did not resolve the external entity: %q", body)
+	}
+	// A benign XML document does not leak file content.
+	if body := httpPost(t, xxe.URL+"/import", `<?xml version="1.0"?><records><r>ok</r></records>`); strings.Contains(body, "root:") {
+		t.Fatalf("benign XML must not leak file content: %q", body)
+	}
+	// The index advertises the import endpoint so a crawler discovers it.
+	if body := httpGet(t, xxe.URL+"/"); !strings.Contains(body, "/import") {
+		t.Fatalf("index must link the import endpoint, got %q", body)
 	}
 }

--- a/internal/bench/challenge.go
+++ b/internal/bench/challenge.go
@@ -13,6 +13,7 @@ package bench
 import (
 	"fmt"
 	"html"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -643,7 +644,59 @@ func Builtin() []Challenge {
 				_, _ = fmt.Fprint(w, "forbidden: not your order")
 			}),
 		},
+		{
+			// XXE: POST an XML document to /import. A DOCTYPE that declares an
+			// external entity pointing at a local file is resolved, and the file
+			// content comes back in the response (simulated /etc/passwd read).
+			Name: "xxe", Class: "xxe", Endpoint: "/import", Param: "",
+			Desc: "Resolves external XML entities in a posted document (XXE file read).",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/" {
+					w.Header().Set("Content-Type", "text/html; charset=utf-8")
+					_, _ = fmt.Fprint(w, `<html><body><h1>Data Import</h1><p>POST an XML document to <a href="/import">/import</a> to import records.</p><form action="/import" method="post"><textarea name="xml"></textarea><button>Import</button></form></body></html>`)
+					return
+				}
+				body, _ := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+				w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+				if hasXXEPayload(string(body)) {
+					// Simulated external-entity resolution: the referenced local
+					// file is read and echoed back in the import result.
+					_, _ = fmt.Fprint(w, "imported 1 record: root:x:0:0:root:/root:/bin/bash\ndaemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin\n")
+					return
+				}
+				_, _ = fmt.Fprint(w, "imported 0 records\n")
+			}),
+		},
+		{
+			// NEGATIVE CONTROL (xxe): the XML parser has external-entity
+			// resolution disabled, so a DOCTYPE/SYSTEM entity is never expanded
+			// and no file content is ever returned.
+			Name: "safe-import", Class: "xxe", Endpoint: "/import", Param: "", Negative: true,
+			Desc: "NEGATIVE CONTROL: external entities disabled; DOCTYPE ignored (no XXE).",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/" {
+					w.Header().Set("Content-Type", "text/html; charset=utf-8")
+					_, _ = fmt.Fprint(w, `<html><body><h1>Data Import</h1><p>POST an XML document to <a href="/import">/import</a> to import records.</p><form action="/import" method="post"><textarea name="xml"></textarea><button>Import</button></form></body></html>`)
+					return
+				}
+				_, _ = io.Copy(io.Discard, io.LimitReader(r.Body, 1<<20))
+				w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+				// SAFE: external entities are disabled — a DOCTYPE is ignored and
+				// never expanded, so no local file is ever read.
+				_, _ = fmt.Fprint(w, "imported 0 records\n")
+			}),
+		},
 	}
+}
+
+// hasXXEPayload reports whether an XML document declares an external entity that
+// pulls in a local file — the classic XXE payload: a DOCTYPE with a SYSTEM
+// identifier referencing a file: URL (or /etc/passwd directly). A benign
+// document declares no such external entity.
+func hasXXEPayload(body string) bool {
+	b := strings.ToLower(body)
+	return strings.Contains(b, "<!doctype") && strings.Contains(b, "system") &&
+		(strings.Contains(b, "file:") || strings.Contains(b, "/etc/passwd"))
 }
 
 // looksLikePasswdTraversal reports whether a file parameter uses ../ traversal to


### PR DESCRIPTION
## Summary

Broadens black-box benchmark class coverage to **XXE** — a class the finding classifier already recognizes (CWE-611 / "xml external entity") but no challenge exercised.

## What changed

- **`xxe` positive challenge**: a `/import` endpoint that accepts a POSTed XML document. When the document declares an external entity pointing at a local file (a `DOCTYPE` with a `SYSTEM` `file://` identifier), it resolves the entity and reflects the file content in the import result (a simulated `/etc/passwd` read).
- **`safe-import` negative control**: the same endpoint with external-entity resolution disabled, so a `DOCTYPE` is ignored and no file content is ever returned — reporting XXE there is a false positive.
- Both advertise the XML import endpoint from a crawlable `/` index (discoverability).

The benchmark now covers **23 challenges (14 positive + 9 negative)**.

## Tests

`TestXxeChallengeExhibitsVuln` (payload -> `root:` leak; benign XML -> no leak; index links `/import`), extended `TestNegativeControlsAreSafe` (safe-import never leaks), and updated `TestRunWithFakeScanFunc` (xxe 1/2 under the nil fake).

Operator-only benchmark tooling; the shipped binary is unchanged (releases build only `./cmd/xalgorix`).