### PR TITLE
release: v4.6.44

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.43
+VERSION=4.6.44
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.43"
+var version = "4.6.44"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.44 — black-box benchmark now covers XXE (positive + negative control).

Bumps version to 4.6.44 in cmd/xalgorix/main.go and Makefile. Feature already merged via #568; this is the version-bump release PR. Tag v4.6.44 pushed.