### PR TITLE
feat(bench): add CSRF challenge (positive + negative control)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v4.6.45](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.45) — Benchmark now covers CSRF (positive + negative) (2026-09-03)
+
+### Added
+- **The black-box benchmark now exercises CSRF detection, completing coverage of every class the finding classifier recognizes.** Adds a `csrf` positive challenge: a state-changing `POST /account/email` (change the account email) whose form carries no anti-CSRF token and whose handler requires none, so a request forged from any origin changes state. A matching `safe-account` negative control serves the same form with a per-session anti-CSRF token and refuses any POST whose token is missing or wrong (403), so reporting CSRF there is a false positive. Both advertise the change-email endpoint from a crawlable `/` index. The benchmark now runs 25 challenges (15 positive + 10 negative), and every classifier-supported class (xss, sqli, open_redirect, idor, ssrf, rce, lfi, ssti, xxe, csrf) has at least one challenge. Operator-only benchmark tooling; the shipped binary is unchanged (releases build only `./cmd/xalgorix`).
+
 ## [v4.6.44](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.44) — Benchmark now covers XXE (positive + negative) (2026-09-03)
 
 ### Added

--- a/internal/bench/bench_test.go
+++ b/internal/bench/bench_test.go
@@ -188,6 +188,10 @@ func TestRunWithFakeScanFunc(t *testing.T) {
 	if byClass["xxe"] != [2]int{1, 2} {
 		t.Fatalf("expected xxe 1/2, got %v", byClass["xxe"])
 	}
+	// csrf = csrf (positive, unsolved by this fake) + safe-account (negative, clean) => 1/2.
+	if byClass["csrf"] != [2]int{1, 2} {
+		t.Fatalf("expected csrf 1/2, got %v", byClass["csrf"])
+	}
 }
 
 func TestNewBuiltinChallengesExhibitVuln(t *testing.T) {
@@ -594,6 +598,17 @@ func TestNegativeControlsAreSafe(t *testing.T) {
 	if body := httpPost(t, simp.URL+"/import", xxePayload); strings.Contains(body, "root:") {
 		t.Fatalf("safe-import must not resolve external entities, got %q", body)
 	}
+
+	// safe-account: the change-email form embeds an anti-CSRF token and a
+	// tokenless POST is refused (no state change).
+	sa := challengeByName(t, "safe-account").Start()
+	defer sa.Close()
+	if body := httpGet(t, sa.URL+"/"); !strings.Contains(body, "csrf_token") {
+		t.Fatalf("safe-account form must embed an anti-CSRF token, got %q", body)
+	}
+	if status, body := httpPostForm(t, sa.URL+"/account/email", "email=attacker@evil.example"); status != http.StatusForbidden || strings.Contains(body, "updated") {
+		t.Fatalf("safe-account must refuse a tokenless POST, got status=%d body=%q", status, body)
+	}
 }
 
 // httpPost sends an XML body to url and returns the response body as a string.
@@ -624,5 +639,36 @@ func TestXxeChallengeExhibitsVuln(t *testing.T) {
 	// The index advertises the import endpoint so a crawler discovers it.
 	if body := httpGet(t, xxe.URL+"/"); !strings.Contains(body, "/import") {
 		t.Fatalf("index must link the import endpoint, got %q", body)
+	}
+}
+
+// httpPostForm submits form-encoded data and returns the status code and body.
+func httpPostForm(t *testing.T, url, data string) (int, string) {
+	t.Helper()
+	resp, err := http.Post(url, "application/x-www-form-urlencoded", strings.NewReader(data))
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(b)
+}
+
+func TestCsrfChallengeExhibitsVuln(t *testing.T) {
+	csrf := challengeByName(t, "csrf").Start()
+	defer csrf.Close()
+
+	// The change-email form is discoverable and carries NO anti-CSRF token.
+	body := httpGet(t, csrf.URL+"/")
+	if !strings.Contains(body, "/account/email") {
+		t.Fatalf("index must expose the change-email endpoint, got %q", body)
+	}
+	if strings.Contains(strings.ToLower(body), "csrf") {
+		t.Fatalf("vulnerable change-email form must carry no anti-CSRF token, got %q", body)
+	}
+	// The state change is accepted with no token (cross-site forgeable).
+	status, resp := httpPostForm(t, csrf.URL+"/account/email", "email=attacker@evil.example")
+	if status != http.StatusOK || !strings.Contains(resp, "updated") {
+		t.Fatalf("csrf endpoint must accept a tokenless state change, got status=%d body=%q", status, resp)
 	}
 }

--- a/internal/bench/challenge.go
+++ b/internal/bench/challenge.go
@@ -686,6 +686,53 @@ func Builtin() []Challenge {
 				_, _ = fmt.Fprint(w, "imported 0 records\n")
 			}),
 		},
+		{
+			// CSRF: a state-changing POST (change the account email) protected by
+			// nothing — the form carries no anti-CSRF token and the handler
+			// requires none, so a form auto-submitted from any origin silently
+			// changes the victim's email. Discoverable via the "/" index form.
+			Name: "csrf", Class: "csrf", Endpoint: "/account/email", Param: "",
+			Desc: "State-changing POST /account/email accepts requests with no anti-CSRF token (CSRF).",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodPost {
+					_ = r.ParseForm()
+					// VULNERABLE: the email change is applied with no anti-CSRF
+					// token and no Origin/Referer check — any site can submit it.
+					w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+					_, _ = fmt.Fprint(w, "account email updated\n")
+					return
+				}
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				// The change-email form carries NO anti-CSRF token field.
+				_, _ = fmt.Fprint(w, `<html><body><h1>Account settings</h1><p>Change the email on your account.</p><form action="/account/email" method="post"><input name="email" type="email"><button>Save</button></form></body></html>`)
+			}),
+		},
+		{
+			// NEGATIVE CONTROL (csrf): the change-email form embeds a per-session
+			// anti-CSRF token and the handler rejects any POST whose token is
+			// missing or wrong, so a forged cross-site submission cannot change
+			// state.
+			Name: "safe-account", Class: "csrf", Endpoint: "/account/email", Param: "", Negative: true,
+			Desc: "NEGATIVE CONTROL: change-email POST requires a valid anti-CSRF token (no CSRF).",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				const csrfToken = "sess-csrf-7f3a9c2e"
+				if r.Method == http.MethodPost {
+					_ = r.ParseForm()
+					// SAFE: a missing or incorrect anti-CSRF token is refused, so
+					// a cross-site request cannot change the account email.
+					if r.PostFormValue("csrf_token") != csrfToken {
+						w.WriteHeader(http.StatusForbidden)
+						_, _ = fmt.Fprint(w, "invalid csrf token\n")
+						return
+					}
+					w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+					_, _ = fmt.Fprint(w, "account email updated\n")
+					return
+				}
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				_, _ = fmt.Fprintf(w, `<html><body><h1>Account settings</h1><p>Change the email on your account.</p><form action="/account/email" method="post"><input type="hidden" name="csrf_token" value="%s"><input name="email" type="email"><button>Save</button></form></body></html>`, csrfToken)
+			}),
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary

Completes black-box benchmark class coverage: **CSRF** is the last class the finding classifier already recognizes (CWE-352 / "cross-site request forgery") that had no challenge exercising it.

## What changed

- **`csrf` positive challenge**: a state-changing `POST /account/email` (change the account email) whose form carries **no** anti-CSRF token and whose handler requires none, so a request forged from any origin changes state.
- **`safe-account` negative control**: the same change-email form with a per-session anti-CSRF token; any POST whose token is missing or wrong is refused with **403**, so reporting CSRF there is a false positive.
- Both advertise the change-email endpoint from a crawlable `/` index (discoverability).

The benchmark now runs **25 challenges (15 positive + 10 negative)**, and every classifier-supported class (xss, sqli, open_redirect, idor, ssrf, rce, lfi, ssti, xxe, csrf) has at least one challenge.

## Tests

`TestCsrfChallengeExhibitsVuln` (form has no token; tokenless POST -> 200 "updated"), extended `TestNegativeControlsAreSafe` (safe-account form embeds a token; tokenless POST -> 403, no state change), and updated `TestRunWithFakeScanFunc` (csrf 1/2 under the nil fake).

Operator-only benchmark tooling; the shipped binary is unchanged (releases build only `./cmd/xalgorix`).