### PR TITLE
fix(scanner): use system Chrome + stop dropping browser-confirmed XSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v4.6.46](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.46) — Browser-backed XSS detection: use system Chrome, stop dropping confirmed XSS (2026-09-03)
+
+### Fixed
+- **The scanner now uses a system-installed Google Chrome (`/usr/bin/chrome`, `/opt/google/chrome/chrome`) instead of falling through to rod's bundled/downloaded Chromium.** On hosts whose only browser is Google Chrome, rod's `LookPath` and the previous well-known-path list both missed it, so the browser silently fell back to a ~170MB Chromium auto-download (which then fails offline) — breaking `verify_xss` and every browser-backed check. Those install locations are now probed explicitly before the auto-download fallback.
+- **A genuinely browser-confirmed reflected XSS is no longer dropped by the reflection-only false-positive gate.** `verify_xss` records concrete browser-execution proof (a dialog/console/DOM signal carrying the injected nonce) in the scan ledger, but the model does not always paste that verdict into `exploitation_proof`, so the finding was gated as "reflection only." The report path now folds the ledger's authoritative `verify_xss` confirmation into the proof before the gate runs, so a confirmed XSS is judged on the real evidence. Verified end-to-end against the benchmark: the reflected-XSS challenge now detects, confirms, reports, and is independently `verified`.
+
 ## [v4.6.45](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.45) — Benchmark now covers CSRF (positive + negative) (2026-09-03)
 
 ### Added

--- a/internal/tools/browser/browser.go
+++ b/internal/tools/browser/browser.go
@@ -269,6 +269,25 @@ func detectCaidoPort() int {
 //go:embed extension/*
 var extensionFS embed.FS
 
+// wellKnownBrowserPaths lists absolute paths to probe when neither
+// XALGORIX_BROWSER_PATH nor rod's launcher.LookPath locate a browser. It exists
+// because rod's LookPath name list misses some real installs — most notably
+// Google Chrome at /opt/google/chrome/chrome (commonly symlinked as
+// /usr/bin/chrome). Without these entries a host whose only browser is Google
+// Chrome falls through to rod's ~170MB Chromium auto-download (which then often
+// fails offline), so verify_xss and every browser-backed check silently break.
+func wellKnownBrowserPaths() []string {
+	return []string{
+		"/usr/bin/chromium",
+		"/usr/bin/chromium-browser",
+		"/usr/bin/google-chrome-stable",
+		"/usr/bin/google-chrome",
+		"/usr/bin/chrome",           // Google Chrome (common symlink)
+		"/opt/google/chrome/chrome", // Google Chrome default install location
+		"/snap/bin/chromium",
+	}
+}
+
 // getChromiumPath returns the path to a Chromium binary.
 // Priority: 1) XALGORIX_BROWSER_PATH env  2) System-installed browser  3) Rod auto-download (~170MB first run)
 func getChromiumPath(ctxID string) (string, error) {
@@ -290,14 +309,7 @@ func getChromiumPath(ctxID string) (string, error) {
 	}
 
 	// 3. Well-known browser paths (fallback for systems where LookPath misses)
-	knownPaths := []string{
-		"/usr/bin/chromium",
-		"/usr/bin/chromium-browser",
-		"/usr/bin/google-chrome-stable",
-		"/usr/bin/google-chrome",
-		"/snap/bin/chromium",
-	}
-	for _, p := range knownPaths {
+	for _, p := range wellKnownBrowserPaths() {
 		if _, err := os.Stat(p); err == nil {
 			log.Printf("[browser] Using browser found at well-known path: %s", p)
 			return p, nil

--- a/internal/tools/browser/prelaunch_test.go
+++ b/internal/tools/browser/prelaunch_test.go
@@ -49,3 +49,23 @@ func TestPreLaunch_AllCommands(t *testing.T) {
 		})
 	}
 }
+
+// TestWellKnownBrowserPathsIncludeGoogleChrome guards the fix for hosts whose
+// only browser is Google Chrome at /opt/google/chrome/chrome (often symlinked
+// as /usr/bin/chrome): those paths must be probed so getChromiumPath uses the
+// installed browser instead of falling through to rod's ~170MB auto-download.
+func TestWellKnownBrowserPathsIncludeGoogleChrome(t *testing.T) {
+	paths := wellKnownBrowserPaths()
+	for _, want := range []string{"/usr/bin/chrome", "/opt/google/chrome/chrome"} {
+		found := false
+		for _, p := range paths {
+			if p == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("wellKnownBrowserPaths() must include %q so Google Chrome installs are used; got %v", want, paths)
+		}
+	}
+}

--- a/internal/tools/reporting/reporting.go
+++ b/internal/tools/reporting/reporting.go
@@ -363,6 +363,22 @@ func reportVulnWithContextIDAndVerifier(contextID string, verifier FindingVerifi
 	// real output into the wrong field). Generic prose must never masquerade as
 	// proof: doing so silently defeats Gate 2 and yields "evidence" that merely
 	// restates the description, so notifications/reports carry no real proof.
+	// ── Bridge: fold browser-confirmed XSS proof from the ledger into the proof ──
+	// verify_xss records concrete browser-execution proof (a dialog/console/DOM
+	// signal carrying the injected nonce) in the shared ledger, but models do not
+	// reliably paste that verdict into exploitation_proof — so a genuinely
+	// browser-confirmed XSS gets dropped by the reflection-only gate below. When
+	// the ledger holds a verify_xss confirmation for this scan, fold it into the
+	// proof so the finding is judged on the real evidence, not on what the model
+	// happened to paste.
+	if reportLooksLikeXSS(title, args["description"], args["cwe_id"]) {
+		if bp := ledgerBrowserXSSProof(contextID); bp != "" &&
+			!strings.Contains(strings.ToLower(proof), "browser-confirmed xss") {
+			proof = strings.TrimSpace(proof + "\n" + bp)
+			args["exploitation_proof"] = proof
+		}
+	}
+
 	if proof == "" {
 		for _, cand := range []string{args["description"], args["technical_analysis"], args["poc_description"]} {
 			if c := strings.TrimSpace(cand); len(c) >= 20 && HasConcreteImpact(c) {
@@ -1015,6 +1031,46 @@ func checkFabricatedFinding(title, endpoint, description, proof, severity string
 		} {
 			if strings.Contains(blob, m) {
 				return fmt.Sprintf("❌ REJECTED: '%s' reports the target as UNREACHABLE (matched %q) — that is an availability/scope issue, not a %s vulnerability. Note it with add_note and finish gracefully; only report an actionable finding backed by a concrete exploitation outcome against a reachable endpoint.", title, m, strings.ToUpper(severity))
+			}
+		}
+	}
+	return ""
+}
+
+// reportLooksLikeXSS reports whether a finding is an XSS claim, by title/
+// description keyword or CWE-79.
+func reportLooksLikeXSS(title, description, cwe string) bool {
+	lower := strings.ToLower(title + " " + description)
+	if strings.Contains(lower, "xss") ||
+		strings.Contains(lower, "cross-site script") ||
+		strings.Contains(lower, "cross site script") {
+		return true
+	}
+	return strings.Contains(strings.ToLower(cwe), "79")
+}
+
+// ledgerBrowserXSSProof returns the browser verifier's confirmation summary for
+// a browser-confirmed XSS recorded in this scan's ledger, or "" when none is
+// present. verify_xss (internal/tools/browser) records concrete execution proof
+// — a dialog/console/DOM signal carrying the injected nonce — as an "exploit"
+// evidence on a verify_xss-origin xss hypothesis. That ledger record, not
+// whatever the model pasted into exploitation_proof, is the authoritative proof
+// that the payload actually RAN, so callers fold it into the reported proof to
+// stop the reflection-only false-positive gate from dropping a genuinely
+// confirmed XSS.
+func ledgerBrowserXSSProof(contextID string) string {
+	sc := scanctx.Get(contextID)
+	if sc == nil || sc.Ledger == nil {
+		return ""
+	}
+	for _, h := range sc.Ledger.All() {
+		if !strings.EqualFold(h.VulnClass, "xss") || !strings.EqualFold(h.Origin, "verify_xss") {
+			continue
+		}
+		for _, ev := range h.Evidence {
+			if strings.EqualFold(ev.Kind, "exploit") &&
+				strings.Contains(strings.ToLower(ev.Summary), "browser-confirmed xss") {
+				return ev.Summary
 			}
 		}
 	}

--- a/internal/tools/reporting/reporting_test.go
+++ b/internal/tools/reporting/reporting_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
 	"github.com/xalgord/xalgorix/v4/internal/tools"
 )
 
@@ -2095,5 +2096,58 @@ func TestLooksLikeSQLError(t *testing.T) {
 		if LooksLikeSQLError(s) {
 			t.Errorf("LooksLikeSQLError should NOT match benign text %q", s)
 		}
+	}
+}
+
+// TestLedgerBrowserXSSProof verifies the bridge that rescues a genuinely
+// browser-confirmed XSS from the reflection-only false-positive gate: verify_xss
+// records the execution proof in the shared ledger, and the report flow folds
+// that authoritative proof into the finding so it is judged on real evidence
+// rather than on whatever string the model pasted.
+func TestLedgerBrowserXSSProof(t *testing.T) {
+	sc := scanctx.New("rep-xss-bridge-test", "")
+	scanctx.Activate(sc)
+	defer scanctx.Deactivate(sc.ID)
+
+	// No verify_xss confirmation yet → no bridged proof.
+	if got := ledgerBrowserXSSProof(sc.ID); got != "" {
+		t.Fatalf("expected empty proof before any verify_xss confirmation, got %q", got)
+	}
+
+	// Record a browser-confirmed XSS the way finalizeXSSVerdict does.
+	h := sc.Ledger.Upsert(scanctx.Hypothesis{
+		Title:     "Browser-confirmed XSS at /search",
+		VulnClass: "xss",
+		Endpoint:  "/search",
+		Parameter: "q",
+		Origin:    "verify_xss",
+	})
+	sc.Ledger.AddEvidence(h.ID, scanctx.Evidence{
+		Kind:    "exploit",
+		Summary: `Browser-confirmed XSS: a dialog:alert dialog carrying the nonce "XV-7a91" fired while loading http://x/search?q=<script>alert('XV-7a91')</script>.`,
+	})
+
+	got := ledgerBrowserXSSProof(sc.ID)
+	if !strings.Contains(strings.ToLower(got), "browser-confirmed xss") {
+		t.Fatalf("expected the browser-confirmed proof summary, got %q", got)
+	}
+
+	// The bridged proof must satisfy the reflection-only XSS gate even though the
+	// description still contains the raw <script> payload (the classic drop case).
+	if rej := checkFalsePositive(
+		"Reflected XSS in /search?q",
+		"payload <script>alert('XV-7a91')</script> reflected and executed",
+		"high",
+		got,
+	); rej != "" {
+		t.Fatalf("browser-confirmed XSS proof must pass the FP gate, got rejection: %s", rej)
+	}
+
+	// A different scan class in the ledger must not be mistaken for XSS proof.
+	if !reportLooksLikeXSS("Reflected XSS in q", "", "") {
+		t.Fatal("reportLooksLikeXSS should detect an XSS title")
+	}
+	if reportLooksLikeXSS("SQL injection in id", "error-based", "CWE-89") {
+		t.Fatal("reportLooksLikeXSS must not classify SQLi as XSS")
 	}
 }


### PR DESCRIPTION
## Summary

Two fixes surfaced by running the benchmark against the **real agent** (high-rate-limit MiniMax), both affecting the **shipped scanner**, not just the benchmark.

## 1. Browser resolution uses system Chrome
On a host whose only browser is Google Chrome at `/opt/google/chrome/chrome` (commonly symlinked `/usr/bin/chrome`), rod's `LookPath` and our previous well-known-path list both missed it, so the scanner fell through to rod's ~170MB Chromium auto-download (which fails offline). That silently broke `verify_xss` and every browser-backed check. `wellKnownBrowserPaths()` now probes the Google Chrome locations before the auto-download fallback.

## 2. Browser-confirmed XSS is no longer dropped
`verify_xss` records concrete browser-execution proof (a dialog/console/DOM signal carrying the injected nonce) in the scan ledger, but the model doesn't reliably paste that verdict into `exploitation_proof` — so the reflection-only false-positive gate dropped a genuinely confirmed XSS. The report path now folds the ledger's authoritative `verify_xss` confirmation into the proof before the gates (`ledgerBrowserXSSProof`), so a confirmed XSS is judged on the real evidence. (reporting already imports scanctx; no import cycle.)

## Validation
End-to-end against the benchmark, the reflected-XSS challenge went from **8m timeout / no finding** to **detected, confirmed, reported, independently `verified`** (`CWE-79`). New unit tests: `TestWellKnownBrowserPathsIncludeGoogleChrome`, `TestLedgerBrowserXSSProof`. reporting + browser unit tests pass.