### PR TITLE
release: v4.6.46

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.45
+VERSION=4.6.46
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.45"
+var version = "4.6.46"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.46 — browser-backed XSS detection: use system Chrome, stop dropping browser-confirmed XSS.

Bumps version to 4.6.46 in cmd/xalgorix/main.go and Makefile. Fixes already merged via #572; this is the version-bump release PR. Tag v4.6.46 pushed.