### PR TITLE
feat(bench): agent-event diagnostics + single-signal error-SQLi challenge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [v4.6.47](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.47) — Benchmark: agent-event diagnostics + single-signal error-SQLi challenge (2026-09-03)
+
+### Changed
+- **The operator benchmark runner (`cmd/xalgorix-bench`) now logs the agent's tool calls, verifier/report outcomes, errors, and finish reason** instead of silently discarding every agent event. A failing challenge is now diagnosable end to end — you can see whether the agent discovered the route, which verifier ran, what proof it pasted, and why the reporting gate accepted or rejected the finding.
+
+### Fixed
+- **The error-based SQLi benchmark challenge no longer reflects its `id` parameter unescaped.** That unescaped reflection was an accidental reflected-XSS red herring that pulled the scanner off the SQL injection the challenge is meant to measure (a real run spent its whole budget chasing the reflection and never confirmed the SQLi). The `id` is now HTML-escaped in both the normal and the SQL-error response paths, so the only signal is the SQL syntax error on quote injection — one unambiguous vulnerability per challenge.
+
+Operator-only benchmark tooling; the shipped binary is unchanged (releases build only `./cmd/xalgorix`).
+
 ## [v4.6.46](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.46) — Browser-backed XSS detection: use system Chrome, stop dropping confirmed XSS (2026-09-03)
 
 ### Fixed

--- a/cmd/xalgorix-bench/main.go
+++ b/cmd/xalgorix-bench/main.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/xalgord/xalgorix/v4/internal/agent"
@@ -86,12 +87,34 @@ func realScan(instruction string) bench.ScanFunc {
 			reporting.CleanupContext(sc.ID)
 		}()
 
-		// Drain agent events so the agent never blocks on emit.
+		// Drain agent events. Logging the agent's tool calls, verifier/report
+		// outcomes, errors, and finish reason to stderr is what makes a failing
+		// challenge diagnosable — without it the run is a black box (only infra
+		// logs show). Kept compact (one line per event, args/outputs truncated)
+		// and prefixed with the scan id so a multi-challenge run stays readable.
 		events := make(chan agent.Event, 512)
 		done := make(chan struct{})
 		go func() {
 			defer close(done)
-			for range events {
+			for ev := range events {
+				switch ev.Type {
+				case "tool_call":
+					fmt.Fprintf(os.Stderr, "  [ev %s] → %s %s\n", scanID, ev.ToolName, briefArgs(ev.ToolArgs))
+				case "tool_result":
+					if ev.ToolResult.Error != "" {
+						fmt.Fprintf(os.Stderr, "  [ev %s] ✗ %s: %s\n", scanID, ev.ToolName, truncate(oneLine(ev.ToolResult.Error), 240))
+					} else if isDiagResultTool(ev.ToolName) {
+						fmt.Fprintf(os.Stderr, "  [ev %s] ✓ %s: %s\n", scanID, ev.ToolName, truncate(oneLine(ev.ToolResult.Output), 240))
+					}
+				case "error":
+					fmt.Fprintf(os.Stderr, "  [ev %s] ERROR %s\n", scanID, truncate(oneLine(ev.Content), 240))
+				case "finished":
+					if ev.Aborted {
+						fmt.Fprintf(os.Stderr, "  [ev %s] FINISHED aborted=%s %s\n", scanID, ev.AbortReason, truncate(oneLine(ev.Content), 160))
+					} else {
+						fmt.Fprintf(os.Stderr, "  [ev %s] FINISHED %s\n", scanID, truncate(oneLine(ev.Content), 160))
+					}
+				}
 			}
 		}()
 
@@ -134,4 +157,55 @@ func realScan(instruction string) bench.ScanFunc {
 		}
 		return findings, nil
 	}
+}
+
+// isDiagResultTool reports whether a tool's successful result is worth logging
+// in full for diagnosis (verifiers, reporting, OOB polling, authz) — as opposed
+// to noisy recon output (curl/ffuf/nuclei) whose call args already tell the
+// story.
+func isDiagResultTool(name string) bool {
+	switch name {
+	case "verify_xss", "verify_sqli", "verify_ssti", "verify_oob",
+		"report_vulnerability", "oob_callback", "probe_hypothesis", "authz_matrix":
+		return true
+	}
+	return false
+}
+
+// briefArgs renders tool args as a compact, deterministic "k=v" list with each
+// value shortened, so a tool_call line shows what mattered (the URL, payload,
+// title, severity, …) without dumping large request bodies.
+func briefArgs(args map[string]string) string {
+	if len(args) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(args))
+	for k := range args {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		v := oneLine(args[k])
+		if v == "" {
+			continue
+		}
+		parts = append(parts, k+"="+truncate(v, 100))
+	}
+	return truncate(strings.Join(parts, " "), 300)
+}
+
+// oneLine collapses whitespace/newlines so a multi-line value stays on one log
+// line.
+func oneLine(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// truncate shortens s to at most n runes, appending an ellipsis when cut.
+func truncate(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n]) + "…"
 }

--- a/internal/bench/bench_test.go
+++ b/internal/bench/bench_test.go
@@ -62,6 +62,16 @@ func TestBuiltinChallengesExhibitVuln(t *testing.T) {
 	if body := httpGet(t, sqli.URL+"/product?id=1'"); !strings.Contains(strings.ToLower(body), "sql syntax") {
 		t.Fatalf("error-sqli did not leak a SQL error: %q", body)
 	}
+	// error-sqli must expose ONLY the SQLi signal — no reflected-XSS red herring.
+	// The id is HTML-escaped in both the normal and the SQL-error path, so a
+	// <script> payload is never reflected raw (which would distract a scanner
+	// onto XSS instead of the SQL injection this challenge tests).
+	if body := httpGet(t, sqli.URL+"/product?id=<script>alert(1)</script>"); strings.Contains(body, "<script>alert(1)</script>") {
+		t.Fatalf("error-sqli must HTML-escape id (no XSS red herring), got %q", body)
+	}
+	if body := httpGet(t, sqli.URL+"/product?id='<script>alert(1)</script>"); strings.Contains(body, "<script>alert(1)</script>") {
+		t.Fatalf("error-sqli must HTML-escape id in the SQL-error path too, got %q", body)
+	}
 }
 
 func httpGet(t *testing.T, url string) string {

--- a/internal/bench/challenge.go
+++ b/internal/bench/challenge.go
@@ -137,12 +137,17 @@ func Builtin() []Challenge {
 					return
 				}
 				id := r.URL.Query().Get("id")
+				// HTML-escape the reflected id in BOTH paths so this challenge
+				// exposes exactly one unambiguous signal — the SQL error on quote
+				// injection — and NOT an accidental reflected-XSS red herring that
+				// pulls a scanner off the SQLi it is meant to detect.
+				safeID := html.EscapeString(id)
 				if containsQuote(id) {
 					w.WriteHeader(http.StatusInternalServerError)
-					_, _ = fmt.Fprintf(w, "Database error: You have an error in your SQL syntax; check the manual near '%s' at line 1", id)
+					_, _ = fmt.Fprintf(w, "Database error: You have an error in your SQL syntax; check the manual near '%s' at line 1", safeID)
 					return
 				}
-				_, _ = fmt.Fprintf(w, "<html><body>Product #%s</body></html>", id)
+				_, _ = fmt.Fprintf(w, "<html><body>Product #%s</body></html>", safeID)
 			}),
 		},
 		{


### PR DESCRIPTION
Both surfaced while running the benchmark against the **real agent** to measure the scanner's true pass rate.

## 1. Benchmark runner now logs agent events
`cmd/xalgorix-bench` previously drained and **discarded** every agent event, so a failing challenge was a black box (only infra logs). It now logs the agent's tool calls (name + brief args), verifier/report outcomes, errors, and finish reason — one compact line per event, prefixed with the scan id. Failures are now diagnosable: did it discover the route, which verifier ran, what proof did it paste, why did the reporting gate accept/reject.

## 2. error-SQLi challenge is now single-signal
The error-based SQLi challenge reflected its `id` parameter **unescaped** (in `Product #%s` and the SQL-error text) — an accidental reflected-XSS red herring. A real agent run spent its whole budget chasing the reflection (rejected reflection-only) and never confirmed the SQLi. `id` is now HTML-escaped in both paths, so the only signal is the SQL syntax error on quote injection (one unambiguous vulnerability per challenge, per the challenge-set design rule).

Operator-only benchmark tooling; the shipped binary is unchanged (releases build only `./cmd/xalgorix`). New test coverage asserts the id is escaped in both response paths.