### PR TITLE
release: v4.6.47

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.46
+VERSION=4.6.47
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.46"
+var version = "4.6.47"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.47 — benchmark agent-event diagnostics + single-signal error-SQLi challenge.

Bumps version to 4.6.47 in cmd/xalgorix/main.go and Makefile. Changes already merged via #574; this is the version-bump release PR. Tag v4.6.47 pushed. Operator-only benchmark tooling; shipped binary unchanged.