### PR TITLE
release: v4.6.48

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.47
+VERSION=4.6.48
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.47"
+var version = "4.6.48"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.48 — steer the agent to the deterministic verifiers on first class signal.

Bumps version to 4.6.48 in cmd/xalgorix/main.go and Makefile. Change already merged via #576; this is the version-bump release PR. Tag v4.6.48 pushed. Shipped-binary improvement (core agent methodology): validated that error-based SQLi and command injection challenges now confirm via the verifiers and report verified findings.