### PR TITLE
fix(bench): SSTI challenges are single-signal (no incidental XSS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v4.6.49](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.49) — Benchmark: SSTI challenges are single-signal (no incidental XSS) (2026-09-03)
+
+### Fixed
+- **The `ssti` and `whitebox-ssti` benchmark challenges no longer expose an incidental reflected XSS.** `sstiRender` reflected the `name` parameter unescaped, so the app exhibited both template injection AND a browser-confirmable reflected XSS. Now that the agent reliably confirms XSS (v4.6.46), a real run reported the easier XSS (CWE-79) and never scored the intended `ssti` class. `sstiRender` now HTML-escapes the input before evaluating `{{ a * b }}` (braces, digits, spaces, and `*` are untouched by escaping, so the `{{7*7}} → 49` probe still confirms), so the only signal is template injection — one unambiguous vulnerability per challenge.
+
+Operator-only benchmark tooling; the shipped binary is unchanged (releases build only `./cmd/xalgorix`).
+
 ## [v4.6.48](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.48) — Reach for the deterministic verifiers on first signal (2026-09-03)
 
 ### Changed

--- a/internal/bench/bench_test.go
+++ b/internal/bench/bench_test.go
@@ -218,6 +218,12 @@ func TestNewBuiltinChallengesExhibitVuln(t *testing.T) {
 	if body := httpGet(t, ssti.URL+"/greet?name={{7*7}}"); !strings.Contains(body, "Hello, 49!") {
 		t.Fatalf("ssti did not evaluate the template expression: %q", body)
 	}
+	// ssti exposes ONLY the template-injection signal — a <script> payload is
+	// HTML-escaped, so there is no reflected-XSS red herring to pull a scanner
+	// off the SSTI onto the easier (browser-confirmable) XSS.
+	if body := httpGet(t, ssti.URL+"/greet?name=<script>alert(1)</script>"); strings.Contains(body, "<script>alert(1)</script>") {
+		t.Fatalf("ssti must HTML-escape name (no XSS red herring), got %q", body)
+	}
 
 	// lfi: path traversal to passwd returns fabricated passwd content.
 	lfi := challengeByName(t, "lfi").Start()
@@ -379,6 +385,10 @@ func TestWhiteboxSstiChallengeExhibitsVuln(t *testing.T) {
 	// A benign name is echoed literally, not evaluated.
 	if body := httpGet(t, srv.URL+"/internal/preview?name=alice"); !strings.Contains(body, "alice") || strings.Contains(body, "49") {
 		t.Fatalf("benign name must be echoed literally, not evaluated: %q", body)
+	}
+	// Exposes ONLY the SSTI signal — a <script> payload is HTML-escaped (no XSS red herring).
+	if body := httpGet(t, srv.URL+"/internal/preview?name=%3Cscript%3Ealert(1)%3C%2Fscript%3E"); strings.Contains(body, "<script>alert(1)</script>") {
+		t.Fatalf("whitebox-ssti must HTML-escape name (no XSS red herring), got %q", body)
 	}
 	// Health endpoint is benign.
 	if body := httpGet(t, srv.URL+"/healthz"); !strings.Contains(body, "ok") {

--- a/internal/bench/challenge.go
+++ b/internal/bench/challenge.go
@@ -784,9 +784,14 @@ var sstiExpr = regexp.MustCompile(`\{\{\s*(\d+)\s*\*\s*(\d+)\s*\}\}`)
 
 // sstiRender evaluates any {{ a * b }} expressions in s (returning the product),
 // simulating a template engine that evaluates attacker input — so the classic
-// {{7*7}} → 49 probe is confirmable.
+// {{7*7}} → 49 probe is confirmable. The input is HTML-escaped FIRST so the
+// challenge exposes ONLY its template-injection signal and not an accidental
+// reflected-XSS red herring (html.EscapeString leaves {, }, *, digits, and
+// spaces untouched, so a {{7*7}} payload still matches and evaluates, while any
+// injected markup like <script> is neutralized).
 func sstiRender(s string) string {
-	return sstiExpr.ReplaceAllStringFunc(s, func(m string) string {
+	escaped := html.EscapeString(s)
+	return sstiExpr.ReplaceAllStringFunc(escaped, func(m string) string {
 		parts := sstiExpr.FindStringSubmatch(m)
 		a, _ := strconv.Atoi(parts[1])
 		b, _ := strconv.Atoi(parts[2])


### PR DESCRIPTION
## Summary
Running the benchmark against the real agent showed the `ssti` challenge being reported as **reflected XSS** (CWE-79, browser-verified) instead of the intended SSTI class. `sstiRender` reflected `name` unescaped, so `/greet` exhibited both template injection and an incidental reflected XSS — and now that the agent reliably confirms XSS (v4.6.46), it reports the easier XSS and never scores `ssti`. Same flaw pattern as the error-SQLi red herring fixed in v4.6.47.

## Change
`sstiRender` HTML-escapes the input **before** evaluating `{{ a * b }}`. Escaping leaves braces, digits, spaces and `*` untouched, so the `{{7*7}} → 49` probe still confirms template injection, while injected markup like `<script>` is neutralized. Fixes both `ssti` and `whitebox-ssti` (both render via `sstiRender`).

New test coverage asserts `<script>` is escaped in both challenges while `{{7*7}}` still evaluates to 49.

Operator-only benchmark tooling; the shipped binary is unchanged (releases build only `./cmd/xalgorix`).