### PR TITLE
release: v4.6.49

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.48
+VERSION=4.6.49
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.48"
+var version = "4.6.49"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.49 — SSTI benchmark challenges are single-signal (HTML-escape the reflected name so there is no incidental XSS red herring). Change already merged via #578; version-bump release PR. Tag v4.6.49 pushed. Operator-only benchmark tooling; shipped binary unchanged.