### PR TITLE
release: v4.6.50

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.49
+VERSION=4.6.50
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.49"
+var version = "4.6.50"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.50 — verify_xxe, a deterministic XML External Entity confirmer (sibling of verify_sqli/verify_ssti). Change already merged via #580; version-bump release PR. Tag v4.6.50 pushed. Shipped-binary improvement: validated end-to-end that the xxe benchmark challenge now confirms via verify_xxe and reports an independently verified CWE-611 finding.