### PR TITLE
fix(agent): update_plan tolerates omitted task_id/status (stop wasting scan turns)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v4.6.51](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.51) — Stop wasting scan turns on malformed update_plan calls (2026-09-03)
+
+### Fixed
+- **`update_plan` no longer rejects calls that omit `task_id` or `status`** — a shape models emit often, where each rejection previously burned a whole scan iteration on a "missing required parameter" error (a single benchmark run wasted ~13 turns this way, budget that then never reached detection and reporting). Plan status is advisory bookkeeping that never gates a finding, so the tool now infers safely: an omitted `status` defaults to `active`, and an omitted `task_id` applies to the single currently-active task (or the next pending task when marking one active), asking for an explicit id only when genuinely ambiguous. The status vocabulary is also more forgiving (`in_progress`, `done`, `n/a`, …). This returns wasted turns to actual detection on every scan — including black-box, where the agent's turn budget is the main constraint.
+
 ## [v4.6.50](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.50) — verify_xxe: a deterministic XML External Entity confirmer (2026-09-03)
 
 ### Added

--- a/internal/agent/plan_tools.go
+++ b/internal/agent/plan_tools.go
@@ -65,8 +65,8 @@ func (a *Agent) registerPlanTools(reg *tools.Registry) {
 			"evidence, so you only need this for tasks it can't infer (e.g. ruling a class " +
 			"not-applicable).",
 		Parameters: []tools.Parameter{
-			{Name: "task_id", Description: "The task id from build_plan", Required: true},
-			{Name: "status", Description: "One of: active, completed, skipped", Required: true},
+			{Name: "task_id", Description: "The task id from build_plan. If omitted, the single currently-active task is updated (or, when marking one active, the next pending task).", Required: false},
+			{Name: "status", Description: "One of: active, completed, skipped (default: active).", Required: false},
 			{Name: "notes", Description: "Optional rationale / finding reference", Required: false},
 		},
 		Execute: a.updatePlanTool,
@@ -144,12 +144,28 @@ func (a *Agent) updatePlanTool(args map[string]string) (tools.Result, error) {
 	id := strings.TrimSpace(args["task_id"])
 	status := strings.ToLower(strings.TrimSpace(args["status"]))
 	notes := strings.TrimSpace(args["notes"])
-	if id == "" {
-		return tools.Result{Error: "task_id is required"}, nil
-	}
+
 	plan := a.state.Plan
 	if plan == nil || plan.IsEmpty() {
 		return tools.Result{Error: "no plan exists yet — call build_plan first"}, nil
+	}
+
+	// Tolerate the two malformed shapes models emit most — each otherwise burns a
+	// whole iteration on a "missing required parameter" rejection, and plan status
+	// is advisory bookkeeping that never gates a finding, so inferring is safe:
+	//   - status omitted  → "active" (the common intent: the task is being started).
+	//   - task_id omitted → the single currently-active task when unambiguous (the
+	//                       agent is almost always updating what it is on), else the
+	//                       next pending task when marking one active.
+	if status == "" {
+		status = "active"
+	}
+	if id == "" {
+		if inferred := inferPlanTaskID(plan, status); inferred != "" {
+			id = inferred
+		} else {
+			return tools.Result{Error: fmt.Sprintf("task_id is required — current task ids: %s", planIDList(plan))}, nil
+		}
 	}
 	t := plan.Get(id)
 	if t == nil {
@@ -157,11 +173,11 @@ func (a *Agent) updatePlanTool(args map[string]string) (tools.Result, error) {
 	}
 	var st TaskStatus
 	switch status {
-	case "active":
+	case "active", "in_progress", "in-progress", "inprogress", "started", "start", "working", "doing":
 		st = TaskActive
-	case "completed", "complete", "done":
+	case "completed", "complete", "done", "finished", "covered":
 		st = TaskCompleted
-	case "skipped", "skip", "n/a", "na", "not-applicable":
+	case "skipped", "skip", "n/a", "na", "not-applicable", "not_applicable", "notapplicable":
 		st = TaskSkipped
 	default:
 		return tools.Result{Error: "status must be one of: active, completed, skipped (got " + args["status"] + ")"}, nil
@@ -176,6 +192,35 @@ func (a *Agent) updatePlanTool(args map[string]string) (tools.Result, error) {
 	}
 	pending, active, completed, skipped := plan.Counts()
 	return tools.Result{Output: fmt.Sprintf("Task %q → %s. Plan: %d pending, %d active, %d completed, %d skipped (%d%% complete).", id, st, pending, active, completed, skipped, plan.ProgressPct())}, nil
+}
+
+// inferPlanTaskID picks the task an update_plan call with no task_id most likely
+// means: the single task currently active (the agent is updating what it is
+// working on) or — when marking something active with none active yet — the next
+// pending task. Returns "" when the choice is ambiguous, so the caller can ask
+// for an explicit id.
+func inferPlanTaskID(plan *Plan, status string) string {
+	if plan == nil {
+		return ""
+	}
+	var active []*Task
+	for _, t := range plan.Tasks {
+		if t.Status == TaskActive {
+			active = append(active, t)
+		}
+	}
+	if len(active) == 1 {
+		return active[0].ID
+	}
+	if len(active) == 0 {
+		switch status {
+		case "active", "in_progress", "in-progress", "inprogress", "started", "start", "working", "doing":
+			if next := plan.NextTasks(1); len(next) == 1 {
+				return next[0].ID
+			}
+		}
+	}
+	return ""
 }
 
 // clampPhase forces a phase into the 1-22 methodology range.

--- a/internal/agent/planner_test.go
+++ b/internal/agent/planner_test.go
@@ -352,3 +352,55 @@ func contains(list []string, s string) bool {
 	}
 	return false
 }
+
+// TestUpdatePlanToolTolerance covers the friction-reducing inference: a model
+// that omits status or task_id (the two shapes it botches most) no longer burns
+// an iteration on a "missing required parameter" rejection.
+func TestUpdatePlanToolTolerance(t *testing.T) {
+	newAgent := func() *Agent {
+		a := &Agent{state: NewScanState()}
+		a.state.Plan = AutoPlan([]string{"/x"}, nil)
+		return a
+	}
+
+	// status omitted → defaults to active.
+	a := newAgent()
+	if res, _ := a.updatePlanTool(map[string]string{"task_id": "recon"}); res.Error != "" {
+		t.Fatalf("omitted status should default to active, got error: %s", res.Error)
+	}
+	if got := a.state.Plan.Get("recon"); got == nil || got.Status != TaskActive {
+		t.Fatalf("recon should be active after status-defaulted update, got %v", got)
+	}
+
+	// task_id omitted with a single active task → applies to that task.
+	if res, _ := a.updatePlanTool(map[string]string{"status": "completed"}); res.Error != "" {
+		t.Fatalf("task_id inference (single active) should succeed, got error: %s", res.Error)
+	}
+	if got := a.state.Plan.Get("recon"); got == nil || got.Status != TaskCompleted {
+		t.Fatalf("recon should be completed via single-active inference, got %v", got)
+	}
+
+	// task_id omitted, none active, status=active → the next pending task.
+	a2 := newAgent()
+	if res, _ := a2.updatePlanTool(map[string]string{"status": "active"}); res.Error != "" {
+		t.Fatalf("marking the next pending task active should succeed, got error: %s", res.Error)
+	}
+	if _, active, _, _ := a2.state.Plan.Counts(); active != 1 {
+		t.Fatalf("exactly one task should be active after next-pending inference, got %d", active)
+	}
+
+	// task_id omitted, multiple active → ambiguous → a helpful error (not a silent wrong update).
+	a3 := newAgent()
+	a3.state.Plan.SetStatus("recon", TaskActive)
+	var other string
+	for _, tk := range a3.state.Plan.Tasks {
+		if tk.ID != "recon" {
+			other = tk.ID
+			break
+		}
+	}
+	a3.state.Plan.SetStatus(other, TaskActive)
+	if res, _ := a3.updatePlanTool(map[string]string{"status": "completed"}); res.Error == "" {
+		t.Fatal("ambiguous task_id (multiple active) should error with a task-id hint")
+	}
+}


### PR DESCRIPTION
## Summary
Surfaced by running the benchmark against the real agent: models frequently emit `update_plan` with `task_id` or `status` missing, and the registry rejected each as a "missing required parameter" error — burning a whole scan iteration. One ssti run wasted **~13 turns** this way (the same friction showed on whitebox-cmdi). That budget never reached detection/exploitation.

## Change
Plan status is advisory bookkeeping that never gates a finding, so `task_id`/`status` are now optional and inferred safely:
- omitted `status` → `active` (the common intent: a task is being started);
- omitted `task_id` → the single currently-active task, or the next pending task when marking one active; ambiguous only when multiple tasks are active, where it returns a task-id hint instead of a silent wrong update.

Status synonyms are also broadened (`in_progress`, `done`, `n/a`, …).

## Why it matters for black-box
On black-box scans the agent's **turn budget** is the binding constraint (LLM latency + the finite loop), so eliminating ~a dozen guaranteed-wasted turns per scan goes straight into more probing, verifying, and reporting. Helps every scan.

Tests: `TestUpdatePlanToolTolerance` (status default, single-active inference, next-pending inference, ambiguous→error) plus the existing `TestUpdatePlanTool`. Full agent package tests pass.