### PR TITLE
release: v4.6.51

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.50
+VERSION=4.6.51
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.50"
+var version = "4.6.51"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.51 — update_plan tolerates omitted task_id/status, so the agent stops wasting scan turns on 'missing required parameter' rejections (black-box turn budget goes to detection instead). Change already merged via #582; version-bump release PR. Tag v4.6.51 pushed. Shipped-binary improvement.