### PR TITLE
release: v4.6.52

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.51
+VERSION=4.6.52
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.51"
+var version = "4.6.52"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.52 — verify_csrf, a deterministic Cross-Site Request Forgery confirmer, completing the verifier family (sqli/ssti/xss/xxe/csrf). Feature already merged via #584; this is the version-bump release PR. Tag v4.6.52 pushed. Shipped-binary improvement.