### PR TITLE
feat(browser): verify_xss confirms POST-based reflected XSS in one call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## [v4.6.52](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.52) — verify_csrf completes the deterministic confirmer family (2026-09-03)
+## [v4.6.53](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.53) — verify_xss confirms POST-based reflected XSS in one call (2026-09-04)
+
+### Added
+- **`verify_xss` now confirms POST-based reflected XSS**, not just GET. Pass the form action as `url` and the request body as `data` (a urlencoded form body such as `search=<payload>`); `method` defaults to `POST` whenever `data` is present. The verifier stages a self-submitting, cross-origin form and lets the browser perform a real top-level POST navigation, so the response renders as a document and a POST-reflected payload actually executes — exactly as it would for a victim, which a `fetch()`/XHR can never reproduce. The execution oracle is unchanged (a dialog/console/DOM marker carrying the nonce), so the verdict stays proof-of-execution, and a confirmation records the same browser-origin CWE-79 evidence the reporting bridge already folds into findings.
+
+### Fixed
+- **Removed the biggest black-box budget sink on form-driven targets.** Because `verify_xss` was GET-only, a reflected XSS reachable only through a POST form could not be confirmed with the tool, so the agent hand-drove the confirmation with dozens of `browser_action` steps (and often hand-rolled scripts) — on one real target that single gap consumed the large majority of the scan's tool budget and still failed to produce an independently verified finding. POST-based reflected XSS now confirms in a single `verify_xss` call, returning that budget to broader probing and reporting.
 
 ### Added
 - **`verify_csrf`, a Cross-Site Request Forgery confirmer** — the last member of the deterministic verifier family (`verify_sqli` / `verify_ssti` / `verify_xss` / `verify_xxe` / `verify_oob`), so every common injectable or forgeable class now has a one-call path that records exploit-proven evidence. Given a URL (or ledger hypothesis) and the state-change body, it replays the request the way an attacker's page would — a forged `Origin`/`Referer` and no anti-CSRF token, reusing the scan session's cookies — and confirms CSRF when the server accepts it (2xx/3xx with no token/forbidden rejection). It records CWE-352 evidence in the ledger and does not auto-report. It is deliberately production-safe: it **declines** when the endpoint is protected by an `Authorization` header (Bearer/Basic), which a cross-site attacker's browser never attaches, so it will not false-positive on token-auth APIs. Same safety envelope as the other verifiers (internal-host scope check, request-rate gate, no redirect following, disabled in passive mode).

--- a/internal/tools/browser/browser.go
+++ b/internal/tools/browser/browser.go
@@ -219,7 +219,7 @@ ACTIONS:
   new_tab      — Open a new browser tab
   switch_tab   — Switch between tabs
   close        — Close browser
-  verify_xss   — CONFIRM an XSS payload actually executes in the browser (proof of execution, not reflection). Navigate to a URL whose payload emits a unique nonce and pass nonce=<that value>; confirmed only if the nonce is observed executing. Three oracles are accepted: a JS dialog (alert/confirm/prompt('XV-8f3a')), a console call (console.log('XV-8f3a')) — useful when a filter strips alert — or a DOM marker (document.title='XV-8f3a' or window.name='XV-8f3a') for DOM-only sinks. Use before reporting XSS.
+  verify_xss   — CONFIRM an XSS payload actually executes in the browser (proof of execution, not reflection). Point it at a payload that emits a unique nonce and pass nonce=<that value>; confirmed only if the nonce is observed executing. Three oracles are accepted: a JS dialog (alert/confirm/prompt('XV-8f3a')), a console call (console.log('XV-8f3a')) — useful when a filter strips alert — or a DOM marker (document.title='XV-8f3a' or window.name='XV-8f3a') for DOM-only sinks. GET (default): pass url=<URL carrying the payload>. POST-reflected XSS: pass url=<form action> plus data=<urlencoded body, e.g. search=<payload>> (method defaults to POST when data is set) — this performs a real form POST and confirms in ONE call, so do NOT hand-build form submissions with browser_action. Use before reporting XSS.
 
 SIGNUP/LOGIN WORKFLOW:
   1. launch url=https://target.com/signup
@@ -240,6 +240,8 @@ SIGNUP/LOGIN WORKFLOW:
 			{Name: "code", Description: "JavaScript code to execute (for execute_js)", Required: false},
 			{Name: "nonce", Description: "Unique marker your XSS payload emits (for verify_xss) via a dialog (alert/confirm/prompt), console.log(), or a DOM marker (document.title / window.name). Execution is confirmed only if this nonce is observed executing.", Required: false},
 			{Name: "parameter", Description: "The injected parameter under test (for verify_xss), used to label the ledger hypothesis.", Required: false},
+			{Name: "data", Description: "Request body for POST-based verify_xss: a urlencoded form body like search=<payload>&x=1 (values are decoded once, then the browser re-encodes them at submit). Providing data makes verify_xss submit a real form POST to url and confirm POST-reflected XSS in one call.", Required: false},
+			{Name: "method", Description: "HTTP method for verify_xss: GET (default) navigates to url; POST (default when data is set) submits url as a form POST with body=data. Use POST for reflected XSS that only triggers on form submission.", Required: false},
 			{Name: "direction", Description: "Scroll direction: up or down (for scroll)", Required: false},
 			{Name: "tab_id", Description: "Tab ID (for switch_tab)", Required: false},
 			{Name: "proxy", Description: "Proxy: 'caido', 'none', or proxy URL", Required: false},
@@ -664,7 +666,7 @@ func browserActionWithContext(ctxID string, args map[string]string) (tools.Resul
 	case "close":
 		return closeBrowser(ctxID)
 	case "verify_xss":
-		return verifyXSS(ctxID, args["url"], args["nonce"], args["parameter"])
+		return verifyXSS(ctxID, args["url"], args["nonce"], args["parameter"], args["data"], args["method"])
 	default:
 		return tools.Result{}, fmt.Errorf("unknown browser action: %s. Available: launch, goto, snapshot, click, type, submit, scroll, screenshot, get_html, execute_js, get_cookies, set_cookie, save_session, load_session, list_sessions, wait, select, fill_form, get_url, iframe, main_frame, extract_links, new_tab, switch_tab, close, verify_xss", command)
 	}

--- a/internal/tools/browser/integration_test.go
+++ b/internal/tools/browser/integration_test.go
@@ -2,6 +2,8 @@ package browser
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -574,5 +576,62 @@ func TestBrowserSnapshot_Full(t *testing.T) {
 	_, err = browserActionWithContext(ctxID, map[string]string{"command": "click", "selector": "@e2"})
 	if err != nil {
 		t.Fatalf("Semantic click failed: %v", err)
+	}
+}
+
+// ═══════════════════════════════════════════════════════════
+// 3.10 verify_xss POST path (POST-based reflected XSS)
+// ═══════════════════════════════════════════════════════════
+
+// TestVerifyXSS_POST_Reflected exercises the POST path of verify_xss end-to-end
+// against a local endpoint that reflects the POSTed `q` parameter unescaped —
+// a POST-based reflected XSS. The endpoint reflects ONLY on POST (a GET yields a
+// benign page), so a pass proves the real form-POST navigation, not a GET
+// fallback. This is the exact shape that previously forced the agent to
+// hand-drive dozens of browser_action steps because verify_xss was GET-only.
+func TestVerifyXSS_POST_Reflected(t *testing.T) {
+	nonce := "XV-post-42"
+	payload := "<script>alert('" + nonce + "')</script>"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reflected := ""
+		if r.Method == http.MethodPost {
+			_ = r.ParseForm()
+			reflected = r.PostFormValue("q") // reflected unescaped, POST only
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprintf(w, "<!doctype html><html><body>results for: %s</body></html>", reflected)
+	}))
+	defer srv.Close()
+
+	ctxID := "int-verifyxss-post"
+	sc := scanctx.New(ctxID, srv.URL)
+	scanctx.Activate(sc)
+	defer scanctx.Deactivate(ctxID)
+	launchCtx(t, ctxID, "")
+
+	res, err := browserActionWithContext(ctxID, map[string]string{
+		"command":   "verify_xss",
+		"url":       srv.URL + "/search",
+		"data":      "q=" + payload,
+		"nonce":     nonce,
+		"parameter": "q",
+	})
+	if err != nil {
+		t.Fatalf("verify_xss POST returned error: %v", err)
+	}
+	if ok, _ := res.Metadata["xss_confirmed"].(bool); !ok {
+		t.Fatalf("expected POST-reflected XSS to be confirmed; output=%q error=%q", res.Output, res.Error)
+	}
+	// The confirmation must be recorded as browser-origin exploit evidence so the
+	// reporting bridge can fold it into the finding.
+	found := false
+	for _, h := range sc.Ledger.All() {
+		if strings.EqualFold(h.VulnClass, "xss") && h.Origin == "verify_xss" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a verify_xss xss hypothesis in the ledger, got %d", sc.Ledger.Len())
 	}
 }

--- a/internal/tools/browser/xssverify.go
+++ b/internal/tools/browser/xssverify.go
@@ -2,6 +2,7 @@ package browser
 
 import (
 	"fmt"
+	"html"
 	"net/url"
 	"strings"
 	"time"
@@ -13,13 +14,21 @@ import (
 // verifyXSS confirms that an XSS payload actually EXECUTES in the browser
 // (rather than merely being reflected). The caller injects a payload that
 // raises a JavaScript dialog carrying a unique nonce — e.g. alert('XV-8f3a') —
-// and passes that nonce here. We clear prior signals, navigate to the payload
-// URL (dialogs are captured + auto-dismissed by setupDialogHandler), then poll
-// briefly for a dialog whose message carries the nonce. A match is concrete
-// proof of execution and is recorded as browser-confirmed XSS evidence in the
-// shared ledger. This directly addresses the low XSS precision of
+// and passes that nonce here. We clear prior signals, drive the browser to the
+// payload (dialogs are captured + auto-dismissed by setupDialogHandler), then
+// poll briefly for a dialog whose message carries the nonce. A match is
+// concrete proof of execution and is recorded as browser-confirmed XSS evidence
+// in the shared ledger. This directly addresses the low XSS precision of
 // reflection-only scanners.
-func verifyXSS(ctxID, rawURL, nonce, parameter string) (tools.Result, error) {
+//
+// Both request methods are supported. For GET (the default when no body is
+// given) we navigate to rawURL. For POST — set method=POST or just pass a body
+// via data — we stage a self-submitting cross-origin form and let the browser
+// perform a real top-level POST, rendering the response as a document so a
+// POST-reflected payload runs. Without this, POST-based reflected XSS could not
+// be confirmed and the agent burned large budgets hand-building form
+// submissions with dozens of browser_action calls.
+func verifyXSS(ctxID, rawURL, nonce, parameter, data, method string) (tools.Result, error) {
 	nonce = strings.TrimSpace(nonce)
 	if nonce == "" {
 		return tools.Result{Error: "nonce is required — inject a unique marker via alert()/confirm()/prompt() (e.g. alert('XV-8f3a')) and pass that same marker as nonce so execution can be confirmed unambiguously."}, nil
@@ -33,11 +42,45 @@ func verifyXSS(ctxID, rawURL, nonce, parameter string) (tools.Result, error) {
 	// Clear stale signals so only this navigation can satisfy the match.
 	clearExecSignals(ctxID)
 
-	if strings.TrimSpace(rawURL) != "" {
-		if err := s.page.Timeout(20 * time.Second).Navigate(rawURL); err != nil {
-			return tools.Result{Error: fmt.Sprintf("navigation to %q failed: %v", rawURL, err)}, nil
+	// Decide GET vs POST. A request body (data) implies POST unless method says
+	// otherwise. The POST path is what lets verify_xss confirm POST-reflected XSS
+	// in a single call instead of the agent hand-driving dozens of browser_action
+	// steps to build and submit a form.
+	method = strings.ToUpper(strings.TrimSpace(method))
+	data = strings.TrimSpace(data)
+	if method == "" {
+		if data != "" {
+			method = "POST"
+		} else {
+			method = "GET"
 		}
-		_ = s.page.Timeout(10 * time.Second).WaitStable(time.Second)
+	}
+
+	if method == "GET" {
+		// Navigate directly to the payload URL (original behavior).
+		if strings.TrimSpace(rawURL) != "" {
+			if err := s.page.Timeout(20 * time.Second).Navigate(rawURL); err != nil {
+				return tools.Result{Error: fmt.Sprintf("navigation to %q failed: %v", rawURL, err)}, nil
+			}
+			_ = s.page.Timeout(10 * time.Second).WaitStable(time.Second)
+		}
+	} else {
+		// Perform a real top-level POST navigation via a self-submitting,
+		// cross-origin form. The browser renders the response as a document, so a
+		// POST-reflected payload executes exactly as it would for a victim — which
+		// a fetch()/XHR cannot reproduce (those never render or run the response).
+		if strings.TrimSpace(rawURL) == "" {
+			return tools.Result{Error: "url is required for a POST verify_xss — pass the form's action URL and the body via data (e.g. data=\"search=<payload>\")."}, nil
+		}
+		if err := s.page.Timeout(20 * time.Second).SetDocumentContent(buildXSSFormHTML(rawURL, data)); err != nil {
+			return tools.Result{Error: fmt.Sprintf("could not stage the POST form for %q: %v", rawURL, err)}, nil
+		}
+		// Submit on a 0ms timer so this Eval returns before navigation tears down
+		// the JS context (avoids a spurious "context destroyed" error).
+		if _, err := s.page.Timeout(10 * time.Second).Eval(`() => { const f = document.forms['xssverify']; if (!f) { return false; } setTimeout(() => f.submit(), 0); return true; }`); err != nil {
+			return tools.Result{Error: fmt.Sprintf("could not submit the POST form to %q: %v", rawURL, err)}, nil
+		}
+		_ = s.page.Timeout(15 * time.Second).WaitStable(time.Second)
 	}
 
 	// Dialogs and console messages fire asynchronously during/after load; poll a
@@ -122,4 +165,61 @@ func ledgerForCtx(ctxID string) *scanctx.LedgerStore {
 		return sc.Ledger
 	}
 	return nil
+}
+
+// buildXSSFormHTML builds a self-submitting HTML form that POSTs `data` (a
+// urlencoded request body, exactly what an application/x-www-form-urlencoded
+// POST carries) to `action`. Loaded via SetDocumentContent and submitted from
+// verifyXSS, the browser performs a real top-level POST navigation and renders
+// the response as a document — the only context in which a POST-reflected
+// payload executes. Field names/values are HTML-escaped for the attribute
+// context; the browser URL-encodes them again at submit time, so the server
+// receives the intended body (single-encoded).
+func buildXSSFormHTML(action, data string) string {
+	var b strings.Builder
+	b.WriteString(`<!doctype html><html><head><meta charset="utf-8"></head><body>`)
+	b.WriteString(`<form id="xssverify" method="POST" action="`)
+	b.WriteString(html.EscapeString(action))
+	b.WriteString(`">`)
+	for _, kv := range parseFormBody(data) {
+		b.WriteString(`<input type="hidden" name="`)
+		b.WriteString(html.EscapeString(kv[0]))
+		b.WriteString(`" value="`)
+		b.WriteString(html.EscapeString(kv[1]))
+		b.WriteString(`">`)
+	}
+	b.WriteString(`</form></body></html>`)
+	return b.String()
+}
+
+// parseFormBody splits a urlencoded form body ("a=1&b=2") into ordered
+// key/value pairs, URL-decoding each side once (so a payload the agent already
+// percent-encoded is decoded now and re-encoded by the browser at submit,
+// avoiding double-encoding). Order and duplicates are preserved so the request
+// matches what the agent specified. Typical XSS payloads contain no '%' or '+'
+// and pass through verbatim.
+func parseFormBody(data string) [][2]string {
+	data = strings.TrimSpace(data)
+	data = strings.TrimPrefix(data, "?")
+	if data == "" {
+		return nil
+	}
+	var out [][2]string
+	for _, pair := range strings.Split(data, "&") {
+		if pair == "" {
+			continue
+		}
+		key, val := pair, ""
+		if i := strings.IndexByte(pair, '='); i >= 0 {
+			key, val = pair[:i], pair[i+1:]
+		}
+		if dk, err := url.QueryUnescape(key); err == nil {
+			key = dk
+		}
+		if dv, err := url.QueryUnescape(val); err == nil {
+			val = dv
+		}
+		out = append(out, [2]string{key, val})
+	}
+	return out
 }

--- a/internal/tools/browser/xssverify_test.go
+++ b/internal/tools/browser/xssverify_test.go
@@ -141,11 +141,62 @@ func TestVerifyXSSErrorPaths(t *testing.T) {
 	ctxID := "xss-err-" + t.Name()
 
 	// Missing nonce → corrective error, no browser needed.
-	if res, _ := verifyXSS(ctxID, "https://app/x", "", ""); res.Error == "" || !strings.Contains(res.Error, "nonce is required") {
+	if res, _ := verifyXSS(ctxID, "https://app/x", "", "", "", ""); res.Error == "" || !strings.Contains(res.Error, "nonce is required") {
 		t.Fatalf("expected nonce-required error, got %#v", res)
 	}
 	// Nonce present but no browser launched → clear "launch first" error.
-	if res, _ := verifyXSS(ctxID, "https://app/x", "XV-1", ""); res.Error == "" || !strings.Contains(res.Error, "browser not launched") {
+	if res, _ := verifyXSS(ctxID, "https://app/x", "XV-1", "", "", ""); res.Error == "" || !strings.Contains(res.Error, "browser not launched") {
 		t.Fatalf("expected browser-not-launched error, got %#v", res)
+	}
+}
+
+func TestParseFormBody(t *testing.T) {
+	// Order + duplicates preserved; empty pairs skipped; leading '?' tolerated.
+	got := parseFormBody("?a=1&b=2&a=3&&c=")
+	want := [][2]string{{"a", "1"}, {"b", "2"}, {"a", "3"}, {"c", ""}}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d pairs, got %d (%#v)", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("pair %d: expected %v, got %v", i, want[i], got[i])
+		}
+	}
+
+	// A percent-encoded value is decoded once (so the browser re-encodes cleanly).
+	if got := parseFormBody("q=%3Cscript%3E"); len(got) != 1 || got[0] != [2]string{"q", "<script>"} {
+		t.Fatalf("expected single-decoded value, got %#v", got)
+	}
+
+	// A bare key with no '=' is a present-but-empty field.
+	if got := parseFormBody("flag"); len(got) != 1 || got[0] != [2]string{"flag", ""} {
+		t.Fatalf("expected bare key as empty-valued field, got %#v", got)
+	}
+
+	if got := parseFormBody("   "); got != nil {
+		t.Fatalf("expected nil for blank body, got %#v", got)
+	}
+}
+
+func TestBuildXSSFormHTMLPOST(t *testing.T) {
+	// The action and a payload carrying '<', '>', quotes must be HTML-escaped in
+	// the attribute context so the markup stays well-formed (the browser decodes
+	// the attribute back to the raw payload and URL-encodes it at submit).
+	h := buildXSSFormHTML("https://app/search", `q=<svg onload=alert('XV-1')>`)
+	for _, want := range []string{
+		`method="POST"`,
+		`action="https://app/search"`,
+		`id="xssverify"`,
+		`name="q"`,
+		`value="&lt;svg onload=alert(&#39;XV-1&#39;)&gt;"`,
+	} {
+		if !strings.Contains(h, want) {
+			t.Fatalf("expected form HTML to contain %q, got:\n%s", want, h)
+		}
+	}
+	// The raw, unescaped payload must NOT leak into the markup (that would break
+	// the attribute and change what gets submitted).
+	if strings.Contains(h, "<svg onload=") {
+		t.Fatalf("payload must be HTML-escaped in the attribute, got:\n%s", h)
 	}
 }


### PR DESCRIPTION
## Summary
`verify_xss` was **GET-only** — it navigated to a payload URL — so a reflected XSS reachable only through a **POST form** could not be confirmed with the tool. On a real target that single gap made the agent hand-drive confirmation with **dozens of `browser_action` steps** (plus hand-rolled scripts), consuming the large majority of the scan's tool budget and still failing to produce an independently verified finding.

## Change
Add a POST path to `verify_xss`:
- Pass the form action as `url` and the body as `data` (a urlencoded form body like `search=<payload>`). `method` defaults to **POST** whenever `data` is set.
- The verifier stages a **self-submitting, cross-origin form** via `SetDocumentContent` and lets the browser perform a **real top-level POST navigation**, so the response renders as a document and a POST-reflected payload **actually executes** — which a `fetch()`/XHR can never reproduce (those never render or run the response).
- The execution oracle (dialog/console/DOM marker carrying the nonce) and the verdict are unchanged, so a confirmation records the same browser-origin CWE-79 ledger evidence the reporting bridge already folds into findings.
- Field names/values are HTML-escaped for the attribute context and URL-decoded once from `data`, so the browser re-encodes them cleanly at submit (no double-encoding). **GET behavior is preserved exactly.**

## Why it matters for black-box
Form-driven apps are the common real-world case. Confirming POST-reflected XSS in **one call** instead of dozens of browser steps returns a large slice of the turn/tool budget to broader probing and reporting — directly addressing observed under-detection on a live target.

## Tests
- Unit: `TestParseFormBody`, `TestBuildXSSFormHTMLPOST` (ordering, single-decoding, attribute escaping).
- Integration (real browser, runs in CI): `TestVerifyXSS_POST_Reflected` confirms a **POST-only** reflected XSS against a local `httptest` endpoint and asserts the ledger evidence. Negative verdict path stays covered by `TestFinalizeXSSVerdictNotConfirmed`.