### PR TITLE
release: v4.6.53

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.52
+VERSION=4.6.53
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.52"
+var version = "4.6.53"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.53 — verify_xss now confirms POST-based reflected XSS in one call (pass url=form-action + data=urlencoded-body; method defaults to POST). Removes the biggest black-box budget sink on form-driven targets, where GET-only verify_xss forced the agent to hand-drive confirmation with dozens of browser_action steps. Feature merged via #586; this is the version-bump release PR. Tag v4.6.53 pushed. Shipped-binary improvement.