### PR TITLE
release: v4.6.54

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.53
+VERSION=4.6.54
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.53"
+var version = "4.6.54"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.54 — the assessment methodology now routes a positive probe straight to the matching one-call verifier (verify_sqli/ssti/xss/xxe/csrf, blind→verify_oob; LFI→report_vulnerability), with sqlmap/dalfox demoted to fallback. Closes a black-box conversion gap where the agent probed a parameter but never ran the confirmer. Feature merged via #588; version-bump release PR. Tag v4.6.54 pushed. Shipped-binary improvement.