### PR TITLE
release: v4.6.55

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.54
+VERSION=4.6.55
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.54"
+var version = "4.6.55"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.55 — oob_callback action=poll now escalates after repeated empty polls and tells the agent to STOP polling a dead callback and pivot to in-band confirmation (filtered egress is a recurring black-box budget sink). Counter resets on a real hit; per-token map is bounded. Feature merged via #590; version-bump release PR. Tag v4.6.55 pushed. Shipped-binary improvement.