### PR TITLE
release: v4.6.56

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.55
+VERSION=4.6.56
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.55"
+var version = "4.6.56"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.56 — a finding a deterministic verifier (verify_sqli/ssti/xxe/csrf/xss) already confirmed is now reported as exploit-proven instead of being flagged needs-manual-verification. Generalizes the XSS ledger-proof bridge to every verifier class; a positive disproof from the independent verifier still drops the finding, so it cannot resurrect a false positive. Feature merged via #592; version-bump release PR. Tag v4.6.56 pushed. Shipped-binary improvement.