### PR TITLE
release: v4.6.57

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.56
+VERSION=4.6.57
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.56"
+var version = "4.6.57"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.57 — the OAuth-state false-positive gate no longer rejects a genuine CSRF just because it says 'state' (e.g. 'state-changing POST', the exact wording verify_csrf emits). It now requires an OAuth/authorization context to fire, so a deterministically confirmed cookie-auth CSRF is reported instead of dropped, while the OAuth authorize-endpoint echo FP is still caught. Fix merged via #594; version-bump release PR. Tag v4.6.57 pushed. Shipped-binary improvement.