### PR TITLE
release: v4.6.58

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.57
+VERSION=4.6.58
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.57"
+var version = "4.6.58"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.58 — the benchmark can now host authenticated two-account challenges, and a real BOLA challenge (any logged-in user reads any order; safe-bola enforces ownership) exercises it. Validated: the agent scores PASS (CWE-639 IDOR/BOLA from the cross-account differential). Operator-only benchmark tooling; shipped binary unchanged. Feature merged via #596; version-bump release PR. Tag v4.6.58 pushed.