### PR TITLE
release: v4.6.59

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.58
+VERSION=4.6.59
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.58"
+var version = "4.6.59"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.59 — a BOLA/IDOR flaw that authz_matrix deterministically confirmed now reports as exploit-proven (not needs-manual-verification), and the PHASE playbook steers the agent to run authz_matrix the moment it finds an object-id parameter or authenticated endpoint. Only authz_matrix's high-confidence 'broken access control' signal is trusted; a positive disproof from the independent verifier still drops the finding. Feature merged via #598; version-bump release PR. Tag v4.6.59 pushed. Shipped-binary improvement.