### PR TITLE
release: v4.6.60

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.59
+VERSION=4.6.60
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.59"
+var version = "4.6.60"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.60 — adds a BFLA (Broken Function Level Authorization / privilege escalation) benchmark challenge: an admin-only function reachable by a regular user (safe-bfla enforces the role check). Validated: the agent scores PASS (CWE-862 BFLA, Verified: true). Operator-only benchmark tooling; shipped binary unchanged. Feature merged via #600; version-bump release PR. Tag v4.6.60 pushed.