### PR TITLE
release: v4.6.61

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.60
+VERSION=4.6.61
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.60"
+var version = "4.6.61"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.61 — adds the benchmark's first business-logic coverage: a business_logic class in the scorer + a price/quantity-tampering challenge (/checkout accepts a negative quantity -> negative total; safe-checkout rejects it). Validated: the agent reports the negative-quantity flaw, which the scorer classifies as business_logic (locked in by an exact-title test). Operator-only benchmark tooling; shipped binary unchanged. Feature merged via #602; version-bump release PR. Tag v4.6.61 pushed.