### PR TITLE
release: v4.6.62

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.61
+VERSION=4.6.62
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.61"
+var version = "4.6.62"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.62 — a deterministic guard blocks a rate-throttled full-port nmap scan (nmap -p- with --scan-delay/low --max-rate) before it runs and redirects the agent to a bounded --top-ports scan. Under a rate limit a full 65535-port sweep takes hours and had consumed an entire scan's budget on recon. Fast un-throttled and bounded scans are unaffected. Feature merged via #604; version-bump release PR. Tag v4.6.62 pushed. Shipped-binary improvement.