### PR TITLE
release: v4.6.63

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.62
+VERSION=4.6.63
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.62"
+var version = "4.6.63"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.63 — adds a NoSQL injection benchmark class + an operator-injection auth-bypass challenge (/api/login accepts {"$ne":...}/password[$ne]= to log in without the password; safe-login rejects it with 400). Scorer classifies nosqli (CWE-943 + keywords, ordered before SQLi). Operator-only benchmark tooling; shipped binary unchanged. Feature merged via #606; version-bump release PR. Tag v4.6.63 pushed.