### PR TITLE
feat(bench): CORS misconfiguration class + credentialed-reflect challenge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v4.6.64](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.64) — Benchmark: CORS misconfiguration class + credentialed-reflect challenge (2026-09-04)
+### Added
+- **A `cors` class and a credentialed cross-origin challenge extend the benchmark to CORS misconfiguration**, a pervasive real-world API bug. The new `cors-credentialed-reflect` challenge exposes an `/api/account` endpoint that reflects *any* request `Origin` into `Access-Control-Allow-Origin` while also setting `Access-Control-Allow-Credentials: true` — the classic exploitable pattern (reflected origin + credentials, not a harmless wildcard) — so a page on any attacker origin can make a credentialed cross-origin read of the victim's authenticated data (an email + `api_token`). The `safe-cors` negative control allows credentialed reads only from a single fixed trusted origin and never reflects an arbitrary caller `Origin`, so an over-reporting scanner fails it. The scorer recognizes `cors` via a specific text signal (`CORS` / `cross-origin resource sharing` / `access-control-allow-origin`) checked **before** the CWE — because agents often tag a CORS finding with a generic access-control CWE (e.g. CWE-284) that would otherwise fold it into `idor` — plus CWE-942/346. Operator-only benchmark tooling; the shipped binary is unchanged.
 ## [v4.6.63](https://github.com/xalgorix/xalgorix/releases/tag/v4.6.63) — Benchmark: NoSQL injection (operator-injection auth bypass) class + challenge (2026-09-04)
 
 ### Added

--- a/internal/bench/bench_test.go
+++ b/internal/bench/bench_test.go
@@ -104,6 +104,16 @@ func TestClassifyFinding(t *testing.T) {
 		{"Login bypass", "", "CWE-943", "nosqli"},
 		// Regression: a plain SQLi must STILL classify as sqli, not nosqli.
 		{"SQL injection in id parameter", "union select 1,2,3", "", "sqli"},
+		// CORS: the specific wording classifies as cors, and — critically — wins
+		// over a GENERIC access-control CWE (CWE-284) an agent might attach, which
+		// would otherwise map to idor. CWE-942/346 also map to cors.
+		{"CORS misconfiguration allows credential theft", "reflects arbitrary Origin with Access-Control-Allow-Credentials: true", "CWE-942", "cors"},
+		{"Cross-Origin Resource Sharing misconfiguration", "any origin is reflected", "", "cors"},
+		{"Reflected Access-Control-Allow-Origin with credentials", "attacker origin can read the response", "CWE-284", "cors"},
+		{"Origin validation error on /api/account", "cors policy reflects any origin", "CWE-346", "cors"},
+		// Regression: a genuine access-control finding WITHOUT CORS wording must
+		// still classify as idor (the CORS override must not steal it).
+		{"Broken access control on /api/orders", "unauthorized access to another user's order", "CWE-284", "idor"},
 		{"Broken Function Level Authorization on /api/admin/users", "regular user reached admin function", "CWE-862", "idor"},
 		{"Business logic flaw in checkout", "negative quantity yields a negative total", "", "business_logic"},
 		{"Price manipulation at checkout", "", "CWE-840", "business_logic"},
@@ -904,5 +914,64 @@ func TestNoSQLiChallengeBehavior(t *testing.T) {
 	defer safe.Close()
 	if st, _ := post(safe.URL, `{"username":"admin","password":{"$ne":null}}`); st != http.StatusBadRequest {
 		t.Fatalf("safe-login: operator injection must be 400, got %d", st)
+	}
+}
+
+// TestCORSChallengeBehavior locks in the CORS misconfiguration: the positive
+// challenge reflects an ARBITRARY attacker Origin into
+// Access-Control-Allow-Origin together with Access-Control-Allow-Credentials:
+// true (a credentialed cross-origin read of authenticated data), while the
+// negative control reflects ONLY a single fixed trusted origin.
+func TestCORSChallengeBehavior(t *testing.T) {
+	getOrigin := func(base, origin string) (int, http.Header, string) {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodGet, base+"/api/account", nil)
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		if origin != "" {
+			req.Header.Set("Origin", origin)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET /api/account: %v", err)
+		}
+		defer resp.Body.Close()
+		b, _ := io.ReadAll(resp.Body)
+		return resp.StatusCode, resp.Header, string(b)
+	}
+
+	// Positive: an arbitrary attacker origin is reflected WITH credentials, so
+	// the attacker page can read the authenticated response (the api_token).
+	cors := challengeByName(t, "cors-credentialed-reflect").Start()
+	defer cors.Close()
+	st, hdr, body := getOrigin(cors.URL, "https://evil.example")
+	if st != 200 {
+		t.Fatalf("cors: expected 200, got %d", st)
+	}
+	if hdr.Get("Access-Control-Allow-Origin") != "https://evil.example" {
+		t.Fatalf("cors: attacker Origin must be reflected into ACAO, got %q", hdr.Get("Access-Control-Allow-Origin"))
+	}
+	if hdr.Get("Access-Control-Allow-Credentials") != "true" {
+		t.Fatalf("cors: ACAC must be true, got %q", hdr.Get("Access-Control-Allow-Credentials"))
+	}
+	if !strings.Contains(body, "api_token") {
+		t.Fatalf("cors: response must carry the authenticated data an attacker steals, got %q", body)
+	}
+	// The index links the account API so a crawler discovers the surface.
+	if idx := httpGet(t, cors.URL+"/"); !strings.Contains(idx, "/api/account") {
+		t.Fatalf("cors: index must link /api/account, got %q", idx)
+	}
+
+	// Negative control: an arbitrary attacker origin is NOT reflected (only the
+	// one trusted origin is ever allowed), so there is no CORS flaw.
+	safe := challengeByName(t, "safe-cors").Start()
+	defer safe.Close()
+	if _, shdr, _ := getOrigin(safe.URL, "https://evil.example"); shdr.Get("Access-Control-Allow-Origin") == "https://evil.example" || shdr.Get("Access-Control-Allow-Origin") == "*" {
+		t.Fatalf("safe-cors: must NOT reflect an arbitrary origin, got ACAO=%q", shdr.Get("Access-Control-Allow-Origin"))
+	}
+	// The one trusted origin IS allowed, so it is a working API (not just broken).
+	if _, thdr, _ := getOrigin(safe.URL, "https://app.corp.example"); thdr.Get("Access-Control-Allow-Origin") != "https://app.corp.example" {
+		t.Fatalf("safe-cors: the trusted origin must be allowed, got ACAO=%q", thdr.Get("Access-Control-Allow-Origin"))
 	}
 }

--- a/internal/bench/challenge.go
+++ b/internal/bench/challenge.go
@@ -1002,6 +1002,67 @@ func Builtin() []Challenge {
 				_, _ = fmt.Fprint(w, `{"authenticated":false,"error":"invalid credentials"}`)
 			}),
 		},
+		{
+			// CORS misconfiguration: the account API reflects ANY request Origin
+			// into Access-Control-Allow-Origin AND sets
+			// Access-Control-Allow-Credentials: true, so a page on any attacker
+			// origin can make a credentialed cross-origin request to /api/account
+			// and read the victim's authenticated data (email + API token). This
+			// is the classic EXPLOITABLE CORS bug — reflected origin + credentials
+			// — as opposed to a harmless wildcard without credentials. The
+			// response carries a token so an exploit PoC naturally proves theft.
+			// Class cors.
+			Name: "cors-credentialed-reflect", Class: "cors", Endpoint: "/api/account", Param: "",
+			Desc: "Reflects any Origin into ACAO with Access-Control-Allow-Credentials: true (credentialed cross-origin read of authenticated data).",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/" {
+					// Index tells a crawler the SPA reads the account API
+					// cross-origin, exposing /api/account as the surface to test.
+					w.Header().Set("Content-Type", "text/html; charset=utf-8")
+					_, _ = fmt.Fprint(w, `<html><body><h1>Account</h1><p>Our single-page app loads your profile from <a href="/api/account">/api/account</a> with a credentialed cross-origin fetch.</p></body></html>`)
+					return
+				}
+				// VULNERABLE: echo the caller's Origin back and allow credentials,
+				// so ANY origin can read this authenticated response. With no
+				// Origin header (e.g. a bare curl) fall back to "*" so the
+				// reflection is still observable.
+				origin := r.Header.Get("Origin")
+				if origin == "" {
+					origin = "*"
+				}
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+				w.Header().Set("Access-Control-Allow-Credentials", "true")
+				w.Header().Set("Vary", "Origin")
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `{"user":"admin","email":"admin@corp.example","api_token":"sk_live_9f2a3c7b1e"}`)
+			}),
+		},
+		{
+			// NEGATIVE CONTROL (cors): the account API allows credentialed
+			// cross-origin reads ONLY from a single fixed, trusted origin and
+			// never reflects an arbitrary caller Origin, so an attacker page
+			// cannot read the response — there is no CORS flaw to report.
+			Name: "safe-cors", Class: "cors", Endpoint: "/api/account", Param: "", Negative: true,
+			Desc: "NEGATIVE CONTROL: ACAO is a single fixed trusted origin; arbitrary origins are never reflected (no CORS flaw).",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/" {
+					w.Header().Set("Content-Type", "text/html; charset=utf-8")
+					_, _ = fmt.Fprint(w, `<html><body><h1>Account</h1><p>Our single-page app loads your profile from <a href="/api/account">/api/account</a> with a credentialed cross-origin fetch.</p></body></html>`)
+					return
+				}
+				// SAFE: only ever allow the one trusted first-party origin; an
+				// arbitrary attacker Origin is not reflected and is granted no
+				// credentialed access.
+				const trusted = "https://app.corp.example"
+				if r.Header.Get("Origin") == trusted {
+					w.Header().Set("Access-Control-Allow-Origin", trusted)
+					w.Header().Set("Access-Control-Allow-Credentials", "true")
+				}
+				w.Header().Set("Vary", "Origin")
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `{"user":"admin","email":"admin@corp.example","api_token":"sk_live_9f2a3c7b1e"}`)
+			}),
+		},
 	}
 }
 

--- a/internal/bench/score.go
+++ b/internal/bench/score.go
@@ -155,6 +155,18 @@ func Solved(expectedClass string, findings []reporting.Vulnerability) (bool, str
 // reporting package's private classifier) so the benchmark's notion of "right
 // class" is explicit and stable.
 func classifyFinding(f reporting.Vulnerability) string {
+	text := strings.ToLower(f.Title + " " + f.Description)
+	// CORS is identified by an UNAMBIGUOUS textual signal (a reflected
+	// Access-Control-Allow-Origin / "cross-origin resource sharing" / "CORS
+	// misconfiguration"), checked BEFORE the CWE. Agents frequently tag a CORS
+	// finding with a GENERIC access-control CWE (e.g. CWE-284, which cweClass
+	// maps to idor), so a CWE-first rule would absorb CORS into idor. The CORS
+	// wording is far more specific than a generic CWE, and each benchmark app
+	// hosts exactly one bug, so this override cannot steal a genuine idor/other
+	// finding.
+	if isCORSSignal(text) {
+		return "cors"
+	}
 	// Prefer the CWE: it is the authoritative, structured class signal. A finding
 	// tagged CWE-1336 is SSTI even when its description also mentions the remote
 	// code execution it can escalate to — which would otherwise match the broader
@@ -164,7 +176,6 @@ func classifyFinding(f reporting.Vulnerability) string {
 	if c := cweClass(f.CWE); c != "" {
 		return c
 	}
-	text := strings.ToLower(f.Title + " " + f.Description)
 	for _, m := range classKeywords {
 		for _, kw := range m.keywords {
 			if strings.Contains(text, kw) {
@@ -216,9 +227,22 @@ func canonicalClass(c string) string {
 		return "business_logic"
 	case "nosql", "nosql-injection", "nosql_injection":
 		return "nosqli"
+	case "cors-misconfiguration", "cors-misconfig", "cors_misconfiguration", "cors misconfiguration":
+		return "cors"
 	default:
 		return c
 	}
+}
+
+// isCORSSignal reports whether a finding's text unambiguously describes a CORS
+// misconfiguration. classifyFinding consults this BEFORE the CWE so a CORS
+// finding an agent happened to tag with a generic access-control CWE (e.g.
+// CWE-284) is not miscounted as idor. The phrases are CORS-specific — a genuine
+// idor/xss/etc. finding does not contain them — so the override is safe.
+func isCORSSignal(text string) bool {
+	return strings.Contains(text, "cors") ||
+		strings.Contains(text, "cross-origin resource sharing") ||
+		strings.Contains(text, "access-control-allow-origin")
 }
 
 // cweClass maps a CWE identifier to a canonical class, or "" when unmapped.
@@ -230,6 +254,10 @@ func cweClass(cwe string) string {
 		return "sqli"
 	case "943":
 		return "nosqli"
+	case "942", "346":
+		// CWE-942 (Permissive Cross-domain Policy) / CWE-346 (Origin Validation
+		// Error) — the structured signals for a CORS misconfiguration.
+		return "cors"
 	case "601":
 		return "open_redirect"
 	case "918":


### PR DESCRIPTION
## Summary
Extends the benchmark to **CORS misconfiguration** (a pervasive real-world API bug) — a new `cors` class + a credentialed cross-origin challenge.

## Change (operator-only benchmark tooling — shipped binary unchanged)
- `cors-credentialed-reflect`: `/api/account` reflects **any** request `Origin` into `Access-Control-Allow-Origin` while also setting `Access-Control-Allow-Credentials: true` — the classic exploitable pattern (reflected origin + credentials, not a harmless wildcard). A page on any attacker origin can make a credentialed cross-origin read of the victim's authenticated data (email + `api_token`).
- `safe-cors` negative control: allows credentialed reads only from a single fixed trusted origin and never reflects an arbitrary caller `Origin`.
- Scorer: `isCORSSignal` (`cors` / `cross-origin resource sharing` / `access-control-allow-origin`) checked **before** the CWE — because agents often tag a CORS finding with a generic access-control CWE (e.g. CWE-284) that `cweClass` maps to `idor`, which would otherwise absorb it. Also `cweClass` 942/346→cors and `canonicalClass` cors variants.

## Tests
`TestClassifyFinding` (CORS text→cors incl. **CWE-284+CORS-text→cors override**, CWE-942/346→cors, and a regression that a generic access-control finding **without** CORS wording still→idor), `TestCORSChallengeBehavior` (arbitrary attacker Origin reflected with ACAC:true + api_token present; negative control reflects only the fixed trusted origin). Full `internal/bench` suite + `go vet` + `gofmt` pass.