### PR TITLE
release: v4.6.64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.63
+VERSION=4.6.64
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.63"
+var version = "4.6.64"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.64 — Benchmark: CORS misconfiguration class + credentialed-reflect challenge.

Bumps version to 4.6.64 (cmd/xalgorix/main.go + Makefile). Feature already merged via #608.

Operator-only benchmark tooling; the shipped scanner binary is unchanged from v4.6.63.