### PR TITLE
release: v4.6.65

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.64
+VERSION=4.6.65
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.64"
+var version = "4.6.65"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.65 — Deeper flag-capture exploitation (XSS execution, SSTI/cmdi/LFI escalation, IDOR enumeration).

Bumps version to 4.6.65 (cmd/xalgorix/main.go + Makefile). Feature merged via #611. Raised XBOW validation pass@1 flag-capture from 58/104 to a projected ~70/104.