### PR TITLE
release: v4.6.67

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.66
+VERSION=4.6.67
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.66"
+var version = "4.6.67"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.67.

Ships the agent capability improvements from #615 that recover the IDOR (indirect state-change chain, JWT-not-verified, parameter-trust, numeric-neighborhood sweep), content-discovery (robust wordlist resolution, fast high-value probe, nginx alias off-by-slash, non-standard flag filenames, -maxtime caps), and blind-SSTI (inject-in-block + count/boolean oracle) benchmark classes, plus shell hygiene (no find /, printf over heredocs, time-capped scanners).

Validated by flag capture on previously never-solved XBEN-002/027/043/097/098.