### PR TITLE
release: v4.6.68

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.67
+VERSION=4.6.68
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.67"
+var version = "4.6.68"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.68.

Headline: fixes the real-world 'finds very few vulnerabilities' regression by making the agent doctrine mode-aware — professional assessments now enumerate the full attack surface and report every distinct vulnerability, while CTF/benchmark tasks keep depth-first flag capture (no benchmark regression).

Also adds SQLi (dedicated flag table / creds-then-login / blind), insecure-deserialization->RCE, and auth-bypass (IP-spoof header, HTTP method tampering) capture techniques.