### PR TITLE
release: v4.6.69

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.68
+VERSION=4.6.69
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.68"
+var version = "4.6.69"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.69. Adds MongoDB ObjectId-prediction IDOR, arbitrary-verb HTTP method tampering, and XSS tag-blacklist/whitespace-strip filter bypass. Validated recoveries this cycle: 085 (auth bypass) and 044 (SSTI).