### PR TITLE
release: v4.6.70

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.69
+VERSION=4.6.70
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.69"
+var version = "4.6.70"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.70. Adds the Struts2/OGNL injection -> RCE technique (DEFAULT_MEMBER_ACCESS sandbox bypass, output reflected back), for real-world Struts coverage (S2-045/S2-053/S2-057 class).