### PR TITLE
fix(terminal): hard-cap dirbuster runtime (ffuf/feroxbuster/dirsearch)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1252,6 +1252,7 @@ func (a *Agent) Run(targets []string, instruction string) {
 					}
 					normalized, note := terminal.NormalizeCommandForRequestRatePolicy(contextID, command)
 					normalized = terminal.InjectScanHeadersIntoCommand(normalized)
+					normalized = terminal.CapDirbusterRuntime(normalized)
 					if normalized != command {
 						updatedArgs := make(map[string]string, len(tc.Args))
 						for k, v := range tc.Args {

--- a/internal/tools/terminal/dirbuster_cap_test.go
+++ b/internal/tools/terminal/dirbuster_cap_test.go
@@ -1,0 +1,59 @@
+package terminal
+
+import "testing"
+
+func TestCapDirbusterRuntime(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "ffuf without maxtime gets capped",
+			in:   "ffuf -u http://t/FUZZ -w wl.txt -mc 200",
+			want: "ffuf -u http://t/FUZZ -w wl.txt -mc 200 -maxtime 180",
+		},
+		{
+			name: "ffuf piped to head caps the ffuf stage only",
+			in:   "ffuf -u http://t/FUZZ -w wl.txt | head -60",
+			want: "ffuf -u http://t/FUZZ -w wl.txt -maxtime 180 | head -60",
+		},
+		{
+			name: "ffuf with explicit maxtime is preserved",
+			in:   "ffuf -u http://t/FUZZ -w wl.txt -maxtime 30",
+			want: "ffuf -u http://t/FUZZ -w wl.txt -maxtime 30",
+		},
+		{
+			name: "feroxbuster without time-limit gets capped",
+			in:   "feroxbuster -u http://t -w wl.txt -x php",
+			want: "feroxbuster -u http://t -w wl.txt -x php --time-limit 180s",
+		},
+		{
+			name: "feroxbuster with time-limit preserved",
+			in:   "feroxbuster -u http://t --time-limit 60s",
+			want: "feroxbuster -u http://t --time-limit 60s",
+		},
+		{
+			name: "dirsearch without max-time gets capped",
+			in:   "dirsearch -u http://t -w wl.txt",
+			want: "dirsearch -u http://t -w wl.txt --max-time 180",
+		},
+		{
+			name: "non-dirbuster command untouched",
+			in:   "curl -sk http://t/login",
+			want: "curl -sk http://t/login",
+		},
+		{
+			name: "sqlmap is not capped",
+			in:   "sqlmap -u http://t --batch --dump",
+			want: "sqlmap -u http://t --batch --dump",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := CapDirbusterRuntime(tc.in); got != tc.want {
+				t.Errorf("CapDirbusterRuntime(%q)\n got: %q\nwant: %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/tools/terminal/terminal.go
+++ b/internal/tools/terminal/terminal.go
@@ -147,6 +147,44 @@ func rewriteCommandForRequestRatePolicy(command string, policy scanctx.RequestRa
 	})
 }
 
+// dirbusterRuntimeCapSeconds bounds how long a single content-discovery tool may
+// run before it is force-stopped. Kept below the default per-command timeout so
+// a capped buster still leaves budget for the actual exploitation step.
+const dirbusterRuntimeCapSeconds = 180
+
+// CapDirbusterRuntime injects a hard runtime cap into directory/content
+// brute-force tools when the model omits one. ffuf without -maxtime and
+// feroxbuster without --time-limit routinely run until the full per-command
+// timeout on CTF/real apps (few matches, so a piped `| head` never closes its
+// side of the pipe), which repeatedly burned whole attempts and starved the
+// real exploit (observed on the SQLi/method-tamper/traversal challenges). This
+// is an ALWAYS-ON backstop — independent of the request-rate policy — for the
+// prompt guidance the model sometimes ignores. It only ADDS a cap when none is
+// present, so an explicit smaller bound the model set is preserved.
+func CapDirbusterRuntime(command string) string {
+	cap := strconv.Itoa(dirbusterRuntimeCapSeconds)
+	return rewriteShellSegments(command, func(segment string) string {
+		if hasToolCommand(segment, "ffuf") && !hasCommandFlag(segment, "-maxtime") {
+			segment = appendCommandArg(segment, "-maxtime "+cap)
+		}
+		if hasToolCommand(segment, "feroxbuster") && !hasCommandFlag(segment, "--time-limit") {
+			segment = appendCommandArg(segment, "--time-limit "+cap+"s")
+		}
+		if hasToolCommand(segment, "dirsearch") && !hasCommandFlag(segment, "--max-time") {
+			segment = appendCommandArg(segment, "--max-time "+cap)
+		}
+		return segment
+	})
+}
+
+// hasCommandFlag reports whether a flag (long or short) is already present in a
+// command segment, matched as a whole token so -maxtime does not match e.g.
+// -maxtime-job and --time-limit does not partial-match a longer flag.
+func hasCommandFlag(command, flag string) bool {
+	re := regexp.MustCompile(`(?i)(^|\s)` + regexp.QuoteMeta(flag) + `(?:=|\s|$)`)
+	return re.FindStringIndex(command) != nil
+}
+
 func rewriteShellSegments(command string, rewrite func(string) string) string {
 	var b strings.Builder
 	start := 0


### PR DESCRIPTION
## Problem
The agent repeatedly burned whole scan attempts on a hung directory buster. ffuf without -maxtime (and feroxbuster/dirsearch without their caps) runs until the per-command timeout — worst when piped to `head`, whose pipe never closes when matches are few. After a stalled exploit the model drifts to dirbusting and hangs for minutes, starving the real work. Seen on SQLi (071/095), method-tamper (054), and traversal challenges, and it wastes real-scan budget too.

## Fix
Add `CapDirbusterRuntime`, an always-on command normalizer wired alongside the existing rate-policy and scan-header injectors. Per shell segment it appends a runtime cap (180s) to ffuf (-maxtime), feroxbuster (--time-limit), and dirsearch (--max-time) ONLY when none is present, preserving any explicit smaller bound the model set. sqlmap and non-busters are untouched. Unit-tested (8 cases incl. piped-to-head and existing-flag preservation).

Independent of the request-rate policy, so it applies even when rate limiting is off. Build + gofmt + terminal tests pass.