### PR TITLE
release: v4.6.71

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.70
+VERSION=4.6.71
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.70"
+var version = "4.6.71"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
Release v4.6.71. Hard-caps directory-buster runtime (ffuf/feroxbuster/dirsearch) so a naked buster can no longer hang for the full command timeout and starve the actual exploitation — an always-on command normalizer, independent of the rate policy. Helps both benchmarks and real scans.