### PR TITLE
fix(reporting): never lose a proven finding to a missing description/severity

### DIFF
--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -307,7 +307,7 @@ func (r *Registry) Execute(name string, args map[string]string) (Result, error) 
 	if len(missing) > 0 {
 		if name == "report_vulnerability" {
 			return Result{}, fmt.Errorf(
-				"missing required parameters for tool '%s': %s — call it once more using the canonical XML shape with title, severity, and description in the same function block; endpoint and exploitation_proof are optional registry fields (proof is enforced by the reporting policy for actionable severities)",
+				"missing required parameter for tool '%s': %s — 'title' is the only hard-required field; include it (with severity + description + exploitation_proof for a complete report) inside a single <function=report_vulnerability>...</function> block. severity/description are salvaged if omitted, but proof is still enforced by the reporting policy for actionable severities",
 				name, strings.Join(missing, ", "),
 			)
 		}

--- a/internal/tools/reporting/reporting.go
+++ b/internal/tools/reporting/reporting.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -283,8 +284,8 @@ func RegisterWithVerifier(r *tools.Registry, verifier FindingVerifier) {
    - None/Info (0.0): Missing headers, version disclosure, self-XSS, DNS config issues`,
 		Parameters: []tools.Parameter{
 			{Name: "title", Description: "Vulnerability title", Required: true},
-			{Name: "severity", Description: "Severity per HackerOne CVSS ranges: critical (CVSS 9.0-10.0), high (7.0-8.9), medium (4.0-6.9), low (0.1-3.9), info (0.0). Must match your CVSS score.", Required: true},
-			{Name: "description", Description: "Detailed description of the vulnerability", Required: true},
+			{Name: "severity", Description: "Severity per HackerOne CVSS ranges: critical (CVSS 9.0-10.0), high (7.0-8.9), medium (4.0-6.9), low (0.1-3.9), info (0.0). Must match your CVSS score. If omitted it is derived from cvss (or defaults to medium) so a real finding is never lost — but always set it explicitly.", Required: false},
+			{Name: "description", Description: "Detailed description of the vulnerability. Strongly recommended; if omitted it is synthesized from the title and proof so a real finding is never lost to a missing field.", Required: false},
 			{Name: "exploitation_proof", Description: "REQUIRED for medium+. Concrete evidence of exploitation: extracted data, reflected payload text, command output, timing measurement, callback confirmation. Paste actual output here.", Required: false},
 			{Name: "verification_method", Description: "How you verified: exploited, time_based, data_extracted, callback_received, error_based, blind_confirmed, reflected, authenticated, manual_verified", Required: false},
 			{Name: "oob_token", Description: "For callback-confirmed SSRF: the exact token returned by oob_callback generate. Required so the backend can reject scanner-origin and DNS-only interactions.", Required: false},
@@ -327,11 +328,49 @@ func reportVulnWithContextID(contextID string, args map[string]string) (tools.Re
 
 func reportVulnWithContextIDAndVerifier(contextID string, verifier FindingVerifier, args map[string]string) (tools.Result, error) {
 	severity := strings.ToLower(strings.TrimSpace(args["severity"]))
+	if severity == "" {
+		// Salvage a missing severity (a common model omission) instead of
+		// bouncing a proven finding: derive it from the CVSS score when given,
+		// else default to medium. This never INFLATES severity, and the
+		// severity/proof gates below still apply, so an unproven finding is
+		// still rejected on its own merits.
+		if cv, err := strconv.ParseFloat(strings.TrimSpace(args["cvss"]), 64); err == nil && cv > 0 {
+			severity = severityFromCVSS(cv)
+		} else {
+			severity = "medium"
+		}
+		args["severity"] = severity
+	}
 	proof := strings.TrimSpace(args["exploitation_proof"])
 	method := strings.ToLower(strings.TrimSpace(args["verification_method"]))
 	title := strings.TrimSpace(args["title"])
 	target := strings.TrimSpace(args["target"])
 	endpoint := strings.TrimSpace(args["endpoint"])
+
+	// ── Salvage a missing description ──
+	// `description` is no longer a hard-required registry field: models (esp.
+	// smaller ones) routinely emit a complete report_vulnerability call with
+	// title/severity/proof but drop the prose `description`, which previously
+	// bounced the whole finding as "missing required parameter" and LOST a real,
+	// proven vulnerability. Synthesize one from the strongest available field so
+	// the finding survives; a model-supplied description is always preferred.
+	if strings.TrimSpace(args["description"]) == "" {
+		var synth []string
+		if title != "" {
+			synth = append(synth, title)
+		}
+		for _, k := range []string{"technical_analysis", "impact", "poc_description", "exploitation_proof"} {
+			if v := strings.TrimSpace(args[k]); v != "" {
+				synth = append(synth, v)
+				break
+			}
+		}
+		desc := strings.TrimSpace(strings.Join(synth, "\n\n"))
+		if desc == "" {
+			desc = title
+		}
+		args["description"] = desc
+	}
 
 	// ── Gate 0: Fast duplicate check before spending effort on report validation ──
 	// This is repeated under the write lock just before append to close races.

--- a/internal/tools/reporting/salvage_test.go
+++ b/internal/tools/reporting/salvage_test.go
@@ -1,0 +1,51 @@
+package reporting
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/xalgord/xalgorix/v4/internal/scanctx"
+)
+
+// TestReport_SalvagesMissingDescriptionAndSeverity verifies that a proven
+// finding is NOT lost when the model omits the prose `description` and/or the
+// `severity` field (a common small-model omission). description is synthesized
+// from the title/proof, and severity is derived from cvss.
+func TestReport_SalvagesMissingDescriptionAndSeverity(t *testing.T) {
+	ctxID := "salvage-test-ctx"
+	sc := scanctx.New(ctxID, "")
+	scanctx.Activate(sc)
+	defer scanctx.Deactivate(ctxID)
+
+	args := map[string]string{
+		"title":               "SQL Injection on GET /users/v1/name1 allows extraction of all user records",
+		"exploitation_proof":  "Injected ' UNION SELECT username,password,3,4 FROM users-- ; response returned all users with plaintext passwords: name1:pass1, name2:pass2, admin:pass_admin",
+		"verification_method": "data_extracted",
+		"cvss":                "8.6",
+		"cwe_id":              "CWE-89",
+		"endpoint":            "/users/v1/name1",
+		"method":              "GET",
+		// NOTE: no `description`, no `severity` on purpose.
+	}
+
+	res, err := reportVulnWithContextID(ctxID, args)
+	if err != nil {
+		t.Fatalf("reportVulnWithContextID returned error: %v", err)
+	}
+	if strings.Contains(strings.ToUpper(res.Output), "REJECTED") ||
+		strings.Contains(res.Output, "missing required parameter") {
+		t.Fatalf("finding was rejected instead of salvaged: %s", res.Output)
+	}
+
+	vulns := getStoreByID(ctxID).vulns
+	if len(vulns) != 1 {
+		t.Fatalf("expected 1 recorded vuln, got %d (output=%s)", len(vulns), res.Output)
+	}
+	v := vulns[0]
+	if strings.TrimSpace(v.Description) == "" {
+		t.Errorf("description was not synthesized (empty)")
+	}
+	if v.Severity != "high" {
+		t.Errorf("severity not derived from cvss 8.6: got %q want %q", v.Severity, "high")
+	}
+}


### PR DESCRIPTION
## Problem (measured on a real target)
Deployed VAmPI (OWASP-API-Top-10 vulnerable API, 9 documented vulns) locally and baselined the current build: the agent DISCOVERED ~7+ real vulns (BOLA x several, Mass Assignment, SQLi, Werkzeug debug RCE) but only **4 were recorded** — **9 report_vulnerability calls were rejected for 'missing required parameter: description'** (and one for 'severity'). MiniMax emits a complete report (title/proof/cvss/method) but drops the prose fields, and the registry bounced the whole finding. This is a direct real-world 'finds few vulnerabilities' root cause.

## Fix
Make **title** the only hard-required field of report_vulnerability:
- **description** omitted -> synthesized from title + technical_analysis/impact/poc/exploitation_proof.
- **severity** omitted -> derived from cvss (never inflating) or defaults to medium.

All existing proof / false-positive / claim-consistency / verifier gates still apply, so an unproven or fabricated finding is still rejected on its merits — we only stop discarding *complete, proven* findings over a missing prose field. Unit-tested (salvage_test.go). Build + reporting/tools tests pass.