### PR TITLE
Confine web report logos to the uploads directory

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,6 +7,27 @@ within two business days and aim to ship a fix or mitigation on a
 severity-driven schedule. Do not file public GitHub issues for
 suspected vulnerabilities.
 
+## Dashboard trust boundary
+
+The scanner dashboard is a single-operator administration interface. All
+sessions authenticated with its configured operator credentials have the same
+permissions over scans and provider settings. Session tokens are not separate
+user or tenant identities. Do not give these credentials to mutually untrusted
+users or expose this API as a tenant-facing service. A hosted integration must
+authenticate its own users and enforce scan ownership before accessing the
+scanner through server-held credentials.
+
+LLM provider URLs are trusted operator configuration. Private endpoints are
+supported for local Ollama and OpenAI-compatible gateways. Configure endpoints
+you trust to receive scan context and provider credentials; tenant-facing
+applications must not forward customer-supplied provider URLs or credentials.
+
+Web report logos must be uploaded through the dashboard. Logo references are
+limited to the configured `logos` directory; arbitrary local image paths and
+scan-directory relative paths are not accepted. Saved absolute paths within
+the upload directory remain supported. Re-upload older external logos to use
+them in web reports.
+
 ## Daily scan policy
 
 The [`security-daily`](.github/workflows/security-daily.yml) GitHub Actions

--- a/internal/reporting/generate.go
+++ b/internal/reporting/generate.go
@@ -1,6 +1,7 @@
 package reporting
 
 import (
+	"bytes"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -127,9 +128,9 @@ func sanitizeScanForPDF(s *Scan) *Scan {
 // Options configures a single Generate invocation.
 //
 // LogoPath is an OPTIONAL pre-resolved, pre-validated absolute path to a
-// PNG/JPEG logo. When empty, the cover page falls back to a monogram of
-// the brand initials. Callers in the web layer typically resolve and
-// validate the path with ValidLogo before populating this field.
+// PNG/JPEG logo for trusted local callers. The web layer supplies LogoData
+// and LogoType (png/jpeg) instead, so the renderer cannot reopen a user path.
+// LogoData takes precedence over LogoPath. With neither, branding uses initials.
 //
 // ScanDir is the per-scan working directory. When non-empty the report
 // is written to <ScanDir>/<filename>; otherwise it is written to
@@ -139,6 +140,8 @@ func sanitizeScanForPDF(s *Scan) *Scan {
 // FallbackDir is consulted only when ScanDir is empty.
 type Options struct {
 	LogoPath    string
+	LogoData    []byte
+	LogoType    string
 	ScanDir     string
 	FallbackDir string
 }
@@ -188,6 +191,9 @@ func Generate(scan *Scan, opts Options) (string, error) {
 	duration := FormatDuration(startTime, endTime)
 	brandName := BrandName(scan)
 	logoPath := opts.LogoPath
+	if len(opts.LogoData) > 0 {
+		logoPath = "uploaded-report-logo"
+	}
 	hasLogo := logoPath != ""
 
 	const (
@@ -700,7 +706,12 @@ func Generate(scan *Scan, opts Options) (string, error) {
 	if hasLogo {
 		titleW = cardW - 66
 		logoX, logoY, logoSize := marginX+cardW-58, 40.0, 58.0
-		info := pdf.RegisterImage(logoPath, "")
+		var info *fpdf.ImageInfoType
+		if len(opts.LogoData) > 0 {
+			info = pdf.RegisterImageOptionsReader(logoPath, fpdf.ImageOptions{ImageType: opts.LogoType}, bytes.NewReader(opts.LogoData))
+		} else {
+			info = pdf.RegisterImage(logoPath, "")
+		}
 		if info != nil && info.Height() > 0 && info.Width() > 0 {
 			imgW := logoSize
 			imgH := info.Height() * imgW / info.Width()

--- a/internal/reporting/logo_data_test.go
+++ b/internal/reporting/logo_data_test.go
@@ -1,0 +1,47 @@
+package reporting
+
+import (
+	"bytes"
+	"image"
+	"image/jpeg"
+	"image/png"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGenerateWithLogoData(t *testing.T) {
+	for _, format := range []string{"png", "jpeg"} {
+		t.Run(format, func(t *testing.T) {
+			var data bytes.Buffer
+			logo := image.NewRGBA(image.Rect(0, 0, 2, 2))
+			var err error
+			if format == "png" {
+				err = png.Encode(&data, logo)
+			} else {
+				err = jpeg.Encode(&data, logo, nil)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			dir := t.TempDir()
+			path, err := Generate(&Scan{
+				ID: "logo-test", Target: "example.com", Status: "finished", CompanyName: "Example",
+			}, Options{
+				LogoData: data.Bytes(), LogoType: format,
+				// The in-memory snapshot must take precedence; no file is here.
+				LogoPath: filepath.Join(dir, "missing.png"), ScanDir: dir,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			pdf, err := os.ReadFile(path)
+			if err != nil || !bytes.HasPrefix(pdf, []byte("%PDF-")) {
+				t.Fatalf("expected a PDF from the logo snapshot: %v", err)
+			}
+			if !bytes.Contains(pdf, []byte("/Subtype /Image")) {
+				t.Fatal("PDF does not contain the uploaded image")
+			}
+		})
+	}
+}

--- a/internal/web/report.go
+++ b/internal/web/report.go
@@ -1,10 +1,12 @@
 package web
 
 import (
+	"bytes"
 	"fmt"
 	"image"
 	_ "image/jpeg" // register JPEG decoder for image.Decode on uploaded logos
 	_ "image/png"  // register PNG decoder for image.Decode on uploaded logos
+	"io"
 	"math"
 	"net/url"
 	"os"
@@ -227,46 +229,55 @@ func supportedReportLogoExt(path string) bool {
 	}
 }
 
-func validReportLogo(path string) bool {
-	if !supportedReportLogoExt(path) {
-		return false
-	}
-	info, err := os.Stat(path)
-	if err != nil || !info.Mode().IsRegular() {
-		return false
-	}
-	file, err := os.Open(path)
-	if err != nil {
-		return false
-	}
-	defer file.Close()
-	_, _, err = image.DecodeConfig(file)
-	return err == nil
-}
+const maxReportLogoBytes = 5 << 20
 
-func (s *Server) resolveReportLogoPath(logoPath string) (string, bool) {
+// loadReportLogo reads an uploaded logo through a directory-bound handle.
+// Renderers receive the validated bytes, never a path to reopen after validation.
+func (s *Server) loadReportLogo(logoPath string) ([]byte, string) {
 	logoPath = strings.TrimSpace(logoPath)
-	if logoPath == "" {
-		return "", false
+	if logoPath == "" || strings.TrimSpace(s.dataDir) == "" {
+		return nil, ""
 	}
-	var candidates []string
+	logosDir, err := filepath.Abs(filepath.Join(s.dataDir, "logos"))
+	if err != nil {
+		return nil, ""
+	}
+	name := logoPath
 	if strings.HasPrefix(logoPath, "/uploads/logos/") {
-		candidates = append(candidates, filepath.Join(s.dataDir, "logos", filepath.Base(logoPath)))
+		name = strings.TrimPrefix(logoPath, "/uploads/logos/")
 	} else if filepath.IsAbs(logoPath) {
-		candidates = append(candidates, logoPath)
-	} else {
-		candidates = append(candidates,
-			filepath.Join(s.currentScanDir, logoPath),
-			filepath.Join(s.dataDir, "logos", filepath.Base(logoPath)),
-			logoPath,
-		)
-	}
-	for _, candidate := range candidates {
-		if validReportLogo(candidate) {
-			return candidate, true
+		// Keep legacy saved absolute paths only when they name an upload.
+		name, err = filepath.Rel(logosDir, logoPath)
+		if err != nil {
+			return nil, ""
 		}
 	}
-	return "", false
+	if !filepath.IsLocal(name) || strings.ContainsAny(name, "/\\:\x00") || !supportedReportLogoExt(name) {
+		return nil, ""
+	}
+	root, err := os.OpenRoot(logosDir)
+	if err != nil {
+		return nil, ""
+	}
+	defer func() { _ = root.Close() }()
+	file, err := root.Open(name)
+	if err != nil {
+		return nil, ""
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil || !info.Mode().IsRegular() || info.Size() > maxReportLogoBytes {
+		return nil, ""
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxReportLogoBytes+1))
+	if err != nil || len(data) > maxReportLogoBytes {
+		return nil, ""
+	}
+	_, format, err := image.DecodeConfig(bytes.NewReader(data))
+	if err != nil || (format != "png" && format != "jpeg") {
+		return nil, ""
+	}
+	return data, format
 }
 
 // riskScore computes a weighted overall risk score (0-10) from vulnerabilities.
@@ -548,7 +559,9 @@ func (s *Server) generateReport(scan *ScanRecord) (string, error) {
 	endTime := parseReportTime(scan.FinishedAt)
 	duration := formatReportDuration(startTime, endTime)
 	brandName := reportBrandName(scan)
-	logoPath, hasLogo := s.resolveReportLogoPath(scan.LogoPath)
+	logoData, logoType := s.loadReportLogo(scan.LogoPath)
+	hasLogo := len(logoData) > 0
+	const logoPath = "uploaded-report-logo"
 
 	// Helper: set text color
 	setColor := func(c [3]int) {
@@ -577,7 +590,7 @@ func (s *Server) generateReport(scan *ScanRecord) (string, error) {
 		drawRect(x, y, w, h, palette.muted)
 		drawStrokeRect(x, y, w, h, border)
 		if hasLogo {
-			info := pdf.RegisterImage(logoPath, "")
+			info := pdf.RegisterImageOptionsReader(logoPath, fpdf.ImageOptions{ImageType: logoType}, bytes.NewReader(logoData))
 			if info != nil && info.Height() > 0 && info.Width() > 0 {
 				maxW := w - 6
 				maxH := h - 6

--- a/internal/web/report_logo_test.go
+++ b/internal/web/report_logo_test.go
@@ -1,0 +1,110 @@
+package web
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadReportLogoUploadBoundary(t *testing.T) {
+	s := &Server{dataDir: t.TempDir(), currentScanDir: t.TempDir()}
+	logosDir := filepath.Join(s.dataDir, "logos")
+	if err := os.Mkdir(logosDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	logo := filepath.Join(logosDir, "brand.png")
+	writeTestPNG(t, logo)
+	want, err := os.ReadFile(logo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, ref := range []string{"brand.png", "/uploads/logos/brand.png", logo} {
+		t.Run(ref, func(t *testing.T) {
+			data, format := s.loadReportLogo(ref)
+			if !bytes.Equal(data, want) || format != "png" {
+				t.Fatalf("expected the uploaded PNG, got %d bytes of %q", len(data), format)
+			}
+		})
+	}
+
+	other := filepath.Join(s.currentScanDir, "other.png")
+	writeTestPNG(t, other)
+	for _, ref := range []string{
+		"", ".", "..", "other.png", other,
+		"../brand.png", "/uploads/logos/../brand.png",
+		"nested/brand.png", `nested\brand.png`,
+		"brand.svg", "missing.png", "https://example.com/brand.png",
+	} {
+		t.Run("reject "+ref, func(t *testing.T) {
+			data, format := s.loadReportLogo(ref)
+			if len(data) != 0 || format != "" {
+				t.Fatal("non-upload reference was accepted")
+			}
+		})
+	}
+}
+
+func TestLoadReportLogoRejectsExternalSymlink(t *testing.T) {
+	s := &Server{dataDir: t.TempDir()}
+	logosDir := filepath.Join(s.dataDir, "logos")
+	if err := os.Mkdir(logosDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	other := filepath.Join(t.TempDir(), "other.png")
+	writeTestPNG(t, other)
+	if err := os.Symlink(other, filepath.Join(logosDir, "linked.png")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if data, _ := s.loadReportLogo("linked.png"); len(data) != 0 {
+		t.Fatal("a symlink outside the uploads directory was accepted")
+	}
+}
+
+func TestLoadReportLogoRejectsInvalidFiles(t *testing.T) {
+	s := &Server{dataDir: t.TempDir()}
+	logosDir := filepath.Join(s.dataDir, "logos")
+	if err := os.Mkdir(logosDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(logosDir, "invalid.png"), []byte("not an image"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(logosDir, "directory.png"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	large, err := os.Create(filepath.Join(logosDir, "large.png"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := large.Truncate(maxReportLogoBytes + 1); err != nil {
+		large.Close()
+		t.Fatal(err)
+	}
+	large.Close()
+	for _, name := range []string{"invalid.png", "directory.png", "large.png"} {
+		if data, _ := s.loadReportLogo(name); len(data) != 0 {
+			t.Errorf("invalid logo %q was accepted", name)
+		}
+	}
+}
+
+func TestLegacyReportEmbedsUploadedLogo(t *testing.T) {
+	s := &Server{dataDir: t.TempDir(), currentScanDir: t.TempDir()}
+	logosDir := filepath.Join(s.dataDir, "logos")
+	if err := os.Mkdir(logosDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	writeTestPNG(t, filepath.Join(logosDir, "brand.png"))
+	path, err := s.generateReport(&ScanRecord{
+		ID: "legacy-logo", Target: "example.com", Status: "finished",
+		CompanyName: "Example", LogoPath: "/uploads/logos/brand.png",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pdf, err := os.ReadFile(path)
+	if err != nil || !bytes.Contains(pdf, []byte("/Subtype /Image")) {
+		t.Fatalf("legacy renderer did not embed the uploaded logo: %v", err)
+	}
+}

--- a/internal/web/scan_query.go
+++ b/internal/web/scan_query.go
@@ -162,20 +162,6 @@ func toReportingScan(scan *ScanRecord) *pdfreport.Scan {
 
 // generateReportAt generates a PDF report, saving it to a specific directory.
 func (s *Server) generateReportAt(scan *ScanRecord, scanDir string) (string, error) {
-	// resolveReportLogoPath consults s.currentScanDir as one of its
-	// candidate directories, so it still needs the temporary swap even
-	// though the renderer itself now takes scanDir as an explicit param.
-	s.mu.Lock()
-	prevDir := s.currentScanDir
-	s.currentScanDir = scanDir
-	s.mu.Unlock()
-
-	restoreScanDir := func() {
-		s.mu.Lock()
-		s.currentScanDir = prevDir
-		s.mu.Unlock()
-	}
-
 	// The redesigned reporting package currently renders with Latin core
 	// fonts. Preserve the localized/CJK renderer added on main for non-English
 	// reports until that support is moved into internal/reporting.
@@ -184,15 +170,24 @@ func (s *Server) generateReportAt(scan *ScanRecord, scanDir string) (string, err
 		language = config.NormalizeLanguage(s.cfg.Language)
 	}
 	if language != config.DefaultLanguage {
-		defer restoreScanDir()
+		// The localized renderer still uses currentScanDir for its output path.
+		s.mu.Lock()
+		prevDir := s.currentScanDir
+		s.currentScanDir = scanDir
+		s.mu.Unlock()
+		defer func() {
+			s.mu.Lock()
+			s.currentScanDir = prevDir
+			s.mu.Unlock()
+		}()
 		return s.generateReport(scan)
 	}
 
-	logoPath, _ := s.resolveReportLogoPath(scan.LogoPath)
-	restoreScanDir()
+	logoData, logoType := s.loadReportLogo(scan.LogoPath)
 
 	return pdfreport.Generate(toReportingScan(scan), pdfreport.Options{
-		LogoPath:    logoPath,
+		LogoData:    logoData,
+		LogoType:    logoType,
 		ScanDir:     scanDir,
 		FallbackDir: s.dataDir,
 	})

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -129,9 +129,9 @@ func TestGenerateReportResolvesUploadedLogoPath(t *testing.T) {
 		Events: []WSEvent{{Type: "message", Content: "Tech stack detected: nginx"}},
 	}
 
-	resolved, ok := s.resolveReportLogoPath(rec.LogoPath)
-	if !ok || resolved != logoPath {
-		t.Fatalf("resolveReportLogoPath() = %q, %v; want %q, true", resolved, ok, logoPath)
+	logoData, logoType := s.loadReportLogo(rec.LogoPath)
+	if len(logoData) == 0 || logoType != "png" {
+		t.Fatalf("loadReportLogo() returned %d bytes, %q; want PNG data", len(logoData), logoType)
 	}
 	reportPath, err := s.generateReportAt(rec, scanDir)
 	if err != nil {


### PR DESCRIPTION
## What & why

Web report logo references previously resolved outside the configured uploads directory. Restrict web logos to that directory using a directory-bound file handle, enforce the image format and 5 MiB read limit, and pass the validated bytes to both PDF renderers so they do not reopen a supplied path.

Existing upload references and saved absolute paths inside the logos directory remain supported. Logos stored elsewhere must be uploaded through the dashboard again. The security policy now documents the dashboard's single-operator permissions and trusted LLM provider configuration. Scan findings and severity classification are unchanged.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Docs
- [ ] Refactor / internal
- [ ] Other

## How was it tested?

- [ ] `make lint` passes
- [ ] `golangci-lint run --config .golangci.yml ./...` passes
- [ ] `go test ./...` passes
- [x] Added/updated tests for the change

Local verification passed:

- `go fmt ./...` and `go vet ./...`.
- `golangci-lint run --config .golangci.yml --new-from-rev origin/main ./...` (no new lint issues).
- `go test ./internal/reporting`, including PNG/JPEG byte-backed embedding without a source file.
- `go test -race ./internal/web -run 'TestLoadReportLogo|TestGenerateReportResolvesUploadedLogoPath|TestLegacyReportEmbedsUploadedLogo' -count=1`, covering the directory boundary, escaping symlinks, invalid/oversized images, legacy upload paths, and both renderers.

Full `make lint` / `golangci-lint` reports existing SA5011 warnings in tests outside the changed code; the diff-filtered lint check passes. The full Go test suite was not run locally; the focused tests use synthetic data without starting scanner workflows.

## Checklist

- [x] I read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md).
- [x] The tree is `gofmt`-clean.
- [x] I updated docs (`README`, `docs/`, help text) if behavior changed.
- [x] This does not weaken a security control (scope guard, verifier, false-positive gate) without explicit discussion.
- [x] For engine behavior changes: I noted any impact on scan findings/severity.
