### PR TITLE
docs: place sponsors above Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@
 
 ---
 
+## 🤝 Sponsors
+
+Thanks to **[Swiftproxy](https://www.swiftproxy.net/?ref=xalgorix)** for sponsoring Xalgorix.
+
+<a href="https://www.swiftproxy.net/?ref=xalgorix">
+  <img src="assets/swiftproxy_xalgorix.png" alt="Swiftproxy sponsors Xalgorix — residential proxies for authorized testing across locations" width="860" />
+</a>
+
+Your app can behave differently depending on where a request comes from. For Xalgorix users checking their own applications across regions, Swiftproxy offers **location targeting** to review regional behavior and **sticky sessions** to help keep a consistent IP during a test session. It supports **HTTP(S) and SOCKS5**, the same proxy protocols Xalgorix supports.
+
+Residential proxies from **$0.70/GB**. **Free testing is available**, and Xalgorix users get **10% off** with code **`PROXY90`**.
+
+[**Explore Swiftproxy and request a free test →**](https://www.swiftproxy.net/?ref=xalgorix)
+
+---
+
 ## 🚀 Quick Start
 
 **Install (one line):**
@@ -216,20 +232,6 @@ If Xalgorix saves you a triage cycle, please **[⭐ star the repo](https://githu
 | 🔔 Integrations   | AgentMail test inboxes, verification emails, OTP flows, email triage events, Discord and Telegram notifications.            |
 | ⚙️ Configuration  | Dashboard settings for LLM, AgentMail, Discord, Telegram, proxy, runtime, browser, auth, rate limits, and resources.       |
 | 🛡️ Runtime safety | Resource-aware instance limits and loopback-only binding unless external access is explicitly configured with auth.         |
-
-## 🤝 Sponsors
-
-Thanks to **[Swiftproxy](https://www.swiftproxy.net/?ref=xalgorix)** for sponsoring Xalgorix.
-
-<a href="https://www.swiftproxy.net/?ref=xalgorix">
-  <img src="assets/swiftproxy_xalgorix.png" alt="Swiftproxy sponsors Xalgorix — residential proxies for authorized testing across locations" width="860" />
-</a>
-
-Your app can behave differently depending on where a request comes from. For Xalgorix users checking their own applications across regions, Swiftproxy offers **location targeting** to review regional behavior and **sticky sessions** to help keep a consistent IP during a test session. It supports **HTTP(S) and SOCKS5**, the same proxy protocols Xalgorix supports.
-
-Residential proxies from **$0.70/GB**. **Free testing is available**, and Xalgorix users get **10% off** with code **`PROXY90`**.
-
-[**Explore Swiftproxy and request a free test →**](https://www.swiftproxy.net/?ref=xalgorix)
 
 ## 📥 Installation
 


### PR DESCRIPTION
## What & why

Move the Sponsors section from below Features to immediately above Quick Start, after Screenshots. This keeps the project visuals first while making the sponsor placement easier to find before installation begins.

## Type of change

- [x] Docs

## How was it tested?

- [x] `git diff --check` passes.
- [x] Reviewed the section order: Screenshots, Sponsors, Quick Start.
- [x] Verified there is one Sponsors section and that its banner, referral links, copy, discount, and contents link remain intact.
- Go checks were not rerun for this README-only rearrangement. Executable sources match the previous validation recorded in #635: formatting and `go vet` passed, lint reported existing SA5011 diagnostics, and browser tests encountered an occupied local port.

## Checklist

- [x] I read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md).
- [x] The README is updated.
- [x] This does not change a security control or engine behavior.