### PR TITLE
release: v4.6.75

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY=xalgorix
 BUILD_DIR=./build
-VERSION=4.6.74
+VERSION=4.6.75
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
 webui/node_modules: webui/package.json webui/package-lock.json

--- a/cmd/xalgorix/main.go
+++ b/cmd/xalgorix/main.go
@@ -32,7 +32,7 @@ import (
 // The hardcoded fallback is only used when developers `go run` the package
 // without ldflags. It is a `var` (not `const`) precisely so ldflags can
 // rewrite it.
-var version = "4.6.74"
+var version = "4.6.75"
 
 const defaultWebPort = 9137
 


### PR DESCRIPTION
## Release v4.6.75

Ships the portable content-discovery wordlist resolution from #638 and closes #630.

- Supports both case-sensitive SecLists and seclists install layouts.
- Searches common distribution wordlist paths.
- Uses a bundled scan-local tmp/wordlists fallback when no host list is installed.
- Preserves user-provided and generated wordlists.

Verification: make build; xalgorix --version; focused terminal and command tests.